### PR TITLE
node: publish Core's `sequence` ZMQ topic for block connects and disconnects

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -137,9 +137,21 @@ keeps its ownership for retry.
 
 Still open around it: returning a disconnected block's transactions through one
 production admission pipeline shared by Electrum, P2P relay, and reorg handling;
-publishing a disconnect notification; and backfilling the filter index after a
-gap. Raw mempool insertion is not reconsideration because it cannot reconstruct
-fee, policy, conflict, and ancestry metadata.
+and backfilling the filter index after a gap. The `pubsequence` stream publishes
+block connect/disconnect notifications, but intentionally does not publish
+mempool `A`/`R` events: the current mempool counter and mutation reasons cannot
+yet guarantee the enforcer's required contiguous transaction event sequence.
+Raw mempool insertion is not reconsideration because it cannot reconstruct fee,
+policy, conflict, and ancestry metadata.
+
+### Sequence stream
+
+The Core-compatible `pubsequence` ZMQ stream is a unified block-event stream.
+Each event carries the block hash, one label (`C` for connect or `D` for
+disconnect), and a topic-local little-endian `u32` sequence counter. Reorg
+disconnects are emitted tip-first before connects on the replacement branch.
+This implementation deliberately omits mempool `A`/`R` events until the
+mempool has per-transaction sequence assignment and explicit removal reasons.
 
 ### Dispatch-bound parallelism
 

--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ header tip against the applied tip each tick and switches branches when the
 applied chain is outweighed.
 
 It is still not the node to depend on. A disconnected block's transactions do
-not return to the mempool, no disconnect notification is published, and the
-filter index is not backfilled across a gap. `docs/README.md` lists the rest.
+not return to the mempool, and the filter index is not backfilled across a gap.
+The ZMQ `pubsequence` stream now publishes block connect/disconnect events, but
+does not emit mempool `A`/`R` events. `docs/README.md` lists the rest.
 
 ## Documentation
 

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -1206,6 +1206,14 @@ pub(crate) fn disconnect_block_admitted(
         .applied_tip
         .store(Some(Arc::new(parent_tip.clone())));
 
+    if handles.zmq_publisher.wants_notifications() {
+        handles
+            .zmq_publisher
+            .publish_sequence(crate::zmq_publisher::SequenceEvent::Disconnected(
+                block_hash,
+            ));
+    }
+
     // The rollback finished in memory, so the marker moves to `RolledBack`.
     // It stays set: a checkpoint has not captured this yet.
     handles
@@ -1218,14 +1226,6 @@ pub(crate) fn disconnect_block_admitted(
                 source: Box::new(ApplyError::UndoPersistence(error)),
             })
         })?;
-
-    if handles.zmq_publisher.wants_notifications() {
-        handles
-            .zmq_publisher
-            .publish_sequence(crate::zmq_publisher::SequenceEvent::Disconnected(
-                block_hash,
-            ));
-    }
 
     // The marker deliberately stays set here.
     //
@@ -6594,6 +6594,114 @@ mod consensus_rule_tests {
         ) -> Result<Option<DisconnectMarker>, bitcoin_rs_storage::StorageError> {
             Ok(None)
         }
+    }
+
+    #[derive(Debug, Default)]
+    struct CompleteRejectingUndoStore {
+        inner: InMemoryUndoStore,
+    }
+
+    impl UndoStore for CompleteRejectingUndoStore {
+        fn persist_undo(
+            &self,
+            height: u32,
+            hash: Hash256,
+            record: &[u8],
+        ) -> Result<(), bitcoin_rs_storage::StorageError> {
+            self.inner.persist_undo(height, hash, record)
+        }
+
+        fn load_undo(
+            &self,
+            height: u32,
+            hash: Hash256,
+        ) -> Result<Option<Vec<u8>>, bitcoin_rs_storage::StorageError> {
+            self.inner.load_undo(height, hash)
+        }
+
+        fn arm_disconnect(
+            &self,
+            height: u32,
+            hash: Hash256,
+        ) -> Result<(), bitcoin_rs_storage::StorageError> {
+            self.inner.arm_disconnect(height, hash)
+        }
+
+        fn cancel_disconnect(&self) -> Result<(), bitcoin_rs_storage::StorageError> {
+            self.inner.cancel_disconnect()
+        }
+
+        fn complete_disconnect(
+            &self,
+            _height: u32,
+            _hash: Hash256,
+        ) -> Result<(), bitcoin_rs_storage::StorageError> {
+            Err(bitcoin_rs_storage::StorageError::Backend(
+                "injected marker completion failure".to_owned(),
+            ))
+        }
+
+        fn disarm_disconnect(&self) -> Result<(), bitcoin_rs_storage::StorageError> {
+            self.inner.disarm_disconnect()
+        }
+
+        fn load_disconnect_marker(
+            &self,
+        ) -> Result<Option<DisconnectMarker>, bitcoin_rs_storage::StorageError> {
+            self.inner.load_disconnect_marker()
+        }
+    }
+
+    #[test]
+    fn disconnect_sequence_event_publishes_before_marker_completion_failure()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let genesis = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest);
+        let mut handles =
+            apply_handles_without_tx_index(Network::Regtest, Arc::new(UtxoSet::new()));
+        handles.undo_store = Arc::new(CompleteRejectingUndoStore::default());
+        let genesis_tip = applied_header_tip(
+            &handles,
+            Hash256::from_le_bytes(genesis.block_hash().as_byte_array()),
+            &genesis,
+            0,
+        )?;
+        handles.applied_tip.store(Some(Arc::new(genesis_tip)));
+
+        let block = mined_block_with_prev_hash_and_transactions(
+            genesis.block_hash(),
+            vec![coinbase_transaction(6)],
+        )?;
+        apply_block(&handles, &block)?;
+
+        let publisher = Arc::new(RecordingSequencePublisher::default());
+        let publisher_handle: Arc<dyn crate::ZmqPublisher> = publisher.clone();
+        handles = handles.with_zmq_publisher(publisher_handle);
+        publisher.events.lock().clear();
+        *publisher.next_sequence.lock() = 0;
+
+        let outcome = disconnect_block(&handles, &block);
+        assert!(
+            matches!(outcome, Err(crate::DisconnectError::MarkerStuck { .. })),
+            "marker completion failure must report MarkerStuck, got {outcome:?}"
+        );
+        assert_eq!(
+            publisher.events.lock().as_slice(),
+            &[(
+                Hash256::from_le_bytes(block.block_hash().as_byte_array()),
+                b'D',
+                0
+            )]
+        );
+        assert_eq!(
+            handles
+                .applied_tip
+                .load_full()
+                .as_deref()
+                .map(|tip| tip.height),
+            Some(0),
+            "the applied tip must already be rolled back on MarkerStuck"
+        );
+        Ok(())
     }
 
     /// The ordering contract: undo is written before the UTXO commit and before

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -2325,9 +2325,6 @@ fn apply_block_admitted(
         // Best-effort ZMQ event emission. Failures must not propagate per the
         // ZmqPublisher contract; the trait's methods return `()`.
         handles.zmq_publisher.publish_hashblock(tip.hash);
-        handles
-            .zmq_publisher
-            .publish_sequence(crate::zmq_publisher::SequenceEvent::Connected(tip.hash));
         if wants_rawblock {
             handles.zmq_publisher.publish_rawblock(&block_bytes);
         }
@@ -2343,6 +2340,11 @@ fn apply_block_admitted(
         }
     }
     handles.applied_tip.store(Some(Arc::new(tip.clone())));
+    if handles.zmq_publisher.wants_notifications() {
+        handles
+            .zmq_publisher
+            .publish_sequence(crate::zmq_publisher::SequenceEvent::Connected(tip.hash));
+    }
     if let Some(sampler) = &handles.g2_muhash_sampler
         && sampler.wants_height(height)
     {
@@ -8810,6 +8812,61 @@ mod consensus_rule_tests {
                 ),
             ]
         );
+        Ok(())
+    }
+
+    #[derive(Debug)]
+    struct AppliedTipVisiblePublisher {
+        applied_tip: Arc<ArcSwapOption<TipSnapshot>>,
+        expected: Hash256,
+        seen: Mutex<Vec<Hash256>>,
+    }
+
+    impl crate::ZmqPublisher for AppliedTipVisiblePublisher {
+        fn publish_hashblock(&self, _hash: Hash256) {}
+
+        fn publish_hashtx(&self, _txid: bitcoin::Txid) {}
+
+        fn publish_rawblock(&self, _bytes: &[u8]) {}
+
+        fn publish_rawtx(&self, _bytes: &[u8]) {}
+
+        fn publish_sequence(&self, event: crate::SequenceEvent) {
+            if let crate::SequenceEvent::Connected(hash) = event {
+                assert_eq!(
+                    self.applied_tip.load_full().as_deref().map(|tip| tip.hash),
+                    Some(self.expected),
+                    "applied tip must be visible before publishing C"
+                );
+                self.seen.lock().push(hash);
+            }
+        }
+    }
+
+    #[test]
+    fn connected_sequence_event_observes_the_published_applied_tip()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let handles = apply_handles_without_tx_index(Network::Regtest, Arc::new(UtxoSet::new()));
+        let genesis = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest);
+        let genesis_hash = Hash256::from_le_bytes(genesis.block_hash().as_byte_array());
+        let genesis_tip = applied_header_tip(&handles, genesis_hash, &genesis, 0)?;
+        handles.applied_tip.store(Some(Arc::new(genesis_tip)));
+        let block = mined_block_with_prev_hash_and_transactions(
+            genesis.block_hash(),
+            vec![coinbase_transaction(5)],
+        )?;
+        let expected = Hash256::from_le_bytes(block.block_hash().as_byte_array());
+        let publisher = Arc::new(AppliedTipVisiblePublisher {
+            applied_tip: Arc::clone(&handles.applied_tip),
+            expected,
+            seen: Mutex::new(Vec::new()),
+        });
+        let publisher_handle: Arc<dyn crate::ZmqPublisher> = publisher.clone();
+        let handles = handles.with_zmq_publisher(publisher_handle);
+
+        apply_block(&handles, &block)?;
+
+        assert_eq!(*publisher.seen.lock(), vec![expected]);
         Ok(())
     }
 

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -1044,10 +1044,21 @@ pub fn disconnect_block(
     handles: &ApplyHandles,
     block: &bitcoin::Block,
 ) -> core::result::Result<TipSnapshot, crate::DisconnectError> {
+    use bitcoin::hashes::Hash as _;
+
     let transition = handles
         .begin_chain_transition()
         .map_err(|error| crate::DisconnectError::Refused(Box::new(error)))?;
-    disconnect_block_admitted(handles, block, &transition)
+    let result = disconnect_block_admitted(handles, block, &transition);
+    drop(transition);
+    if result.is_ok() && handles.zmq_publisher.wants_notifications() {
+        handles
+            .zmq_publisher
+            .publish_sequence(crate::zmq_publisher::SequenceEvent::Disconnected(
+                Hash256::from_le_bytes(&block.block_hash().to_byte_array()),
+            ));
+    }
+    result
 }
 
 /// Disconnects one block while the caller holds admission and `chain_transition`.
@@ -2315,6 +2326,9 @@ fn apply_block_admitted(
         // Best-effort ZMQ event emission. Failures must not propagate per the
         // ZmqPublisher contract; the trait's methods return `()`.
         handles.zmq_publisher.publish_hashblock(tip.hash);
+        handles
+            .zmq_publisher
+            .publish_sequence(crate::zmq_publisher::SequenceEvent::Connected(tip.hash));
         if wants_rawblock {
             handles.zmq_publisher.publish_rawblock(&block_bytes);
         }

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -1044,20 +1044,11 @@ pub fn disconnect_block(
     handles: &ApplyHandles,
     block: &bitcoin::Block,
 ) -> core::result::Result<TipSnapshot, crate::DisconnectError> {
-    use bitcoin::hashes::Hash as _;
-
     let transition = handles
         .begin_chain_transition()
         .map_err(|error| crate::DisconnectError::Refused(Box::new(error)))?;
     let result = disconnect_block_admitted(handles, block, &transition);
     drop(transition);
-    if result.is_ok() && handles.zmq_publisher.wants_notifications() {
-        handles
-            .zmq_publisher
-            .publish_sequence(crate::zmq_publisher::SequenceEvent::Disconnected(
-                Hash256::from_le_bytes(&block.block_hash().to_byte_array()),
-            ));
-    }
     result
 }
 
@@ -1227,6 +1218,14 @@ pub(crate) fn disconnect_block_admitted(
                 source: Box::new(ApplyError::UndoPersistence(error)),
             })
         })?;
+
+    if handles.zmq_publisher.wants_notifications() {
+        handles
+            .zmq_publisher
+            .publish_sequence(crate::zmq_publisher::SequenceEvent::Disconnected(
+                block_hash,
+            ));
+    }
 
     // The marker deliberately stays set here.
     //
@@ -8688,6 +8687,128 @@ mod consensus_rule_tests {
                 applied_block.txdata[0].compute_txid().as_byte_array()
             )),
             "the applied branch's coins must survive an aborted switch"
+        );
+        Ok(())
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingSequencePublisher {
+        events: Mutex<Vec<(Hash256, u8, u32)>>,
+        next_sequence: Mutex<u32>,
+    }
+
+    impl crate::ZmqPublisher for RecordingSequencePublisher {
+        fn publish_hashblock(&self, _hash: Hash256) {}
+
+        fn publish_hashtx(&self, _txid: bitcoin::Txid) {}
+
+        fn publish_rawblock(&self, _bytes: &[u8]) {}
+
+        fn publish_rawtx(&self, _bytes: &[u8]) {}
+
+        fn publish_sequence(&self, event: crate::SequenceEvent) {
+            let (hash, label) = match event {
+                crate::SequenceEvent::Connected(hash) => (hash, b'C'),
+                crate::SequenceEvent::Disconnected(hash) => (hash, b'D'),
+            };
+            let mut next_sequence = self.next_sequence.lock();
+            self.events.lock().push((hash, label, *next_sequence));
+            *next_sequence += 1;
+        }
+    }
+
+    #[test]
+    fn reorg_sequence_events_disconnect_old_tip_before_connecting_new_branch()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let utxo = Arc::new(UtxoSet::new());
+        let publisher = Arc::new(RecordingSequencePublisher::default());
+        let publisher_handle: Arc<dyn crate::ZmqPublisher> = publisher.clone();
+        let mut handles = apply_handles_without_tx_index(Network::Regtest, Arc::clone(&utxo))
+            .with_zmq_publisher(publisher_handle);
+        let bodies = Arc::new(MapBodyStore::default());
+        let body_handle: Arc<dyn crate::apply::PruneBodyStore> = bodies.clone();
+        handles.block_body_store = Some(body_handle);
+
+        let genesis = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest);
+        let genesis_hash = Hash256::from_le_bytes(genesis.block_hash().as_byte_array());
+        let genesis_tip = applied_header_tip(&handles, genesis_hash, &genesis, 0)?;
+        handles.applied_tip.store(Some(Arc::new(genesis_tip)));
+
+        let old_one = mined_block_with_prev_hash_and_transactions(
+            genesis.block_hash(),
+            vec![coinbase_transaction(1)],
+        )?;
+        let old_one_raw = bytes::Bytes::from(bitcoin::consensus::encode::serialize(&old_one));
+        let old_one_tip = apply_block_with_serialized(&handles, &old_one, old_one_raw.clone())?;
+        bodies
+            .bodies
+            .write()
+            .insert((old_one_tip.height, old_one_tip.hash), old_one_raw.to_vec());
+
+        let old_two = mined_block_with_prev_hash_and_transactions(
+            old_one.block_hash(),
+            vec![coinbase_transaction(2)],
+        )?;
+        let old_two_raw = bytes::Bytes::from(bitcoin::consensus::encode::serialize(&old_two));
+        let old_two_tip = apply_block_with_serialized(&handles, &old_two, old_two_raw.clone())?;
+        bodies
+            .bodies
+            .write()
+            .insert((old_two_tip.height, old_two_tip.hash), old_two_raw.to_vec());
+        publisher.events.lock().clear();
+        *publisher.next_sequence.lock() = 0;
+
+        let new_one = mined_block_with_prev_hash_and_transactions(
+            genesis.block_hash(),
+            vec![coinbase_transaction(3)],
+        )?;
+        let new_two = mined_block_with_prev_hash_and_transactions(
+            new_one.block_hash(),
+            vec![coinbase_transaction(4)],
+        )?;
+        let target = {
+            let mut tree = handles.block_tree.write();
+            let mut target = None;
+            for (height, block) in [(1_u32, &new_one), (2_u32, &new_two)] {
+                target = Some(tree.insert_header(block.header, NodeStatus::HeaderValid)?);
+                bodies.bodies.write().insert(
+                    (
+                        height,
+                        Hash256::from_le_bytes(block.block_hash().as_byte_array()),
+                    ),
+                    bitcoin::consensus::encode::serialize(block),
+                );
+            }
+            target.ok_or_else(|| anyhow::anyhow!("new branch has no target"))?
+        };
+
+        crate::reorg::switch_to_branch(&handles, target, |_| None, |_| {})?;
+
+        let events = publisher.events.lock().clone();
+        assert_eq!(
+            events,
+            vec![
+                (
+                    Hash256::from_le_bytes(old_two.block_hash().as_byte_array()),
+                    b'D',
+                    0
+                ),
+                (
+                    Hash256::from_le_bytes(old_one.block_hash().as_byte_array()),
+                    b'D',
+                    1
+                ),
+                (
+                    Hash256::from_le_bytes(new_one.block_hash().as_byte_array()),
+                    b'C',
+                    2
+                ),
+                (
+                    Hash256::from_le_bytes(new_two.block_hash().as_byte_array()),
+                    b'C',
+                    3
+                ),
+            ]
         );
         Ok(())
     }

--- a/crates/node/src/bitcoin_conf_compat.rs
+++ b/crates/node/src/bitcoin_conf_compat.rs
@@ -68,10 +68,12 @@ fn apply_key(layer: &mut ConfigLayer, key: &str, value: &str) {
         "zmqpubhashtx" => push_endpoint(&mut layer.zmqpubhashtx, value),
         "zmqpubrawblock" => push_endpoint(&mut layer.zmqpubrawblock, value),
         "zmqpubrawtx" => push_endpoint(&mut layer.zmqpubrawtx, value),
+        "zmqpubsequence" => push_endpoint(&mut layer.zmqpubsequence, value),
         "zmqpubhashblockhwm" => layer.zmqpubhashblockhwm = value.parse().ok(),
         "zmqpubhashtxhwm" => layer.zmqpubhashtxhwm = value.parse().ok(),
         "zmqpubrawblockhwm" => layer.zmqpubrawblockhwm = value.parse().ok(),
         "zmqpubrawtxhwm" => layer.zmqpubrawtxhwm = value.parse().ok(),
+        "zmqpubsequencehwm" => layer.zmqpubsequencehwm = value.parse().ok(),
         _ => {}
     }
     if layer.rpc_user.is_some() || layer.rpc_password.is_some() {
@@ -196,6 +198,9 @@ impl ConfigLayerMerge for ConfigLayer {
         if other.zmqpubrawtx.is_some() {
             self.zmqpubrawtx.clone_from(&other.zmqpubrawtx);
         }
+        if other.zmqpubsequence.is_some() {
+            self.zmqpubsequence.clone_from(&other.zmqpubsequence);
+        }
         if other.zmqpubhashblockhwm.is_some() {
             self.zmqpubhashblockhwm = other.zmqpubhashblockhwm;
         }
@@ -207,6 +212,9 @@ impl ConfigLayerMerge for ConfigLayer {
         }
         if other.zmqpubrawtxhwm.is_some() {
             self.zmqpubrawtxhwm = other.zmqpubrawtxhwm;
+        }
+        if other.zmqpubsequencehwm.is_some() {
+            self.zmqpubsequencehwm = other.zmqpubsequencehwm;
         }
     }
 }

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -151,6 +151,10 @@ pub struct Config {
     pub zmqpubrawblockhwm: Option<u32>,
     /// Optional `rawtx` PUB socket high-water mark.
     pub zmqpubrawtxhwm: Option<u32>,
+    /// ZMQ `sequence` PUB bind endpoints.
+    pub zmqpubsequence: Vec<String>,
+    /// Optional `sequence` PUB socket high-water mark.
+    pub zmqpubsequencehwm: Option<u32>,
     /// Block height at or below which script verification is skipped during block apply.
     ///
     /// On mainnet the default is the hash-pinned assume-valid anchor
@@ -211,6 +215,8 @@ impl fmt::Debug for Config {
             .field("zmqpubhashtxhwm", &self.zmqpubhashtxhwm)
             .field("zmqpubrawblockhwm", &self.zmqpubrawblockhwm)
             .field("zmqpubrawtxhwm", &self.zmqpubrawtxhwm)
+            .field("zmqpubsequence", &self.zmqpubsequence)
+            .field("zmqpubsequencehwm", &self.zmqpubsequencehwm)
             .field("assume_valid_height", &self.assume_valid_height)
             .finish_non_exhaustive()
     }
@@ -259,6 +265,8 @@ impl Config {
             zmqpubhashtxhwm: None,
             zmqpubrawblockhwm: None,
             zmqpubrawtxhwm: None,
+            zmqpubsequence: Vec::new(),
+            zmqpubsequencehwm: None,
             assume_valid_height: network
                 .assume_valid_anchor()
                 .map_or(0, |(height, _)| height),
@@ -357,6 +365,7 @@ impl Config {
             ("zmqpubhashtxhwm", self.zmqpubhashtxhwm),
             ("zmqpubrawblockhwm", self.zmqpubrawblockhwm),
             ("zmqpubrawtxhwm", self.zmqpubrawtxhwm),
+            ("zmqpubsequencehwm", self.zmqpubsequencehwm),
         ] {
             if hwm.is_some_and(|value| value > 2_147_483_647) {
                 bail!("{name} exceeds libzmq SNDHWM range");
@@ -393,6 +402,12 @@ impl Config {
             &self.zmqpubrawtx,
             self.zmqpubrawtxhwm,
         );
+        push_zmq_publications(
+            &mut publications,
+            crate::zmq_publisher::ZmqTopic::Sequence,
+            &self.zmqpubsequence,
+            self.zmqpubsequencehwm,
+        );
         publications
     }
 
@@ -427,6 +442,7 @@ impl Config {
         Ok(config)
     }
 
+    #[allow(clippy::too_many_lines)]
     fn apply_layer(&mut self, layer: &ConfigLayer) {
         if let Some(network) = layer.network {
             self.network = network;
@@ -513,6 +529,9 @@ impl Config {
         if let Some(endpoints) = &layer.zmqpubrawtx {
             self.zmqpubrawtx.clone_from(endpoints);
         }
+        if let Some(endpoints) = &layer.zmqpubsequence {
+            self.zmqpubsequence.clone_from(endpoints);
+        }
         if let Some(hwm) = layer.zmqpubhashblockhwm {
             self.zmqpubhashblockhwm = Some(hwm);
         }
@@ -524,6 +543,9 @@ impl Config {
         }
         if let Some(hwm) = layer.zmqpubrawtxhwm {
             self.zmqpubrawtxhwm = Some(hwm);
+        }
+        if let Some(hwm) = layer.zmqpubsequencehwm {
+            self.zmqpubsequencehwm = Some(hwm);
         }
         if let Some(height) = layer.assume_valid_height {
             self.assume_valid_height = height;
@@ -624,6 +646,8 @@ pub(crate) struct ConfigLayer {
     pub(crate) zmqpubrawblock: Option<Vec<String>>,
     #[arg(long = "zmqpubrawtx", value_delimiter = ',')]
     pub(crate) zmqpubrawtx: Option<Vec<String>>,
+    #[arg(long = "zmqpubsequence", value_delimiter = ',')]
+    pub(crate) zmqpubsequence: Option<Vec<String>>,
     #[arg(long = "zmqpubhashblockhwm")]
     pub(crate) zmqpubhashblockhwm: Option<u32>,
     #[arg(long = "zmqpubhashtxhwm")]
@@ -632,6 +656,8 @@ pub(crate) struct ConfigLayer {
     pub(crate) zmqpubrawblockhwm: Option<u32>,
     #[arg(long = "zmqpubrawtxhwm")]
     pub(crate) zmqpubrawtxhwm: Option<u32>,
+    #[arg(long = "zmqpubsequencehwm")]
+    pub(crate) zmqpubsequencehwm: Option<u32>,
     #[arg(long = "assume-valid-height")]
     pub(crate) assume_valid_height: Option<u32>,
 }
@@ -708,6 +734,9 @@ impl ConfigLayer {
                 "BITCOIN_RS_ZMQPUBRAWTX" => {
                     layer.zmqpubrawtx = Some(parse_string_list(value));
                 }
+                "BITCOIN_RS_ZMQPUBSEQUENCE" => {
+                    layer.zmqpubsequence = Some(parse_string_list(value));
+                }
                 "BITCOIN_RS_ZMQPUBHASHBLOCKHWM" => {
                     layer.zmqpubhashblockhwm = Some(value.parse()?);
                 }
@@ -719,6 +748,9 @@ impl ConfigLayer {
                 }
                 "BITCOIN_RS_ZMQPUBRAWTXHWM" => {
                     layer.zmqpubrawtxhwm = Some(value.parse()?);
+                }
+                "BITCOIN_RS_ZMQPUBSEQUENCEHWM" => {
+                    layer.zmqpubsequencehwm = Some(value.parse()?);
                 }
                 "BITCOIN_RS_ASSUME_VALID_HEIGHT" => {
                     layer.assume_valid_height = Some(value.parse()?);

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -65,4 +65,6 @@ pub use run::run;
 pub use state::{ApplyError, DisconnectError};
 pub use sync::BlockSync;
 pub use utxo_view::UtxoSetView;
-pub use zmq_publisher::{NoOpZmqPublisher, SocketZmqPublisher, TracingZmqPublisher, ZmqPublisher};
+pub use zmq_publisher::{
+    NoOpZmqPublisher, SequenceEvent, SocketZmqPublisher, TracingZmqPublisher, ZmqPublisher,
+};

--- a/crates/node/src/reorg.rs
+++ b/crates/node/src/reorg.rs
@@ -197,10 +197,9 @@ where
             continue;
         }
 
-        let mut disconnected = Vec::with_capacity(disconnect.len());
         for body in &disconnect {
             match crate::apply::disconnect_block_admitted(handles, &body.block, &transition) {
-                Ok(_) => disconnected.push(body.hash),
+                Ok(_) => {}
                 Err(
                     error @ (DisconnectError::Fatal { .. } | DisconnectError::MarkerStuck { .. }),
                 ) => {
@@ -246,13 +245,6 @@ where
             }
         }
         drop(transition);
-        if handles.zmq_publisher.wants_notifications() {
-            for hash in disconnected {
-                handles
-                    .zmq_publisher
-                    .publish_sequence(crate::zmq_publisher::SequenceEvent::Disconnected(hash));
-            }
-        }
         for body in &connect[..connected] {
             connected_body(body.hash);
         }

--- a/crates/node/src/reorg.rs
+++ b/crates/node/src/reorg.rs
@@ -197,9 +197,10 @@ where
             continue;
         }
 
+        let mut disconnected = Vec::with_capacity(disconnect.len());
         for body in &disconnect {
             match crate::apply::disconnect_block_admitted(handles, &body.block, &transition) {
-                Ok(_) => {}
+                Ok(_) => disconnected.push(body.hash),
                 Err(
                     error @ (DisconnectError::Fatal { .. } | DisconnectError::MarkerStuck { .. }),
                 ) => {
@@ -245,6 +246,13 @@ where
             }
         }
         drop(transition);
+        if handles.zmq_publisher.wants_notifications() {
+            for hash in disconnected {
+                handles
+                    .zmq_publisher
+                    .publish_sequence(crate::zmq_publisher::SequenceEvent::Disconnected(hash));
+            }
+        }
         for body in &connect[..connected] {
             connected_body(body.hash);
         }

--- a/crates/node/src/zmq_publisher.rs
+++ b/crates/node/src/zmq_publisher.rs
@@ -383,16 +383,20 @@ impl ZmqPublisher for SocketZmqPublisher {
     }
 
     fn publish_sequence(&self, event: SequenceEvent) {
-        let mut body = [0_u8; 33];
-        body[..32].copy_from_slice(&hash_body_from_hash(event.hash()));
-        body[32] = event.label();
-        self.publish(ZmqTopic::Sequence, &body);
+        self.publish(ZmqTopic::Sequence, &sequence_payload(event));
     }
 }
 
 pub(crate) fn hash_body_from_hash(hash: Hash256) -> [u8; 32] {
     let mut body = hash.to_le_bytes();
     body.reverse();
+    body
+}
+
+pub(crate) fn sequence_payload(event: SequenceEvent) -> [u8; 33] {
+    let mut body = [0_u8; 33];
+    body[..32].copy_from_slice(&hash_body_from_hash(event.hash()));
+    body[32] = event.label();
     body
 }
 
@@ -466,20 +470,20 @@ mod tests {
     fn sequence_event_payload_uses_core_hash_orientation_and_label() {
         let le = core::array::from_fn(|index| u8::try_from(index).unwrap_or_default());
         let hash = Hash256::from_le_bytes(&le);
-        let mut expected = [0_u8; 33];
-        expected[..32].copy_from_slice(hash_body_from_hash(hash).as_slice());
-        expected[32] = b'C';
         assert_eq!(
-            expected,
+            sequence_payload(SequenceEvent::Connected(hash)),
             [
                 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11,
                 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, b'C'
             ]
         );
-        expected[32] = b'D';
-        assert_eq!(expected[32], b'D');
-        assert_eq!(sequence_body(0x0102_0304), [0x04, 0x03, 0x02, 0x01]);
-        assert_eq!(SequenceEvent::Disconnected(hash).label(), b'D');
+        assert_eq!(
+            sequence_payload(SequenceEvent::Disconnected(hash)),
+            [
+                31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11,
+                10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, b'D'
+            ]
+        );
     }
 
     #[test]

--- a/crates/node/src/zmq_publisher.rs
+++ b/crates/node/src/zmq_publisher.rs
@@ -27,6 +27,8 @@ pub enum ZmqTopic {
     RawBlock,
     /// Raw serialized transaction notification.
     RawTx,
+    /// Block sequence notification.
+    Sequence,
 }
 
 impl ZmqTopic {
@@ -38,6 +40,7 @@ impl ZmqTopic {
             Self::HashTx => "hashtx",
             Self::RawBlock => "rawblock",
             Self::RawTx => "rawtx",
+            Self::Sequence => "sequence",
         }
     }
 
@@ -49,6 +52,7 @@ impl ZmqTopic {
             Self::HashTx => "pubhashtx",
             Self::RawBlock => "pubrawblock",
             Self::RawTx => "pubrawtx",
+            Self::Sequence => "pubsequence",
         }
     }
 
@@ -58,6 +62,31 @@ impl ZmqTopic {
             Self::HashTx => 1,
             Self::RawBlock => 2,
             Self::RawTx => 3,
+            Self::Sequence => 4,
+        }
+    }
+}
+
+/// Event published on Core's unified `sequence` topic.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SequenceEvent {
+    /// A block was connected.
+    Connected(Hash256),
+    /// A block was disconnected.
+    Disconnected(Hash256),
+}
+
+impl SequenceEvent {
+    fn hash(self) -> Hash256 {
+        match self {
+            Self::Connected(hash) | Self::Disconnected(hash) => hash,
+        }
+    }
+
+    const fn label(self) -> u8 {
+        match self {
+            Self::Connected(_) => b'C',
+            Self::Disconnected(_) => b'D',
         }
     }
 }
@@ -104,6 +133,9 @@ pub trait ZmqPublisher: Send + Sync + core::fmt::Debug {
 
     /// Publish a `rawtx` notification with the serialized transaction bytes.
     fn publish_rawtx(&self, bytes: &[u8]);
+
+    /// Publish a block event on Core's unified `sequence` topic.
+    fn publish_sequence(&self, _event: SequenceEvent) {}
 }
 
 /// Default no-op implementation. All methods discard their input silently.
@@ -132,6 +164,8 @@ impl ZmqPublisher for NoOpZmqPublisher {
     fn publish_rawblock(&self, _bytes: &[u8]) {}
 
     fn publish_rawtx(&self, _bytes: &[u8]) {}
+
+    fn publish_sequence(&self, _event: SequenceEvent) {}
 }
 
 /// `ZmqPublisher` that emits each event via `tracing::info!`.
@@ -173,6 +207,15 @@ impl ZmqPublisher for TracingZmqPublisher {
             len = bytes.len(),
         );
     }
+
+    fn publish_sequence(&self, event: SequenceEvent) {
+        tracing::info!(
+            target: "bitcoin_rs_node::zmq",
+            topic = "sequence",
+            hash = %event.hash().to_string_be(),
+            label = event.label(),
+        );
+    }
 }
 
 struct EndpointSocket {
@@ -188,7 +231,8 @@ pub struct SocketZmqPublisher {
     hashtx_endpoints: Vec<usize>,
     rawblock_endpoints: Vec<usize>,
     rawtx_endpoints: Vec<usize>,
-    counters: [AtomicU32; 4],
+    sequence_endpoints: Vec<usize>,
+    counters: [AtomicU32; 5],
 }
 
 impl fmt::Debug for SocketZmqPublisher {
@@ -210,6 +254,7 @@ impl SocketZmqPublisher {
         let mut hashtx_endpoints = Vec::new();
         let mut rawblock_endpoints = Vec::new();
         let mut rawtx_endpoints = Vec::new();
+        let mut sequence_endpoints = Vec::new();
 
         for publication in publications {
             if let Some(existing_hwm) = endpoint_hwms.get(&publication.endpoint) {
@@ -258,6 +303,7 @@ impl SocketZmqPublisher {
                 ZmqTopic::HashTx => hashtx_endpoints.push(endpoint_index),
                 ZmqTopic::RawBlock => rawblock_endpoints.push(endpoint_index),
                 ZmqTopic::RawTx => rawtx_endpoints.push(endpoint_index),
+                ZmqTopic::Sequence => sequence_endpoints.push(endpoint_index),
             }
         }
 
@@ -268,6 +314,7 @@ impl SocketZmqPublisher {
             hashtx_endpoints,
             rawblock_endpoints,
             rawtx_endpoints,
+            sequence_endpoints,
             counters: core::array::from_fn(|_| AtomicU32::new(0)),
         })
     }
@@ -299,6 +346,7 @@ impl SocketZmqPublisher {
             ZmqTopic::HashTx => &self.hashtx_endpoints,
             ZmqTopic::RawBlock => &self.rawblock_endpoints,
             ZmqTopic::RawTx => &self.rawtx_endpoints,
+            ZmqTopic::Sequence => &self.sequence_endpoints,
         }
     }
 }
@@ -332,6 +380,13 @@ impl ZmqPublisher for SocketZmqPublisher {
 
     fn publish_rawtx(&self, bytes: &[u8]) {
         self.publish(ZmqTopic::RawTx, bytes);
+    }
+
+    fn publish_sequence(&self, event: SequenceEvent) {
+        let mut body = [0_u8; 33];
+        body[..32].copy_from_slice(&hash_body_from_hash(event.hash()));
+        body[32] = event.label();
+        self.publish(ZmqTopic::Sequence, &body);
     }
 }
 
@@ -377,6 +432,7 @@ mod tests {
         publisher.publish_hashtx(bitcoin::Txid::from_byte_array([0; 32]));
         publisher.publish_rawblock(&[]);
         publisher.publish_rawtx(&[]);
+        publisher.publish_sequence(SequenceEvent::Connected(Hash256::default()));
     }
 
     #[test]
@@ -389,6 +445,7 @@ mod tests {
         publisher.publish_hashtx(bitcoin::Txid::from_byte_array([0; 32]));
         publisher.publish_rawblock(&[1, 2, 3]);
         publisher.publish_rawtx(&[4, 5, 6]);
+        publisher.publish_sequence(SequenceEvent::Disconnected(Hash256::default()));
     }
 
     #[test]
@@ -403,6 +460,26 @@ mod tests {
 
         assert_eq!(hash_body_from_hash(hash), expected);
         assert_eq!(sequence_body(0x0102_0304), [0x04, 0x03, 0x02, 0x01]);
+    }
+
+    #[test]
+    fn sequence_event_payload_uses_core_hash_orientation_and_label() {
+        let le = core::array::from_fn(|index| u8::try_from(index).unwrap_or_default());
+        let hash = Hash256::from_le_bytes(&le);
+        let mut expected = [0_u8; 33];
+        expected[..32].copy_from_slice(hash_body_from_hash(hash).as_slice());
+        expected[32] = b'C';
+        assert_eq!(
+            expected,
+            [
+                31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11,
+                10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, b'C'
+            ]
+        );
+        expected[32] = b'D';
+        assert_eq!(expected[32], b'D');
+        assert_eq!(sequence_body(0x0102_0304), [0x04, 0x03, 0x02, 0x01]);
+        assert_eq!(SequenceEvent::Disconnected(hash).label(), b'D');
     }
 
     #[test]
@@ -501,5 +578,50 @@ mod tests {
         }
 
         anyhow::bail!("timed out waiting for ZMQ PUB/SUB notification")
+    }
+
+    #[test]
+    fn socket_publisher_delivers_shared_sequence_stream() -> anyhow::Result<()> {
+        let socket_dir = tempfile::tempdir()?;
+        let socket_path = socket_dir.path().join("sequence.sock");
+        let endpoint = format!("ipc://{}", socket_path.display());
+        let publisher = SocketZmqPublisher::bind(&[ZmqPublication {
+            topic: ZmqTopic::Sequence,
+            endpoint: endpoint.clone(),
+            hwm: 10,
+        }])?;
+        let context = zmq::Context::new();
+        let subscriber = context.socket(zmq::SUB)?;
+        subscriber.set_subscribe(b"sequence")?;
+        subscriber.connect(&endpoint)?;
+
+        let hash = Hash256::from_le_bytes(&[0x22_u8; 32]);
+        thread::sleep(Duration::from_millis(100));
+        publisher.publish_sequence(SequenceEvent::Connected(hash));
+        publisher.publish_sequence(SequenceEvent::Disconnected(hash));
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let mut received = Vec::new();
+        while Instant::now() < deadline && received.len() < 2 {
+            match subscriber.recv_multipart(zmq::DONTWAIT) {
+                Ok(frames) => received.push(frames),
+                Err(zmq::Error::EAGAIN) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(25));
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        assert_eq!(received.len(), 2);
+        let connected = &received[0];
+        let disconnected = &received[1];
+        assert_eq!(connected[0], b"sequence");
+        assert_eq!(connected[1].len(), 33);
+        assert_eq!(connected[1][..32], hash_body_from_hash(hash));
+        assert_eq!(connected[1][32], b'C');
+        assert_eq!(disconnected[1][..32], hash_body_from_hash(hash));
+        assert_eq!(disconnected[1][32], b'D');
+        let connected_sequence = u32::from_le_bytes(connected[2].as_slice().try_into()?);
+        let disconnected_sequence = u32::from_le_bytes(disconnected[2].as_slice().try_into()?);
+        assert_eq!(disconnected_sequence, connected_sequence + 1);
+        Ok(())
     }
 }

--- a/crates/node/tests/bitcoin_conf_compat.rs
+++ b/crates/node/tests/bitcoin_conf_compat.rs
@@ -71,6 +71,8 @@ fn bitcoin_conf_zmq_keys_map_into_config_in_order() -> Result<()> {
 [regtest]
 -zmqpubrawtx=tcp://127.0.0.1:28334
 -zmqpubrawtxhwm=6
+-zmqpubsequence=tcp://127.0.0.1:28335
+-zmqpubsequencehwm=7
 ",
     )?;
 
@@ -87,6 +89,11 @@ fn bitcoin_conf_zmq_keys_map_into_config_in_order() -> Result<()> {
     assert_eq!(config.zmqpubhashblockhwm, Some(5));
     assert_eq!(config.zmqpubrawtx, vec!["tcp://127.0.0.1:28334".to_owned()]);
     assert_eq!(config.zmqpubrawtxhwm, Some(6));
+    assert_eq!(
+        config.zmqpubsequence,
+        vec!["tcp://127.0.0.1:28335".to_owned()]
+    );
+    assert_eq!(config.zmqpubsequencehwm, Some(7));
     Ok(())
 }
 

--- a/crates/node/tests/config_layered.rs
+++ b/crates/node/tests/config_layered.rs
@@ -120,6 +120,8 @@ fn zmq_layers_parse_precedence_and_publication_order() -> Result<()> {
         r#"
 zmqpubhashblock = ["tcp://127.0.0.1:28332", "tcp://127.0.0.1:28333"]
 zmqpubhashblockhwm = 9
+zmqpubsequence = ["tcp://127.0.0.1:28338"]
+zmqpubsequencehwm = 13
 "#,
     )?;
     fs::write(
@@ -149,6 +151,10 @@ zmqpubhashblockhwm = 9
             "tcp://127.0.0.1:28337",
             "--zmqpubrawtxhwm",
             "12",
+            "--zmqpubsequence",
+            "tcp://127.0.0.1:28339",
+            "--zmqpubsequencehwm",
+            "14",
         ],
     )?;
 
@@ -166,7 +172,10 @@ zmqpubhashblockhwm = 9
         .map(|publication| publication.hwm)
         .collect();
 
-    assert_eq!(topics, ["hashblock", "hashblock", "hashtx", "rawtx"]);
+    assert_eq!(
+        topics,
+        ["hashblock", "hashblock", "hashtx", "rawtx", "sequence"]
+    );
     assert_eq!(
         endpoints,
         [
@@ -174,9 +183,10 @@ zmqpubhashblockhwm = 9
             "tcp://127.0.0.1:28333",
             "tcp://127.0.0.1:28336",
             "tcp://127.0.0.1:28337",
+            "tcp://127.0.0.1:28339",
         ]
     );
-    assert_eq!(hwms, [9, 9, 1_000, 12]);
+    assert_eq!(hwms, [9, 9, 1_000, 12, 14]);
     Ok(())
 }
 

--- a/crates/node/tests/rpc_wiring.rs
+++ b/crates/node/tests/rpc_wiring.rs
@@ -24,6 +24,8 @@ fn rpc_context_shares_arc_identity_with_node_state() -> Result<()> {
     config.txindex = true;
     config.zmqpubhashblock = vec!["inproc://rpc-wiring-zmq-pubhashblock".to_owned()];
     config.zmqpubhashblockhwm = Some(21);
+    config.zmqpubsequence = vec!["inproc://rpc-wiring-zmq-pubsequence".to_owned()];
+    config.zmqpubsequencehwm = Some(22);
     let state = NodeState::open(config)?;
 
     let chain_tip = state.chain_tip();
@@ -81,6 +83,11 @@ fn rpc_context_shares_arc_identity_with_node_state() -> Result<()> {
         "mempool must share identity"
     );
     assert!(
+        ctx.zmq_notifications()
+            .iter()
+            .any(|notification| notification.notification_type == "pubsequence")
+    );
+    assert!(
         Arc::ptr_eq(&ctx.blocks, &blocks),
         "blocks must share identity"
     );
@@ -129,9 +136,11 @@ fn rpc_context_shares_arc_identity_with_node_state() -> Result<()> {
         "banned must share identity"
     );
     let notifications = ctx.zmq_notifications();
-    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications.len(), 2);
     assert_eq!(notifications[0].notification_type.as_str(), "pubhashblock");
     assert_eq!(notifications[0].hwm, 21);
+    assert_eq!(notifications[1].notification_type.as_str(), "pubsequence");
+    assert_eq!(notifications[1].hwm, 22);
 
     Ok(())
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,9 @@ transition stops the process.
 
 Reorg handling still does not return disconnected transactions to the mempool.
 That requires one production admission pipeline shared by Electrum, P2P relay,
-and reorg handling. Production transaction relay is also incomplete.
+and reorg handling. Production transaction relay is also incomplete. The ZMQ
+`pubsequence` stream publishes block connect/disconnect events, but intentionally
+does not emit mempool `A`/`R` events until mempool event sequencing is redesigned.
 
 Also incomplete: metrics coverage and parts of the CLI and RPC surface.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,9 +5,10 @@ tell it worked before moving on.
 
 Before you start: this node reorganises off a losing branch, but several
 things around that still do not work. A disconnected block's transactions are
-dropped rather than returned to the mempool, no disconnect notification is
-published, and the filter index is not backfilled across a gap. Do not make it
-the node you depend on. See [README.md](README.md) for the rest of the gaps.
+dropped rather than returned to the mempool, and the filter index is not
+backfilled across a gap. ZMQ `pubsequence` publishes block connect/disconnect
+events but intentionally omits mempool `A`/`R` events. Do not make it the node
+you depend on. See [README.md](README.md) for the rest of the gaps.
 
 ## Prerequisites
 

--- a/docs/solutions/architecture-patterns/node-reorg-execution-design.md
+++ b/docs/solutions/architecture-patterns/node-reorg-execution-design.md
@@ -155,7 +155,7 @@ Open:
 | Piece | Notes |
 |---|---|
 | Mempool reconsideration | Block transactions need the same production admission pipeline as Electrum and future P2P relay. Direct insertion is invalid because it fabricates admission metadata |
-| Disconnect notification | ZMQ `pubsequence` publishes connects and disconnects; mempool `A`/`R` events remain intentionally absent until event sequencing and removal reasons are redesigned |
+| Mempool sequence events | Mempool `A`/`R` notifications remain intentionally absent until event sequencing and removal reasons are redesigned |
 | Filter-index backfill | a gap leaves the index unavailable from that point, by design; nothing repairs it |
 | Real crash replay | the node detects and refuses torn disconnect state, but cannot replay or repair it in place |
 | Un-ignore `g10_reorg_deep` | prove the full path against `bitcoind` regtest |

--- a/docs/solutions/architecture-patterns/node-reorg-execution-design.md
+++ b/docs/solutions/architecture-patterns/node-reorg-execution-design.md
@@ -53,8 +53,10 @@ Done:
 * A fatal disconnect closes apply admission and sets the process shutdown token.
   The durable marker prevents a restart on torn state.
 
-Still open: transaction reconsideration, disconnect notification, filter-index
-backfill, real crash replay, and the ignored live `g10_reorg_deep` gate.
+Still open: transaction reconsideration, filter-index backfill, real crash
+replay, and the ignored live `g10_reorg_deep` gate. ZMQ now publishes block
+disconnect notifications through `pubsequence`, but mempool `A`/`R` events remain
+intentionally open.
 Transaction reconsideration requires one production admission pipeline shared
 by Electrum, P2P relay, and reorg handling. Raw mempool insertion cannot supply
 the required fee, policy, conflict, and ancestry metadata.
@@ -153,7 +155,7 @@ Open:
 | Piece | Notes |
 |---|---|
 | Mempool reconsideration | Block transactions need the same production admission pipeline as Electrum and future P2P relay. Direct insertion is invalid because it fabricates admission metadata |
-| Disconnect notification | ZMQ publishes connects; disconnects are silent |
+| Disconnect notification | ZMQ `pubsequence` publishes connects and disconnects; mempool `A`/`R` events remain intentionally absent until event sequencing and removal reasons are redesigned |
 | Filter-index backfill | a gap leaves the index unavailable from that point, by design; nothing repairs it |
 | Real crash replay | the node detects and refuses torn disconnect state, but cannot replay or repair it in place |
 | Un-ignore `g10_reorg_deep` | prove the full path against `bitcoind` regtest |


### PR DESCRIPTION
## Summary

Adds Bitcoin Core's `sequence` ZMQ topic, carrying **block** events only (`C` on connect, `D` on disconnect). This is the last piece a remote [`bip300301_enforcer`](https://github.com/LayerTwo-Labs/bip300301_enforcer) needs to drive its validator off bitcoin-rs: it subscribes to exactly one topic (`sequence`, `lib/cli.rs`), and when `--node-zmq-addr-sequence` is omitted it *discovers* the endpoint by looking for `pubsequence` in `getzmqnotifications` and hard-errors if it is absent. Complements #49 (REST) — no BIP300/301 logic is ported, and none of Core's other notification surface is added.

Frame layout is the three-frame shape its parser requires (`cusf-enforcer-mempool/lib/zmq.rs`), and the topic gets its own counter, which is what makes the counter *unified across event kinds* — one stream, one monotonic `u32`:

```
frame 0: b"sequence"
frame 1: 32-byte block hash (Core wire orientation, same helper as `hashblock`) ++ b'C' | b'D'
frame 2: u32 LE counter, shared by C and D
```

The publisher API takes a `SequenceEvent` enum rather than a method per label, so adding the mempool variants later doesn't reshape `ZmqPublisher`. The four existing topics and their independent counters are untouched.

### Why `A`/`R` are deliberately absent

Core also multiplexes mempool add/remove onto this topic. Emitting them now would be *worse than silence*: the consumer treats a mempool-sequence gap as fatal, but never checks tx-sequence continuity if no tx events arrive — so C/D-only leaves the validator path fully working and degrades the enforcer's mempool mode to an empty mempool instead of a hard error. Our mempool cannot currently produce a gapless per-transaction sequence: `remove_entries` bumps once per *call* rather than per transaction, `prioritise` bumps with no membership change, `insert_entry` discards the IDs of the evictions it triggers, and reorg reconsideration is still unfinished (`docs/solutions/architecture-patterns/node-reorg-execution-design.md`), so no legitimate `A` can follow a `D` yet. That needs a per-transaction event-sequence and a removal-reason model in `crates/mempool` — a separate change, documented rather than faked.

### Emission points

Both labels are published where the chainstate mutation *lands*, which is what makes the stream safe to react to:

```
connect:    apply chainstate -> applied_tip.store(new) -> publish C
disconnect: roll back        -> (tip updated)          -> publish D
reorg:      D(old tip) -> D(old tip-1) -> ... -> C(fork+1) -> ... -> C(new tip)
            counter contiguous across the whole interleaved stream
```

Two ordering bugs are fixed by that placement, both of which a subscriber can actually observe:

- Emitting `C` before `applied_tip.store` let a subscriber act on a connect while RPC still reported the *parent* as the tip — and the enforcer's `C` handler calls straight back into the node.
- Collecting disconnect hashes and publishing them after the connect loop put the new branch's `C`s *before* the old branch's `D`s, so the enforcer would have called `connect_block` for a block whose parent was not its tip. Emitting at the success path of `disconnect_block_admitted` makes publication order equal occurrence order for every caller and removes the deferred list.

Both are pinned by tests: an executor-driven reorg asserts the exact `D…C…` sequence with a contiguous counter, and a publisher that reads `applied_tip` during emission asserts the announced block is already the visible tip.

Configured like the existing topics (`--zmqpubsequence`, `BITCOIN_RS_ZMQPUBSEQUENCE`, `zmqpubsequence` in `bitcoin.conf`, HWM sibling, layered config), and `getzmqnotifications` reports `pubsequence` so endpoint auto-discovery works.

Docs that claimed disconnects are silent (`README.md`, `docs/getting-started.md`, `docs/README.md`, the reorg-design table) are reconciled, and `CONCEPTS.md` gains the sequence-stream term.

Verified live against Bitcoin Core 27.0 on regtest — frames diffed against Core's own `sequence` stream over 200 blocks and a reorg ([evidence](https://github.com/gosuda/bitcoin-rs/pull/52#issuecomment-5254632611)).


Link to Devin session: https://app.devin.ai/sessions/2cf54a23e1494fd080fa7541dadf06ff
Requested by: @metaphorics