### PR TITLE
docs(benchmarks): publish end-to-end sync evidence

### DIFF
--- a/docs/benchmarks/data/end-to-end-sync/rs-parprep-current-candidate-r2.json
+++ b/docs/benchmarks/data/end-to-end-sync/rs-parprep-current-candidate-r2.json
@@ -1,0 +1,143 @@
+{
+  "assume_valid_height": 0,
+  "bitcoin_cli": "bitcoin-cli",
+  "bitcoin_cli_args": [],
+  "block_bytes": 687984205,
+  "block_count": 150001,
+  "block_source": "bitcoin-cli",
+  "blockfilterindex": false,
+  "blocks_per_second": 1550.6835049918768,
+  "data_dir": "/home/alpha/bench-g14/rs-parprep-current-candidate-r2",
+  "decode_seconds": 2.407282162,
+  "elapsed_seconds": 96.732182626,
+  "fetch_seconds": 0.828116771,
+  "git_head": "9ce0727ced19644e551d1eac7895993fe43a7db6",
+  "measurement_target": "mainnet-prefix-replay",
+  "rest_url": null,
+  "rss_high_water_bytes": 323145728,
+  "schema": "mainnet-prefix-replay-v1",
+  "stage_seconds": [
+    {
+      "count": 150001,
+      "stage": "node.apply_block.total_seconds",
+      "sum_seconds": 91.9682967469997
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.script_verify_seconds",
+      "sum_seconds": 63.885183343999266
+    },
+    {
+      "count": 67891,
+      "stage": "node.apply_block.script_parallel_seconds",
+      "sum_seconds": 47.51026043799994
+    },
+    {
+      "count": 23883,
+      "stage": "node.apply_block.script_verify_serial_overlay_seconds",
+      "sum_seconds": 35.02858236799989
+    },
+    {
+      "count": 44008,
+      "stage": "node.apply_block.script_verify_parallel_seconds",
+      "sum_seconds": 28.854060556000043
+    },
+    {
+      "count": 67891,
+      "stage": "node.apply_block.script_prepare_seconds",
+      "sum_seconds": 10.500164023000002
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.utxo_commit_seconds",
+      "sum_seconds": 4.511884360000024
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_body_persist_seconds",
+      "sum_seconds": 4.481973903000005
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_rules_seconds",
+      "sum_seconds": 3.785610447999989
+    },
+    {
+      "count": 67891,
+      "stage": "node.apply_block.script_resolution_seconds",
+      "sum_seconds": 2.643067947000027
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.coinbase_maturity_seconds",
+      "sum_seconds": 1.5670060759999969
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.bip30_bip34_seconds",
+      "sum_seconds": 0.5460412000000004
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_tree_insert_seconds",
+      "sum_seconds": 0.48337798199999515
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.utxo_changes_seconds",
+      "sum_seconds": 0.4317700860000012
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_record_seconds",
+      "sum_seconds": 0.2578473729999959
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.pow_self_consistency_seconds",
+      "sum_seconds": 0.21510853200000582
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.pow_limit_continuity_seconds",
+      "sum_seconds": 0.016593728000000765
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.coin_stats_finish_seconds",
+      "sum_seconds": 0.00825527999999868
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.mempool_evict_seconds",
+      "sum_seconds": 0.007420944000000361
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.bip68_seconds",
+      "sum_seconds": 0.004973045000000162
+    },
+    {
+      "count": 82110,
+      "stage": "node.apply_block.script_verify_coinbase_only_seconds",
+      "sum_seconds": 0.002540420000000228
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.tx_index_ingest_seconds",
+      "sum_seconds": 0.001990643000000897
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.filter_index_seconds",
+      "sum_seconds": 0.0019376150000010887
+    }
+  ],
+  "start_hash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+  "start_height": 0,
+  "stop_hash": "0000000000000a3290f20e75860d505ce0e948a1d1d846bec7e39015d242884b",
+  "stop_height": 150000,
+  "storage_backend": "fjall",
+  "tx_count": 1718407,
+  "txindex": false
+}

--- a/docs/benchmarks/data/end-to-end-sync/rs-parprep-current-control-r1.json
+++ b/docs/benchmarks/data/end-to-end-sync/rs-parprep-current-control-r1.json
@@ -1,0 +1,143 @@
+{
+  "assume_valid_height": 0,
+  "bitcoin_cli": "bitcoin-cli",
+  "bitcoin_cli_args": [],
+  "block_bytes": 687984205,
+  "block_count": 150001,
+  "block_source": "bitcoin-cli",
+  "blockfilterindex": false,
+  "blocks_per_second": 1691.7261061203355,
+  "data_dir": "/home/alpha/bench-g14/rs-parprep-current-control-r1",
+  "decode_seconds": 1.930059026,
+  "elapsed_seconds": 88.667426398,
+  "fetch_seconds": 0.783287588,
+  "git_head": "9ce0727ced19644e551d1eac7895993fe43a7db6",
+  "measurement_target": "mainnet-prefix-replay",
+  "rest_url": null,
+  "rss_high_water_bytes": 316219392,
+  "schema": "mainnet-prefix-replay-v1",
+  "stage_seconds": [
+    {
+      "count": 150001,
+      "stage": "node.apply_block.total_seconds",
+      "sum_seconds": 84.80197701000064
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.script_verify_seconds",
+      "sum_seconds": 62.55528400199935
+    },
+    {
+      "count": 67891,
+      "stage": "node.apply_block.script_parallel_seconds",
+      "sum_seconds": 47.64260302599993
+    },
+    {
+      "count": 23883,
+      "stage": "node.apply_block.script_verify_serial_overlay_seconds",
+      "sum_seconds": 35.56251433000016
+    },
+    {
+      "count": 44008,
+      "stage": "node.apply_block.script_verify_parallel_seconds",
+      "sum_seconds": 26.990046919000008
+    },
+    {
+      "count": 67891,
+      "stage": "node.apply_block.script_prepare_seconds",
+      "sum_seconds": 10.599645385000015
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_body_persist_seconds",
+      "sum_seconds": 3.999154621000001
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.utxo_commit_seconds",
+      "sum_seconds": 3.567192771000011
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_rules_seconds",
+      "sum_seconds": 2.8142071160000004
+    },
+    {
+      "count": 67891,
+      "stage": "node.apply_block.script_resolution_seconds",
+      "sum_seconds": 2.2146185700000087
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.coinbase_maturity_seconds",
+      "sum_seconds": 1.2542397560000134
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.bip30_bip34_seconds",
+      "sum_seconds": 0.47065203200000216
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_tree_insert_seconds",
+      "sum_seconds": 0.43186281800000625
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.utxo_changes_seconds",
+      "sum_seconds": 0.3533947339999989
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_record_seconds",
+      "sum_seconds": 0.2234740929999976
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.pow_self_consistency_seconds",
+      "sum_seconds": 0.2013924720000383
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.pow_limit_continuity_seconds",
+      "sum_seconds": 0.011291056999999763
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.coin_stats_finish_seconds",
+      "sum_seconds": 0.008770754999999636
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.mempool_evict_seconds",
+      "sum_seconds": 0.007505151999999447
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.bip68_seconds",
+      "sum_seconds": 0.0035351450000004436
+    },
+    {
+      "count": 82110,
+      "stage": "node.apply_block.script_verify_coinbase_only_seconds",
+      "sum_seconds": 0.002722753000000173
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.tx_index_ingest_seconds",
+      "sum_seconds": 0.0015983370000008643
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.filter_index_seconds",
+      "sum_seconds": 0.0015866130000009235
+    }
+  ],
+  "start_hash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+  "start_height": 0,
+  "stop_hash": "0000000000000a3290f20e75860d505ce0e948a1d1d846bec7e39015d242884b",
+  "stop_height": 150000,
+  "storage_backend": "fjall",
+  "tx_count": 1718407,
+  "txindex": false
+}

--- a/docs/benchmarks/data/end-to-end-sync/rs-replay-150k-kernel.json
+++ b/docs/benchmarks/data/end-to-end-sync/rs-replay-150k-kernel.json
@@ -1,0 +1,128 @@
+{
+  "assume_valid_height": 0,
+  "bitcoin_cli": "bitcoin-cli",
+  "bitcoin_cli_args": [],
+  "block_bytes": 687984205,
+  "block_count": 150001,
+  "block_source": "rest",
+  "blockfilterindex": false,
+  "blocks_per_second": 645.9766168796388,
+  "data_dir": "/home/alpha/bench-g14/rs-replay-datadir-kernel",
+  "decode_seconds": 4.555582097,
+  "elapsed_seconds": 232.208095588,
+  "fetch_seconds": 28.564630002,
+  "git_head": "fb2227ec98101da22238a49660b928297697b1cb",
+  "measurement_target": "mainnet-prefix-replay",
+  "rest_url": "127.0.0.1:8332",
+  "rss_high_water_bytes": 2382901248,
+  "schema": "mainnet-prefix-replay-v1",
+  "stage_seconds": [
+    {
+      "count": 150001,
+      "stage": "node.apply_block.total_seconds",
+      "sum_seconds": 196.2619067730007
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.script_verify_seconds",
+      "sum_seconds": 139.75990129299964
+    },
+    {
+      "count": 23883,
+      "stage": "node.apply_block.script_verify_serial_overlay_seconds",
+      "sum_seconds": 73.48396910800018
+    },
+    {
+      "count": 44008,
+      "stage": "node.apply_block.script_verify_parallel_seconds",
+      "sum_seconds": 66.26709349800028
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_body_persist_seconds",
+      "sum_seconds": 12.451360844000007
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.utxo_commit_seconds",
+      "sum_seconds": 8.97270504100002
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_rules_seconds",
+      "sum_seconds": 5.568082347999974
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.bip30_bip34_seconds",
+      "sum_seconds": 2.841841981000011
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.coinbase_maturity_seconds",
+      "sum_seconds": 2.6745023900000153
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_tree_insert_seconds",
+      "sum_seconds": 1.227567051000019
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_record_seconds",
+      "sum_seconds": 0.6765661570000059
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.utxo_changes_seconds",
+      "sum_seconds": 0.5656633490000019
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.pow_self_consistency_seconds",
+      "sum_seconds": 0.5503178339998633
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.pow_limit_continuity_seconds",
+      "sum_seconds": 0.03633066199999984
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.coin_stats_finish_seconds",
+      "sum_seconds": 0.02279401699999753
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.mempool_evict_seconds",
+      "sum_seconds": 0.019616002000000743
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.bip68_seconds",
+      "sum_seconds": 0.010170462000000071
+    },
+    {
+      "count": 82110,
+      "stage": "node.apply_block.script_verify_coinbase_only_seconds",
+      "sum_seconds": 0.008838687000001504
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.tx_index_ingest_seconds",
+      "sum_seconds": 0.006004355000004328
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.filter_index_seconds",
+      "sum_seconds": 0.0047896360000016566
+    }
+  ],
+  "start_hash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+  "start_height": 0,
+  "stop_hash": "0000000000000a3290f20e75860d505ce0e948a1d1d846bec7e39015d242884b",
+  "stop_height": 150000,
+  "storage_backend": "fjall",
+  "tx_count": 1718407,
+  "txindex": false
+}

--- a/docs/benchmarks/data/end-to-end-sync/rs-replay-150k-parverify.json
+++ b/docs/benchmarks/data/end-to-end-sync/rs-replay-150k-parverify.json
@@ -1,0 +1,128 @@
+{
+  "assume_valid_height": 0,
+  "bitcoin_cli": "bitcoin-cli",
+  "bitcoin_cli_args": [],
+  "block_bytes": 687984205,
+  "block_count": 150001,
+  "block_source": "rest",
+  "blockfilterindex": false,
+  "blocks_per_second": 506.3990080406017,
+  "data_dir": "/home/alpha/bench-g14/rs-replay-datadir",
+  "decode_seconds": 4.8679622380000005,
+  "elapsed_seconds": 296.211085761,
+  "fetch_seconds": 28.289635514,
+  "git_head": "3023eb08ae1bdc882cd29373c837612039172ae8",
+  "measurement_target": "mainnet-prefix-replay",
+  "rest_url": "127.0.0.1:8332",
+  "rss_high_water_bytes": 2372628480,
+  "schema": "mainnet-prefix-replay-v1",
+  "stage_seconds": [
+    {
+      "count": 150001,
+      "stage": "node.apply_block.total_seconds",
+      "sum_seconds": 260.0216636310011
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.script_verify_seconds",
+      "sum_seconds": 200.68949742999803
+    },
+    {
+      "count": 23883,
+      "stage": "node.apply_block.script_verify_serial_overlay_seconds",
+      "sum_seconds": 104.98051463799959
+    },
+    {
+      "count": 44008,
+      "stage": "node.apply_block.script_verify_parallel_seconds",
+      "sum_seconds": 95.6963414970003
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_body_persist_seconds",
+      "sum_seconds": 12.856825151000203
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.utxo_commit_seconds",
+      "sum_seconds": 9.405603880000005
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_rules_seconds",
+      "sum_seconds": 5.625089758000059
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.bip30_bip34_seconds",
+      "sum_seconds": 4.0998140700000105
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.coinbase_maturity_seconds",
+      "sum_seconds": 2.833530683000039
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_tree_insert_seconds",
+      "sum_seconds": 1.202297485000004
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.block_record_seconds",
+      "sum_seconds": 0.6831291010000027
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.pow_self_consistency_seconds",
+      "sum_seconds": 0.6017232949997476
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.utxo_changes_seconds",
+      "sum_seconds": 0.5649161810000018
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.pow_limit_continuity_seconds",
+      "sum_seconds": 0.03970735999999853
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.coin_stats_finish_seconds",
+      "sum_seconds": 0.023684008999998667
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.mempool_evict_seconds",
+      "sum_seconds": 0.023110184999998614
+    },
+    {
+      "count": 82110,
+      "stage": "node.apply_block.script_verify_coinbase_only_seconds",
+      "sum_seconds": 0.012641295000000316
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.bip68_seconds",
+      "sum_seconds": 0.009737262999999876
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.tx_index_ingest_seconds",
+      "sum_seconds": 0.005913901000004
+    },
+    {
+      "count": 150001,
+      "stage": "node.apply_block.filter_index_seconds",
+      "sum_seconds": 0.005016293000001817
+    }
+  ],
+  "start_hash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+  "start_height": 0,
+  "stop_hash": "0000000000000a3290f20e75860d505ce0e948a1d1d846bec7e39015d242884b",
+  "stop_height": 150000,
+  "storage_backend": "fjall",
+  "tx_count": 1718407,
+  "txindex": false
+}

--- a/docs/benchmarks/data/end-to-end-sync/rs-spendable-local-nobody-a014.json
+++ b/docs/benchmarks/data/end-to-end-sync/rs-spendable-local-nobody-a014.json
@@ -1,0 +1,129 @@
+{
+  "assume_valid_height": 642000,
+  "bitcoin_cli": "bitcoin-cli",
+  "bitcoin_cli_args": [],
+  "block_bytes": 291475980916,
+  "block_count": 642001,
+  "block_source": "legacy-fjall-chainstate",
+  "blockfilterindex": false,
+  "blocks_per_second": 65.25556968411264,
+  "data_dir": "/home/alpha/bench-g14/rs-spendable-local-nobody-a014",
+  "decode_seconds": 1112.344593023,
+  "elapsed_seconds": 9838.256000335,
+  "fetch_seconds": 2.789232627,
+  "git_head": "9ce0727ced19644e551d1eac7895993fe43a7db6",
+  "measurement_target": "mainnet-prefix-replay",
+  "rest_url": null,
+  "rss_high_water_bytes": 7330131968,
+  "schema": "mainnet-prefix-replay-v1",
+  "source_chainstate": "/home/alpha/bench-g14/rs-thin-final-20260727/chainstate",
+  "stage_seconds": [
+    {
+      "count": 642001,
+      "stage": "node.apply_block.total_seconds",
+      "sum_seconds": 8059.159316124981
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.block_rules_seconds",
+      "sum_seconds": 2039.3014868940388
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.script_verify_seconds",
+      "sum_seconds": 1943.2414133509953
+    },
+    {
+      "count": 485284,
+      "stage": "node.apply_block.script_verify_serial_overlay_seconds",
+      "sum_seconds": 1928.596317897989
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.coinbase_maturity_seconds",
+      "sum_seconds": 1020.5662368230198
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.utxo_commit_seconds",
+      "sum_seconds": 516.3519315530074
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.utxo_changes_seconds",
+      "sum_seconds": 153.32236281100242
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.bip68_seconds",
+      "sum_seconds": 60.704907881001034
+    },
+    {
+      "count": 67761,
+      "stage": "node.apply_block.script_verify_parallel_seconds",
+      "sum_seconds": 14.639741829999988
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.bip30_bip34_seconds",
+      "sum_seconds": 4.441684902000147
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.block_tree_insert_seconds",
+      "sum_seconds": 3.910462024999979
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.block_record_seconds",
+      "sum_seconds": 2.3286623749999795
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.pow_self_consistency_seconds",
+      "sum_seconds": 1.0346224329999223
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.pow_limit_continuity_seconds",
+      "sum_seconds": 0.16112257000002833
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.coin_stats_finish_seconds",
+      "sum_seconds": 0.1146286260000087
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.mempool_evict_seconds",
+      "sum_seconds": 0.06560732200001153
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.block_body_persist_seconds",
+      "sum_seconds": 0.039601792999996284
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.filter_index_seconds",
+      "sum_seconds": 0.024322936999914984
+    },
+    {
+      "count": 642001,
+      "stage": "node.apply_block.tx_index_ingest_seconds",
+      "sum_seconds": 0.00790762599996381
+    },
+    {
+      "count": 88956,
+      "stage": "node.apply_block.script_verify_coinbase_only_seconds",
+      "sum_seconds": 0.005353623000000225
+    }
+  ],
+  "start_hash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+  "start_height": 0,
+  "stop_hash": "00000000000000000008d02622c7a1b96735ed23bbbcdeb2d9fd04d2e4c71a73",
+  "stop_height": 642000,
+  "storage_backend": "fjall",
+  "tx_count": 554786295,
+  "txindex": false
+}

--- a/docs/benchmarks/end-to-end-sync.md
+++ b/docs/benchmarks/end-to-end-sync.md
@@ -1,0 +1,226 @@
+# End-to-end sync benchmarks
+
+> **Evidence status:** This page publishes completed historical runs and their raw JSON. It is not a current-HEAD full-tip result or a G14 performance-gate pass. No completed run here reaches height 957,600, no paired Bitcoin Core artifact exists, and none measures commit `4cfd3df`. Treat every number as descriptive unless a comparison below states that its range, source, validation posture, and commit match.
+>
+> This publication is provisional. A clean paired 0–957,600 G14 campaign remains separate follow-up work.
+
+The machine-readable attachments preserve every recorded field and stage timer. The source artifacts do not record the exact command line, compiler flags, CPU affinity, cache state, host identity, exit code, or replication count. Those missing fields prevent a reproducible controlled claim.
+
+## Completed machine-readable runs
+
+| Run | Range | Validation | Block source | Commit | Elapsed | Throughput | Peak RSS | Raw artifact |
+|---|---:|---|---|---|---:|---:|---:|---|
+| Current-campaign control, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `bitcoin-cli` | `9ce0727` | 88.667s | 1,691.726 blocks/s | 301.6 MiB | [`rs-parprep-current-control-r1.json`](data/end-to-end-sync/rs-parprep-current-control-r1.json) |
+| Current-campaign candidate, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `bitcoin-cli` | `9ce0727` | 96.732s | 1,550.684 blocks/s | 308.2 MiB | [`rs-parprep-current-candidate-r2.json`](data/end-to-end-sync/rs-parprep-current-candidate-r2.json) |
+| Long local replay, 0–642,000 | 0–642,000 | Assume-valid through 642,000 | `legacy-fjall-chainstate` | `9ce0727` | 2h 43m 58.256s | 65.256 blocks/s | 6.827 GiB | [`rs-spendable-local-nobody-a014.json`](data/end-to-end-sync/rs-spendable-local-nobody-a014.json) |
+| Portable full-validation replay, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `rest` | `3023eb0` | 296.211s | 506.399 blocks/s | 2.210 GiB | [`rs-replay-150k-parverify.json`](data/end-to-end-sync/rs-replay-150k-parverify.json) |
+| Kernel full-validation replay, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `rest` | `fb2227e` | 232.208s | 645.977 blocks/s | 2.219 GiB | [`rs-replay-150k-kernel.json`](data/end-to-end-sync/rs-replay-150k-kernel.json) |
+
+All five artifacts pass these structural checks: schema `mainnet-prefix-replay-v1`, genesis start hash, positive elapsed time and throughput, non-empty stage list, and `block_count = stop_height - start_height + 1`.
+
+## Same-range observations
+
+The two current-campaign 150,000-block files share the same recorded commit, height and hash window, `bitcoin-cli` source, fjall backend, and full-validation posture. The files do not record the command or treatment that distinguishes “candidate” from “control.” Each is a single run:
+
+- Candidate elapsed time was **9.096% higher** than control (96.732s vs 88.667s).
+- Candidate throughput was **8.337% lower** (1550.684 vs 1691.726 blocks/s).
+- Candidate peak RSS was **2.190% higher** (308.2 MiB vs 301.6 MiB).
+
+These are observed differences only. They do not establish a regression, a causal treatment effect, or a population mean.
+
+The older portable and kernel replays share the 0–150,000 range, REST source, full-validation posture, and stop hash, but use different commits and verification engines. They are useful historical results, not a controlled A/B. The 642,000-block replay uses an assume-valid posture and a local legacy fjall chainstate, so it is not comparable to either 150,000-block group.
+
+## Historical live-network results
+
+These values were recorded in campaign verdict notes, not in the attached JSON. Their raw logs remain outside the repository, so this table is an index, not immutable evidence.
+
+| Run | Range | Validation posture | Elapsed | Source note |
+|---|---:|---|---:|---|
+| gocoin live IBD | 0–150,000 | Historical scripts skipped | ~277s | `cross-node-ibd-150k-verdict.md` |
+| Bitcoin Core 31.0 live IBD | 0–150,000 | Default assume-valid | 628s | `cross-node-ibd-150k-verdict.md` |
+| bitcoin-rs single-peer live IBD (`8f98e42`) | 0–150,000 | Full script verification | 5,332.2s | `cross-node-ibd-150k-verdict.md` |
+| bitcoin-rs multi-peer portable #1 (`71db91d`) | 0–150,000 | Full script verification | 810.1s | `rs-ibd-150k-multipeer-verdict.md` |
+| bitcoin-rs multi-peer portable #2 (`71db91d`) | 0–150,000 | Full script verification | 801.5s | `rs-ibd-150k-multipeer-verdict.md` |
+| bitcoin-rs kernel | 0–150,000 | Full script verification | 369.5s | `rs-ibd-150k-multipeer-verdict.md` |
+| bitcoin-rs kernel | 0–150,000 | Assume-valid through 150,000 | 359.5s | `rs-ibd-150k-multipeer-verdict.md` |
+
+The live runs were sequential single samples. Peer conditions and validation posture differ across implementations. Do not use the table as a controlled cross-node ranking.
+
+## Excluded incomplete evidence
+
+| Artifact | Observed range | Why it is excluded |
+|---|---:|---|
+| `rs-curated-current-r1.log` | Partial | The run stopped on the v3 snapshot limit at a transaction with 440 live outputs. |
+| `fixed-fulltip-rss.csv` | 18,987–645,804 | RSS sampling ended before the target; peak was 14,503,188 KiB. There is no completed sync timing. |
+| `rs-full-tip-20260727.log` | 0–957,600 attempt | The run rejected the height-957,600 header because its nBits did not match the locally computed retarget. |
+| Bitcoin Core full-tip comparator | — | No completed, provenance-bound comparator artifact exists. |
+
+Later code changed both failed bitcoin-rs paths, but no completed rerun is attached. This report does not infer results from those fixes.
+
+## G14 gate status
+
+| Budget | Required evidence | Status in this publication |
+|---|---|---|
+| IBD throughput | bitcoin-rs faster than Bitcoin Core on one identical window | Not measured |
+| UTXO commit p95 | ≤50ms for blocks ≥4MiB | Not captured |
+| Electrum history p95 | ≤30ms over 10,000 non-empty calls | Not captured |
+| Tip RSS | ≤16GiB with fjall, txindex, and blockfilterindex | Not measured at a completed tip; attached runs have indexes disabled |
+
+The ignored `g14_perf_budgets` gate must remain unclaimed.
+
+## Raw artifact integrity
+
+| Artifact | SHA-256 |
+|---|---|
+| `rs-parprep-current-control-r1.json` | `9abe40cf9c9992ec82e36e4cfceef3f9839519e9437c48096fbe14b7ac91200c` |
+| `rs-parprep-current-candidate-r2.json` | `2bf227a0892d7420f1d18600665fdef3e23c2502f1e7e6d0a77908e99394dc44` |
+| `rs-spendable-local-nobody-a014.json` | `a464e6f6d7c29037c451720e0cbe924340ed7d85c51634c01ecfd25c3ee70339` |
+| `rs-replay-150k-parverify.json` | `f1704f895a958afcf5fcce2f829954056e9864af87bf4f0483c29af36599ac29` |
+| `rs-replay-150k-kernel.json` | `d722ab149c39c5f13e18c6358ab999f4c1f44ce46b37a9d0eb87bfd45e0b91a9` |
+
+## Full recorded stage timers
+
+### Current-campaign control, 0–150,000
+
+Artifact: [`rs-parprep-current-control-r1.json`](data/end-to-end-sync/rs-parprep-current-control-r1.json). Stage timers are nested and are not additive.
+
+| Stage | Samples | Sum (seconds) |
+|---|---:|---:|
+| `node.apply_block.total_seconds` | 150,001 | 84.801977 |
+| `node.apply_block.script_verify_seconds` | 150,001 | 62.555284 |
+| `node.apply_block.script_parallel_seconds` | 67,891 | 47.642603 |
+| `node.apply_block.script_verify_serial_overlay_seconds` | 23,883 | 35.562514 |
+| `node.apply_block.script_verify_parallel_seconds` | 44,008 | 26.990047 |
+| `node.apply_block.script_prepare_seconds` | 67,891 | 10.599645 |
+| `node.apply_block.block_body_persist_seconds` | 150,001 | 3.999155 |
+| `node.apply_block.utxo_commit_seconds` | 150,001 | 3.567193 |
+| `node.apply_block.block_rules_seconds` | 150,001 | 2.814207 |
+| `node.apply_block.script_resolution_seconds` | 67,891 | 2.214619 |
+| `node.apply_block.coinbase_maturity_seconds` | 150,001 | 1.254240 |
+| `node.apply_block.bip30_bip34_seconds` | 150,001 | 0.470652 |
+| `node.apply_block.block_tree_insert_seconds` | 150,001 | 0.431863 |
+| `node.apply_block.utxo_changes_seconds` | 150,001 | 0.353395 |
+| `node.apply_block.block_record_seconds` | 150,001 | 0.223474 |
+| `node.apply_block.pow_self_consistency_seconds` | 150,001 | 0.201392 |
+| `node.apply_block.pow_limit_continuity_seconds` | 150,001 | 0.011291 |
+| `node.apply_block.coin_stats_finish_seconds` | 150,001 | 0.008771 |
+| `node.apply_block.mempool_evict_seconds` | 150,001 | 0.007505 |
+| `node.apply_block.bip68_seconds` | 150,001 | 0.003535 |
+| `node.apply_block.script_verify_coinbase_only_seconds` | 82,110 | 0.002723 |
+| `node.apply_block.tx_index_ingest_seconds` | 150,001 | 0.001598 |
+| `node.apply_block.filter_index_seconds` | 150,001 | 0.001587 |
+
+### Current-campaign candidate, 0–150,000
+
+Artifact: [`rs-parprep-current-candidate-r2.json`](data/end-to-end-sync/rs-parprep-current-candidate-r2.json). Stage timers are nested and are not additive.
+
+| Stage | Samples | Sum (seconds) |
+|---|---:|---:|
+| `node.apply_block.total_seconds` | 150,001 | 91.968297 |
+| `node.apply_block.script_verify_seconds` | 150,001 | 63.885183 |
+| `node.apply_block.script_parallel_seconds` | 67,891 | 47.510260 |
+| `node.apply_block.script_verify_serial_overlay_seconds` | 23,883 | 35.028582 |
+| `node.apply_block.script_verify_parallel_seconds` | 44,008 | 28.854061 |
+| `node.apply_block.script_prepare_seconds` | 67,891 | 10.500164 |
+| `node.apply_block.utxo_commit_seconds` | 150,001 | 4.511884 |
+| `node.apply_block.block_body_persist_seconds` | 150,001 | 4.481974 |
+| `node.apply_block.block_rules_seconds` | 150,001 | 3.785610 |
+| `node.apply_block.script_resolution_seconds` | 67,891 | 2.643068 |
+| `node.apply_block.coinbase_maturity_seconds` | 150,001 | 1.567006 |
+| `node.apply_block.bip30_bip34_seconds` | 150,001 | 0.546041 |
+| `node.apply_block.block_tree_insert_seconds` | 150,001 | 0.483378 |
+| `node.apply_block.utxo_changes_seconds` | 150,001 | 0.431770 |
+| `node.apply_block.block_record_seconds` | 150,001 | 0.257847 |
+| `node.apply_block.pow_self_consistency_seconds` | 150,001 | 0.215109 |
+| `node.apply_block.pow_limit_continuity_seconds` | 150,001 | 0.016594 |
+| `node.apply_block.coin_stats_finish_seconds` | 150,001 | 0.008255 |
+| `node.apply_block.mempool_evict_seconds` | 150,001 | 0.007421 |
+| `node.apply_block.bip68_seconds` | 150,001 | 0.004973 |
+| `node.apply_block.script_verify_coinbase_only_seconds` | 82,110 | 0.002540 |
+| `node.apply_block.tx_index_ingest_seconds` | 150,001 | 0.001991 |
+| `node.apply_block.filter_index_seconds` | 150,001 | 0.001938 |
+
+### Long local replay, 0–642,000
+
+Artifact: [`rs-spendable-local-nobody-a014.json`](data/end-to-end-sync/rs-spendable-local-nobody-a014.json). Stage timers are nested and are not additive.
+
+| Stage | Samples | Sum (seconds) |
+|---|---:|---:|
+| `node.apply_block.total_seconds` | 642,001 | 8059.159316 |
+| `node.apply_block.block_rules_seconds` | 642,001 | 2039.301487 |
+| `node.apply_block.script_verify_seconds` | 642,001 | 1943.241413 |
+| `node.apply_block.script_verify_serial_overlay_seconds` | 485,284 | 1928.596318 |
+| `node.apply_block.coinbase_maturity_seconds` | 642,001 | 1020.566237 |
+| `node.apply_block.utxo_commit_seconds` | 642,001 | 516.351932 |
+| `node.apply_block.utxo_changes_seconds` | 642,001 | 153.322363 |
+| `node.apply_block.bip68_seconds` | 642,001 | 60.704908 |
+| `node.apply_block.script_verify_parallel_seconds` | 67,761 | 14.639742 |
+| `node.apply_block.bip30_bip34_seconds` | 642,001 | 4.441685 |
+| `node.apply_block.block_tree_insert_seconds` | 642,001 | 3.910462 |
+| `node.apply_block.block_record_seconds` | 642,001 | 2.328662 |
+| `node.apply_block.pow_self_consistency_seconds` | 642,001 | 1.034622 |
+| `node.apply_block.pow_limit_continuity_seconds` | 642,001 | 0.161123 |
+| `node.apply_block.coin_stats_finish_seconds` | 642,001 | 0.114629 |
+| `node.apply_block.mempool_evict_seconds` | 642,001 | 0.065607 |
+| `node.apply_block.block_body_persist_seconds` | 642,001 | 0.039602 |
+| `node.apply_block.filter_index_seconds` | 642,001 | 0.024323 |
+| `node.apply_block.tx_index_ingest_seconds` | 642,001 | 0.007908 |
+| `node.apply_block.script_verify_coinbase_only_seconds` | 88,956 | 0.005354 |
+
+### Portable full-validation replay, 0–150,000
+
+Artifact: [`rs-replay-150k-parverify.json`](data/end-to-end-sync/rs-replay-150k-parverify.json). Stage timers are nested and are not additive.
+
+| Stage | Samples | Sum (seconds) |
+|---|---:|---:|
+| `node.apply_block.total_seconds` | 150,001 | 260.021664 |
+| `node.apply_block.script_verify_seconds` | 150,001 | 200.689497 |
+| `node.apply_block.script_verify_serial_overlay_seconds` | 23,883 | 104.980515 |
+| `node.apply_block.script_verify_parallel_seconds` | 44,008 | 95.696341 |
+| `node.apply_block.block_body_persist_seconds` | 150,001 | 12.856825 |
+| `node.apply_block.utxo_commit_seconds` | 150,001 | 9.405604 |
+| `node.apply_block.block_rules_seconds` | 150,001 | 5.625090 |
+| `node.apply_block.bip30_bip34_seconds` | 150,001 | 4.099814 |
+| `node.apply_block.coinbase_maturity_seconds` | 150,001 | 2.833531 |
+| `node.apply_block.block_tree_insert_seconds` | 150,001 | 1.202297 |
+| `node.apply_block.block_record_seconds` | 150,001 | 0.683129 |
+| `node.apply_block.pow_self_consistency_seconds` | 150,001 | 0.601723 |
+| `node.apply_block.utxo_changes_seconds` | 150,001 | 0.564916 |
+| `node.apply_block.pow_limit_continuity_seconds` | 150,001 | 0.039707 |
+| `node.apply_block.coin_stats_finish_seconds` | 150,001 | 0.023684 |
+| `node.apply_block.mempool_evict_seconds` | 150,001 | 0.023110 |
+| `node.apply_block.script_verify_coinbase_only_seconds` | 82,110 | 0.012641 |
+| `node.apply_block.bip68_seconds` | 150,001 | 0.009737 |
+| `node.apply_block.tx_index_ingest_seconds` | 150,001 | 0.005914 |
+| `node.apply_block.filter_index_seconds` | 150,001 | 0.005016 |
+
+### Kernel full-validation replay, 0–150,000
+
+Artifact: [`rs-replay-150k-kernel.json`](data/end-to-end-sync/rs-replay-150k-kernel.json). Stage timers are nested and are not additive.
+
+| Stage | Samples | Sum (seconds) |
+|---|---:|---:|
+| `node.apply_block.total_seconds` | 150,001 | 196.261907 |
+| `node.apply_block.script_verify_seconds` | 150,001 | 139.759901 |
+| `node.apply_block.script_verify_serial_overlay_seconds` | 23,883 | 73.483969 |
+| `node.apply_block.script_verify_parallel_seconds` | 44,008 | 66.267093 |
+| `node.apply_block.block_body_persist_seconds` | 150,001 | 12.451361 |
+| `node.apply_block.utxo_commit_seconds` | 150,001 | 8.972705 |
+| `node.apply_block.block_rules_seconds` | 150,001 | 5.568082 |
+| `node.apply_block.bip30_bip34_seconds` | 150,001 | 2.841842 |
+| `node.apply_block.coinbase_maturity_seconds` | 150,001 | 2.674502 |
+| `node.apply_block.block_tree_insert_seconds` | 150,001 | 1.227567 |
+| `node.apply_block.block_record_seconds` | 150,001 | 0.676566 |
+| `node.apply_block.utxo_changes_seconds` | 150,001 | 0.565663 |
+| `node.apply_block.pow_self_consistency_seconds` | 150,001 | 0.550318 |
+| `node.apply_block.pow_limit_continuity_seconds` | 150,001 | 0.036331 |
+| `node.apply_block.coin_stats_finish_seconds` | 150,001 | 0.022794 |
+| `node.apply_block.mempool_evict_seconds` | 150,001 | 0.019616 |
+| `node.apply_block.bip68_seconds` | 150,001 | 0.010170 |
+| `node.apply_block.script_verify_coinbase_only_seconds` | 82,110 | 0.008839 |
+| `node.apply_block.tx_index_ingest_seconds` | 150,001 | 0.006004 |
+| `node.apply_block.filter_index_seconds` | 150,001 | 0.004790 |
+
+## Harness
+
+The attached JSON was emitted by `crates/node/examples/mainnet_prefix_replay.rs`. The artifacts record the range, boundary hashes, backend, index flags, source kind, data directory, elapsed/fetch/decode time, block and transaction counts, peak RSS, commit, and stage timers. They do not capture enough launch or host state to reconstruct the exact original command. A future publishable G14 run must use the repository G14 daemon adapters and evidence manifest instead of reconstructing missing provenance from these files.

--- a/docs/benchmarks/end-to-end-sync.md
+++ b/docs/benchmarks/end-to-end-sync.md
@@ -3,6 +3,7 @@
 > **Evidence status:** This page publishes completed historical runs and their raw JSON. It is not a current-HEAD full-tip result or a G14 performance-gate pass. No completed run here reaches height 957,600, no paired Bitcoin Core artifact exists, and none measures commit `4cfd3df`. Treat every number as descriptive unless a comparison below states that its range, source, validation posture, and commit match.
 >
 > This publication is provisional. A clean paired 0–957,600 G14 campaign remains separate follow-up work.
+> Commit `9ce0727ced19644e551d1eac7895993fe43a7db6` is an unpushed local research revision not resolvable from remote history. The historical `kernel` and `parverify` verification-engine labels are inferred from filenames and run notes, not machine-recorded Cargo feature metadata.
 
 The machine-readable attachments preserve every recorded field and stage timer. The source artifacts do not record the exact command line, compiler flags, CPU affinity, cache state, host identity, exit code, or replication count. Those missing fields prevent a reproducible controlled claim.
 
@@ -13,8 +14,8 @@ The machine-readable attachments preserve every recorded field and stage timer. 
 | Current-campaign control, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `bitcoin-cli` | `9ce0727` | 88.667s | 1,691.726 blocks/s | 301.6 MiB | [`rs-parprep-current-control-r1.json`](data/end-to-end-sync/rs-parprep-current-control-r1.json) |
 | Current-campaign candidate, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `bitcoin-cli` | `9ce0727` | 96.732s | 1,550.684 blocks/s | 308.2 MiB | [`rs-parprep-current-candidate-r2.json`](data/end-to-end-sync/rs-parprep-current-candidate-r2.json) |
 | Long local replay, 0–642,000 | 0–642,000 | Assume-valid through 642,000 | `legacy-fjall-chainstate` | `9ce0727` | 2h 43m 58.256s | 65.256 blocks/s | 6.827 GiB | [`rs-spendable-local-nobody-a014.json`](data/end-to-end-sync/rs-spendable-local-nobody-a014.json) |
-| Portable full-validation replay, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `rest` | `3023eb0` | 296.211s | 506.399 blocks/s | 2.210 GiB | [`rs-replay-150k-parverify.json`](data/end-to-end-sync/rs-replay-150k-parverify.json) |
-| Kernel full-validation replay, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `rest` | `fb2227e` | 232.208s | 645.977 blocks/s | 2.219 GiB | [`rs-replay-150k-kernel.json`](data/end-to-end-sync/rs-replay-150k-kernel.json) |
+| Inferred `parverify` full-validation replay, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `rest` | `3023eb0` | 296.211s | 506.399 blocks/s | 2.210 GiB | [`rs-replay-150k-parverify.json`](data/end-to-end-sync/rs-replay-150k-parverify.json) |
+| Inferred `kernel` full-validation replay, 0–150,000 | 0–150,000 | Full (`assume_valid_height=0`) | `rest` | `fb2227e` | 232.208s | 645.977 blocks/s | 2.219 GiB | [`rs-replay-150k-kernel.json`](data/end-to-end-sync/rs-replay-150k-kernel.json) |
 
 All five artifacts pass these structural checks: schema `mainnet-prefix-replay-v1`, genesis start hash, positive elapsed time and throughput, non-empty stage list, and `block_count = stop_height - start_height + 1`.
 
@@ -28,7 +29,7 @@ The two current-campaign 150,000-block files share the same recorded commit, hei
 
 These are observed differences only. They do not establish a regression, a causal treatment effect, or a population mean.
 
-The older portable and kernel replays share the 0–150,000 range, REST source, full-validation posture, and stop hash, but use different commits and verification engines. They are useful historical results, not a controlled A/B. The 642,000-block replay uses an assume-valid posture and a local legacy fjall chainstate, so it is not comparable to either 150,000-block group.
+The older `parverify` and `kernel` replays share the 0–150,000 range, REST source, full-validation posture, and stop hash, but use different commits and the `kernel`/`parverify` engine labels are inferred from filenames and run notes, not recorded Cargo features. They are useful historical results, not a controlled A/B. The 642,000-block replay uses an assume-valid posture and a local legacy fjall chainstate, so it is not comparable to either 150,000-block group.
 
 ## Historical live-network results
 


### PR DESCRIPTION
## Summary

Reviewers can now inspect five completed end-to-end replay artifacts inside the repository instead of relying on a local benchmark directory. The report keeps measured replay data separate from historical live-network notes and states the missing provenance that prevents controlled or G14 claims.

This publication is provisional. A clean paired 0–957,600 full-tip campaign remains separate follow-up work.

## Published evidence

| Scope | Validation | Attached runs |
|---|---|---:|
| 0–150,000 | Full script verification | 4 |
| 0–642,000 | Assume-valid through 642,000 | 1 |

- Preserves all five source JSON files byte-for-byte.
- Lists every recorded stage timer and each artifact SHA-256.
- Separates same-range observations from causal performance claims.
- Records incomplete full-tip attempts and leaves every G14 budget unclaimed.

## Validation

- Parsed every attachment as `mainnet-prefix-replay-v1`.
- Verified block-count/range invariants, report links, source byte identity, listed hashes, and all 106 stage rows.
- Independent evidence review confirmed the hashes, arithmetic, range/count/hash relationships, links, and stage rows; its one attribution finding was resolved by removing the regression claim.
