### PR TITLE
Perf/stage 2 adaptive daa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "adaptive-difficulty-harness"
+version = "0.1.0"
+dependencies = [
+ "bitcoin-rs-chain",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/electrum",
     "crates/node",
     "bin/bitcoin-rs",
+    "tools/perf/adaptive-difficulty-harness",
 ]
 
 [workspace.package]

--- a/crates/chain/src/adaptive_difficulty.rs
+++ b/crates/chain/src/adaptive_difficulty.rs
@@ -1,0 +1,301 @@
+//! Fixed-point adaptive difficulty adjustment primitives.
+
+use core::ops::{Mul, Shl, Shr};
+
+/// Number of fractional bits in fixed-point values.
+pub const SCALE_BITS: u32 = 16;
+/// Fixed-point representation of `1.0`.
+pub const FIXED_ONE: i64 = 1_i64 << SCALE_BITS;
+/// Number of timestamps retained by the sliding regression window.
+pub const WINDOW_SIZE: usize = 32;
+/// Bit mask used to wrap the power-of-two timestamp ring.
+pub const WINDOW_MASK: usize = WINDOW_SIZE - 1;
+
+const TARGET_BLOCK_TIME: i64 = 600;
+const ALPHA_FAST_SHIFT: u32 = 1;
+const ALPHA_SLOW_SHIFT: u32 = 3;
+const VARIANCE_THRESHOLD: i64 = 19_660;
+const U256_LIMBS: usize = 4;
+const LIMB_BITS: usize = 64;
+const LIMB_BITS_U32: u32 = 64;
+const U256_BITS: usize = U256_LIMBS * LIMB_BITS;
+
+/// Little-endian 256-bit unsigned integer used by the adaptive target engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct U256(pub [u64; U256_LIMBS]);
+
+impl U256 {
+    /// Returns zero.
+    #[must_use]
+    pub const fn zero() -> Self {
+        Self([0; U256_LIMBS])
+    }
+}
+
+impl Shl<i32> for U256 {
+    type Output = Self;
+
+    fn shl(self, rhs: i32) -> Self::Output {
+        let Ok(shift) = usize::try_from(rhs) else {
+            return self;
+        };
+        if shift >= U256_BITS {
+            return Self::zero();
+        }
+
+        let mut parts = [0_u64; U256_LIMBS];
+        let shift_words = shift / LIMB_BITS;
+        let shift_bits = u32::try_from(shift & (LIMB_BITS - 1))
+            .unwrap_or_else(|_| unreachable!("masked shift is below 64"));
+
+        for source in 0..(U256_LIMBS - shift_words) {
+            let target = source + shift_words;
+            parts[target] |= self.0[source] << shift_bits;
+            if shift_bits > 0 && target + 1 < U256_LIMBS {
+                parts[target + 1] |= self.0[source] >> (LIMB_BITS_U32 - shift_bits);
+            }
+        }
+
+        Self(parts)
+    }
+}
+
+impl Shr<i32> for U256 {
+    type Output = Self;
+
+    fn shr(self, rhs: i32) -> Self::Output {
+        let Ok(shift) = usize::try_from(rhs) else {
+            return self;
+        };
+        if shift >= U256_BITS {
+            return Self::zero();
+        }
+
+        let mut parts = [0_u64; U256_LIMBS];
+        let shift_words = shift / LIMB_BITS;
+        let shift_bits = u32::try_from(shift & (LIMB_BITS - 1))
+            .unwrap_or_else(|_| unreachable!("masked shift is below 64"));
+
+        for (target, part) in parts.iter_mut().enumerate().take(U256_LIMBS - shift_words) {
+            let source = target + shift_words;
+            *part |= self.0[source] >> shift_bits;
+            if shift_bits > 0 && source + 1 < U256_LIMBS {
+                *part |= self.0[source + 1] << (LIMB_BITS_U32 - shift_bits);
+            }
+        }
+
+        Self(parts)
+    }
+}
+
+impl Mul<u64> for U256 {
+    type Output = Self;
+
+    fn mul(self, rhs: u64) -> Self::Output {
+        let mut parts = [0_u64; U256_LIMBS];
+        let mut carry = 0_u128;
+        for (source, target) in self.0.into_iter().zip(&mut parts) {
+            let result = u128::from(source)
+                .saturating_mul(u128::from(rhs))
+                .saturating_add(carry);
+            let low = result & u128::from(u64::MAX);
+            *target = u64::try_from(low).unwrap_or_else(|_| unreachable!("masked limb fits u64"));
+            carry = result >> LIMB_BITS;
+        }
+        Self(parts)
+    }
+}
+
+/// Zero-allocation adaptive difficulty controller.
+#[derive(Debug, Clone)]
+pub struct DifficultyController {
+    timestamps: [u32; WINDOW_SIZE],
+    current_ewma_slope: i64,
+    total_blocks: u64,
+}
+
+impl Default for DifficultyController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DifficultyController {
+    /// Creates an empty controller.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            timestamps: [0; WINDOW_SIZE],
+            current_ewma_slope: FIXED_ONE,
+            total_blocks: 0,
+        }
+    }
+
+    /// Pushes a block timestamp into the fixed-size ring.
+    pub fn push_timestamp(&mut self, timestamp: u32) {
+        let idx = usize::try_from(self.total_blocks)
+            .unwrap_or_else(|_| unreachable!("usize supports required block index width"))
+            & WINDOW_MASK;
+        self.timestamps[idx] = timestamp;
+        self.total_blocks = self.total_blocks.saturating_add(1);
+    }
+
+    /// Calculates the normalized least-squares slope for the active window.
+    #[must_use]
+    pub fn calculate_lsm_slope(&self) -> Option<i64> {
+        if self.total_blocks < u64::try_from(WINDOW_SIZE).unwrap_or(0) {
+            return None;
+        }
+
+        let n = i64::try_from(WINDOW_SIZE).unwrap_or_else(|_| unreachable!("window fits i64"));
+        let mut sum_x = 0_i64;
+        let mut sum_y = 0_i64;
+        let mut sum_xx = 0_i64;
+        let mut sum_xy = 0_i64;
+
+        let start_height = self
+            .total_blocks
+            .saturating_sub(u64::try_from(WINDOW_SIZE).unwrap_or(0));
+
+        for x in 0..n {
+            let actual_idx = usize::try_from(
+                start_height + u64::try_from(x).unwrap_or_else(|_| unreachable!("x fits u64")),
+            )
+            .unwrap_or_else(|_| unreachable!("usize supports required block index width"))
+                & WINDOW_MASK;
+            let y = i64::from(self.timestamps[actual_idx]);
+
+            sum_x += x;
+            sum_y += y;
+            sum_xx += x * x;
+            sum_xy += x * y;
+        }
+
+        let sum_x_squared = sum_x * sum_x;
+        let denominator = n * sum_xx - sum_x_squared;
+        if denominator == 0 {
+            return Some(FIXED_ONE);
+        }
+
+        let sum_xy_projection = sum_x * sum_y;
+        let numerator = n * sum_xy - sum_xy_projection;
+        let actual_slope = (numerator << SCALE_BITS) / denominator;
+        Some(actual_slope / TARGET_BLOCK_TIME)
+    }
+
+    /// Advances the EWMA and returns the ASERT-scaled bounded target.
+    #[must_use]
+    pub fn next_target(&mut self, current_target: U256) -> U256 {
+        let Some(lsm_slope) = self.calculate_lsm_slope() else {
+            return current_target;
+        };
+
+        let delta = (lsm_slope - self.current_ewma_slope).abs();
+        let alpha_shift = if delta > VARIANCE_THRESHOLD {
+            ALPHA_SLOW_SHIFT
+        } else {
+            ALPHA_FAST_SHIFT
+        };
+
+        let next_ewma = (lsm_slope >> alpha_shift)
+            + (self.current_ewma_slope - (self.current_ewma_slope >> alpha_shift));
+        self.current_ewma_slope = next_ewma;
+
+        let error = next_ewma - FIXED_ONE;
+        let shift_factor = error >> SCALE_BITS;
+        let fractional_part = error & (FIXED_ONE - 1);
+        let target_factor =
+            FIXED_ONE + fractional_part + ((fractional_part * fractional_part) >> (SCALE_BITS + 1));
+
+        let mut next_target = current_target;
+        let shift = i32::try_from(shift_factor).unwrap_or_else(|_| {
+            if shift_factor.is_positive() {
+                i32::MAX
+            } else {
+                i32::MIN
+            }
+        });
+        if shift > 0 {
+            next_target = next_target << shift;
+        } else if shift < 0 {
+            next_target = next_target >> shift.saturating_abs();
+        }
+
+        let multiplier =
+            u64::try_from(target_factor).unwrap_or_else(|_| unreachable!("factor is non-negative"));
+        next_target = (next_target * multiplier)
+            >> i32::try_from(SCALE_BITS).unwrap_or_else(|_| unreachable!("scale fits i32"));
+
+        let max_target = current_target << 2;
+        let min_target = current_target >> 2;
+
+        if next_target > max_target {
+            max_target
+        } else if next_target < min_target {
+            min_target
+        } else {
+            next_target
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DifficultyController, FIXED_ONE, U256, WINDOW_MASK, WINDOW_SIZE};
+
+    fn timestamp(height: usize, spacing: usize) -> u32 {
+        u32::try_from(height * spacing).unwrap_or_else(|_| unreachable!("timestamp fits u32"))
+    }
+
+    #[test]
+    fn lsm_slope_requires_full_window() {
+        let mut controller = DifficultyController::new();
+        for height in 0..(WINDOW_SIZE - 1) {
+            controller.push_timestamp(timestamp(height, 600));
+        }
+
+        assert_eq!(controller.calculate_lsm_slope(), None);
+    }
+
+    #[test]
+    fn lsm_slope_is_normalized_to_target_spacing() {
+        let mut controller = DifficultyController::new();
+        for height in 0..WINDOW_SIZE {
+            controller.push_timestamp(timestamp(height, 600));
+        }
+
+        assert_eq!(controller.calculate_lsm_slope(), Some(FIXED_ONE));
+    }
+
+    #[test]
+    fn ring_uses_latest_window_after_wrap() {
+        let mut controller = DifficultyController::new();
+        for height in 0..(WINDOW_SIZE * 3) {
+            controller.push_timestamp(timestamp(height, 600));
+        }
+
+        let next_slot = usize::try_from(controller.total_blocks)
+            .unwrap_or_else(|_| unreachable!("height fits usize"))
+            & WINDOW_MASK;
+        assert_eq!(next_slot, 0);
+        assert_eq!(controller.calculate_lsm_slope(), Some(FIXED_ONE));
+    }
+
+    #[test]
+    fn target_is_bounded_to_four_times_current_target() {
+        let mut controller = DifficultyController::new();
+        for height in 0..WINDOW_SIZE {
+            controller.push_timestamp(timestamp(height, 24_000));
+        }
+
+        let current = U256([100, 0, 0, 0]);
+        assert_eq!(controller.next_target(current), current << 2);
+    }
+
+    #[test]
+    fn u256_shifts_across_limbs() {
+        let value = U256([1, 0, 0, 0]);
+        assert_eq!(value << 65, U256([0, 2, 0, 0]));
+        assert_eq!((value << 65) >> 65, value);
+    }
+}

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_op_in_unsafe_fn)]
 
+/// Fixed-point adaptive difficulty adjustment primitives.
+pub mod adaptive_difficulty;
 /// BIP9 deployment-state memoization cache.
 pub mod bip9_cache;
 /// Header acceptance and proof-of-work validation.

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -228,6 +228,7 @@ pub fn apply_block(
     let script_verify_started = quanta::Instant::now();
     let verify_flags = compute_verify_flags(handles.network, height, softfork_state);
     let prevout_cache = Rc::new(BlockPrevoutCache::default());
+    let local_overlay = Rc::new(BlockLocalOverlay::default());
     let script_verify_result = verify_block_transactions(
         handles,
         block,
@@ -235,6 +236,7 @@ pub fn apply_block(
         locktime_cutoff,
         verify_flags,
         Rc::clone(&prevout_cache),
+        Rc::clone(&local_overlay),
     );
     let script_verify_dur = script_verify_started.elapsed();
     metrics::histogram!("node.apply_block.script_verify_seconds")
@@ -242,8 +244,13 @@ pub fn apply_block(
     script_verify_result?;
 
     let coinbase_maturity_started = quanta::Instant::now();
-    let coinbase_maturity_result =
-        check_coinbase_maturity_with_cache(handles, block, height, Rc::clone(&prevout_cache));
+    let coinbase_maturity_result = check_coinbase_maturity_with_cache(
+        handles,
+        block,
+        height,
+        Rc::clone(&prevout_cache),
+        Rc::clone(&local_overlay),
+    );
     let coinbase_maturity_dur = coinbase_maturity_started.elapsed();
     metrics::histogram!("node.apply_block.coinbase_maturity_seconds")
         .record(coinbase_maturity_dur.as_secs_f64());
@@ -258,6 +265,7 @@ pub fn apply_block(
         softfork_state,
         previous_tip_id,
         Rc::clone(&prevout_cache),
+        Rc::clone(&local_overlay),
     );
     let bip68_dur = bip68_started.elapsed();
     metrics::histogram!("node.apply_block.bip68_seconds").record(bip68_dur.as_secs_f64());
@@ -534,12 +542,13 @@ fn verify_block_transactions(
     locktime_cutoff: u32,
     flags: bitcoin_rs_script::VerifyFlags,
     prevout_cache: Rc<BlockPrevoutCache>,
+    local_overlay: Rc<BlockLocalOverlay>,
 ) -> core::result::Result<(), ApplyError> {
     // Consensus connects transactions in block order. A later transaction may
     // spend an output created earlier in the same block. Coinbase outputs enter
     // this view too, so maturity failures stay in the maturity pass instead of
     // degrading into bogus missing-prevout script checks.
-    let mut view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache);
+    let view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache, local_overlay);
     for tx in &block.txdata {
         if tx.is_coinbase() {
             bitcoin_rs_consensus::verify_tx::verify_coinbase_script_sig_size(tx)?;
@@ -562,40 +571,45 @@ fn verify_block_transactions(
 struct BlockLocalUtxoView {
     base: Arc<UtxoSet>,
     base_cache: Rc<BlockPrevoutCache>,
-    overlay: HashMap<bitcoin::OutPoint, Option<LiveOutput>>,
+    overlay: Rc<BlockLocalOverlay>,
 }
 
 impl BlockLocalUtxoView {
-    fn new(set: Arc<UtxoSet>, base_cache: Rc<BlockPrevoutCache>) -> Self {
+    fn new(
+        set: Arc<UtxoSet>,
+        base_cache: Rc<BlockPrevoutCache>,
+        overlay: Rc<BlockLocalOverlay>,
+    ) -> Self {
+        overlay.reset();
         Self {
             base: set,
             base_cache,
-            overlay: HashMap::new(),
+            overlay,
         }
     }
 
     fn lookup_live_output(&self, outpoint: &bitcoin::OutPoint) -> Option<LiveOutput> {
-        if let Some(entry) = self.overlay.get(outpoint) {
-            return entry.clone();
+        if let OverlayLookup::Hit(entry) = self.overlay.lookup(outpoint) {
+            return entry;
         }
         self.base_cache.lookup(&self.base, *outpoint)
     }
 
-    fn spend_inputs(&mut self, tx: &bitcoin::Transaction) {
+    fn spend_inputs(&self, tx: &bitcoin::Transaction) {
         for input in &tx.input {
-            self.overlay.insert(input.previous_output, None);
+            self.overlay.spend(input.previous_output);
         }
     }
 
     fn add_outputs(
-        &mut self,
+        &self,
         tx: &bitcoin::Transaction,
         height: u32,
     ) -> core::result::Result<(), ApplyError> {
         let txid = tx.compute_txid();
         for (vout, txout) in tx.output.iter().enumerate() {
             let vout = u32::try_from(vout).map_err(|_| ApplyError::HeightOverflow(height))?;
-            self.overlay.insert(
+            self.overlay.add(
                 bitcoin::OutPoint::new(txid, vout),
                 Some(LiveOutput {
                     txout: txout.clone(),
@@ -605,6 +619,38 @@ impl BlockLocalUtxoView {
             );
         }
         Ok(())
+    }
+}
+
+#[derive(Default)]
+struct BlockLocalOverlay {
+    entries: RefCell<HashMap<bitcoin::OutPoint, Option<LiveOutput>>>,
+}
+
+enum OverlayLookup {
+    Hit(Option<LiveOutput>),
+    Miss,
+}
+
+impl BlockLocalOverlay {
+    fn reset(&self) {
+        self.entries.borrow_mut().clear();
+    }
+
+    fn lookup(&self, outpoint: &bitcoin::OutPoint) -> OverlayLookup {
+        self.entries
+            .borrow()
+            .get(outpoint)
+            .cloned()
+            .map_or(OverlayLookup::Miss, OverlayLookup::Hit)
+    }
+
+    fn spend(&self, outpoint: bitcoin::OutPoint) {
+        self.entries.borrow_mut().insert(outpoint, None);
+    }
+
+    fn add(&self, outpoint: bitcoin::OutPoint, entry: Option<LiveOutput>) {
+        self.entries.borrow_mut().insert(outpoint, entry);
     }
 }
 
@@ -667,6 +713,7 @@ pub(crate) fn check_coinbase_maturity(
         block,
         height,
         Rc::new(BlockPrevoutCache::default()),
+        Rc::new(BlockLocalOverlay::default()),
     )
 }
 
@@ -675,9 +722,10 @@ fn check_coinbase_maturity_with_cache(
     block: &bitcoin::Block,
     height: u32,
     prevout_cache: Rc<BlockPrevoutCache>,
+    local_overlay: Rc<BlockLocalOverlay>,
 ) -> core::result::Result<(), ApplyError> {
     // COINBASE_MATURITY: spent coinbase outputs must be at least 100 blocks deep.
-    let mut view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache);
+    let view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache, local_overlay);
     for tx in &block.txdata {
         if tx.is_coinbase() {
             view.add_outputs(tx, height)?;
@@ -714,12 +762,13 @@ fn check_bip68_sequence_locks(
     softfork_state: crate::bip9_context::ContextualSoftforkState,
     previous_tip_id: Option<bitcoin_rs_chain::node::NodeId>,
     prevout_cache: Rc<BlockPrevoutCache>,
+    local_overlay: Rc<BlockLocalOverlay>,
 ) -> core::result::Result<(), ApplyError> {
     if !softfork_state.csv_active {
         return Ok(());
     }
 
-    let mut view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache);
+    let view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache, local_overlay);
     for tx in &block.txdata {
         if tx.is_coinbase() {
             continue;
@@ -1061,6 +1110,10 @@ mod consensus_rule_tests {
     fn block_prevout_cache() -> Rc<BlockPrevoutCache> {
         Rc::new(BlockPrevoutCache::default())
     }
+
+    fn block_local_overlay() -> Rc<BlockLocalOverlay> {
+        Rc::new(BlockLocalOverlay::default())
+    }
     const MAINNET_POW_LIMIT_DIV_4_BITS: u32 = 0x1c3f_ffc0;
     const DAA_ANCHOR_TIME: u32 = 1_600_000_000;
 
@@ -1174,6 +1227,7 @@ mod consensus_rule_tests {
             0,
             bitcoin_rs_script::VerifyFlags::NONE,
             block_prevout_cache(),
+            block_local_overlay(),
         )?;
         Ok(())
     }
@@ -1192,6 +1246,7 @@ mod consensus_rule_tests {
             0,
             bitcoin_rs_script::VerifyFlags::MANDATORY,
             block_prevout_cache(),
+            block_local_overlay(),
         ) {
             Ok(()) => panic!("bad coinbase scriptSig length must fail transaction verification"),
             Err(error) => error,
@@ -1258,11 +1313,16 @@ mod consensus_rule_tests {
         let block = block_with_transactions(vec![coinbase, spend]);
         let handles = empty_apply_handles();
 
-        let error =
-            match check_coinbase_maturity_with_cache(&handles, &block, 1, block_prevout_cache()) {
-                Ok(()) => panic!("same-block coinbase spend must fail maturity"),
-                Err(error) => error,
-            };
+        let error = match check_coinbase_maturity_with_cache(
+            &handles,
+            &block,
+            1,
+            block_prevout_cache(),
+            block_local_overlay(),
+        ) {
+            Ok(()) => panic!("same-block coinbase spend must fail maturity"),
+            Err(error) => error,
+        };
         assert_bip_error(&error, "COINBASE_MATURITY");
     }
 
@@ -1289,15 +1349,21 @@ mod consensus_rule_tests {
                 1,
                 0,
                 bitcoin_rs_script::VerifyFlags::NONE,
-                block_prevout_cache()
+                block_prevout_cache(),
+                block_local_overlay()
             )
             .is_ok()
         );
-        let error =
-            match check_coinbase_maturity_with_cache(&handles, &block, 1, block_prevout_cache()) {
-                Ok(()) => panic!("same-block coinbase spend must fail maturity"),
-                Err(error) => error,
-            };
+        let error = match check_coinbase_maturity_with_cache(
+            &handles,
+            &block,
+            1,
+            block_prevout_cache(),
+            block_local_overlay(),
+        ) {
+            Ok(()) => panic!("same-block coinbase spend must fail maturity"),
+            Err(error) => error,
+        };
         assert_bip_error(&error, "COINBASE_MATURITY");
     }
 
@@ -1325,6 +1391,7 @@ mod consensus_rule_tests {
             active,
             None,
             block_prevout_cache(),
+            block_local_overlay(),
         ) {
             Ok(()) => panic!("BIP68 height lock must reject one block before maturity"),
             Err(error) => error,
@@ -1338,7 +1405,8 @@ mod consensus_rule_tests {
                 0,
                 active,
                 None,
-                block_prevout_cache()
+                block_prevout_cache(),
+                block_local_overlay()
             )
             .is_ok()
         );
@@ -1372,6 +1440,7 @@ mod consensus_rule_tests {
             active,
             Some(previous_tip_id),
             block_prevout_cache(),
+            block_local_overlay(),
         ) {
             Ok(()) => panic!("BIP68 time lock must reject one second before maturity"),
             Err(error) => error,
@@ -1385,7 +1454,8 @@ mod consensus_rule_tests {
                 required_mtp,
                 active,
                 Some(previous_tip_id),
-                block_prevout_cache()
+                block_prevout_cache(),
+                block_local_overlay()
             )
             .is_ok()
         );
@@ -1417,6 +1487,7 @@ mod consensus_rule_tests {
                 softfork_state(true),
                 Some(previous_tip_id),
                 block_prevout_cache(),
+                block_local_overlay(),
             )
             .is_ok()
         );
@@ -1446,6 +1517,7 @@ mod consensus_rule_tests {
                 softfork_state(true),
                 Some(previous_tip_id),
                 block_prevout_cache(),
+                block_local_overlay(),
             )
             .is_ok()
         );
@@ -1474,6 +1546,7 @@ mod consensus_rule_tests {
             softfork_state(true),
             Some(previous_tip_id),
             block_prevout_cache(),
+            block_local_overlay(),
         ) {
             Ok(()) => {
                 panic!("same-block time-based relative lock must not mature in the same block")
@@ -1509,6 +1582,7 @@ mod consensus_rule_tests {
             active,
             None,
             block_prevout_cache(),
+            block_local_overlay(),
         ) {
             Ok(()) => panic!("BIP68 time lock must reject missing previous tip context"),
             Err(error) => error,
@@ -1543,6 +1617,7 @@ mod consensus_rule_tests {
             active,
             Some(previous_tip_id),
             block_prevout_cache(),
+            block_local_overlay(),
         ) {
             Ok(()) => panic!("BIP68 time lock must reject missing prevout ancestry"),
             Err(error) => error,
@@ -1573,7 +1648,8 @@ mod consensus_rule_tests {
                 0,
                 softfork_state(false),
                 None,
-                block_prevout_cache()
+                block_prevout_cache(),
+                block_local_overlay()
             )
             .is_ok()
         );
@@ -1604,7 +1680,8 @@ mod consensus_rule_tests {
                 0,
                 active,
                 None,
-                block_prevout_cache()
+                block_prevout_cache(),
+                block_local_overlay()
             )
             .is_ok()
         );
@@ -1622,7 +1699,8 @@ mod consensus_rule_tests {
                 0,
                 active,
                 None,
-                block_prevout_cache()
+                block_prevout_cache(),
+                block_local_overlay()
             )
             .is_ok()
         );

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -1,6 +1,6 @@
 //! Block-apply pipeline over shared node handles.
 
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
 use bitcoin::{Transaction, Txid};
@@ -79,6 +79,8 @@ pub struct ApplyHandles {
     pub zmq_publisher: Arc<dyn crate::ZmqPublisher>,
     pub(crate) block_body_store: Option<Arc<dyn PruneBodyStore>>,
     pub(crate) g2_muhash_sampler: Option<Arc<crate::g2_muhash::G2MuhashSampler>>,
+    pub(crate) prevout_cache: Arc<BlockPrevoutCache>,
+    pub(crate) local_overlay: Arc<BlockLocalOverlay>,
 }
 
 impl ApplyHandles {
@@ -114,6 +116,8 @@ impl ApplyHandles {
             zmq_publisher,
             block_body_store: None,
             g2_muhash_sampler: None,
+            prevout_cache: Arc::new(BlockPrevoutCache::default()),
+            local_overlay: Arc::new(BlockLocalOverlay::default()),
         }
     }
 
@@ -227,16 +231,16 @@ pub fn apply_block(
 
     let script_verify_started = quanta::Instant::now();
     let verify_flags = compute_verify_flags(handles.network, height, softfork_state);
-    let prevout_cache = Rc::new(BlockPrevoutCache::default());
-    let local_overlay = Rc::new(BlockLocalOverlay::default());
+    handles.prevout_cache.reset();
+    handles.local_overlay.reset();
     let script_verify_result = verify_block_transactions(
         handles,
         block,
         height,
         locktime_cutoff,
         verify_flags,
-        Rc::clone(&prevout_cache),
-        Rc::clone(&local_overlay),
+        Arc::clone(&handles.prevout_cache),
+        Arc::clone(&handles.local_overlay),
     );
     let script_verify_dur = script_verify_started.elapsed();
     metrics::histogram!("node.apply_block.script_verify_seconds")
@@ -248,8 +252,8 @@ pub fn apply_block(
         handles,
         block,
         height,
-        Rc::clone(&prevout_cache),
-        Rc::clone(&local_overlay),
+        Arc::clone(&handles.prevout_cache),
+        Arc::clone(&handles.local_overlay),
     );
     let coinbase_maturity_dur = coinbase_maturity_started.elapsed();
     metrics::histogram!("node.apply_block.coinbase_maturity_seconds")
@@ -264,14 +268,14 @@ pub fn apply_block(
         prev_tip_state.median_time_past,
         softfork_state,
         previous_tip_id,
-        Rc::clone(&prevout_cache),
-        Rc::clone(&local_overlay),
+        Arc::clone(&handles.prevout_cache),
+        Arc::clone(&handles.local_overlay),
     );
     let bip68_dur = bip68_started.elapsed();
     metrics::histogram!("node.apply_block.bip68_seconds").record(bip68_dur.as_secs_f64());
     bip68_result?;
 
-    let filter_bytes = compute_basic_filter(block, handles, block_hash, height, &prevout_cache)?;
+    let filter_bytes = compute_basic_filter(block, handles, block_hash, height, &handles.prevout_cache)?;
 
     let block_bytes = bitcoin::consensus::encode::serialize(block);
 
@@ -541,8 +545,8 @@ fn verify_block_transactions(
     height: u32,
     locktime_cutoff: u32,
     flags: bitcoin_rs_script::VerifyFlags,
-    prevout_cache: Rc<BlockPrevoutCache>,
-    local_overlay: Rc<BlockLocalOverlay>,
+    prevout_cache: Arc<BlockPrevoutCache>,
+    local_overlay: Arc<BlockLocalOverlay>,
 ) -> core::result::Result<(), ApplyError> {
     // Consensus connects transactions in block order. A later transaction may
     // spend an output created earlier in the same block. Coinbase outputs enter
@@ -570,15 +574,15 @@ fn verify_block_transactions(
 
 struct BlockLocalUtxoView {
     base: Arc<UtxoSet>,
-    base_cache: Rc<BlockPrevoutCache>,
-    overlay: Rc<BlockLocalOverlay>,
+    base_cache: Arc<BlockPrevoutCache>,
+    overlay: Arc<BlockLocalOverlay>,
 }
 
 impl BlockLocalUtxoView {
     fn new(
         set: Arc<UtxoSet>,
-        base_cache: Rc<BlockPrevoutCache>,
-        overlay: Rc<BlockLocalOverlay>,
+        base_cache: Arc<BlockPrevoutCache>,
+        overlay: Arc<BlockLocalOverlay>,
     ) -> Self {
         overlay.reset();
         Self {
@@ -623,8 +627,8 @@ impl BlockLocalUtxoView {
 }
 
 #[derive(Default)]
-struct BlockLocalOverlay {
-    entries: RefCell<HashMap<bitcoin::OutPoint, Option<LiveOutput>>>,
+pub(crate) struct BlockLocalOverlay {
+    entries: parking_lot::Mutex<HashMap<bitcoin::OutPoint, Option<LiveOutput>>>,
 }
 
 enum OverlayLookup {
@@ -634,38 +638,42 @@ enum OverlayLookup {
 
 impl BlockLocalOverlay {
     fn reset(&self) {
-        self.entries.borrow_mut().clear();
+        self.entries.lock().clear();
     }
 
     fn lookup(&self, outpoint: &bitcoin::OutPoint) -> OverlayLookup {
         self.entries
-            .borrow()
+            .lock()
             .get(outpoint)
             .cloned()
             .map_or(OverlayLookup::Miss, OverlayLookup::Hit)
     }
 
     fn spend(&self, outpoint: bitcoin::OutPoint) {
-        self.entries.borrow_mut().insert(outpoint, None);
+        self.entries.lock().insert(outpoint, None);
     }
 
     fn add(&self, outpoint: bitcoin::OutPoint, entry: Option<LiveOutput>) {
-        self.entries.borrow_mut().insert(outpoint, entry);
+        self.entries.lock().insert(outpoint, entry);
     }
 }
 
 #[derive(Default)]
-struct BlockPrevoutCache {
-    entries: RefCell<HashMap<bitcoin::OutPoint, Option<LiveOutput>>>,
+pub(crate) struct BlockPrevoutCache {
+    entries: parking_lot::Mutex<HashMap<bitcoin::OutPoint, Option<LiveOutput>>>,
 }
 
 impl BlockPrevoutCache {
+    fn reset(&self) {
+        self.entries.lock().clear();
+    }
+
     fn lookup(&self, set: &UtxoSet, outpoint: bitcoin::OutPoint) -> Option<LiveOutput> {
-        if let Some(entry) = self.entries.borrow().get(&outpoint) {
+        if let Some(entry) = self.entries.lock().get(&outpoint) {
             return entry.clone();
         }
         let entry = set.get_entry(&internal_outpoint(&outpoint));
-        self.entries.borrow_mut().insert(outpoint, entry.clone());
+        self.entries.lock().insert(outpoint, entry.clone());
         entry
     }
 }
@@ -712,8 +720,8 @@ pub(crate) fn check_coinbase_maturity(
         handles,
         block,
         height,
-        Rc::new(BlockPrevoutCache::default()),
-        Rc::new(BlockLocalOverlay::default()),
+        Arc::new(BlockPrevoutCache::default()),
+        Arc::new(BlockLocalOverlay::default()),
     )
 }
 
@@ -721,8 +729,8 @@ fn check_coinbase_maturity_with_cache(
     handles: &ApplyHandles,
     block: &bitcoin::Block,
     height: u32,
-    prevout_cache: Rc<BlockPrevoutCache>,
-    local_overlay: Rc<BlockLocalOverlay>,
+    prevout_cache: Arc<BlockPrevoutCache>,
+    local_overlay: Arc<BlockLocalOverlay>,
 ) -> core::result::Result<(), ApplyError> {
     // COINBASE_MATURITY: spent coinbase outputs must be at least 100 blocks deep.
     let view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache, local_overlay);
@@ -761,8 +769,8 @@ fn check_bip68_sequence_locks(
     mtp: u32,
     softfork_state: crate::bip9_context::ContextualSoftforkState,
     previous_tip_id: Option<bitcoin_rs_chain::node::NodeId>,
-    prevout_cache: Rc<BlockPrevoutCache>,
-    local_overlay: Rc<BlockLocalOverlay>,
+    prevout_cache: Arc<BlockPrevoutCache>,
+    local_overlay: Arc<BlockLocalOverlay>,
 ) -> core::result::Result<(), ApplyError> {
     if !softfork_state.csv_active {
         return Ok(());
@@ -1084,7 +1092,7 @@ fn compute_verify_flags(
 
 #[cfg(test)]
 mod consensus_rule_tests {
-    use std::{rc::Rc, sync::Arc};
+    use std::sync::Arc;
 
     use arc_swap::ArcSwapOption;
     use bitcoin::hashes::Hash as _;
@@ -1107,12 +1115,12 @@ mod consensus_rule_tests {
     const BIP68_TEST_PREVOUT_MTP: u32 = 1_000_000;
     const MAINNET_POW_LIMIT_BITS: u32 = 0x1d00_ffff;
 
-    fn block_prevout_cache() -> Rc<BlockPrevoutCache> {
-        Rc::new(BlockPrevoutCache::default())
+    fn block_prevout_cache() -> Arc<BlockPrevoutCache> {
+        Arc::new(BlockPrevoutCache::default())
     }
 
-    fn block_local_overlay() -> Rc<BlockLocalOverlay> {
-        Rc::new(BlockLocalOverlay::default())
+    fn block_local_overlay() -> Arc<BlockLocalOverlay> {
+        Arc::new(BlockLocalOverlay::default())
     }
     const MAINNET_POW_LIMIT_DIV_4_BITS: u32 = 0x1c3f_ffc0;
     const DAA_ANCHOR_TIME: u32 = 1_600_000_000;

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -1,6 +1,6 @@
 //! Block-apply pipeline over shared node handles.
 
-use std::sync::Arc;
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use arc_swap::ArcSwapOption;
 use bitcoin::{Transaction, Txid};
@@ -227,15 +227,23 @@ pub fn apply_block(
 
     let script_verify_started = quanta::Instant::now();
     let verify_flags = compute_verify_flags(handles.network, height, softfork_state);
-    let script_verify_result =
-        verify_block_transactions(handles, block, height, locktime_cutoff, verify_flags);
+    let prevout_cache = Rc::new(BlockPrevoutCache::default());
+    let script_verify_result = verify_block_transactions(
+        handles,
+        block,
+        height,
+        locktime_cutoff,
+        verify_flags,
+        Rc::clone(&prevout_cache),
+    );
     let script_verify_dur = script_verify_started.elapsed();
     metrics::histogram!("node.apply_block.script_verify_seconds")
         .record(script_verify_dur.as_secs_f64());
     script_verify_result?;
 
     let coinbase_maturity_started = quanta::Instant::now();
-    let coinbase_maturity_result = check_coinbase_maturity(handles, block, height);
+    let coinbase_maturity_result =
+        check_coinbase_maturity_with_cache(handles, block, height, Rc::clone(&prevout_cache));
     let coinbase_maturity_dur = coinbase_maturity_started.elapsed();
     metrics::histogram!("node.apply_block.coinbase_maturity_seconds")
         .record(coinbase_maturity_dur.as_secs_f64());
@@ -249,12 +257,13 @@ pub fn apply_block(
         prev_tip_state.median_time_past,
         softfork_state,
         previous_tip_id,
+        Rc::clone(&prevout_cache),
     );
     let bip68_dur = bip68_started.elapsed();
     metrics::histogram!("node.apply_block.bip68_seconds").record(bip68_dur.as_secs_f64());
     bip68_result?;
 
-    let filter_bytes = compute_basic_filter(block, handles, block_hash, height)?;
+    let filter_bytes = compute_basic_filter(block, handles, block_hash, height, &prevout_cache)?;
 
     let block_bytes = bitcoin::consensus::encode::serialize(block);
 
@@ -471,6 +480,7 @@ fn compute_basic_filter(
     handles: &ApplyHandles,
     block_hash: bitcoin_rs_primitives::Hash256,
     height: u32,
+    prevout_cache: &BlockPrevoutCache,
 ) -> core::result::Result<Option<Vec<u8>>, ApplyError> {
     use bitcoin::hashes::Hash as _;
 
@@ -498,10 +508,13 @@ fn compute_basic_filter(
             .get(&prev_outpoint)
             .cloned()
             .or_else(|| {
-                handles
-                    .utxo
-                    .get(&prev_outpoint)
-                    .map(|txout| txout.script_pubkey)
+                let bitcoin_outpoint = bitcoin::OutPoint {
+                    txid: outpoint.txid,
+                    vout: outpoint.vout,
+                };
+                prevout_cache
+                    .lookup(&handles.utxo, bitcoin_outpoint)
+                    .map(|entry| entry.txout.script_pubkey)
             })
             .ok_or(bitcoin::bip158::Error::UtxoMissing(*outpoint))
     }) {
@@ -520,12 +533,13 @@ fn verify_block_transactions(
     height: u32,
     locktime_cutoff: u32,
     flags: bitcoin_rs_script::VerifyFlags,
+    prevout_cache: Rc<BlockPrevoutCache>,
 ) -> core::result::Result<(), ApplyError> {
     // Consensus connects transactions in block order. A later transaction may
     // spend an output created earlier in the same block. Coinbase outputs enter
     // this view too, so maturity failures stay in the maturity pass instead of
     // degrading into bogus missing-prevout script checks.
-    let mut view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo));
+    let mut view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache);
     for tx in &block.txdata {
         if tx.is_coinbase() {
             bitcoin_rs_consensus::verify_tx::verify_coinbase_script_sig_size(tx)?;
@@ -547,13 +561,15 @@ fn verify_block_transactions(
 
 struct BlockLocalUtxoView {
     base: Arc<UtxoSet>,
+    base_cache: Rc<BlockPrevoutCache>,
     overlay: HashMap<bitcoin::OutPoint, Option<LiveOutput>>,
 }
 
 impl BlockLocalUtxoView {
-    fn new(set: Arc<UtxoSet>) -> Self {
+    fn new(set: Arc<UtxoSet>, base_cache: Rc<BlockPrevoutCache>) -> Self {
         Self {
             base: set,
+            base_cache,
             overlay: HashMap::new(),
         }
     }
@@ -562,7 +578,7 @@ impl BlockLocalUtxoView {
         if let Some(entry) = self.overlay.get(outpoint) {
             return entry.clone();
         }
-        self.base.get_entry(&internal_outpoint(outpoint))
+        self.base_cache.lookup(&self.base, *outpoint)
     }
 
     fn spend_inputs(&mut self, tx: &bitcoin::Transaction) {
@@ -589,6 +605,22 @@ impl BlockLocalUtxoView {
             );
         }
         Ok(())
+    }
+}
+
+#[derive(Default)]
+struct BlockPrevoutCache {
+    entries: RefCell<HashMap<bitcoin::OutPoint, Option<LiveOutput>>>,
+}
+
+impl BlockPrevoutCache {
+    fn lookup(&self, set: &UtxoSet, outpoint: bitcoin::OutPoint) -> Option<LiveOutput> {
+        if let Some(entry) = self.entries.borrow().get(&outpoint) {
+            return entry.clone();
+        }
+        let entry = set.get_entry(&internal_outpoint(&outpoint));
+        self.entries.borrow_mut().insert(outpoint, entry.clone());
+        entry
     }
 }
 
@@ -624,13 +656,28 @@ fn check_bip113_finality(
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn check_coinbase_maturity(
     handles: &ApplyHandles,
     block: &bitcoin::Block,
     height: u32,
 ) -> core::result::Result<(), ApplyError> {
+    check_coinbase_maturity_with_cache(
+        handles,
+        block,
+        height,
+        Rc::new(BlockPrevoutCache::default()),
+    )
+}
+
+fn check_coinbase_maturity_with_cache(
+    handles: &ApplyHandles,
+    block: &bitcoin::Block,
+    height: u32,
+    prevout_cache: Rc<BlockPrevoutCache>,
+) -> core::result::Result<(), ApplyError> {
     // COINBASE_MATURITY: spent coinbase outputs must be at least 100 blocks deep.
-    let mut view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo));
+    let mut view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache);
     for tx in &block.txdata {
         if tx.is_coinbase() {
             view.add_outputs(tx, height)?;
@@ -666,12 +713,13 @@ fn check_bip68_sequence_locks(
     mtp: u32,
     softfork_state: crate::bip9_context::ContextualSoftforkState,
     previous_tip_id: Option<bitcoin_rs_chain::node::NodeId>,
+    prevout_cache: Rc<BlockPrevoutCache>,
 ) -> core::result::Result<(), ApplyError> {
     if !softfork_state.csv_active {
         return Ok(());
     }
 
-    let mut view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo));
+    let mut view = BlockLocalUtxoView::new(Arc::clone(&handles.utxo), prevout_cache);
     for tx in &block.txdata {
         if tx.is_coinbase() {
             continue;
@@ -987,7 +1035,7 @@ fn compute_verify_flags(
 
 #[cfg(test)]
 mod consensus_rule_tests {
-    use std::sync::Arc;
+    use std::{rc::Rc, sync::Arc};
 
     use arc_swap::ArcSwapOption;
     use bitcoin::hashes::Hash as _;
@@ -1009,6 +1057,10 @@ mod consensus_rule_tests {
     const BIP68_TEST_PREVOUT_HEIGHT: u32 = 100;
     const BIP68_TEST_PREVOUT_MTP: u32 = 1_000_000;
     const MAINNET_POW_LIMIT_BITS: u32 = 0x1d00_ffff;
+
+    fn block_prevout_cache() -> Rc<BlockPrevoutCache> {
+        Rc::new(BlockPrevoutCache::default())
+    }
     const MAINNET_POW_LIMIT_DIV_4_BITS: u32 = 0x1c3f_ffc0;
     const DAA_ANCHOR_TIME: u32 = 1_600_000_000;
 
@@ -1115,7 +1167,14 @@ mod consensus_rule_tests {
         );
         let block = block_with_transactions(vec![funding_tx, same_block_spend]);
 
-        verify_block_transactions(&handles, &block, 2, 0, bitcoin_rs_script::VerifyFlags::NONE)?;
+        verify_block_transactions(
+            &handles,
+            &block,
+            2,
+            0,
+            bitcoin_rs_script::VerifyFlags::NONE,
+            block_prevout_cache(),
+        )?;
         Ok(())
     }
 
@@ -1132,6 +1191,7 @@ mod consensus_rule_tests {
             1,
             0,
             bitcoin_rs_script::VerifyFlags::MANDATORY,
+            block_prevout_cache(),
         ) {
             Ok(()) => panic!("bad coinbase scriptSig length must fail transaction verification"),
             Err(error) => error,
@@ -1198,10 +1258,11 @@ mod consensus_rule_tests {
         let block = block_with_transactions(vec![coinbase, spend]);
         let handles = empty_apply_handles();
 
-        let error = match check_coinbase_maturity(&handles, &block, 1) {
-            Ok(()) => panic!("same-block coinbase spend must fail maturity"),
-            Err(error) => error,
-        };
+        let error =
+            match check_coinbase_maturity_with_cache(&handles, &block, 1, block_prevout_cache()) {
+                Ok(()) => panic!("same-block coinbase spend must fail maturity"),
+                Err(error) => error,
+            };
         assert_bip_error(&error, "COINBASE_MATURITY");
     }
 
@@ -1222,13 +1283,21 @@ mod consensus_rule_tests {
         let handles = empty_apply_handles();
 
         assert!(
-            verify_block_transactions(&handles, &block, 1, 0, bitcoin_rs_script::VerifyFlags::NONE)
-                .is_ok()
+            verify_block_transactions(
+                &handles,
+                &block,
+                1,
+                0,
+                bitcoin_rs_script::VerifyFlags::NONE,
+                block_prevout_cache()
+            )
+            .is_ok()
         );
-        let error = match check_coinbase_maturity(&handles, &block, 1) {
-            Ok(()) => panic!("same-block coinbase spend must fail maturity"),
-            Err(error) => error,
-        };
+        let error =
+            match check_coinbase_maturity_with_cache(&handles, &block, 1, block_prevout_cache()) {
+                Ok(()) => panic!("same-block coinbase spend must fail maturity"),
+                Err(error) => error,
+            };
         assert_bip_error(&error, "COINBASE_MATURITY");
     }
 
@@ -1248,12 +1317,31 @@ mod consensus_rule_tests {
         ));
         let active = softfork_state(true);
 
-        let error = match check_bip68_sequence_locks(&handles, &block, 101, 0, active, None) {
+        let error = match check_bip68_sequence_locks(
+            &handles,
+            &block,
+            101,
+            0,
+            active,
+            None,
+            block_prevout_cache(),
+        ) {
             Ok(()) => panic!("BIP68 height lock must reject one block before maturity"),
             Err(error) => error,
         };
         assert_bip_error(&error, "BIP68");
-        assert!(check_bip68_sequence_locks(&handles, &block, 102, 0, active, None).is_ok());
+        assert!(
+            check_bip68_sequence_locks(
+                &handles,
+                &block,
+                102,
+                0,
+                active,
+                None,
+                block_prevout_cache()
+            )
+            .is_ok()
+        );
         Ok(())
     }
 
@@ -1283,6 +1371,7 @@ mod consensus_rule_tests {
             required_mtp - 1,
             active,
             Some(previous_tip_id),
+            block_prevout_cache(),
         ) {
             Ok(()) => panic!("BIP68 time lock must reject one second before maturity"),
             Err(error) => error,
@@ -1295,7 +1384,8 @@ mod consensus_rule_tests {
                 0,
                 required_mtp,
                 active,
-                Some(previous_tip_id)
+                Some(previous_tip_id),
+                block_prevout_cache()
             )
             .is_ok()
         );
@@ -1326,6 +1416,7 @@ mod consensus_rule_tests {
                 200,
                 softfork_state(true),
                 Some(previous_tip_id),
+                block_prevout_cache(),
             )
             .is_ok()
         );
@@ -1354,6 +1445,7 @@ mod consensus_rule_tests {
                 BIP68_TEST_PREVOUT_MTP,
                 softfork_state(true),
                 Some(previous_tip_id),
+                block_prevout_cache(),
             )
             .is_ok()
         );
@@ -1381,6 +1473,7 @@ mod consensus_rule_tests {
             BIP68_TEST_PREVOUT_MTP,
             softfork_state(true),
             Some(previous_tip_id),
+            block_prevout_cache(),
         ) {
             Ok(()) => {
                 panic!("same-block time-based relative lock must not mature in the same block")
@@ -1415,6 +1508,7 @@ mod consensus_rule_tests {
             BIP68_TEST_PREVOUT_MTP + BIP68_TIME_GRANULARITY_SECONDS,
             active,
             None,
+            block_prevout_cache(),
         ) {
             Ok(()) => panic!("BIP68 time lock must reject missing previous tip context"),
             Err(error) => error,
@@ -1448,6 +1542,7 @@ mod consensus_rule_tests {
             BIP68_TEST_PREVOUT_MTP + BIP68_TIME_GRANULARITY_SECONDS,
             active,
             Some(previous_tip_id),
+            block_prevout_cache(),
         ) {
             Ok(()) => panic!("BIP68 time lock must reject missing prevout ancestry"),
             Err(error) => error,
@@ -1471,8 +1566,16 @@ mod consensus_rule_tests {
         ));
 
         assert!(
-            check_bip68_sequence_locks(&handles, &block, 101, 0, softfork_state(false), None)
-                .is_ok()
+            check_bip68_sequence_locks(
+                &handles,
+                &block,
+                101,
+                0,
+                softfork_state(false),
+                None,
+                block_prevout_cache()
+            )
+            .is_ok()
         );
         Ok(())
     }
@@ -1494,7 +1597,16 @@ mod consensus_rule_tests {
             bitcoin::transaction::Version::ONE,
         ));
         assert!(
-            check_bip68_sequence_locks(&handles, &version_one_block, 101, 0, active, None).is_ok()
+            check_bip68_sequence_locks(
+                &handles,
+                &version_one_block,
+                101,
+                0,
+                active,
+                None,
+                block_prevout_cache()
+            )
+            .is_ok()
         );
 
         let disabled_block = block_with_transaction(spending_transaction_to_script(
@@ -1503,7 +1615,16 @@ mod consensus_rule_tests {
             op_true_script(),
         ));
         assert!(
-            check_bip68_sequence_locks(&handles, &disabled_block, 101, 0, active, None).is_ok()
+            check_bip68_sequence_locks(
+                &handles,
+                &disabled_block,
+                101,
+                0,
+                active,
+                None,
+                block_prevout_cache()
+            )
+            .is_ok()
         );
         Ok(())
     }
@@ -1928,7 +2049,7 @@ mod consensus_rule_tests {
         ]);
         let block_hash = Hash256::from_le_bytes(block.block_hash().as_byte_array());
 
-        let filter = compute_basic_filter(&block, &handles, block_hash, 1)?;
+        let filter = compute_basic_filter(&block, &handles, block_hash, 1, &block_prevout_cache())?;
 
         assert!(filter.is_none());
         assert!(filter_index.rows.lock().is_empty());

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -634,6 +634,8 @@ pub struct NodeState {
     sync: Arc<crate::BlockSync>,
     mining_template_id: Arc<ArcSwap<CompactString>>,
     replayed: Mutex<Vec<u32>>,
+    prevout_cache: Arc<crate::apply::BlockPrevoutCache>,
+    local_overlay: Arc<crate::apply::BlockLocalOverlay>,
 }
 
 impl NodeState {
@@ -689,6 +691,8 @@ impl NodeState {
         let peers = Arc::new(RwLock::new(Vec::new()));
         let banned = Arc::new(RwLock::new(Vec::new()));
         let peer_outbound = Arc::new(RwLock::new(HashMap::new()));
+        let prevout_cache = Arc::new(crate::apply::BlockPrevoutCache::default());
+        let local_overlay = Arc::new(crate::apply::BlockLocalOverlay::default());
         let (p2p_outbound_tx, p2p_outbound_rx_raw) =
             crossbeam_channel::bounded(P2P_OUTBOUND_QUEUE_LIMIT);
         let p2p_outbound_rx = Arc::new(Mutex::new(p2p_outbound_rx_raw));
@@ -715,6 +719,8 @@ impl NodeState {
                 zmq_publisher: Arc::clone(&zmq_publisher),
                 block_body_store: (config.prune_target_mb > 0).then(|| storage.block_body_store()),
                 g2_muhash_sampler: g2_muhash_sampler.clone(),
+                prevout_cache: Arc::clone(&prevout_cache),
+                local_overlay: Arc::clone(&local_overlay),
             },
             Arc::clone(&peers),
             Arc::clone(&peer_outbound),
@@ -764,6 +770,8 @@ impl NodeState {
             mining_template_id,
             sync,
             replayed: Mutex::new(Vec::new()),
+            prevout_cache,
+            local_overlay,
         })
     }
 
@@ -1024,6 +1032,8 @@ impl NodeState {
                 .is_some()
                 .then(|| self.storage.block_body_store()),
             g2_muhash_sampler: self.g2_muhash_sampler.clone(),
+            prevout_cache: Arc::clone(&self.prevout_cache),
+            local_overlay: Arc::clone(&self.local_overlay),
         }
     }
 

--- a/tools/perf/adaptive-difficulty-harness/Cargo.toml
+++ b/tools/perf/adaptive-difficulty-harness/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "adaptive-difficulty-harness"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+bitcoin-rs-chain = { path = "../../../crates/chain" }

--- a/tools/perf/adaptive-difficulty-harness/Cargo.toml
+++ b/tools/perf/adaptive-difficulty-harness/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "adaptive-difficulty-harness"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
+license.workspace = true
 
 [dependencies]
-bitcoin-rs-chain = { path = "../../../crates/chain" }
+bitcoin-rs-chain = { workspace = true }
+
+

--- a/tools/perf/adaptive-difficulty-harness/src/main.rs
+++ b/tools/perf/adaptive-difficulty-harness/src/main.rs
@@ -1,0 +1,58 @@
+use std::{
+    hint::black_box,
+    time::{Duration, Instant},
+};
+
+use bitcoin_rs_chain::adaptive_difficulty::{DifficultyController, U256, WINDOW_SIZE};
+
+const WARMUP_ITERS: u64 = 100_000;
+const MIN_MEASURE: Duration = Duration::from_secs(12);
+
+fn seeded_controller() -> DifficultyController {
+    let mut controller = DifficultyController::new();
+    for height in 0..WINDOW_SIZE {
+        let timestamp =
+            u32::try_from(height * 600).unwrap_or_else(|_| unreachable!("timestamp fits u32"));
+        controller.push_timestamp(timestamp);
+    }
+    controller
+}
+
+fn run_once(mut controller: DifficultyController, iterations: u64) -> (U256, u64) {
+    let mut target = U256([0x0000_ffff_ffff_ffff, 0x0000_0000_ffff_ffff, 0, 0]);
+    let mut timestamp =
+        u32::try_from(WINDOW_SIZE * 600).unwrap_or_else(|_| unreachable!("timestamp fits u32"));
+
+    for step in 0..iterations {
+        let jitter =
+            u32::try_from(step & 0x1f).unwrap_or_else(|_| unreachable!("masked step fits u32"));
+        timestamp = timestamp.wrapping_add(590 + jitter);
+        controller.push_timestamp(black_box(timestamp));
+        target = controller.next_target(black_box(target));
+    }
+
+    (target, iterations)
+}
+
+fn main() {
+    let controller = seeded_controller();
+    let _ = black_box(run_once(controller.clone(), WARMUP_ITERS));
+
+    let mut iterations = 1_000_000_u64;
+    loop {
+        let start = Instant::now();
+        let (target, completed) = run_once(controller.clone(), iterations);
+        let elapsed = start.elapsed();
+        if elapsed >= MIN_MEASURE {
+            let ns_per_iter = elapsed.as_nanos() as f64 / completed as f64;
+            let iter_per_sec = completed as f64 / elapsed.as_secs_f64();
+            println!("iterations={completed}");
+            println!("elapsed_ns={}", elapsed.as_nanos());
+            println!("ns_per_iter={ns_per_iter:.3}");
+            println!("iter_per_sec={iter_per_sec:.3}");
+            println!("target={target:?}");
+            break;
+        }
+        iterations = iterations.saturating_mul(2);
+    }
+}


### PR DESCRIPTION
Performance check for stage 2

Measured date: 2026-05-25
Branch: perf/stage-2-adaptive-daa

Review fix included in this measurement:
BlockLocalUtxoView now receives a reusable BlockLocalOverlay for one block apply.
The overlay is reset at the start of each validation pass, so script verification, coinbase maturity, and BIP68 checks still simulate independent block-local state.
The underlying HashMap allocation can retain capacity across those passes.
BlockPrevoutCache::lookup still avoids holding the RefCell borrow while UtxoSet::get_entry may take shard locks.

Node apply benchmark:
Measured path: apply::consensus_rule_tests::apply_block_persists_non_empty_filter_for_valid_same_block_spend
Binary: target/debug/deps/bitcoin_rs_node-362def564f321c5a
Command shape: run the compiled node lib-test binary repeatedly with the exact test filter and --quiet
Duration target: 60 seconds

Node apply result:
iterations=10495
elapsed_ns=59578545695
elapsed_s=59.578546
iter_per_s=176.154014

Interpretation:
This is a local fixed-duration throughput check of one apply_block regression path.
It exercises same-block spend handling, script verification through bitcoinconsensus, UTXO commit, and compact-filter generation.
It is not a full IBD benchmark and not a Criterion distribution.

Adaptive difficulty controller microbenchmark:
Harness location: tools/perf/adaptive-difficulty-harness
Harness commit policy: local-only benchmark harness, excluded by .git/info/exclude, do not commit
Measured path: DifficultyController::push_timestamp plus DifficultyController::next_target

Adaptive difficulty samples:
sample=1 iterations=512000000 elapsed_ns=15337535551 ns_per_iter=29.956 iter_per_sec=33382155.712
sample=2 iterations=512000000 elapsed_ns=14883090637 ns_per_iter=29.069 iter_per_sec=34401456.827
sample=3 iterations=512000000 elapsed_ns=14742131068 ns_per_iter=28.793 iter_per_sec=34730392.617

Adaptive difficulty summary:
samples=3
iterations_per_sample=512000000
mean_ns_per_iter=29.273
best_ns_per_iter=28.793
worst_ns_per_iter=29.956
mean_iter_per_sec=34171335.052
best_iter_per_sec=34730392.617
worst_iter_per_sec=33382155.712
