### PR TITLE
rpc: Core-compatible REST gateway so a remote bip300301_enforcer can use bitcoin-rs as its mainchain node

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -2,6 +2,13 @@
 
 Shared domain vocabulary for this project: entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound processes learnings; direct edits are fine. Glossary only, not a spec or catch-all.
 
+## Node interfaces
+
+### REST gateway
+The optional, unauthenticated Bitcoin Core-compatible HTTP surface served on
+the existing JSON-RPC listener. It is enabled with `rest=1`; JSON-RPC requests
+on the same listener retain their configured authentication.
+
 ## Initial Block Download
 
 ### Initial Block Download (IBD)

--- a/crates/node/src/bitcoin_conf_compat.rs
+++ b/crates/node/src/bitcoin_conf_compat.rs
@@ -54,6 +54,7 @@ fn apply_key(layer: &mut ConfigLayer, key: &str, value: &str) {
         "rpcuser" => layer.rpc_user = Some(value.to_owned()),
         "rpcpassword" => layer.rpc_password = Some(value.to_owned()),
         "rpccookiefile" => layer.rpc_cookie = Some(value.into()),
+        "rest" => layer.rest = parse_core_bool(value),
         "listen" if parse_core_bool(value).is_some_and(|listen| !listen) => {
             layer.p2p_listen = Some(Vec::new());
         }
@@ -138,6 +139,9 @@ impl ConfigLayerMerge for ConfigLayer {
         }
         if other.rpc_bind.is_some() {
             self.rpc_bind = other.rpc_bind;
+        }
+        if other.rest.is_some() {
+            self.rest = other.rest;
         }
         if other.rpc_auth.is_some() {
             self.rpc_auth.clone_from(&other.rpc_auth);

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -431,6 +431,7 @@ impl Config {
         Ok(config)
     }
 
+    #[allow(clippy::too_many_lines)]
     fn apply_layer(&mut self, layer: &ConfigLayer) {
         if let Some(network) = layer.network {
             self.network = network;

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -667,7 +667,7 @@ impl ConfigLayer {
                 "BITCOIN_RS_DATA_DIR" => layer.data_dir = Some(PathBuf::from(value)),
                 "BITCOIN_RS_STORAGE_BACKEND" => layer.storage_backend = Some(value.to_owned()),
                 "BITCOIN_RS_RPC_BIND" => layer.rpc_bind = Some(value.parse()?),
-                "BITCOIN_RS_REST" => layer.rest = Some(value.parse()?),
+                "BITCOIN_RS_REST" => layer.rest = Some(parse_bool(value)?),
                 "BITCOIN_RS_RPC_USER" => layer.rpc_user = Some(value.to_owned()),
                 "BITCOIN_RS_RPC_PASSWORD" => layer.rpc_password = Some(value.to_owned()),
                 "BITCOIN_RS_RPC_COOKIE" => layer.rpc_cookie = Some(PathBuf::from(value)),

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -94,6 +94,8 @@ pub struct Config {
     pub storage_backend: String,
     /// JSON-RPC bind address.
     pub rpc_bind: SocketAddr,
+    /// Whether the Bitcoin Core-compatible REST gateway is enabled.
+    pub rest: bool,
     /// JSON-RPC authentication configuration.
     pub rpc_auth: Auth,
     /// Optional Electrum TCP bind address.
@@ -171,6 +173,7 @@ impl fmt::Debug for Config {
             .field("data_dir", &self.data_dir)
             .field("storage_backend", &self.storage_backend)
             .field("rpc_bind", &self.rpc_bind)
+            .field("rest", &self.rest)
             .field("rpc_auth", &self.rpc_auth)
             .field("electrum_bind", &self.electrum_bind)
             .field("electrum_tls_cert", &self.electrum_tls_cert)
@@ -231,6 +234,7 @@ impl Config {
             data_dir: PathBuf::from(".bitcoin-rs"),
             storage_backend: DEFAULT_STORAGE_BACKEND.to_owned(),
             rpc_bind: SocketAddr::from(([127, 0, 0, 1], network.default_rpc_port())),
+            rest: false,
             rpc_auth: Auth::default(),
             electrum_bind: None,
             electrum_tls_cert: None,
@@ -440,6 +444,9 @@ impl Config {
         if let Some(rpc_bind) = layer.rpc_bind {
             self.rpc_bind = rpc_bind;
         }
+        if let Some(rest) = layer.rest {
+            self.rest = rest;
+        }
         if let Some(auth) = &layer.rpc_auth {
             self.rpc_auth = auth.clone();
         }
@@ -566,6 +573,9 @@ pub(crate) struct ConfigLayer {
     pub(crate) storage_backend: Option<String>,
     #[arg(long = "rpc-bind")]
     pub(crate) rpc_bind: Option<SocketAddr>,
+    /// Enable the Bitcoin Core-compatible REST gateway.
+    #[arg(long)]
+    pub(crate) rest: Option<bool>,
     #[arg(skip)]
     pub(crate) rpc_auth: Option<Auth>,
     #[arg(long = "rpc-user")]
@@ -656,6 +666,7 @@ impl ConfigLayer {
                 "BITCOIN_RS_DATA_DIR" => layer.data_dir = Some(PathBuf::from(value)),
                 "BITCOIN_RS_STORAGE_BACKEND" => layer.storage_backend = Some(value.to_owned()),
                 "BITCOIN_RS_RPC_BIND" => layer.rpc_bind = Some(value.parse()?),
+                "BITCOIN_RS_REST" => layer.rest = Some(value.parse()?),
                 "BITCOIN_RS_RPC_USER" => layer.rpc_user = Some(value.to_owned()),
                 "BITCOIN_RS_RPC_PASSWORD" => layer.rpc_password = Some(value.to_owned()),
                 "BITCOIN_RS_RPC_COOKIE" => layer.rpc_cookie = Some(PathBuf::from(value)),

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -626,6 +626,7 @@ pub fn run(mut config: Config) -> Result<()> {
         rpc_handler,
         RPC_MAX_CONNECTIONS,
         RPC_IDLE_TIMEOUT,
+        state.config().rest,
     )?;
     let rpc_local_addr = rpc_server.local_addr()?;
     tracing::info!(addr = %rpc_local_addr, "rpc listener bound");

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -29,6 +29,12 @@ impl Handler {
         Self { ctx }
     }
 
+    /// Returns the shared context used by the handlers.
+    #[must_use]
+    pub fn context(&self) -> &Arc<Context> {
+        &self.ctx
+    }
+
     /// Dispatches one Bitcoin Core-compatible JSON-RPC method.
     pub fn dispatch(&self, method: &str, params: &Value) -> Result<Value, RpcError> {
         match method {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -19,6 +19,8 @@ pub mod context;
 pub mod error;
 /// Method dispatch and Core-compatible handlers.
 pub mod handlers;
+/// Bitcoin Core-compatible REST endpoints.
+pub mod rest;
 /// Synchronous HTTP/1.1 JSON-RPC server.
 pub mod server;
 

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use bitcoin::block::Header;
 use bitcoin::consensus::encode::serialize;
+use bitcoin::hashes::Hash as _;
 use bitcoin::hex::{DisplayHex as _, FromHex as _};
 use bitcoin_rs_primitives::Hash256;
 use sonic_rs::{Value, json};
@@ -116,7 +117,7 @@ fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<(BlockRecord,
         let Some(header) = decode_header(&record) else {
             break;
         };
-        if header.prev_blockhash.to_string() != previous_hash.to_string_be() {
+        if Hash256::from_le_bytes(header.prev_blockhash.as_byte_array()) != previous_hash {
             break;
         }
         previous_hash = record.hash;
@@ -250,7 +251,6 @@ fn not_found_with(message: &'static str) -> Response {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
-    use bitcoin::hashes::Hash as _;
     use bitcoin::{BlockHash, CompactTarget, TxMerkleNode, block::Version};
     use sonic_rs::JsonValueTrait;
 

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -60,17 +60,17 @@ pub fn route(ctx: &Arc<Context>, path: &str, query: &str, enabled: bool) -> Resp
 
 fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
     let Some((hash_text, format)) = suffix.rsplit_once('.') else {
-        return bad_request_owned(format!("Invalid hash: {suffix}"));
+        return not_found_with("output format not found");
     };
     if !matches!(format, "json" | "hex" | "bin") {
-        return bad_request_owned(format!("Invalid hash: {suffix}"));
+        return bad_request_owned(format!("Invalid hash: {hash_text}"));
     }
     let count = match parse_count(query) {
         Ok(count) => count,
         Err(response) => return response,
     };
     let Ok(hash) = Hash256::from_str(hash_text) else {
-        return bad_request_owned(format!("Invalid hash: {suffix}"));
+        return bad_request_owned(format!("Invalid hash: {hash_text}"));
     };
     let records = header_records(ctx, hash, count);
     match format {
@@ -92,7 +92,7 @@ fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
                 body
             }),
         ),
-        _ => bad_request_owned(format!("Invalid hash: {suffix}")),
+        _ => bad_request_owned(format!("Invalid hash: {hash_text}")),
     }
 }
 
@@ -120,7 +120,7 @@ fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<HeaderRecord>
             return vec![start];
         };
         if active_start != start_id {
-            return vec![start];
+            return Vec::new();
         }
         let last_height = start
             .height
@@ -149,6 +149,9 @@ fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<HeaderRecord>
         return truncate_at_linkage_break(records);
     }
 
+    // Cache-only records predate tree publication, so their active-chain
+    // membership cannot be established here; preserve the singleton fallback
+    // for those records rather than turning a usable header into a 404.
     let Some(record) = ctx.block_by_hash(hash) else {
         return Vec::new();
     };
@@ -179,9 +182,6 @@ fn parse_count(query: &str) -> Result<u32, Response> {
     let mut count = None;
     for pair in query.split('&') {
         let Some((key, value)) = pair.split_once('=') else {
-            if pair == "count" {
-                return Err(invalid_count(pair));
-            }
             continue;
         };
         if key == "count" {
@@ -362,11 +362,19 @@ mod tests {
         assert_eq!(response.status, 400);
         assert_eq!(
             String::from_utf8(response.body).expect("error body"),
-            "Invalid hash: 0000000000000000000000000000000000000000000000000000000000000000.txt"
+            "Invalid hash: 0000000000000000000000000000000000000000000000000000000000000000"
         );
+        let response = route(&ctx, "/rest/headers/not-a-hash.json", "", true);
+        assert_eq!(response.status, 400);
         assert_eq!(
-            route(&ctx, "/rest/headers/not-a-hash.json", "", true).status,
-            400
+            String::from_utf8(response.body).expect("error body"),
+            "Invalid hash: not-a-hash"
+        );
+        let response = route(&ctx, "/rest/headers/not-a-hash", "", true);
+        assert_eq!(response.status, 404);
+        assert_eq!(
+            String::from_utf8(response.body).expect("error body"),
+            "output format not found"
         );
         let response = route(&ctx, "/rest/headers/not-a-hash.json", "count=0", true);
         assert_eq!(response.status, 400);
@@ -398,6 +406,7 @@ mod tests {
             400
         );
         assert_eq!(parse_count("limit=5").expect("unknown query"), 5);
+        assert_eq!(parse_count("count").expect("bare query key"), 5);
         assert_eq!(parse_count("count=3&foo=1").expect("unknown query"), 3);
         assert_eq!(parse_count("foo=1&count=3").expect("unknown query"), 3);
     }
@@ -603,7 +612,7 @@ mod tests {
     }
 
     #[test]
-    fn headers_side_branch_returns_only_requested_header() {
+    fn headers_side_branch_returns_empty() {
         let ctx = Arc::new(Context::new());
         let bits = CompactTarget::from_consensus(0x1d00_ffff);
         let genesis = Header {
@@ -656,8 +665,7 @@ mod tests {
             true,
         );
         let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
-        assert_eq!(values.len(), 1);
-        assert_eq!(values[0].get("height").and_then(Value::as_u64), Some(1));
+        assert!(values.is_empty());
     }
 
     #[test]

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -92,7 +92,7 @@ fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
                 body
             }),
         ),
-        _ => unreachable!("header format checked above"),
+        _ => bad_request_owned(format!("Invalid hash: {suffix}")),
     }
 }
 

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -29,6 +29,13 @@ pub struct Response {
     pub body: Vec<u8>,
 }
 
+#[derive(Clone)]
+struct HeaderRecord {
+    hash: Hash256,
+    height: u32,
+    header: Header,
+}
+
 /// Routes one REST request.
 ///
 /// REST is deliberately distinct from unknown routes: a disabled gateway and
@@ -58,33 +65,30 @@ fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
     if !matches!(format, "json" | "hex" | "bin") {
         return bad_request_owned(format!("Invalid hash: {suffix}"));
     }
-    let Ok(hash) = Hash256::from_str(hash_text) else {
-        return bad_request_owned(format!("Invalid hash: {suffix}"));
-    };
     let count = match parse_count(query) {
         Ok(count) => count,
         Err(response) => return response,
     };
+    let Ok(hash) = Hash256::from_str(hash_text) else {
+        return bad_request_owned(format!("Invalid hash: {suffix}"));
+    };
     let records = header_records(ctx, hash, count);
     match format {
         "json" => {
-            let values = records
-                .iter()
-                .map(|(record, header)| header_json(record, header))
-                .collect::<Vec<_>>();
+            let values = records.iter().map(header_json).collect::<Vec<_>>();
             json_response(Ok(Value::from(values)))
         }
         "hex" => {
             let body = records
                 .iter()
-                .map(|(_, header)| serialize(header).to_lower_hex_string())
+                .map(|record| serialize(&record.header).to_lower_hex_string())
                 .collect::<String>();
             text_response("text/plain", body.into_bytes())
         }
         "bin" => binary_response(
             "application/octet-stream",
-            &records.iter().fold(Vec::new(), |mut body, (_, header)| {
-                body.extend(serialize(header));
+            &records.iter().fold(Vec::new(), |mut body, record| {
+                body.extend(serialize(&record.header));
                 body
             }),
         ),
@@ -92,37 +96,79 @@ fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
     }
 }
 
-fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<(BlockRecord, Header)> {
-    let Some(start) = ctx.block_by_hash(hash) else {
+fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<HeaderRecord> {
+    let tree = ctx.block_tree.read();
+    if let Some(start_id) = tree.lookup(hash)
+        && let Ok(start_node) = tree.node(start_id)
+    {
+        let start = HeaderRecord {
+            hash: start_node.hash,
+            height: start_node.height,
+            header: start_node.header,
+        };
+        let Some(tip) = tree.tip() else {
+            return vec![start];
+        };
+        let Ok(tip_node) = tree.node(tip.tip_id) else {
+            return vec![start];
+        };
+        let Some(active_start) = tree.node_at_height_from(tip.tip_id, start.height) else {
+            return vec![start];
+        };
+        if active_start != start_id {
+            return vec![start];
+        }
+        let last_height = start
+            .height
+            .saturating_add(count.saturating_sub(1))
+            .min(tip_node.height);
+        let Some(last_id) = tree.node_at_height_from(tip.tip_id, last_height) else {
+            return vec![start];
+        };
+        let mut records = Vec::with_capacity(usize::try_from(count).unwrap_or(usize::MAX));
+        let mut cursor = last_id;
+        while let Ok(node) = tree.node(cursor) {
+            records.push(HeaderRecord {
+                hash: node.hash,
+                height: node.height,
+                header: node.header,
+            });
+            if cursor == start_id {
+                break;
+            }
+            let Some(parent) = node.parent else {
+                break;
+            };
+            cursor = parent;
+        }
+        records.reverse();
+        return truncate_at_linkage_break(records);
+    }
+
+    let Some(record) = ctx.block_by_hash(hash) else {
         return Vec::new();
     };
-    let mut records = Vec::with_capacity(usize::try_from(count).unwrap_or(usize::MAX));
-    let Some(start_header) = decode_header(&start) else {
-        return records;
+    let Some(header) = decode_header(&record) else {
+        return Vec::new();
     };
-    let active_hash = ctx.block_by_height(start.height).map(|record| record.hash);
-    if active_hash != Some(hash) {
-        records.push((start, start_header));
-        return records;
-    }
-    let start_height = start.height;
-    let mut previous_hash = start.hash;
-    records.push((start, start_header));
-    for height in
-        start_height.saturating_add(1)..=start_height.saturating_add(count.saturating_sub(1))
-    {
-        let Some(record) = ctx.block_by_height(height) else {
-            break;
-        };
-        let Some(header) = decode_header(&record) else {
-            break;
-        };
-        if Hash256::from_le_bytes(header.prev_blockhash.as_byte_array()) != previous_hash {
-            break;
+    vec![HeaderRecord {
+        hash: record.hash,
+        height: record.height,
+        header,
+    }]
+}
+
+fn truncate_at_linkage_break(mut records: Vec<HeaderRecord>) -> Vec<HeaderRecord> {
+    let mut previous_hash = None;
+    records.retain(|record| {
+        let linked = previous_hash.is_none_or(|hash| {
+            Hash256::from_le_bytes(record.header.prev_blockhash.as_byte_array()) == hash
+        });
+        if linked {
+            previous_hash = Some(record.hash);
         }
-        previous_hash = record.hash;
-        records.push((record, header));
-    }
+        linked
+    });
     records
 }
 
@@ -165,16 +211,16 @@ fn decode_header(record: &BlockRecord) -> Option<Header> {
     bitcoin::consensus::encode::deserialize(&bytes).ok()
 }
 
-fn header_json(record: &BlockRecord, header: &Header) -> Value {
+fn header_json(record: &HeaderRecord) -> Value {
     json!({
         "hash": record.hash.to_string_be(),
         "height": record.height,
-        "version": header.version.to_consensus(),
-        "previousblockhash": if record.height == 0 { None::<String> } else { Some(header.prev_blockhash.to_string()) },
-        "merkleroot": header.merkle_root.to_string(),
-        "time": header.time,
-        "bits": format!("{:08x}", header.bits.to_consensus()),
-        "nonce": header.nonce,
+        "version": record.header.version.to_consensus(),
+        "previousblockhash": if record.height == 0 { None::<String> } else { Some(record.header.prev_blockhash.to_string()) },
+        "merkleroot": record.header.merkle_root.to_string(),
+        "time": record.header.time,
+        "bits": format!("{:08x}", record.header.bits.to_consensus()),
+        "nonce": record.header.nonce,
     })
 }
 
@@ -252,7 +298,38 @@ fn not_found_with(message: &'static str) -> Response {
 mod tests {
     use super::*;
     use bitcoin::{BlockHash, CompactTarget, TxMerkleNode, block::Version};
+    use bitcoin_rs_chain::{NodeStatus, TipSnapshot};
     use sonic_rs::JsonValueTrait;
+
+    fn publish_active_chain(ctx: &Context, headers: &[Header]) -> Vec<Hash256> {
+        let (tip_id, hashes) = {
+            let mut tree = ctx.block_tree.write();
+            let mut parent = None;
+            let mut ids = Vec::with_capacity(headers.len());
+            let mut hashes = Vec::with_capacity(headers.len());
+            for header in headers {
+                let id = tree
+                    .insert_node(parent, *header, NodeStatus::Active)
+                    .expect("active header");
+                hashes.push(Hash256::from_le_bytes(header.block_hash().as_byte_array()));
+                ids.push(id);
+                parent = Some(id);
+            }
+            let tip_id = *ids.last().expect("active tip");
+            (tip_id, hashes)
+        };
+        let tree = ctx.block_tree.read();
+        let tip_node = tree.node(tip_id).expect("tip node");
+        let tip = TipSnapshot {
+            tip_id,
+            height: tip_node.height,
+            chainwork: tip_node.chainwork,
+            hash: tip_node.hash,
+        };
+        drop(tree);
+        ctx.set_chain_tip(tip);
+        hashes
+    }
 
     #[test]
     fn disabled_rest_is_not_found() {
@@ -289,6 +366,12 @@ mod tests {
         assert_eq!(
             route(&ctx, "/rest/headers/not-a-hash.json", "", true).status,
             400
+        );
+        let response = route(&ctx, "/rest/headers/not-a-hash.json", "count=0", true);
+        assert_eq!(response.status, 400);
+        assert_eq!(
+            String::from_utf8(response.body).expect("error body"),
+            "Header count is invalid or out of acceptable range (1-2000): 0"
         );
     }
 
@@ -390,9 +473,10 @@ mod tests {
         ctx.add_block(BlockRecord::from_block(0, &genesis));
         ctx.add_block(BlockRecord::from_block(1, &child));
         ctx.add_block(BlockRecord::from_block(2, &tip));
+        publish_active_chain(&ctx, &[genesis.header, child.header, tip.header]);
 
         let path = format!("/rest/headers/{}.json", child.block_hash());
-        let response = route(&ctx, &path, "count=2", true);
+        let response = route(&ctx, &path, "count=2000", true);
         assert_eq!(response.status, 200);
         let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
         assert_eq!(values.len(), 2);
@@ -408,6 +492,111 @@ mod tests {
             CompactTarget::from_unprefixed_hex(bits_text).expect("bits round-trip"),
             bits
         );
+    }
+
+    #[test]
+    fn headers_json_returns_genesis_and_remaining_headers() {
+        let ctx = Arc::new(Context::new());
+        let bits = CompactTarget::from_consensus(0x1d00_ffff);
+        let genesis = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1,
+            bits,
+            nonce: 1,
+        };
+        let child = Header {
+            version: Version::ONE,
+            prev_blockhash: genesis.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 2,
+            bits,
+            nonce: 2,
+        };
+        let tip = Header {
+            version: Version::ONE,
+            prev_blockhash: child.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 3,
+            bits,
+            nonce: 3,
+        };
+        publish_active_chain(&ctx, &[genesis, child, tip]);
+
+        let response = route(
+            &ctx,
+            &format!("/rest/headers/{}.json", genesis.block_hash()),
+            "count=2000",
+            true,
+        );
+        let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
+        assert_eq!(values.len(), 3);
+        assert!(
+            values[0]
+                .get("previousblockhash")
+                .is_some_and(Value::is_null)
+        );
+        assert_eq!(values[0].get("height").and_then(Value::as_u64), Some(0));
+        assert_eq!(values[2].get("height").and_then(Value::as_u64), Some(2));
+    }
+
+    #[test]
+    fn headers_side_branch_returns_only_requested_header() {
+        let ctx = Arc::new(Context::new());
+        let bits = CompactTarget::from_consensus(0x1d00_ffff);
+        let genesis = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1,
+            bits,
+            nonce: 1,
+        };
+        let active_child = Header {
+            version: Version::ONE,
+            prev_blockhash: genesis.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 2,
+            bits,
+            nonce: 2,
+        };
+        let active_tip = Header {
+            version: Version::ONE,
+            prev_blockhash: active_child.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 3,
+            bits,
+            nonce: 3,
+        };
+        let side_child = Header {
+            version: Version::ONE,
+            prev_blockhash: genesis.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 4,
+            bits,
+            nonce: 4,
+        };
+        let ids = publish_active_chain(&ctx, &[genesis, active_child, active_tip]);
+        {
+            let mut tree = ctx.block_tree.write();
+            let parent = tree.lookup(ids[0]).expect("genesis node");
+            tree.insert_node(Some(parent), side_child, NodeStatus::Stale)
+                .expect("side branch header");
+        }
+
+        let response = route(
+            &ctx,
+            &format!(
+                "/rest/headers/{}.json",
+                Hash256::from_le_bytes(side_child.block_hash().as_byte_array())
+            ),
+            "count=2000",
+            true,
+        );
+        let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].get("height").and_then(Value::as_u64), Some(1));
     }
 
     #[test]
@@ -440,6 +629,36 @@ mod tests {
         };
         ctx.add_block(BlockRecord::from_block(0, &genesis));
         ctx.add_block(BlockRecord::from_block(1, &broken_child));
+        let genesis_id = {
+            let mut tree = ctx.block_tree.write();
+            tree.insert_node(None, genesis.header, NodeStatus::Active)
+                .expect("genesis header")
+        };
+        let broken_id = {
+            let mut tree = ctx.block_tree.write();
+            let valid_child = Header {
+                prev_blockhash: genesis.block_hash(),
+                ..broken_child.header
+            };
+            tree.insert_node(Some(genesis_id), valid_child, NodeStatus::Active)
+                .expect("broken child header")
+        };
+        ctx.block_tree
+            .write()
+            .node_mut(broken_id)
+            .expect("broken child node")
+            .header
+            .prev_blockhash = BlockHash::all_zeros();
+        let tree = ctx.block_tree.read();
+        let broken_node = tree.node(broken_id).expect("broken tip");
+        let tip = TipSnapshot {
+            tip_id: broken_id,
+            height: broken_node.height,
+            chainwork: broken_node.chainwork,
+            hash: broken_node.hash,
+        };
+        drop(tree);
+        ctx.set_chain_tip(tip);
 
         let path = format!("/rest/headers/{}.json", genesis.block_hash());
         let response = route(&ctx, &path, "count=2", true);
@@ -471,7 +690,11 @@ mod tests {
             bits: CompactTarget::from_consensus(0x1d00_ffff),
             nonce: 7,
         };
-        let value = header_json(&record, &header);
+        let value = header_json(&HeaderRecord {
+            hash: record.hash,
+            height: record.height,
+            header,
+        });
         for field in [
             "hash",
             "height",

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -29,6 +29,13 @@ pub struct Response {
 }
 
 /// Routes one REST request.
+///
+/// REST is deliberately distinct from unknown routes: a disabled gateway and
+/// a genuinely unknown path return 404, while malformed header parameters
+/// return 400. The enforcer uses 404 on `/rest/*` to diagnose a disabled
+/// gateway, so an unknown but well-formed block hash returns an empty 200
+/// response instead of a misleading 404. Header query parameters other than
+/// `count` are ignored, matching Core's cache-buster-friendly behavior.
 #[must_use]
 pub fn route(ctx: &Arc<Context>, path: &str, query: &str, enabled: bool) -> Response {
     if !enabled {
@@ -45,21 +52,21 @@ pub fn route(ctx: &Arc<Context>, path: &str, query: &str, enabled: bool) -> Resp
 
 fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
     let Some((hash_text, format)) = suffix.rsplit_once('.') else {
-        return not_found();
+        return bad_request_owned(format!("Invalid hash: {suffix}"));
     };
+    if !matches!(format, "json" | "hex" | "bin") {
+        return bad_request_owned(format!("Invalid hash: {suffix}"));
+    }
     let Ok(hash) = Hash256::from_str(hash_text) else {
-        return bad_request("invalid block hash");
+        return bad_request_owned(format!("Invalid hash: {suffix}"));
     };
     let count = match parse_count(query) {
         Ok(count) => count,
         Err(response) => return response,
     };
     let records = header_records(ctx, hash, count);
-    if records.is_empty() {
-        return not_found();
-    }
     let headers: Vec<Header> = records.iter().filter_map(decode_header).collect();
-    if headers.is_empty() {
+    if !records.is_empty() && headers.is_empty() {
         return not_found();
     }
     match format {
@@ -85,7 +92,7 @@ fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
                 body
             }),
         ),
-        _ => not_found(),
+        _ => unreachable!("header format checked above"),
     }
 }
 
@@ -112,16 +119,34 @@ fn parse_count(query: &str) -> Result<u32, Response> {
     if query.is_empty() {
         return Ok(DEFAULT_HEADER_COUNT);
     }
-    let Some(value) = query.strip_prefix("count=") else {
-        return Err(bad_request("invalid count"));
-    };
-    let Ok(value) = value.parse::<u32>() else {
-        return Err(bad_request("invalid count"));
-    };
-    if value == 0 {
-        return Err(bad_request("count must be positive"));
+    let mut count = None;
+    for pair in query.split('&') {
+        let Some((key, value)) = pair.split_once('=') else {
+            if pair == "count" {
+                return Err(invalid_count(pair));
+            }
+            continue;
+        };
+        if key == "count" {
+            count = Some(value);
+        }
     }
-    Ok(value.min(MAX_HEADER_COUNT))
+    let Some(value) = count else {
+        return Ok(DEFAULT_HEADER_COUNT);
+    };
+    let Ok(parsed) = value.parse::<u64>() else {
+        return Err(invalid_count(value));
+    };
+    if !(1..=u64::from(MAX_HEADER_COUNT)).contains(&parsed) {
+        return Err(invalid_count(value));
+    }
+    Ok(u32::try_from(parsed).unwrap_or(MAX_HEADER_COUNT))
+}
+
+fn invalid_count(value: &str) -> Response {
+    bad_request_owned(format!(
+        "Header count is invalid or out of acceptable range (1-2000): {value}"
+    ))
 }
 
 fn decode_header(record: &BlockRecord) -> Option<Header> {
@@ -183,6 +208,15 @@ fn bad_request(message: &'static str) -> Response {
     }
 }
 
+fn bad_request_owned(message: String) -> Response {
+    Response {
+        status: 400,
+        reason: "Bad Request",
+        content_type: "text/plain",
+        body: message.into_bytes(),
+    }
+}
+
 fn not_found() -> Response {
     not_found_with("not found")
 }
@@ -231,15 +265,16 @@ mod tests {
     #[test]
     fn route_rejects_unknown_formats_and_bad_hashes() {
         let ctx = Arc::new(Context::new());
+        let response = route(
+            &ctx,
+            "/rest/headers/0000000000000000000000000000000000000000000000000000000000000000.txt",
+            "",
+            true,
+        );
+        assert_eq!(response.status, 400);
         assert_eq!(
-            route(
-                &ctx,
-                "/rest/headers/0000000000000000000000000000000000000000000000000000000000000000.txt",
-                "",
-                true
-            )
-            .status,
-            404
+            String::from_utf8(response.body).expect("error body"),
+            "Invalid hash: 0000000000000000000000000000000000000000000000000000000000000000.txt"
         );
         assert_eq!(
             route(&ctx, "/rest/headers/not-a-hash.json", "", true).status,
@@ -248,12 +283,55 @@ mod tests {
     }
 
     #[test]
-    fn count_defaults_and_clamps() {
+    fn count_boundaries_and_errors() {
         assert_eq!(parse_count("").expect("default"), 5);
-        assert_eq!(parse_count("count=999999").expect("clamped"), 2_000);
+        assert_eq!(parse_count("count=1").expect("lower boundary"), 1);
+        assert_eq!(parse_count("count=2000").expect("upper boundary"), 2_000);
+        assert_eq!(
+            parse_count("count=2001").expect_err("above range").status,
+            400
+        );
         assert_eq!(parse_count("count=0").expect_err("zero count").status, 400);
+        assert_eq!(
+            parse_count("count=-1").expect_err("negative count").status,
+            400
+        );
         assert_eq!(parse_count("count=bad").expect_err("bad count").status, 400);
-        assert_eq!(parse_count("limit=5").expect_err("bad query").status, 400);
+        assert_eq!(
+            parse_count("count=18446744073709551616")
+                .expect_err("overflow count")
+                .status,
+            400
+        );
+        assert_eq!(parse_count("limit=5").expect("unknown query"), 5);
+        assert_eq!(parse_count("count=3&foo=1").expect("unknown query"), 3);
+        assert_eq!(parse_count("foo=1&count=3").expect("unknown query"), 3);
+    }
+
+    #[test]
+    fn unknown_hash_returns_empty_success_for_all_formats() {
+        let ctx = Arc::new(Context::new());
+        let hash = "0000000000000000000000000000000000000000000000000000000000000001";
+        for format in ["json", "hex", "bin"] {
+            let path = format!("/rest/headers/{hash}.{format}");
+            let response = route(&ctx, &path, "count=1", true);
+            assert_eq!(response.status, 200, "{format}");
+            assert!(
+                response.body.is_empty() || response.body == b"[]",
+                "{format}"
+            );
+        }
+        let with_unknown_param = route(
+            &ctx,
+            &format!("/rest/headers/{hash}.json"),
+            "count=3&foo=1",
+            true,
+        );
+        let without_count = route(&ctx, &format!("/rest/headers/{hash}.json"), "limit=5", true);
+        assert_eq!(with_unknown_param.status, 200);
+        assert_eq!(without_count.status, 200);
+        assert_eq!(with_unknown_param.body, b"[]");
+        assert_eq!(without_count.body, b"[]");
     }
 
     #[test]

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -1,0 +1,362 @@
+//! Small Bitcoin Core-compatible REST surface used by remote clients.
+
+use alloc::sync::Arc;
+use std::str::FromStr;
+
+use bitcoin::block::Header;
+use bitcoin::consensus::encode::serialize;
+use bitcoin::hex::{DisplayHex as _, FromHex as _};
+use bitcoin_rs_primitives::Hash256;
+use sonic_rs::{Value, json};
+
+use crate::context::{BlockRecord, Context};
+use crate::error::RpcError;
+
+const DEFAULT_HEADER_COUNT: u32 = 5;
+const MAX_HEADER_COUNT: u32 = 2_000;
+
+/// HTTP response produced by a REST route.
+#[derive(Debug, Eq, PartialEq)]
+pub struct Response {
+    /// HTTP status code.
+    pub status: u16,
+    /// HTTP reason phrase.
+    pub reason: &'static str,
+    /// MIME type.
+    pub content_type: &'static str,
+    /// Response body.
+    pub body: Vec<u8>,
+}
+
+/// Routes one REST request.
+#[must_use]
+pub fn route(ctx: &Arc<Context>, path: &str, query: &str, enabled: bool) -> Response {
+    if !enabled {
+        return not_found();
+    }
+    if path == "/rest/chaininfo.json" {
+        return json_response(crate::handlers::chain::getblockchaininfo(ctx, &json!([])));
+    }
+    if let Some(rest) = path.strip_prefix("/rest/headers/") {
+        return route_headers(ctx, rest, query);
+    }
+    not_found()
+}
+
+fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
+    let Some((hash_text, format)) = suffix.rsplit_once('.') else {
+        return not_found();
+    };
+    let Ok(hash) = Hash256::from_str(hash_text) else {
+        return bad_request("invalid block hash");
+    };
+    let count = match parse_count(query) {
+        Ok(count) => count,
+        Err(response) => return response,
+    };
+    let records = header_records(ctx, hash, count);
+    if records.is_empty() {
+        return not_found();
+    }
+    let headers: Vec<Header> = records.iter().filter_map(decode_header).collect();
+    if headers.is_empty() {
+        return not_found();
+    }
+    match format {
+        "json" => {
+            let values = records
+                .iter()
+                .zip(headers.iter())
+                .map(|(record, header)| header_json(record, header))
+                .collect::<Vec<_>>();
+            json_response(Ok(Value::from(values)))
+        }
+        "hex" => {
+            let body = headers
+                .iter()
+                .map(|header| serialize(header).to_lower_hex_string())
+                .collect::<String>();
+            text_response("text/plain", body.into_bytes())
+        }
+        "bin" => binary_response(
+            "application/octet-stream",
+            &headers.iter().fold(Vec::new(), |mut body, header| {
+                body.extend(serialize(header));
+                body
+            }),
+        ),
+        _ => not_found(),
+    }
+}
+
+fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<BlockRecord> {
+    let Some(start) = ctx.block_by_hash(hash) else {
+        return Vec::new();
+    };
+    let mut records = Vec::with_capacity(usize::try_from(count).unwrap_or(usize::MAX));
+    let active_hash = ctx.block_by_height(start.height).map(|record| record.hash);
+    if active_hash != Some(hash) {
+        records.push(start);
+        return records;
+    }
+    for height in start.height..=start.height.saturating_add(count.saturating_sub(1)) {
+        let Some(record) = ctx.block_by_height(height) else {
+            break;
+        };
+        records.push(record);
+    }
+    records
+}
+
+fn parse_count(query: &str) -> Result<u32, Response> {
+    if query.is_empty() {
+        return Ok(DEFAULT_HEADER_COUNT);
+    }
+    let Some(value) = query.strip_prefix("count=") else {
+        return Err(bad_request("invalid count"));
+    };
+    let Ok(value) = value.parse::<u32>() else {
+        return Err(bad_request("invalid count"));
+    };
+    if value == 0 {
+        return Err(bad_request("count must be positive"));
+    }
+    Ok(value.min(MAX_HEADER_COUNT))
+}
+
+fn decode_header(record: &BlockRecord) -> Option<Header> {
+    let bytes = Vec::<u8>::from_hex(&record.header_hex).ok()?;
+    bitcoin::consensus::encode::deserialize(&bytes).ok()
+}
+
+fn header_json(record: &BlockRecord, header: &Header) -> Value {
+    json!({
+        "hash": record.hash.to_string_be(),
+        "height": record.height,
+        "version": header.version.to_consensus(),
+        "previousblockhash": if record.height == 0 { None::<String> } else { Some(header.prev_blockhash.to_string()) },
+        "merkleroot": header.merkle_root.to_string(),
+        "time": header.time,
+        "bits": format!("{:08x}", header.bits.to_consensus()),
+        "nonce": header.nonce,
+    })
+}
+
+fn json_response(result: Result<Value, RpcError>) -> Response {
+    match result {
+        Ok(value) => {
+            let body = sonic_rs::to_string(&value).unwrap_or_else(|_| "null".to_owned());
+            text_response("application/json", body.into_bytes())
+        }
+        Err(error) => match error {
+            RpcError::InvalidParams(message) => bad_request(message),
+            RpcError::NotFound(message) => not_found_with(message),
+            _ => Response {
+                status: 500,
+                reason: "Internal Server Error",
+                content_type: "text/plain",
+                body: error.to_string().into_bytes(),
+            },
+        },
+    }
+}
+
+fn text_response(content_type: &'static str, body: Vec<u8>) -> Response {
+    Response {
+        status: 200,
+        reason: "OK",
+        content_type,
+        body,
+    }
+}
+
+fn binary_response(content_type: &'static str, body: &[u8]) -> Response {
+    text_response(content_type, body.to_vec())
+}
+
+fn bad_request(message: &'static str) -> Response {
+    Response {
+        status: 400,
+        reason: "Bad Request",
+        content_type: "text/plain",
+        body: message.as_bytes().to_vec(),
+    }
+}
+
+fn not_found() -> Response {
+    not_found_with("not found")
+}
+
+/// Constructs the Core-style response for an unsupported HTTP path.
+#[must_use]
+pub(crate) fn not_found_response() -> Response {
+    not_found()
+}
+
+fn not_found_with(message: &'static str) -> Response {
+    Response {
+        status: 404,
+        reason: "Not Found",
+        content_type: "text/plain",
+        body: message.as_bytes().to_vec(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use bitcoin::hashes::Hash as _;
+    use bitcoin::{BlockHash, CompactTarget, TxMerkleNode, block::Version};
+    use sonic_rs::JsonValueTrait;
+
+    #[test]
+    fn disabled_rest_is_not_found() {
+        let ctx = Arc::new(Context::new());
+        let response = route(&ctx, "/rest/chaininfo.json", "", false);
+        assert_eq!(response.status, 404);
+    }
+
+    #[test]
+    fn chaininfo_json_uses_enforcer_field_names() {
+        let ctx = Arc::new(Context::new());
+        let response = route(&ctx, "/rest/chaininfo.json", "", true);
+        assert_eq!(response.status, 200);
+        let value: Value = sonic_rs::from_slice(&response.body).expect("chaininfo JSON");
+        for field in ["chain", "blocks", "headers", "bestblockhash"] {
+            assert!(value.get(field).is_some(), "missing {field}");
+        }
+    }
+
+    #[test]
+    fn route_rejects_unknown_formats_and_bad_hashes() {
+        let ctx = Arc::new(Context::new());
+        assert_eq!(
+            route(
+                &ctx,
+                "/rest/headers/0000000000000000000000000000000000000000000000000000000000000000.txt",
+                "",
+                true
+            )
+            .status,
+            404
+        );
+        assert_eq!(
+            route(&ctx, "/rest/headers/not-a-hash.json", "", true).status,
+            400
+        );
+    }
+
+    #[test]
+    fn count_defaults_and_clamps() {
+        assert_eq!(parse_count("").expect("default"), 5);
+        assert_eq!(parse_count("count=999999").expect("clamped"), 2_000);
+        assert_eq!(parse_count("count=0").expect_err("zero count").status, 400);
+        assert_eq!(parse_count("count=bad").expect_err("bad count").status, 400);
+        assert_eq!(parse_count("limit=5").expect_err("bad query").status, 400);
+    }
+
+    #[test]
+    fn headers_json_returns_ordered_active_chain_headers() {
+        use bitcoin::hashes::Hash as _;
+        use bitcoin::{Block, BlockHash, CompactTarget, TxMerkleNode, block::Version};
+
+        let ctx = Arc::new(Context::new());
+        let bits = CompactTarget::from_consensus(0x1d00_ffff);
+        let genesis_header = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1,
+            bits,
+            nonce: 1,
+        };
+        let genesis = Block {
+            header: genesis_header,
+            txdata: Vec::new(),
+        };
+        let child_header = Header {
+            version: Version::ONE,
+            prev_blockhash: genesis.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 2,
+            bits,
+            nonce: 2,
+        };
+        let child = Block {
+            header: child_header,
+            txdata: Vec::new(),
+        };
+        let tip_header = Header {
+            version: Version::ONE,
+            prev_blockhash: child.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 3,
+            bits,
+            nonce: 3,
+        };
+        let tip = Block {
+            header: tip_header,
+            txdata: Vec::new(),
+        };
+        ctx.add_block(BlockRecord::from_block(0, &genesis));
+        ctx.add_block(BlockRecord::from_block(1, &child));
+        ctx.add_block(BlockRecord::from_block(2, &tip));
+
+        let path = format!("/rest/headers/{}.json", child.block_hash());
+        let response = route(&ctx, &path, "count=2", true);
+        assert_eq!(response.status, 200);
+        let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].get("height").and_then(Value::as_u64), Some(1));
+        assert_eq!(values[1].get("height").and_then(Value::as_u64), Some(2));
+        let child_hash = child.block_hash().to_string();
+        assert_eq!(
+            values[0].get("hash").and_then(Value::as_str),
+            Some(child_hash.as_str())
+        );
+        let bits_text = values[0].get("bits").and_then(Value::as_str).expect("bits");
+        assert_eq!(
+            CompactTarget::from_unprefixed_hex(bits_text).expect("bits round-trip"),
+            bits
+        );
+    }
+
+    #[test]
+    fn header_json_uses_enforcer_field_names() {
+        let record = BlockRecord {
+            hash: Hash256::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            )
+            .expect("hash"),
+            height: 1,
+            block_hex: String::new(),
+            body_size: 0,
+            header_hex: String::new(),
+            tx_count: 0,
+            time: 123,
+        };
+        let header = Header {
+            version: Version::from_consensus(1),
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 123,
+            bits: CompactTarget::from_consensus(0x1d00_ffff),
+            nonce: 7,
+        };
+        let value = header_json(&record, &header);
+        for field in [
+            "hash",
+            "height",
+            "version",
+            "previousblockhash",
+            "merkleroot",
+            "time",
+            "bits",
+            "nonce",
+        ] {
+            assert!(value.get(field).is_some(), "missing {field}");
+        }
+        assert_eq!(value.get("bits").and_then(Value::as_str), Some("1d00ffff"));
+    }
+}

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -108,16 +108,16 @@ fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<HeaderRecord>
             header: start_node.header,
         };
         let Some(tip) = applied_tip else {
-            return vec![start];
+            return Vec::new();
         };
         let Ok(tip_node) = tree.node(tip.tip_id) else {
-            return vec![start];
+            return Vec::new();
         };
         if tip_node.hash != tip.hash || tip_node.height != tip.height {
-            return vec![start];
+            return Vec::new();
         }
         let Some(active_start) = tree.node_at_height_from(tip.tip_id, start.height) else {
-            return vec![start];
+            return Vec::new();
         };
         if active_start != start_id {
             return Vec::new();
@@ -127,7 +127,7 @@ fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<HeaderRecord>
             .saturating_add(count.saturating_sub(1))
             .min(tip_node.height);
         let Some(last_id) = tree.node_at_height_from(tip.tip_id, last_height) else {
-            return vec![start];
+            return Vec::new();
         };
         let mut records = Vec::with_capacity(usize::try_from(count).unwrap_or(usize::MAX));
         let mut cursor = last_id;
@@ -532,7 +532,7 @@ mod tests {
             bits,
             nonce: 3,
         };
-        let (applied_tip, applied_hash) = {
+        let applied_tip = {
             let mut tree = ctx.block_tree.write();
             let genesis_id = tree
                 .insert_node(None, genesis, NodeStatus::Active)
@@ -543,25 +543,19 @@ mod tests {
             let applied_tip = tree.tip().expect("applied tip").as_ref().clone();
             tree.insert_node(Some(applied_id), header_tip, NodeStatus::Active)
                 .expect("header tip");
-            (applied_tip, applied_id)
+            applied_tip
         };
         ctx.set_applied_tip(applied_tip);
-        let applied_hash = ctx
-            .block_tree
-            .read()
-            .node(applied_hash)
-            .expect("applied node")
-            .hash;
+        let header_tip_hash = Hash256::from_le_bytes(header_tip.block_hash().as_byte_array());
 
         let response = route(
             &ctx,
-            &format!("/rest/headers/{applied_hash}.json"),
+            &format!("/rest/headers/{header_tip_hash}.json"),
             "count=2000",
             true,
         );
         let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
-        assert_eq!(values.len(), 1);
-        assert_eq!(values[0].get("height").and_then(Value::as_u64), Some(1));
+        assert!(values.is_empty());
     }
 
     #[test]
@@ -727,6 +721,7 @@ mod tests {
             hash: broken_node.hash,
         };
         drop(tree);
+        ctx.set_applied_tip(tip.clone());
         ctx.set_chain_tip(tip);
 
         let path = format!("/rest/headers/{}.json", genesis.block_hash());

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -65,29 +65,24 @@ fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
         Err(response) => return response,
     };
     let records = header_records(ctx, hash, count);
-    let headers: Vec<Header> = records.iter().filter_map(decode_header).collect();
-    if !records.is_empty() && headers.is_empty() {
-        return not_found();
-    }
     match format {
         "json" => {
             let values = records
                 .iter()
-                .zip(headers.iter())
                 .map(|(record, header)| header_json(record, header))
                 .collect::<Vec<_>>();
             json_response(Ok(Value::from(values)))
         }
         "hex" => {
-            let body = headers
+            let body = records
                 .iter()
-                .map(|header| serialize(header).to_lower_hex_string())
+                .map(|(_, header)| serialize(header).to_lower_hex_string())
                 .collect::<String>();
             text_response("text/plain", body.into_bytes())
         }
         "bin" => binary_response(
             "application/octet-stream",
-            &headers.iter().fold(Vec::new(), |mut body, header| {
+            &records.iter().fold(Vec::new(), |mut body, (_, header)| {
                 body.extend(serialize(header));
                 body
             }),
@@ -96,21 +91,36 @@ fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
     }
 }
 
-fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<BlockRecord> {
+fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<(BlockRecord, Header)> {
     let Some(start) = ctx.block_by_hash(hash) else {
         return Vec::new();
     };
     let mut records = Vec::with_capacity(usize::try_from(count).unwrap_or(usize::MAX));
+    let Some(start_header) = decode_header(&start) else {
+        return records;
+    };
     let active_hash = ctx.block_by_height(start.height).map(|record| record.hash);
     if active_hash != Some(hash) {
-        records.push(start);
+        records.push((start, start_header));
         return records;
     }
-    for height in start.height..=start.height.saturating_add(count.saturating_sub(1)) {
+    let start_height = start.height;
+    let mut previous_hash = start.hash;
+    records.push((start, start_header));
+    for height in
+        start_height.saturating_add(1)..=start_height.saturating_add(count.saturating_sub(1))
+    {
         let Some(record) = ctx.block_by_height(height) else {
             break;
         };
-        records.push(record);
+        let Some(header) = decode_header(&record) else {
+            break;
+        };
+        if header.prev_blockhash.to_string() != previous_hash.to_string_be() {
+            break;
+        }
+        previous_hash = record.hash;
+        records.push((record, header));
     }
     records
 }
@@ -398,6 +408,45 @@ mod tests {
             CompactTarget::from_unprefixed_hex(bits_text).expect("bits round-trip"),
             bits
         );
+    }
+
+    #[test]
+    fn headers_truncate_when_linkage_breaks() {
+        use bitcoin::{Block, BlockHash, CompactTarget, TxMerkleNode, block::Version};
+
+        let ctx = Arc::new(Context::new());
+        let bits = CompactTarget::from_consensus(0x1d00_ffff);
+        let genesis = Block {
+            header: Header {
+                version: Version::ONE,
+                prev_blockhash: BlockHash::all_zeros(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 1,
+                bits,
+                nonce: 1,
+            },
+            txdata: Vec::new(),
+        };
+        let broken_child = Block {
+            header: Header {
+                version: Version::ONE,
+                prev_blockhash: BlockHash::all_zeros(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 2,
+                bits,
+                nonce: 2,
+            },
+            txdata: Vec::new(),
+        };
+        ctx.add_block(BlockRecord::from_block(0, &genesis));
+        ctx.add_block(BlockRecord::from_block(1, &broken_child));
+
+        let path = format!("/rest/headers/{}.json", genesis.block_hash());
+        let response = route(&ctx, &path, "count=2", true);
+        assert_eq!(response.status, 200);
+        let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].get("height").and_then(Value::as_u64), Some(0));
     }
 
     #[test]

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -97,6 +97,7 @@ fn route_headers(ctx: &Arc<Context>, suffix: &str, query: &str) -> Response {
 }
 
 fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<HeaderRecord> {
+    let applied_tip = ctx.applied_tip.load_full();
     let tree = ctx.block_tree.read();
     if let Some(start_id) = tree.lookup(hash)
         && let Ok(start_node) = tree.node(start_id)
@@ -106,12 +107,15 @@ fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<HeaderRecord>
             height: start_node.height,
             header: start_node.header,
         };
-        let Some(tip) = tree.tip() else {
+        let Some(tip) = applied_tip else {
             return vec![start];
         };
         let Ok(tip_node) = tree.node(tip.tip_id) else {
             return vec![start];
         };
+        if tip_node.hash != tip.hash || tip_node.height != tip.height {
+            return vec![start];
+        }
         let Some(active_start) = tree.node_at_height_from(tip.tip_id, start.height) else {
             return vec![start];
         };
@@ -159,16 +163,12 @@ fn header_records(ctx: &Context, hash: Hash256, count: u32) -> Vec<HeaderRecord>
 }
 
 fn truncate_at_linkage_break(mut records: Vec<HeaderRecord>) -> Vec<HeaderRecord> {
-    let mut previous_hash = None;
-    records.retain(|record| {
-        let linked = previous_hash.is_none_or(|hash| {
-            Hash256::from_le_bytes(record.header.prev_blockhash.as_byte_array()) == hash
-        });
-        if linked {
-            previous_hash = Some(record.hash);
-        }
-        linked
-    });
+    let Some(break_index) = records.windows(2).position(|pair| {
+        Hash256::from_le_bytes(pair[1].header.prev_blockhash.as_byte_array()) != pair[0].hash
+    }) else {
+        return records;
+    };
+    records.truncate(break_index + 1);
     records
 }
 
@@ -327,6 +327,7 @@ mod tests {
             hash: tip_node.hash,
         };
         drop(tree);
+        ctx.set_applied_tip(tip.clone());
         ctx.set_chain_tip(tip);
         hashes
     }
@@ -492,6 +493,66 @@ mod tests {
             CompactTarget::from_unprefixed_hex(bits_text).expect("bits round-trip"),
             bits
         );
+    }
+
+    #[test]
+    fn headers_do_not_walk_past_applied_tip() {
+        let ctx = Arc::new(Context::new());
+        let bits = CompactTarget::from_consensus(0x1d00_ffff);
+        let genesis = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1,
+            bits,
+            nonce: 1,
+        };
+        let applied = Header {
+            version: Version::ONE,
+            prev_blockhash: genesis.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 2,
+            bits,
+            nonce: 2,
+        };
+        let header_tip = Header {
+            version: Version::ONE,
+            prev_blockhash: applied.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 3,
+            bits,
+            nonce: 3,
+        };
+        let (applied_tip, applied_hash) = {
+            let mut tree = ctx.block_tree.write();
+            let genesis_id = tree
+                .insert_node(None, genesis, NodeStatus::Active)
+                .expect("genesis header");
+            let applied_id = tree
+                .insert_node(Some(genesis_id), applied, NodeStatus::Active)
+                .expect("applied header");
+            let applied_tip = tree.tip().expect("applied tip").as_ref().clone();
+            tree.insert_node(Some(applied_id), header_tip, NodeStatus::Active)
+                .expect("header tip");
+            (applied_tip, applied_id)
+        };
+        ctx.set_applied_tip(applied_tip);
+        let applied_hash = ctx
+            .block_tree
+            .read()
+            .node(applied_hash)
+            .expect("applied node")
+            .hash;
+
+        let response = route(
+            &ctx,
+            &format!("/rest/headers/{applied_hash}.json"),
+            "count=2000",
+            true,
+        );
+        let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].get("height").and_then(Value::as_u64), Some(1));
     }
 
     #[test]
@@ -666,6 +727,67 @@ mod tests {
         let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].get("height").and_then(Value::as_u64), Some(0));
+    }
+
+    #[test]
+    fn headers_truncate_the_tail_after_a_middle_linkage_break() {
+        let ctx = Arc::new(Context::new());
+        let bits = CompactTarget::from_consensus(0x1d00_ffff);
+        let genesis = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1,
+            bits,
+            nonce: 1,
+        };
+        let first = Header {
+            version: Version::ONE,
+            prev_blockhash: genesis.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 2,
+            bits,
+            nonce: 2,
+        };
+        let middle = Header {
+            version: Version::ONE,
+            prev_blockhash: first.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 3,
+            bits,
+            nonce: 3,
+        };
+        let tail = Header {
+            version: Version::ONE,
+            prev_blockhash: middle.block_hash(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 4,
+            bits,
+            nonce: 4,
+        };
+        let hashes = publish_active_chain(&ctx, &[genesis, first, middle, tail]);
+        let middle_id = ctx
+            .block_tree
+            .read()
+            .lookup(hashes[2])
+            .expect("middle node");
+        ctx.block_tree
+            .write()
+            .node_mut(middle_id)
+            .expect("middle node")
+            .header
+            .prev_blockhash = BlockHash::all_zeros();
+
+        let response = route(
+            &ctx,
+            &format!("/rest/headers/{}.json", hashes[0]),
+            "count=2000",
+            true,
+        );
+        let values: Vec<Value> = sonic_rs::from_slice(&response.body).expect("headers JSON");
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].get("height").and_then(Value::as_u64), Some(0));
+        assert_eq!(values[1].get("height").and_then(Value::as_u64), Some(1));
     }
 
     #[test]

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -28,6 +28,8 @@ pub struct RpcServer {
     pub max_connections: usize,
     /// Idle read timeout for each connection.
     pub idle_timeout: Duration,
+    /// Whether Bitcoin Core-compatible REST routes are enabled.
+    pub rest_enabled: bool,
 }
 
 impl RpcServer {
@@ -38,6 +40,7 @@ impl RpcServer {
         handler: Arc<Handler>,
         max_connections: usize,
         idle_timeout: Duration,
+        rest_enabled: bool,
     ) -> io::Result<Self> {
         Ok(Self {
             listener: TcpListener::bind(address)?,
@@ -45,6 +48,7 @@ impl RpcServer {
             handler,
             max_connections,
             idle_timeout,
+            rest_enabled,
         })
     }
 
@@ -109,10 +113,13 @@ impl RpcServer {
 
         let auth = Arc::clone(&self.auth);
         let handler = Arc::clone(&self.handler);
+        let rest_enabled = self.rest_enabled;
         let active = Arc::clone(active);
         let idle_timeout = self.idle_timeout;
         thread::spawn(move || {
-            if let Err(error) = serve_connection(stream, &auth, &handler, idle_timeout) {
+            if let Err(error) =
+                serve_connection(stream, &auth, &handler, rest_enabled, idle_timeout)
+            {
                 debug!(%error, "rpc connection closed with error");
             }
             let mut count = active.lock();
@@ -126,6 +133,7 @@ fn serve_connection(
     stream: TcpStream,
     auth: &Auth,
     handler: &Handler,
+    rest_enabled: bool,
     idle_timeout: Duration,
 ) -> io::Result<()> {
     stream.set_read_timeout(Some(idle_timeout))?;
@@ -142,6 +150,21 @@ fn serve_connection(
                 return Err(error);
             }
         };
+        let keep_alive = request.keep_alive;
+
+        if request.method == "GET" {
+            let response = if request.path.starts_with("/rest/") {
+                let (path, query) = split_path_query(&request.path);
+                crate::rest::route(handler.context(), path, query, rest_enabled)
+            } else {
+                crate::rest::not_found_response()
+            };
+            write_response(reader.get_mut(), &response, keep_alive)?;
+            if !keep_alive {
+                return Ok(());
+            }
+            continue;
+        }
 
         if !auth.validate_header(request.authorization.as_deref()) {
             write_status(
@@ -154,7 +177,6 @@ fn serve_connection(
             return Ok(());
         }
 
-        let keep_alive = request.keep_alive;
         let response = handle_json(handler, &request.body);
         write_json(reader.get_mut(), 200, "OK", &response, keep_alive)?;
         if !keep_alive {
@@ -164,6 +186,8 @@ fn serve_connection(
 }
 
 struct HttpRequest {
+    method: String,
+    path: String,
     authorization: Option<String>,
     keep_alive: bool,
     body: Vec<u8>,
@@ -175,13 +199,33 @@ fn read_request(reader: &mut BufReader<TcpStream>) -> io::Result<Option<HttpRequ
     if bytes == 0 {
         return Ok(None);
     }
-    if !request_line.ends_with("\r\n") || !request_line.starts_with("POST ") {
+    if !request_line.ends_with("\r\n") {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "invalid request line",
         ));
     }
 
+    let request_target = request_line.trim_end_matches(['\r', '\n']);
+    let mut request_parts = request_target.split_whitespace();
+    let Some(method) = request_parts.next() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid request line",
+        ));
+    };
+    let Some(path) = request_parts.next() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid request line",
+        ));
+    };
+    if !matches!(method, "POST" | "GET") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid request method",
+        ));
+    }
     let mut header_bytes = request_line.len();
     let mut content_length = None;
     let mut authorization = None;
@@ -224,15 +268,21 @@ fn read_request(reader: &mut BufReader<TcpStream>) -> io::Result<Option<HttpRequ
         }
     }
 
-    let Some(content_length) = content_length else {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "missing content-length",
-        ));
+    let content_length = match (method, content_length) {
+        ("GET", length) => length.unwrap_or(0),
+        (_, Some(length)) => length,
+        (_, None) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "missing content-length",
+            ));
+        }
     };
     let mut body = vec![0_u8; content_length];
     reader.read_exact(&mut body)?;
     Ok(Some(HttpRequest {
+        method: method.to_owned(),
+        path: path.to_owned(),
         authorization,
         keep_alive,
         body,
@@ -291,6 +341,29 @@ fn write_status(
     stream.flush()
 }
 
+fn split_path_query(path: &str) -> (&str, &str) {
+    path.split_once('?')
+        .map_or((path, ""), |(path, query)| (path, query))
+}
+
+fn write_response(
+    stream: &mut TcpStream,
+    response: &crate::rest::Response,
+    keep_alive: bool,
+) -> io::Result<()> {
+    let connection = if keep_alive { "keep-alive" } else { "close" };
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: {connection}\r\n\r\n",
+        response.status,
+        response.reason,
+        response.content_type,
+        response.body.len()
+    )?;
+    stream.write_all(&response.body)?;
+    stream.flush()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -309,6 +382,7 @@ mod tests {
             handler,
             4,
             core::time::Duration::from_millis(500),
+            false,
         )?;
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = Arc::clone(&shutdown);
@@ -316,5 +390,17 @@ mod tests {
         std::thread::sleep(core::time::Duration::from_millis(150));
         shutdown.store(true, Ordering::Release);
         handle.join().expect("join serve thread")
+    }
+
+    #[test]
+    fn split_path_query_preserves_path_and_query() {
+        assert_eq!(
+            split_path_query("/rest/headers/hash.json?count=10"),
+            ("/rest/headers/hash.json", "count=10")
+        );
+        assert_eq!(
+            split_path_query("/rest/chaininfo.json"),
+            ("/rest/chaininfo.json", "")
+        );
     }
 }

--- a/crates/rpc/tests/auth.rs
+++ b/crates/rpc/tests/auth.rs
@@ -2,13 +2,14 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::time::Duration;
 
 use bitcoin_rs_rpc::auth::constant_time_eq;
 use bitcoin_rs_rpc::{Auth, Context, Handler, RpcServer};
+use sonic_rs::JsonValueTrait;
 use sonic_rs::json;
 
 #[test]
@@ -22,6 +23,66 @@ fn basic_auth_accepts_and_rejects_requests() -> Result<(), Box<dyn std::error::E
 
     let rejected = request(address, "YWxpY2U6YmFk", body)?;
     assert!(rejected.starts_with("HTTP/1.1 401 Unauthorized"));
+    Ok(())
+}
+
+#[test]
+fn rest_enabled_does_not_require_authentication() -> Result<(), Box<dyn std::error::Error>> {
+    let address = spawn_with_rest(Auth::basic("alice", "secret"), true)?;
+    let response = request_get(address, "/rest/chaininfo.json", "close")?;
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    assert!(response.contains("Content-Type: application/json"));
+    let body = response.split_once("\r\n\r\n").ok_or("missing body")?.1;
+    let value: sonic_rs::Value = sonic_rs::from_str(body)?;
+    assert!(value.get("chain").is_some());
+    Ok(())
+}
+
+#[test]
+fn rest_disabled_returns_not_found_without_authentication() -> Result<(), Box<dyn std::error::Error>>
+{
+    let address = spawn_with_rest(Auth::basic("alice", "secret"), false)?;
+    let response = request_get(address, "/rest/chaininfo.json", "close")?;
+    assert!(response.starts_with("HTTP/1.1 404 Not Found"));
+    Ok(())
+}
+
+#[test]
+fn post_json_rpc_still_requires_and_accepts_authentication()
+-> Result<(), Box<dyn std::error::Error>> {
+    let address = spawn_with_rest(Auth::basic("alice", "secret"), true)?;
+    let body = r#"{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}"#;
+    let rejected = request_post(address, body, None, "close")?;
+    assert!(rejected.starts_with("HTTP/1.1 401 Unauthorized"));
+    let accepted = request_post(address, body, Some("YWxpY2U6c2VjcmV0"), "close")?;
+    assert!(accepted.starts_with("HTTP/1.1 200 OK"));
+    assert!(accepted.contains("\"result\":0"));
+    Ok(())
+}
+
+#[test]
+fn non_rest_get_returns_not_found_without_authentication() -> Result<(), Box<dyn std::error::Error>>
+{
+    let address = spawn_with_rest(Auth::basic("alice", "secret"), true)?;
+    let response = request_get(address, "/", "close")?;
+    assert!(response.starts_with("HTTP/1.1 404 Not Found"));
+    Ok(())
+}
+
+#[test]
+fn rest_keep_alive_serves_two_requests() -> Result<(), Box<dyn std::error::Error>> {
+    let address = spawn_with_rest(Auth::basic("alice", "secret"), true)?;
+    let mut stream = TcpStream::connect(address)?;
+    write!(
+        stream,
+        "GET /rest/chaininfo.json HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n\
+         GET /rest/chaininfo.json?ignored=1 HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+    )?;
+    let mut reader = BufReader::new(stream);
+    let first = read_response(&mut reader)?;
+    let second = read_response(&mut reader)?;
+    assert!(first.starts_with("HTTP/1.1 200 OK"));
+    assert!(second.starts_with("HTTP/1.1 200 OK"));
     Ok(())
 }
 
@@ -50,6 +111,13 @@ fn constant_time_compare_checks_length_and_content() {
 }
 
 fn spawn(auth: Auth) -> Result<std::net::SocketAddr, Box<dyn std::error::Error>> {
+    spawn_with_rest(auth, false)
+}
+
+fn spawn_with_rest(
+    auth: Auth,
+    rest_enabled: bool,
+) -> Result<std::net::SocketAddr, Box<dyn std::error::Error>> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let address = listener.local_addr()?;
     let ctx = Arc::new(Context::new());
@@ -60,11 +128,71 @@ fn spawn(auth: Auth) -> Result<std::net::SocketAddr, Box<dyn std::error::Error>>
         handler,
         max_connections: 8,
         idle_timeout: Duration::from_secs(2),
+        rest_enabled,
     };
     thread::spawn(move || {
         let _ignored = server.serve();
     });
     Ok(address)
+}
+
+fn request_get(
+    address: std::net::SocketAddr,
+    path: &str,
+    connection: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut stream = TcpStream::connect(address)?;
+    write!(
+        stream,
+        "GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: {connection}\r\n\r\n"
+    )?;
+    stream.shutdown(std::net::Shutdown::Write)?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    Ok(response)
+}
+
+fn request_post(
+    address: std::net::SocketAddr,
+    body: &str,
+    authorization: Option<&str>,
+    connection: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut stream = TcpStream::connect(address)?;
+    let authorization = authorization.map_or(String::new(), |value| {
+        format!("Authorization: Basic {value}\r\n")
+    });
+    write!(
+        stream,
+        "POST / HTTP/1.1\r\nHost: localhost\r\n{authorization}Content-Length: {}\r\nConnection: {connection}\r\n\r\n{body}",
+        body.len()
+    )?;
+    stream.shutdown(std::net::Shutdown::Write)?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    Ok(response)
+}
+
+fn read_response(reader: &mut BufReader<TcpStream>) -> Result<String, Box<dyn std::error::Error>> {
+    let mut headers = Vec::new();
+    reader.read_until(b'\n', &mut headers)?;
+    loop {
+        let mut line = Vec::new();
+        reader.read_until(b'\n', &mut line)?;
+        headers.extend_from_slice(&line);
+        if line == b"\r\n" {
+            break;
+        }
+    }
+    let header_text = String::from_utf8(headers)?;
+    let content_length = header_text
+        .lines()
+        .find_map(|line| line.strip_prefix("Content-Length: "))
+        .ok_or("missing content length")?
+        .parse::<usize>()?;
+    let mut body = vec![0_u8; content_length];
+    reader.read_exact(&mut body)?;
+    Ok(format!("{header_text}{}", String::from_utf8(body)?))
 }
 
 fn request(

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ This page maps it to what you might want.
 
 - [getting-started.md](getting-started.md) walks from a clone to a syncing
   node.
+- [rest-interface.md](rest-interface.md) documents the optional Core-compatible
+  REST gateway and enforcer integration.
 - [../CONCEPTS.md](../CONCEPTS.md) is the project glossary. Read a term here
   before assuming it means what it means elsewhere in Bitcoin.
 - [../README.md](../README.md) covers the defaults and the measured benchmark.

--- a/docs/rest-interface.md
+++ b/docs/rest-interface.md
@@ -1,0 +1,36 @@
+# REST interface
+
+bitcoin-rs can expose the small Bitcoin Core-compatible REST surface needed by
+remote chain validators. REST uses the existing JSON-RPC listener and port; it
+does not create a second listener. Enable it with Core-style configuration:
+
+```ini
+rest=1
+```
+
+The REST requests are unauthenticated, as in Bitcoin Core. JSON-RPC requests on
+the same listener continue to require their configured authentication. Select
+the listener with the existing `--rpc-bind` option (or its layered config
+equivalent).
+
+Currently implemented endpoints are:
+
+* `GET /rest/chaininfo.json`
+* `GET /rest/headers/{hash}.json?count=N`
+* `GET /rest/headers/{hash}.hex`
+* `GET /rest/headers/{hash}.bin`
+
+Header `count` defaults to 5 and is capped at 2000. Active-chain requests walk
+forward by height. A side-branch hash returns only its own header because the
+available block-tree accessors do not provide child traversal.
+
+The REST gateway does not change the reported `getnetworkinfo` version. When
+using the unmodified `bip300301_enforcer`, pass
+`--bitcoin-core-skip-version-check`.
+
+bitcoin-rs also does not currently publish Bitcoin Core's `pubsequence` ZMQ
+topic. Normal enforcer mempool synchronization therefore requires an explicit
+`--node-zmq-addr-sequence` pointing at a compatible external publisher, or a
+no-mempool/bounded enforcer mode.
+
+REST is off by default. With REST disabled, `/rest/*` returns HTTP 404.

--- a/docs/rest-interface.md
+++ b/docs/rest-interface.md
@@ -25,12 +25,14 @@ Out-of-range, negative, non-numeric, and overflowing values return HTTP 400
 with Core's invalid-count message. Unknown query parameters are ignored, so
 cache-buster parameters do not affect the response.
 
-Active-chain requests walk forward by height. A side-branch or orphaned hash
-returns HTTP 200 with an empty JSON array (or an empty hex/binary body), just
-like an unknown well-formed hash, because Core only walks hashes contained in
-its active chain. Cache-only records that are not yet represented in the tree
-use the existing singleton fallback because their active-chain membership
-cannot be established from the tree.
+Active-chain requests walk forward by height from the applied tip. A
+side-branch, orphaned, or header-only hash above the applied tip returns HTTP
+200 with an empty JSON array (or an empty hex/binary body), just like an
+unknown well-formed hash, because Core only walks hashes contained in its
+active chain. If no applied tip is published, tree-known hashes likewise
+return an empty response. Cache-only records that are not yet represented in
+the tree use the existing singleton fallback because their active-chain
+membership cannot be established from the tree.
 
 The REST gateway does not change the reported `getnetworkinfo` version. When
 using the unmodified `bip300301_enforcer`, pass

--- a/docs/rest-interface.md
+++ b/docs/rest-interface.md
@@ -20,9 +20,15 @@ Currently implemented endpoints are:
 * `GET /rest/headers/{hash}.hex`
 * `GET /rest/headers/{hash}.bin`
 
-Header `count` defaults to 5 and is capped at 2000. Active-chain requests walk
-forward by height. A side-branch hash returns only its own header because the
-available block-tree accessors do not provide child traversal.
+Header `count` defaults to 5 and must be in the inclusive range 1–2000.
+Out-of-range, negative, non-numeric, and overflowing values return HTTP 400
+with Core's invalid-count message. Unknown query parameters are ignored, so
+cache-buster parameters do not affect the response.
+
+Active-chain requests walk forward by height. A side-branch hash returns only
+its own header because the available block-tree accessors do not provide child
+traversal. A well-formed but unknown block hash returns HTTP 200 with an empty
+JSON array (or an empty hex/binary body), matching Core.
 
 The REST gateway does not change the reported `getnetworkinfo` version. When
 using the unmodified `bip300301_enforcer`, pass
@@ -34,3 +40,7 @@ topic. Normal enforcer mempool synchronization therefore requires an explicit
 no-mempool/bounded enforcer mode.
 
 REST is off by default. With REST disabled, `/rest/*` returns HTTP 404.
+Unknown REST routes also return 404; malformed header inputs and unsupported
+header extensions return 400. This distinction is load-bearing for the
+enforcer: it treats a 404 on `/rest/*` as evidence that REST is not enabled,
+so an unknown block hash must not produce a misleading 404.

--- a/docs/rest-interface.md
+++ b/docs/rest-interface.md
@@ -25,10 +25,12 @@ Out-of-range, negative, non-numeric, and overflowing values return HTTP 400
 with Core's invalid-count message. Unknown query parameters are ignored, so
 cache-buster parameters do not affect the response.
 
-Active-chain requests walk forward by height. A side-branch hash returns only
-its own header because the available block-tree accessors do not provide child
-traversal. A well-formed but unknown block hash returns HTTP 200 with an empty
-JSON array (or an empty hex/binary body), matching Core.
+Active-chain requests walk forward by height. A side-branch or orphaned hash
+returns HTTP 200 with an empty JSON array (or an empty hex/binary body), just
+like an unknown well-formed hash, because Core only walks hashes contained in
+its active chain. Cache-only records that are not yet represented in the tree
+use the existing singleton fallback because their active-chain membership
+cannot be established from the tree.
 
 The REST gateway does not change the reported `getnetworkinfo` version. When
 using the unmodified `bip300301_enforcer`, pass
@@ -41,6 +43,9 @@ no-mempool/bounded enforcer mode.
 
 REST is off by default. With REST disabled, `/rest/*` returns HTTP 404.
 Unknown REST routes also return 404; malformed header inputs and unsupported
-header extensions return 400. This distinction is load-bearing for the
-enforcer: it treats a 404 on `/rest/*` as evidence that REST is not enabled,
-so an unknown block hash must not produce a misleading 404.
+header extensions return 400. A missing header extension returns HTTP 404 with
+`output format not found`, while an unsupported extension such as `.txt`
+returns HTTP 400 with `Invalid hash: <hash>`. This distinction is load-bearing
+for the enforcer: it treats a 404 on `/rest/*` as evidence that REST is not
+enabled, so an unknown or non-active block hash must not produce a misleading
+404.


### PR DESCRIPTION
## Summary

Adds the minimal Bitcoin Core-compatible REST surface an unmodified [`bip300301_enforcer`](https://github.com/LayerTwo-Labs/bip300301_enforcer) consumes, so it can be pointed at bitcoin-rs instead of bitcoind. No BIP300/301 consensus logic is ported.

The enforcer's REST client dictates the shape: it builds its base URL as `http://{--node-rpc-addr}` (`app/main.rs`), sends no `Authorization` header, and only calls `GET /rest/chaininfo.json` and `GET /rest/headers/{hash}.json?count=N` (`lib/validator/main_rest_client.rs`); it reads **any** 404 on `/rest/*` as "REST not enabled". So REST is served on the *existing* JSON-RPC listener/port, unauthenticated, off by default behind Core's `rest=1` — not a second listener — and 404 is reserved for exactly the cases that detection is meant to catch (gateway disabled, unknown route, missing output format).

Endpoints: `chaininfo.json` (reuses `getblockchaininfo`), `headers/{hash}.{json,hex,bin}`. Status semantics follow Core: `count` defaults to 5 and must be in `1..=2000` (out of range → 400, no silent clamping), unknown query parameters and valueless keys are ignored, a well-formed hash that is not on the active chain → `200` with an empty body, a bad hash or unsupported extension → `400 Invalid hash: <hash>` (hash only, no extension), a missing extension → `404 output format not found`. Header JSON fields match the enforcer's deserializer, including `bits` as unprefixed hex so `CompactTarget::from_unprefixed_hex` round-trips. `/rest/block/*`, `/rest/tx/*`, `/rest/mempool/*`, `/rest/blockhashbyheight/*` are deliberately not implemented — the enforcer gets raw blocks via `getblock` verbosity 0 over JSON-RPC.

Server change is confined to `serve_connection`, which previously hard-rejected any non-`POST` request line:

```
request = read_request(..)                  // now parses method + path; GET may omit Content-Length,
if request.method == "GET" {                // POST still errors without it (unchanged)
    response = if path.starts_with("/rest/") { rest::route(ctx, path, query, rest_enabled) }
               else { 404 }                 // never falls through into the auth/JSON-RPC path
    write_response(..); continue            // keep-alive preserved, no auth check
}
if !auth.validate_header(..) { 401 }        // POST path byte-identical to before
```

Header traversal mirrors Core's `rest_headers`, whose loop condition is `ActiveChain().Contains(pindex)`: the requested hash must be *positively* on the applied chain, otherwise the result is the empty `200`. That covers side branches, orphans, and headers already known to the tree but not yet applied — during header-first sync a header above the applied tip yields `[]`, and a walk that reaches the applied tip stops there rather than continuing up the header chain. One `block_tree` read snapshot per request serves the whole walk via parent pointers (resolve the hash once, resolve the terminal height once, walk ancestors, reverse), so a large `count` no longer costs a full `Context::blocks` scan per header — `count=2000` on a 6100-block chain went from seconds to ~5 ms — and the walk cannot splice records from two branches mid-reorg. The linkage check is kept as a defense against an internally inconsistent tree and truncates the tail at the first broken link.

Two known gaps for enforcer operators, documented in `docs/rest-interface.md` rather than papered over: `getnetworkinfo` reports version `10000` (major 1) which the enforcer's version gate rejects, so it must run with `--bitcoin-core-skip-version-check`; and bitcoin-rs publishes no ZMQ `pubsequence` topic, so the enforcer's mempool sync needs an explicit `--node-zmq-addr-sequence` or a no-mempool/bounded mode. `pubsequence` can follow separately.

Coverage: unit tests for routing/count boundaries/error precedence (`count` is validated before the hash, as Core does)/active-chain rules/JSON field shapes, socket-level tests in `crates/rpc/tests/auth.rs` (REST 200 without credentials, 404 when disabled, POST JSON-RPC still 401/200 with and without auth, non-`/rest/` GET → 404, keep-alive serving two REST requests on one connection), plus two rounds of runtime verification against a live regtest node peered to Bitcoin Core 27.0 (see PR comments) which is what surfaced the `BITCOIN_RS_REST=1` env-parsing crash, the header-cache scan cost, the applied-vs-header tip boundary, and the Core status/message divergences fixed here.


Link to Devin session: https://app.devin.ai/sessions/2cf54a23e1494fd080fa7541dadf06ff
Requested by: @metaphorics