### PR TITLE
docs: the REST guide still tells operators pubsequence doesn't exist

### DIFF
--- a/docs/rest-interface.md
+++ b/docs/rest-interface.md
@@ -38,10 +38,13 @@ The REST gateway does not change the reported `getnetworkinfo` version. When
 using the unmodified `bip300301_enforcer`, pass
 `--bitcoin-core-skip-version-check`.
 
-bitcoin-rs also does not currently publish Bitcoin Core's `pubsequence` ZMQ
-topic. Normal enforcer mempool synchronization therefore requires an explicit
-`--node-zmq-addr-sequence` pointing at a compatible external publisher, or a
-no-mempool/bounded enforcer mode.
+bitcoin-rs publishes the Core-compatible `pubsequence` ZMQ topic with block
+connect (`C`) and disconnect (`D`) events. The configured endpoint is reported
+by `getzmqnotifications`, so the unmodified enforcer can discover it through
+its normal startup path rather than requiring an external publisher or an
+explicit `--node-zmq-addr-sequence`. Mempool `A`/`R` events remain intentionally
+absent until the mempool has per-transaction event sequencing and explicit
+removal reasons.
 
 REST is off by default. With REST disabled, `/rest/*` returns HTTP 404.
 Unknown REST routes also return 404; malformed header inputs and unsupported


### PR DESCRIPTION
## Summary

`docs/rest-interface.md` landed in #49 while `pubsequence` was still missing, so it tells operators to point the enforcer at an external ZMQ publisher via `--node-zmq-addr-sequence` or to run it in a no-mempool mode. #52 shipped the topic, which makes that instruction actively wrong — it sends someone setting up an enforcer down a workaround for a problem `main` no longer has, when auto-discovery through `getzmqnotifications` now works out of the box.

Rewritten to describe what we ship: block `C`/`D` on `pubsequence`, discoverable via `getzmqnotifications`, with mempool `A`/`R` still intentionally absent — same framing as `README.md`, `docs/getting-started.md` and the reorg-design note, so the docs stop disagreeing with each other. The `getnetworkinfo` version caveat directly above it is untouched, because that one is still true.

Docs only, no code change.


Link to Devin session: https://app.devin.ai/sessions/2cf54a23e1494fd080fa7541dadf06ff
Requested by: @metaphorics