### PR TITLE
fix(checksig-census): preserve over-capacity ECDSA evidence

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [features]
 default = ["kernel"]
 kernel = ["dep:bitcoinkernel"]
+checksig-census = ["kernel"]
 rocksdb = []
 fjall = []
 redb = []

--- a/crates/consensus/examples/kernel_verify_spike.rs
+++ b/crates/consensus/examples/kernel_verify_spike.rs
@@ -7,22 +7,33 @@
 //! the two backends cannot share a binary).
 //!
 //! Two idempotent phases:
-//! 1. **Extract** (skipped when the corpus file already exists): stream
-//!    mainnet blocks `0..=150_000` from a local `bitcoind -rest` endpoint,
-//!    maintain an in-memory outpoint -> prevout map, and keep the top N
-//!    (default 300) blocks by non-coinbase input count, together with every
-//!    spent prevout (script bytes + amount). Coinbase inputs have no prevout
-//!    and are excluded from sampling and measurement.
+//! 1. **Extract** (skipped when the corpus file already exists): replay
+//!    mainnet blocks `0..=--stop-height` from a local `bitcoind -rest`
+//!    endpoint to seed an in-memory outpoint map, then keep the top
+//!    `--sample-count` blocks in `--start-height..=--stop-height` by
+//!    non-coinbase input count, together with every spent prevout.
+//!    Extraction requires `--stop-height`, `--sample-count`, and
+//!    `--min-inputs`. Coinbase inputs have no prevout and are excluded from
+//!    sampling and measurement.
 //! 2. **Measure**: verify every sampled non-coinbase transaction's scripts
-//!    through `KernelContext::verify_tx` at rayon widths 1/8/32 (a dedicated
-//!    `ThreadPoolBuilder` pool per width), with per-height flags derived
-//!    exactly as production's `compute_verify_flags` derives them. Every
-//!    pristine input must verify OK; any rejection aborts loudly with
+//!    through `KernelContext::verify_tx` at rayon widths 1/8/32, with one
+//!    dedicated `ThreadPoolBuilder` pool per width and mainnet
+//!    activation-height flags matching the active chain. Every pristine input
+//!    must verify OK; any rejection aborts loudly with
 //!    height/txid/input index. The timed window includes the per-tx
 //!    serialization + `bitcoinkernel::Transaction` parse inside `verify_tx`
 //!    (production pays both per tx) but excludes corpus load and work-item
 //!    construction (production amortizes block decode and prevout lookup in
 //!    its own pipeline stages).
+//!
+//! CLI:
+//!   --rest-url <host:port>       [127.0.0.1:8332]
+//!   --corpus PATH                (required)
+//!   --output PATH                (required)
+//!   --start-height <u32>         [0]
+//!   --stop-height <u32>          (required when extracting)
+//!   --sample-count <usize>       (required when extracting)
+//!   --min-inputs <usize>         (required when extracting)
 //!
 //! Corpus format (single file, all integers little-endian):
 //! ```text
@@ -49,30 +60,29 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result, bail};
 use bitcoin::consensus::Decodable as _;
+use bitcoin::hashes::Hash as _;
 use bitcoin::{Amount, OutPoint, ScriptBuf, TxOut};
 use bitcoin_rs_consensus::UtxoView;
 use bitcoin_rs_consensus::kernel::KernelContext;
-use bitcoin_rs_primitives::{Network, Tx};
+use bitcoin_rs_primitives::{Hash256, Network, Tx};
 use bitcoin_rs_script::VerifyFlags;
 use rayon::prelude::*;
 use serde_json::json;
 
 const CORPUS_MAGIC: &[u8; 8] = b"KSPIKE1\0";
-const STOP_HEIGHT: u32 = 150_000;
-const SAMPLE_BLOCKS: usize = 300;
-const MIN_CORPUS_INPUTS: usize = 20_000;
 const THREAD_WIDTHS: [usize; 3] = [1, 8, 32];
 
 fn main() -> Result<()> {
     let args = Args::parse(std::env::args_os().skip(1))?;
 
-    if args.corpus.exists() {
+    let needs_extract = !args.corpus.exists();
+    if needs_extract {
+        extract_corpus(&args)?;
+    } else {
         eprintln!(
             "corpus {} exists; skipping extraction",
             args.corpus.display()
         );
-    } else {
-        extract_corpus(&args)?;
     }
 
     let corpus = load_corpus(&args.corpus)?;
@@ -81,9 +91,7 @@ fn main() -> Result<()> {
 
     let rendered = serde_json::to_string_pretty(&report).context("render report JSON")?;
     println!("{rendered}");
-    if let Some(parent) = args.output.parent() {
-        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
-    }
+    ensure_parent(&args.output)?;
     std::fs::write(&args.output, rendered + "\n")
         .with_context(|| format!("write {}", args.output.display()))?;
     Ok(())
@@ -94,31 +102,68 @@ struct Args {
     rest_url: String,
     corpus: PathBuf,
     output: PathBuf,
+    start_height: u32,
+    stop_height: Option<u32>,
+    sample_count: Option<usize>,
+    min_inputs: Option<usize>,
 }
 
 impl Args {
     fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Self> {
-        let mut parsed = Self {
-            rest_url: "127.0.0.1:8332".to_owned(),
-            corpus: PathBuf::from("/home/alpha/bench-g14/results/u0-spike-corpus/corpus.bin"),
-            output: PathBuf::from("/home/alpha/bench-g14/results/u0-kernel-spike.json"),
-        };
+        let mut rest_url = "127.0.0.1:8332".to_owned();
+        let mut corpus: Option<PathBuf> = None;
+        let mut output: Option<PathBuf> = None;
+        let mut start_height: Option<u32> = None;
+        let mut stop_height: Option<u32> = None;
+        let mut sample_count: Option<usize> = None;
+        let mut min_inputs: Option<usize> = None;
         let mut args = args.into_iter();
         while let Some(arg) = args.next() {
             let arg = arg
                 .into_string()
                 .map_err(|value| anyhow::anyhow!("argument is not UTF-8: {}", value.display()))?;
             match arg.as_str() {
-                "--rest-url" => parsed.rest_url = next_arg(&mut args, "--rest-url")?,
-                "--corpus" => parsed.corpus = PathBuf::from(next_arg(&mut args, "--corpus")?),
-                "--output" => parsed.output = PathBuf::from(next_arg(&mut args, "--output")?),
+                "--rest-url" => rest_url = next_arg(&mut args, "--rest-url")?,
+                "--corpus" => corpus = Some(PathBuf::from(next_arg(&mut args, "--corpus")?)),
+                "--output" => output = Some(PathBuf::from(next_arg(&mut args, "--output")?)),
+                "--start-height" => {
+                    start_height = Some(parse_u32(
+                        &next_arg(&mut args, "--start-height")?,
+                        "--start-height",
+                    )?);
+                }
+                "--stop-height" => {
+                    stop_height = Some(parse_u32(
+                        &next_arg(&mut args, "--stop-height")?,
+                        "--stop-height",
+                    )?);
+                }
+                "--sample-count" => {
+                    sample_count = Some(parse_usize(
+                        &next_arg(&mut args, "--sample-count")?,
+                        "--sample-count",
+                    )?);
+                }
+                "--min-inputs" => {
+                    min_inputs = Some(parse_usize(
+                        &next_arg(&mut args, "--min-inputs")?,
+                        "--min-inputs",
+                    )?);
+                }
                 other => bail!(
-                    "unknown argument: {other}\nusage: kernel_verify_spike \
-                     [--rest-url <host:port>] [--corpus <path>] [--output <path>]"
+                    "unknown argument: {other}\nusage: kernel_verify_spike --corpus <path> --output <path> [--rest-url <host:port>] [--start-height <u32>] [--stop-height <u32>] [--sample-count <usize>] [--min-inputs <usize>]"
                 ),
             }
         }
-        Ok(parsed)
+        Ok(Self {
+            rest_url,
+            corpus: corpus.context("--corpus is required")?,
+            output: output.context("--output is required")?,
+            start_height: start_height.unwrap_or(0),
+            stop_height,
+            sample_count,
+            min_inputs,
+        })
     }
 }
 
@@ -129,14 +174,32 @@ fn next_arg(args: &mut impl Iterator<Item = OsString>, name: &str) -> Result<Str
         .map_err(|value| anyhow::anyhow!("{name} value is not UTF-8: {}", value.display()))
 }
 
-/// Mirrors `compute_verify_flags` in `crates/node/src/apply.rs`: P2SH is
-/// always-on for supported validation paths; DERSIG/CLTV/CSV/WITNESS/TAPROOT
-/// gate on activation height. Production resolves CSV/segwit through BIP9
-/// contextual state with these same height predicates as fallback; at the
-/// corpus heights (<= 150k, far below every activation) the two derivations
-/// are identical and every flag except P2SH is off.
-fn production_verify_flags(network: Network, height: u32) -> VerifyFlags {
-    let mut flags = VerifyFlags::P2SH;
+fn parse_u32(value: &str, name: &str) -> Result<u32> {
+    value
+        .parse::<u32>()
+        .with_context(|| format!("{name} must be a non-negative 32-bit integer, got {value}"))
+}
+
+fn parse_usize(value: &str, name: &str) -> Result<usize> {
+    value
+        .parse::<usize>()
+        .with_context(|| format!("{name} must be a non-negative integer, got {value}"))
+}
+
+fn ensure_parent(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    Ok(())
+}
+
+/// Uses the mainnet activation-height fallback, including Core's hash-pinned
+/// BIP16 exception. Production derives BIP9 state from the active header chain.
+fn production_verify_flags(network: Network, height: u32, block_hash: Hash256) -> VerifyFlags {
+    let mut flags = VerifyFlags::NONE;
+    if !network.is_bip16_p2sh_exception(block_hash) {
+        flags = flags.union(VerifyFlags::P2SH);
+    }
     if network.is_bip66_active(height) {
         flags = flags.union(VerifyFlags::DERSIG);
     }
@@ -173,9 +236,32 @@ struct SampleBlock {
 }
 
 fn extract_corpus(args: &Args) -> Result<()> {
+    let stop_height = args
+        .stop_height
+        .context("--stop-height is required to extract a new corpus")?;
+    let sample_count = args
+        .sample_count
+        .context("--sample-count is required to extract a new corpus")?;
+    let min_inputs = args
+        .min_inputs
+        .context("--min-inputs is required to extract a new corpus")?;
+
+    if stop_height < args.start_height {
+        bail!(
+            "inconsistent bounds: stop-height {stop_height} < start-height {}",
+            args.start_height
+        );
+    }
+    if sample_count == 0 {
+        bail!("--sample-count must be greater than zero");
+    }
+    if min_inputs == 0 {
+        bail!("--min-inputs must be greater than zero");
+    }
+
     eprintln!(
-        "extracting corpus: streaming blocks 0..={STOP_HEIGHT} from {}",
-        args.rest_url
+        "extracting corpus: replaying blocks 0..={stop_height}, sampling {}..={stop_height} from {}",
+        args.start_height, args.rest_url
     );
     let started = Instant::now();
     let mut client = RestClient::connect(&args.rest_url)?;
@@ -184,7 +270,7 @@ fn extract_corpus(args: &Args) -> Result<()> {
     let mut keys: BinaryHeap<Reverse<(usize, u32)>> = BinaryHeap::new();
     let mut candidates: hashbrown::HashMap<u32, SampleBlock> = hashbrown::HashMap::new();
 
-    for height in 0..=STOP_HEIGHT {
+    for height in 0..=stop_height {
         let raw = fetch_block(&mut client, height)?;
         let block = bitcoin::Block::consensus_decode(&mut std::io::Cursor::new(raw.as_slice()))
             .with_context(|| format!("decode block at height {height}"))?;
@@ -217,13 +303,13 @@ fn extract_corpus(args: &Args) -> Result<()> {
         }
 
         let input_count = prevouts.len();
-        if input_count > 0 {
+        if height >= args.start_height && input_count > 0 {
             let candidate = SampleBlock {
                 height,
                 raw,
                 prevouts,
             };
-            if keys.len() < SAMPLE_BLOCKS {
+            if keys.len() < sample_count {
                 keys.push(Reverse((input_count, height)));
                 candidates.insert(height, candidate);
             } else if let Some(&Reverse((min_count, min_height))) = keys.peek()
@@ -254,10 +340,8 @@ fn extract_corpus(args: &Args) -> Result<()> {
         samples.len(),
         started.elapsed()
     );
-    if total_inputs < MIN_CORPUS_INPUTS {
-        bail!(
-            "corpus too small: {total_inputs} non-coinbase inputs < required {MIN_CORPUS_INPUTS}"
-        );
+    if total_inputs < min_inputs {
+        bail!("corpus too small: {total_inputs} non-coinbase inputs < required {min_inputs}");
     }
     write_corpus(&args.corpus, &samples)
 }
@@ -276,9 +360,7 @@ fn fetch_block(client: &mut RestClient, height: u32) -> Result<Vec<u8>> {
 }
 
 fn write_corpus(path: &Path, samples: &[SampleBlock]) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
-    }
+    ensure_parent(path)?;
     let file = std::fs::File::create(path).with_context(|| format!("create {}", path.display()))?;
     let mut writer = BufWriter::new(file);
     writer.write_all(CORPUS_MAGIC)?;
@@ -379,7 +461,8 @@ fn build_work_items(corpus: &[SampleBlock]) -> Result<Vec<WorkItem>> {
         let block =
             bitcoin::Block::consensus_decode(&mut std::io::Cursor::new(sample.raw.as_slice()))
                 .with_context(|| format!("decode corpus block at height {}", sample.height))?;
-        let flags = production_verify_flags(Network::Mainnet, sample.height);
+        let block_hash = Hash256::from_le_bytes(block.block_hash().as_byte_array());
+        let flags = production_verify_flags(Network::Mainnet, sample.height, block_hash);
         let mut prevouts = sample.prevouts.iter();
         for tx in &block.txdata {
             if tx.is_coinbase() {
@@ -522,10 +605,14 @@ fn measure(corpus: &[SampleBlock], items: &[WorkItem], args: &Args) -> Result<se
     }
 
     Ok(json!({
-        "schema": "u0-kernel-verify-spike-v1",
+        "schema": "u0-kernel-verify-spike-v2",
         "measurement_target": "bitcoinkernel per-input script verify",
         "git_head": git_head().ok(),
         "comparator": "recorded ~65 us/input effective-serial, bitcoinconsensus backend, same machine",
+        "start_height": args.start_height,
+        "stop_height": args.stop_height,
+        "sample_count": args.sample_count,
+        "min_inputs": args.min_inputs,
         "corpus": {
             "path": args.corpus.display().to_string(),
             "block_count": corpus.len(),
@@ -538,13 +625,15 @@ fn measure(corpus: &[SampleBlock], items: &[WorkItem], args: &Args) -> Result<se
     }))
 }
 
+// Benchmark ratios intentionally trade integer precision for a fractional result.
+#[allow(clippy::as_conversions, clippy::cast_precision_loss)]
 fn duration_us_per_input(elapsed: Duration, total_inputs: usize) -> Result<f64> {
-    let micros = u32::try_from(elapsed.as_micros()).context("elapsed micros exceed u32")?;
-    let inputs = u32::try_from(total_inputs).context("input count exceeds u32")?;
+    let micros = u64::try_from(elapsed.as_micros()).context("elapsed micros exceed u64")?;
+    let inputs = u64::try_from(total_inputs).context("input count exceeds u64")?;
     if inputs == 0 {
         bail!("corpus contains zero inputs");
     }
-    Ok(f64::from(micros) / f64::from(inputs))
+    Ok((micros as f64) / (inputs as f64))
 }
 
 fn git_head() -> Result<String> {

--- a/crates/consensus/src/census_checkpoint.rs
+++ b/crates/consensus/src/census_checkpoint.rs
@@ -1,0 +1,290 @@
+//! Safe wrapper for the non-terminal CHECKSIG census checkpoint C ABI.
+//!
+//! This module is compiled only when the `checksig-census` feature is enabled
+//! and the patched `libbitcoinkernel-sys` crate is linked through the
+//! `bitcoinkernel` dependency. It provides a typed Rust wrapper around the
+//! private `btck_census_checkpoint` and `btck_census_flush` symbols.
+
+#![allow(missing_docs)]
+use std::ffi::c_int;
+use std::mem;
+
+use thiserror::Error;
+
+/// C ABI version for the non-terminal checkpoint structure.
+pub const ABI_VERSION: u32 = 1;
+
+const STRUCT_SIZE_BYTES: usize = 56;
+
+/// Expected in-memory size of [`CensusCheckpoint`] on the C side.
+#[allow(clippy::as_conversions, clippy::cast_possible_truncation)]
+pub const STRUCT_SIZE: u32 = STRUCT_SIZE_BYTES as u32;
+
+/// Fixed size of a BRSREC1 row in bytes.
+const RECORD_ROW_SIZE: u64 = 224;
+
+/// Fixed size of a BRSJRN1 row in bytes.
+const JOURNAL_ROW_SIZE: u64 = 56;
+
+/// Minimum size of a BRSCTX1 row in bytes (`row_len` field + fixed fields).
+const CONTEXT_ROW_MIN_SIZE: u64 = 56;
+
+/// Non-terminal checkpoint returned by the patched kernel census sinks.
+///
+/// This is a byte-for-byte mirror of `btck_CensusCheckpoint` in the native
+/// instrumentation patch. Endpoints include the 8-byte magic and 8-byte
+/// placeholder count header (16 bytes total) for each binary sink.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CensusCheckpoint {
+    pub abi_version: u32,
+    pub struct_size: u32,
+    pub context_rows: u64,
+    pub context_end: u64,
+    pub record_rows: u64,
+    pub record_end: u64,
+    pub journal_rows: u64,
+    pub journal_end: u64,
+}
+
+const _: () = assert!(
+    mem::size_of::<CensusCheckpoint>() == STRUCT_SIZE_BYTES,
+    "CensusCheckpoint layout must match the C ABI"
+);
+
+impl CensusCheckpoint {
+    /// Verify that the reported endpoints are at least 16 bytes and that the
+    /// fixed-size record/journal sinks have byte offsets matching their row
+    /// counts. Context rows are variable-length, so only a minimum bound is
+    /// checked.
+    pub fn validate_coherent(&self) -> Result<(), CensusCheckpointError> {
+        for (name, endpoint) in [
+            ("context", self.context_end),
+            ("record", self.record_end),
+            ("journal", self.journal_end),
+        ] {
+            if endpoint < 16 {
+                return Err(CensusCheckpointError::Incoherent(format!(
+                    "{name}_end {endpoint} is below the 16-byte stream header"
+                )));
+            }
+        }
+
+        let expected_record_end = self
+            .record_rows
+            .checked_mul(RECORD_ROW_SIZE)
+            .and_then(|b| b.checked_add(16))
+            .ok_or_else(|| CensusCheckpointError::Incoherent("record row count overflow".into()))?;
+        if self.record_end != expected_record_end {
+            return Err(CensusCheckpointError::Incoherent(format!(
+                "record_end {} != 16 + record_rows * {} = {}",
+                self.record_end, RECORD_ROW_SIZE, expected_record_end
+            )));
+        }
+
+        let expected_journal_end = self
+            .journal_rows
+            .checked_mul(JOURNAL_ROW_SIZE)
+            .and_then(|b| b.checked_add(16))
+            .ok_or_else(|| {
+                CensusCheckpointError::Incoherent("journal row count overflow".into())
+            })?;
+        if self.journal_end != expected_journal_end {
+            return Err(CensusCheckpointError::Incoherent(format!(
+                "journal_end {} != 16 + journal_rows * {} = {}",
+                self.journal_end, JOURNAL_ROW_SIZE, expected_journal_end
+            )));
+        }
+
+        let min_context_end = self
+            .context_rows
+            .checked_mul(CONTEXT_ROW_MIN_SIZE)
+            .and_then(|b| b.checked_add(16))
+            .ok_or_else(|| {
+                CensusCheckpointError::Incoherent("context row count overflow".into())
+            })?;
+        if self.context_end < min_context_end {
+            return Err(CensusCheckpointError::Incoherent(format!(
+                "context_end {} is below the minimum 16 + context_rows * {} = {}",
+                self.context_end, CONTEXT_ROW_MIN_SIZE, min_context_end
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+/// Errors returned by the checkpoint wrapper.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum CensusCheckpointError {
+    /// The native checkpoint call returned a non-zero status.
+    #[error("native checkpoint failed with status {0}")]
+    KernelFailed(c_int),
+    /// The returned ABI version does not match the Rust wrapper.
+    #[error("ABI version mismatch: expected {expected}, got {actual}")]
+    AbiMismatch { expected: u32, actual: u32 },
+    /// The returned struct size does not match the Rust layout.
+    #[error("struct size mismatch: expected {expected}, got {actual}")]
+    StructSizeMismatch { expected: u32, actual: u32 },
+    /// The checkpoint reported incoherent counts or endpoints.
+    #[error("checkpoint endpoint incoherent: {0}")]
+    Incoherent(String),
+    /// The terminal flush call returned a non-zero status.
+    #[error("terminal flush failed with status {0}")]
+    FlushFailed(c_int),
+}
+
+// SAFETY: these symbols are only available when the patched
+// `libbitcoinkernel-sys` crate is linked through the `bitcoinkernel`
+// dependency (the `checksig-census` feature enables this). Default builds
+// never compile this module and therefore never reference these private C
+// symbols.
+unsafe extern "C" {
+    fn btck_census_checkpoint(out: *mut CensusCheckpoint, out_size: usize) -> c_int;
+    fn btck_census_flush() -> c_int;
+}
+
+/// Capture a non-terminal checkpoint from the native census sinks.
+///
+/// The wrapper initializes a zeroed [`CensusCheckpoint`], calls the private C
+/// ABI, and validates the returned ABI version, struct size, and endpoint
+/// coherence. It does not perform any I/O itself; the native function holds the
+/// sink mutex, flushes all three streams, and returns committed counts and byte
+/// positions.
+pub fn capture() -> Result<CensusCheckpoint, CensusCheckpointError> {
+    let mut raw = CensusCheckpoint::default();
+
+    // SAFETY: `btck_census_checkpoint` is only linked when the patched kernel
+    // is in use. The pointer is valid for the call and `out_size` exactly
+    // matches the C struct size.
+    let rc = unsafe { btck_census_checkpoint(&raw mut raw, mem::size_of::<CensusCheckpoint>()) };
+    if rc != 0 {
+        return Err(CensusCheckpointError::KernelFailed(rc));
+    }
+
+    if raw.abi_version != ABI_VERSION {
+        return Err(CensusCheckpointError::AbiMismatch {
+            expected: ABI_VERSION,
+            actual: raw.abi_version,
+        });
+    }
+    if raw.struct_size != STRUCT_SIZE {
+        return Err(CensusCheckpointError::StructSizeMismatch {
+            expected: STRUCT_SIZE,
+            actual: raw.struct_size,
+        });
+    }
+
+    raw.validate_coherent()?;
+    Ok(raw)
+}
+
+/// Terminally flush the native census sinks.
+///
+/// This patches the 16-byte header counts, flushes, and closes the three binary
+/// streams. It is the only way to finalize a diagnostic run.
+pub fn flush() -> Result<(), CensusCheckpointError> {
+    // SAFETY: `btck_census_flush` is only linked when the patched kernel is in
+    // use. It is idempotent and returns 0 on success.
+    let rc = unsafe { btck_census_flush() };
+    if rc != 0 {
+        Err(CensusCheckpointError::FlushFailed(rc))
+    } else {
+        Ok(())
+    }
+}
+
+/// Returns true if `next` is a non-shrinking successor of `prev`.
+pub fn is_monotonic(prev: &CensusCheckpoint, next: &CensusCheckpoint) -> bool {
+    next.context_rows >= prev.context_rows
+        && next.record_rows >= prev.record_rows
+        && next.journal_rows >= prev.journal_rows
+        && next.context_end >= prev.context_end
+        && next.record_end >= prev.record_end
+        && next.journal_end >= prev.journal_end
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn struct_size_matches_c_expectation() {
+        assert_eq!(mem::size_of::<CensusCheckpoint>(), 56);
+        assert_eq!(STRUCT_SIZE, 56);
+    }
+
+    #[test]
+    fn validate_coherent_accepts_exact_fixed_sinks() {
+        let cp = CensusCheckpoint {
+            abi_version: ABI_VERSION,
+            struct_size: STRUCT_SIZE,
+            context_rows: 0,
+            context_end: 16,
+            record_rows: 2,
+            record_end: 16 + 2 * RECORD_ROW_SIZE,
+            journal_rows: 1,
+            journal_end: 16 + JOURNAL_ROW_SIZE,
+        };
+        assert_eq!(cp.validate_coherent(), Ok(()));
+    }
+
+    #[test]
+    fn validate_coherent_accepts_exact_context_row_minimum() {
+        let mut checkpoint = CensusCheckpoint {
+            context_rows: 1,
+            context_end: 16 + 4 + 52,
+            record_end: 16,
+            journal_end: 16,
+            ..Default::default()
+        };
+        assert_eq!(checkpoint.validate_coherent(), Ok(()));
+
+        checkpoint.context_end -= 1;
+        assert!(checkpoint.validate_coherent().is_err());
+    }
+
+    #[test]
+    fn validate_coherent_rejects_short_endpoints() {
+        let mut cp = CensusCheckpoint {
+            context_end: 15,
+            record_end: 16,
+            journal_end: 16,
+            ..Default::default()
+        };
+        assert!(cp.validate_coherent().is_err());
+        cp.context_end = 16;
+        cp.record_end = 15;
+        assert!(cp.validate_coherent().is_err());
+    }
+
+    #[test]
+    fn validate_coherent_rejects_mismatched_record_size() {
+        let cp = CensusCheckpoint {
+            record_rows: 1,
+            record_end: 16 + RECORD_ROW_SIZE - 1,
+            journal_rows: 0,
+            journal_end: 16,
+            context_rows: 0,
+            context_end: 16,
+            ..Default::default()
+        };
+        assert!(cp.validate_coherent().is_err());
+    }
+
+    #[test]
+    fn is_monotonic_detects_shrink() {
+        let a = CensusCheckpoint {
+            record_rows: 2,
+            record_end: 100,
+            ..Default::default()
+        };
+        let mut b = a;
+        assert!(is_monotonic(&a, &b));
+        b.record_rows = 1;
+        assert!(!is_monotonic(&a, &b));
+        b.record_rows = 3;
+        b.record_end = 99;
+        assert!(!is_monotonic(&a, &b));
+    }
+}

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -36,6 +36,9 @@ pub mod bip66;
 pub mod bip68;
 /// BIP9 versionbits checks.
 pub mod bip9;
+/// Non-terminal CHECKSIG census checkpoint ABI wrapper.
+#[cfg(feature = "checksig-census")]
+pub mod census_checkpoint;
 /// Dual-path block connection.
 pub mod connect_block;
 /// Feature-gated bitcoinkernel wrapper.

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -84,6 +84,10 @@ mdbx = [
     "bitcoin-rs-storage/mdbx",
 ]
 kernel = ["bitcoin-rs-consensus/kernel"]
+checksig-census = [
+    "kernel",
+    "bitcoin-rs-consensus/checksig-census",
+]
 mimalloc = ["dep:mimalloc"]
 utreexo = ["dep:bitcoin-rs-utreexo"]
 prometheus-http = ["metrics-exporter-prometheus/http-listener"]

--- a/crates/node/examples/export_active_chain_corpus.rs
+++ b/crates/node/examples/export_active_chain_corpus.rs
@@ -1,0 +1,186 @@
+#![allow(missing_docs)]
+#![allow(clippy::print_stdout)]
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result, bail};
+use bitcoin::hex::DisplayHex as _;
+use bitcoin_rs_node::Network;
+use bitcoin_rs_node::config::Config;
+use bitcoin_rs_node::state::NodeState;
+
+fn main() -> Result<()> {
+    let args = Args::parse(std::env::args_os().skip(1))?;
+    let network = parse_network(&args.network)?;
+
+    let manifest = if let Some(rest_url) = &args.rest_url {
+        bitcoin_rs_node::corpus::export_corpus_from_rest(
+            rest_url,
+            network,
+            args.stop_height,
+            &args.archive,
+            &args.manifest,
+        )
+        .context("export corpus from REST")?
+    } else {
+        let Some(data_dir) = args.data_dir.as_ref() else {
+            bail!("exactly one corpus source must be configured");
+        };
+        let mut config = Config::default_for_network(network);
+        config.data_dir.clone_from(data_dir);
+        config.storage_backend.clone_from(&args.storage_backend);
+        config.p2p_listen.clear();
+        config.dns_seeds_enabled = false;
+
+        let state = NodeState::open(config).context("open node state")?;
+        bitcoin_rs_node::corpus::export_active_chain_corpus(
+            &state,
+            network,
+            args.stop_height,
+            &args.archive,
+            &args.manifest,
+        )
+        .context("export active-chain corpus")?
+    };
+
+    println!("exported active chain 0..={}", manifest.stop_height);
+    println!("archive: {}", args.archive.display());
+    println!("manifest: {}", args.manifest.display());
+    println!("archive size: {} bytes", manifest.archive.size);
+    println!(
+        "archive sha256: {}",
+        manifest.archive.sha256.as_slice().to_lower_hex_string()
+    );
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Args {
+    data_dir: Option<PathBuf>,
+    rest_url: Option<String>,
+    storage_backend: String,
+    network: String,
+    stop_height: u32,
+    archive: PathBuf,
+    manifest: PathBuf,
+}
+
+impl Args {
+    fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Self> {
+        let mut parsed = Self {
+            data_dir: None,
+            rest_url: None,
+            storage_backend: "fjall".to_owned(),
+            network: "mainnet".to_owned(),
+            stop_height: 0,
+            archive: PathBuf::new(),
+            manifest: PathBuf::new(),
+        };
+        let mut data_dir = None;
+        let mut rest_url = None;
+        let mut archive = None;
+        let mut manifest = None;
+        let mut stop_height = None;
+
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            let arg = arg.to_string_lossy();
+            match arg.as_ref() {
+                "--data-dir" => data_dir = Some(PathBuf::from(next_arg(&mut args, "--data-dir")?)),
+                "--rest-url" => rest_url = Some(next_arg(&mut args, "--rest-url")?),
+                "--storage-backend" => {
+                    parsed.storage_backend = next_arg(&mut args, "--storage-backend")?;
+                }
+                "--network" => parsed.network = next_arg(&mut args, "--network")?,
+                "--stop-height" => {
+                    stop_height = Some(parse_height(&next_arg(&mut args, "--stop-height")?)?);
+                }
+                "--archive" => archive = Some(PathBuf::from(next_arg(&mut args, "--archive")?)),
+                "--manifest" => manifest = Some(PathBuf::from(next_arg(&mut args, "--manifest")?)),
+                other => bail!("unknown argument: {other}"),
+            }
+        }
+
+        if data_dir.is_some() == rest_url.is_some() {
+            bail!("provide exactly one of --data-dir or --rest-url");
+        }
+        parsed.data_dir = data_dir;
+        parsed.rest_url = rest_url;
+        parsed.archive = archive.context("--archive is required")?;
+        parsed.manifest = manifest.context("--manifest is required")?;
+        parsed.stop_height = stop_height.context("--stop-height is required")?;
+        Ok(parsed)
+    }
+}
+
+fn next_arg(args: &mut impl Iterator<Item = OsString>, name: &str) -> Result<String> {
+    args.next()
+        .with_context(|| format!("{name} requires a value"))
+        .map(|s| s.to_string_lossy().into_owned())
+}
+
+fn parse_height(s: &str) -> Result<u32> {
+    s.parse::<u32>()
+        .with_context(|| format!("invalid height: {s}"))
+}
+
+fn parse_network(value: &str) -> Result<Network> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "main" | "mainnet" | "bitcoin" => Ok(Network::Mainnet),
+        "test" | "testnet" | "testnet3" => Ok(Network::Testnet3),
+        "testnet4" => Ok(Network::Testnet4),
+        "signet" => Ok(Network::Signet),
+        "regtest" => Ok(Network::Regtest),
+        other => bail!("unsupported network {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::Args;
+
+    fn base_args() -> Vec<OsString> {
+        vec![
+            "--archive".into(),
+            "/tmp/archive.dat".into(),
+            "--manifest".into(),
+            "/tmp/manifest.json".into(),
+            "--stop-height".into(),
+            "1".into(),
+        ]
+    }
+
+    #[test]
+    fn data_dir_alone_is_accepted() {
+        let mut args = base_args();
+        args.extend(["--data-dir".into(), "/tmp/data".into()]);
+        assert!(Args::parse(args).is_ok());
+    }
+
+    #[test]
+    fn rest_url_alone_is_accepted() {
+        let mut args = base_args();
+        args.extend(["--rest-url".into(), "127.0.0.1:18443".into()]);
+        assert!(Args::parse(args).is_ok());
+    }
+
+    #[test]
+    fn neither_source_is_rejected() {
+        assert!(Args::parse(base_args()).is_err());
+    }
+
+    #[test]
+    fn both_sources_are_rejected() {
+        let mut args = base_args();
+        args.extend([
+            "--data-dir".into(),
+            "/tmp/data".into(),
+            "--rest-url".into(),
+            "127.0.0.1:18443".into(),
+        ]);
+        assert!(Args::parse(args).is_err());
+    }
+}

--- a/crates/node/examples/mainnet_prefix_replay.rs
+++ b/crates/node/examples/mainnet_prefix_replay.rs
@@ -6,21 +6,71 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::ffi::OsString;
-use std::io::{BufRead as _, BufReader, Read as _, Write as _};
-use std::net::TcpStream;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result, bail};
-use bitcoin::Block;
 use bitcoin::consensus::Decodable as _;
-use bitcoin::hex::FromHex as _;
+use bitcoin::hashes::Hash as _;
+use bitcoin::hex::{DisplayHex as _, FromHex as _};
+use bitcoin::{Block, BlockHash, Weight};
 use bitcoin_rs_node::Network;
 use bitcoin_rs_node::config::Config;
+use bitcoin_rs_node::corpus::CorpusManifest;
+use bitcoin_rs_node::corpus::{CoreRestClient, CoreRestError, FetchedBlock, fetch_rest_block};
 use bitcoin_rs_node::state::NodeState;
+use bitcoin_rs_storage::CoreFrameReader;
 use serde_json::json;
+use sha2::{Digest as _, Sha256};
+
+/// A reader that hashes every byte it yields.
+///
+/// Used so a Core-framed archive can be verified with a single streaming pass.
+struct HashingReader<R> {
+    inner: R,
+    state: Sha256,
+    bytes_read: u64,
+}
+
+impl<R: std::io::Read> HashingReader<R> {
+    fn new(inner: R) -> Self {
+        Self {
+            inner,
+            state: Sha256::new(),
+            bytes_read: 0,
+        }
+    }
+
+    fn bytes_read(&self) -> u64 {
+        self.bytes_read
+    }
+
+    fn digest(&self) -> [u8; 32] {
+        let out = self.state.clone().finalize();
+        let mut bytes = [0_u8; 32];
+        bytes.copy_from_slice(out.as_ref());
+        bytes
+    }
+}
+
+impl<R: std::io::Read> std::io::Read for HashingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        if n > 0 {
+            self.state.update(&buf[..n]);
+            let read_len = u64::try_from(n)
+                .map_err(|_| std::io::Error::other("read length does not fit u64"))?;
+            self.bytes_read = self
+                .bytes_read
+                .checked_add(read_len)
+                .ok_or_else(|| std::io::Error::other("bytes read overflow u64"))?;
+        }
+        Ok(n)
+    }
+}
 
 /// Proves a window's scripts in one dispatch, then applies its blocks in order.
 ///
@@ -46,6 +96,7 @@ struct ReplayTotals {
 /// Walks `start_height..=stop_height`, applying each window as it fills.
 fn replay_prefix(
     args: &Args,
+    manifest: Option<&CorpusManifest>,
     apply_handles: &bitcoin_rs_node::apply::ApplyHandles,
 ) -> Result<ReplayTotals> {
     let mut tx_count = 0_usize;
@@ -55,9 +106,10 @@ fn replay_prefix(
     let started = Instant::now();
     let mut start_hash = None;
     let mut stop_hash = None;
+    let mut prev_hash: Option<BlockHash> = None;
 
     let window = args.window.max(1);
-    let mut source = open_block_source(args)?;
+    let mut source = open_block_source(args, apply_handles.network, manifest)?;
     let mut window_blocks: Vec<Block> = Vec::new();
     let mut window_bytes: Vec<bytes::Bytes> = Vec::new();
     let mut window_bytes_held = 0_usize;
@@ -75,7 +127,47 @@ fn replay_prefix(
         let mut cursor = std::io::Cursor::new(bytes.as_slice());
         let block = Block::consensus_decode(&mut cursor)
             .with_context(|| format!("decode block bytes at height {height}"))?;
+        let consumed = cursor.position();
+        let payload_len =
+            u64::try_from(bytes.len()).context("block payload length does not fit u64")?;
+        if consumed != payload_len {
+            let consumed =
+                usize::try_from(consumed).context("decoded block length does not fit usize")?;
+            bail!(
+                "block payload at height {height} has {} trailing bytes",
+                bytes.len().saturating_sub(consumed)
+            );
+        }
         decode_time += decode_started.elapsed();
+
+        let actual_hash = block.block_hash();
+        if actual_hash.to_string() != hash {
+            bail!("block hash mismatch at height {height}: source {hash}, decoded {actual_hash}");
+        }
+        if height == 0 {
+            if block.header.prev_blockhash != BlockHash::from_byte_array([0; 32]) {
+                bail!(
+                    "genesis block at height 0 has non-zero prev_blockhash {}",
+                    block.header.prev_blockhash
+                );
+            }
+            if actual_hash.to_string() != apply_handles.network.genesis_block_hash().to_string_be()
+            {
+                bail!(
+                    "genesis block hash mismatch at height 0: expected {}, got {actual_hash}",
+                    apply_handles.network.genesis_block_hash().to_string_be()
+                );
+            }
+        } else if let Some(prev) = prev_hash {
+            if block.header.prev_blockhash != prev {
+                bail!(
+                    "prev_blockhash mismatch at height {height}: expected {prev}, got {}",
+                    block.header.prev_blockhash
+                );
+            }
+        }
+        prev_hash = Some(actual_hash);
+
         tx_count = tx_count.saturating_add(block.txdata.len());
         block_bytes = block_bytes.saturating_add(bytes.len());
         // Flushed BEFORE appending when this block would cross the byte cap,
@@ -98,6 +190,9 @@ fn replay_prefix(
             window_bytes_held = 0;
         }
     }
+    source
+        .ensure_eof()
+        .with_context(|| "trailing data in Core-framed archive")?;
     apply_window(apply_handles, &mut window_blocks, &mut window_bytes)?;
     Ok(ReplayTotals {
         start_hash,
@@ -110,8 +205,10 @@ fn replay_prefix(
     })
 }
 
-/// long before the bodies arrived. Without that the window can never prove and
-/// the driver silently measures the unbatched path.
+/// Inserts headers before applying a window.
+///
+/// Production receives headers before block bodies. The replay must do the
+/// same or the window cannot prove and the driver measures the unbatched path.
 fn apply_window(
     handles: &bitcoin_rs_node::apply::ApplyHandles,
     blocks: &mut Vec<Block>,
@@ -152,6 +249,81 @@ fn apply_window(
     Ok(())
 }
 
+#[derive(Debug)]
+struct FileInputs {
+    manifest: CorpusManifest,
+    manifest_path: PathBuf,
+    manifest_bytes_len: u64,
+    manifest_sha: [u8; 32],
+    blocks_path: PathBuf,
+}
+
+fn prepare_file_inputs(args: &Args) -> Result<FileInputs> {
+    let blocks_path = args
+        .blocks_file
+        .as_ref()
+        .context("file mode requires --blocks-file")?;
+    let manifest_path = args
+        .corpus_manifest
+        .as_ref()
+        .context("file mode requires --corpus-manifest")?;
+    let (manifest, manifest_bytes) = CorpusManifest::load_with_bytes(manifest_path)
+        .with_context(|| format!("load corpus manifest {}", manifest_path.display()))?;
+    if manifest.network != Network::Mainnet {
+        bail!(
+            "corpus manifest network is {:?}, expected mainnet",
+            manifest.network
+        );
+    }
+    if manifest.genesis_hash != Network::Mainnet.genesis_block_hash() {
+        bail!(
+            "corpus manifest genesis hash {} does not match mainnet genesis {}",
+            manifest.genesis_hash.to_string_be(),
+            Network::Mainnet.genesis_block_hash().to_string_be()
+        );
+    }
+    if manifest.start_height != 0 {
+        bail!(
+            "corpus manifest start height is {}, expected 0",
+            manifest.start_height
+        );
+    }
+    if manifest.stop_height != args.stop_height {
+        bail!(
+            "corpus manifest stop height {} does not match --stop-height {}",
+            manifest.stop_height,
+            args.stop_height
+        );
+    }
+    let archive_size = std::fs::metadata(blocks_path)
+        .with_context(|| format!("stat archive {}", blocks_path.display()))?
+        .len();
+    if archive_size != manifest.archive.size {
+        bail!(
+            "archive size {} does not match manifest {} for {}",
+            archive_size,
+            manifest.archive.size,
+            blocks_path.display()
+        );
+    }
+    let manifest_digest = Sha256::digest(&manifest_bytes);
+    let mut manifest_sha = [0_u8; 32];
+    manifest_sha.copy_from_slice(manifest_digest.as_ref());
+    let manifest_bytes_len =
+        u64::try_from(manifest_bytes.len()).context("manifest length does not fit u64")?;
+    Ok(FileInputs {
+        manifest,
+        manifest_path: manifest_path.clone(),
+        manifest_bytes_len,
+        manifest_sha,
+        blocks_path: blocks_path.clone(),
+    })
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "replay setup and custody output form one ordered transaction"
+)]
 fn main() -> Result<()> {
     let args = Args::parse(std::env::args_os().skip(1))?;
     if args.stop_height < args.start_height {
@@ -176,6 +348,15 @@ fn main() -> Result<()> {
         bitcoin_rs_node::metrics::install_metrics(Some(([127, 0, 0, 1], 0).into()))
             .context("install metrics recorder")?;
 
+    // Validate manifest identity, range, and archive size before opening state.
+    // The single replay read validates every frame and the final archive digest.
+    let file_mode = args.blocks_file.is_some();
+    let file_inputs = if file_mode {
+        Some(prepare_file_inputs(&args).context("prepare file-mode inputs")?)
+    } else {
+        None
+    };
+
     let state = NodeState::open(config).context("open node state")?;
     let mut apply_handles = state.apply_handles();
     // Offline tool: no header sync loop ever runs, so a hash-pinned gate would
@@ -192,7 +373,11 @@ fn main() -> Result<()> {
         fetch_time,
         decode_time,
         elapsed,
-    } = replay_prefix(&args, &apply_handles)?;
+    } = replay_prefix(
+        &args,
+        file_inputs.as_ref().map(|f| &f.manifest),
+        &apply_handles,
+    )?;
     // The full UTXO scan is opt-in and starts after the internal replay timer.
     // Performance custody runs must omit it because process wall and CPU still
     // include the scan; separate validation runs pass this option.
@@ -205,47 +390,116 @@ fn main() -> Result<()> {
         .stop_height
         .saturating_sub(args.start_height)
         .saturating_add(1);
-    let stage_seconds = stage_decomposition(metrics_handle);
-    let block_source = if args.blocks_file.is_some() {
-        "file"
-    } else if args.rest_url.is_some() {
-        "rest"
+    let stage_seconds = stage_decomposition(metrics_handle.clone());
+    let snapshot = metrics_handle
+        .as_ref()
+        .map(bitcoin_rs_node::metrics::MetricsHandle::snapshot)
+        .unwrap_or_default();
+    let window_verify_success_total = counter_value(&snapshot, "node.window.verify_success_total");
+
+    if file_mode {
+        if window <= 1 {
+            bail!("file custody requires --window > 1");
+        }
+        if window_verify_success_total == 0 {
+            bail!("file custody requires at least one successful window verification dispatch");
+        }
+    }
+
+    let checkpoint_generation = if file_mode {
+        Some(
+            state
+                .publish_checkpoint()
+                .context("publish clean checkpoint")?,
+        )
     } else {
-        "bitcoin-cli"
+        None
     };
-    let artifact = json!({
-        "schema": "mainnet-prefix-replay-v1",
-        "measurement_target": "mainnet-prefix-replay",
-        "git_head": git_head().ok(),
-        "storage_backend": args.storage_backend,
-        "txindex": args.txindex,
-        "blockfilterindex": args.blockfilterindex,
-        "assume_valid_height": args.assume_valid_height,
-        // The effective value, not the raw flag: `--window 0` normalises to 1.
-        // Without this two artifacts from `--window 1` and `--window 64` are
-        // indistinguishable by configuration, and those are exactly the two runs
-        // the validation gate compares.
-        "window": window,
-        "start_height": args.start_height,
-        "start_hash": start_hash,
-        "stop_height": args.stop_height,
-        "stop_hash": stop_hash,
-        "block_count": block_count,
-        "tx_count": tx_count,
-        "block_bytes": block_bytes,
-        "elapsed_seconds": elapsed.as_secs_f64(),
-        "blocks_per_second": f64::from(block_count) / elapsed.as_secs_f64(),
-        "fetch_seconds": fetch_time.as_secs_f64(),
-        "decode_seconds": decode_time.as_secs_f64(),
-        "stage_seconds": stage_seconds,
-        "rss_high_water_bytes": rss_high_water_bytes(),
-        "bitcoin_cli": args.bitcoin_cli,
-        "bitcoin_cli_args": args.bitcoin_cli_args,
-        "block_source": block_source,
-        "rest_url": args.rest_url,
-        "blocks_file": args.blocks_file,
-        "data_dir": args.data_dir,
-    });
+
+    let artifact = if file_mode {
+        let inputs = file_inputs
+            .as_ref()
+            .context("file mode requires prepared inputs")?;
+        json!({
+            "schema": "mainnet-prefix-replay-v2",
+            "measurement_target": "mainnet-prefix-replay",
+            "git_head": git_head().ok(),
+            "network": "mainnet",
+            "network_magic": inputs.manifest.network_magic.as_slice().to_lower_hex_string(),
+            "genesis_hash": inputs.manifest.genesis_hash.to_string_be(),
+            "corpus_manifest": {
+                "schema": CorpusManifest::SCHEMA,
+                "version": CorpusManifest::VERSION,
+                "path": inputs.manifest_path,
+                "bytes": inputs.manifest_bytes_len,
+                "sha256": inputs.manifest_sha.as_slice().to_lower_hex_string(),
+            },
+            "archive": {
+                "path": inputs.blocks_path,
+                "bytes": inputs.manifest.archive.size,
+                "sha256": inputs.manifest.archive.sha256.as_slice().to_lower_hex_string(),
+            },
+            "start_height": args.start_height,
+            "start_hash": start_hash,
+            "stop_height": args.stop_height,
+            "stop_hash": stop_hash,
+            "assume_valid_height": args.assume_valid_height,
+            // The effective value, not the raw flag: `--window 0` normalises to 1.
+            "window": window,
+            "window_verify_success_total": window_verify_success_total,
+            "checkpoint_generation": checkpoint_generation
+                .context("file mode requires a published checkpoint")?,
+            "storage_backend": args.storage_backend,
+            "txindex": args.txindex,
+            "blockfilterindex": args.blockfilterindex,
+            "block_count": block_count,
+            "tx_count": tx_count,
+            "block_bytes": block_bytes,
+            "elapsed_seconds": elapsed.as_secs_f64(),
+            "blocks_per_second": f64::from(block_count) / elapsed.as_secs_f64(),
+            "fetch_seconds": fetch_time.as_secs_f64(),
+            "decode_seconds": decode_time.as_secs_f64(),
+            "stage_seconds": stage_seconds,
+            "rss_high_water_bytes": rss_high_water_bytes(),
+            "block_source": "file",
+            "data_dir": args.data_dir,
+        })
+    } else {
+        let block_source = if args.rest_url.is_some() {
+            "rest"
+        } else {
+            "bitcoin-cli"
+        };
+        json!({
+            "schema": "mainnet-prefix-replay-v1",
+            "measurement_target": "mainnet-prefix-replay",
+            "git_head": git_head().ok(),
+            "storage_backend": args.storage_backend,
+            "txindex": args.txindex,
+            "blockfilterindex": args.blockfilterindex,
+            "assume_valid_height": args.assume_valid_height,
+            "window": window,
+            "start_height": args.start_height,
+            "start_hash": start_hash,
+            "stop_height": args.stop_height,
+            "stop_hash": stop_hash,
+            "block_count": block_count,
+            "tx_count": tx_count,
+            "block_bytes": block_bytes,
+            "elapsed_seconds": elapsed.as_secs_f64(),
+            "blocks_per_second": f64::from(block_count) / elapsed.as_secs_f64(),
+            "fetch_seconds": fetch_time.as_secs_f64(),
+            "decode_seconds": decode_time.as_secs_f64(),
+            "stage_seconds": stage_seconds,
+            "rss_high_water_bytes": rss_high_water_bytes(),
+            "bitcoin_cli": args.bitcoin_cli,
+            "bitcoin_cli_args": args.bitcoin_cli_args,
+            "block_source": block_source,
+            "rest_url": args.rest_url,
+            "blocks_file": args.blocks_file,
+            "data_dir": args.data_dir,
+        })
+    };
     let rendered = serde_json::to_string_pretty(&artifact).context("render artifact JSON")?;
     if let Some(output) = args.output {
         std::fs::write(&output, rendered + "\n")
@@ -287,7 +541,10 @@ struct Args {
     bitcoin_cli: String,
     bitcoin_cli_args: Vec<String>,
     rest_url: Option<String>,
+    /// Path to a Core-framed archive (network magic + u32 LE length + block payload).
     blocks_file: Option<PathBuf>,
+    /// Path to the validated corpus manifest for the Core-framed archive.
+    corpus_manifest: Option<PathBuf>,
     assume_valid_height: u32,
     data_dir: PathBuf,
     output: Option<PathBuf>,
@@ -307,6 +564,7 @@ impl Args {
             bitcoin_cli_args: Vec::new(),
             rest_url: None,
             blocks_file: None,
+            corpus_manifest: None,
             assume_valid_height: 0,
             data_dir: PathBuf::from(".bitcoin-rs-mainnet-prefix-replay"),
             output: None,
@@ -332,6 +590,10 @@ impl Args {
                 "--rest-url" => parsed.rest_url = Some(next_arg(&mut args, "--rest-url")?),
                 "--blocks-file" => {
                     parsed.blocks_file = Some(PathBuf::from(next_arg(&mut args, "--blocks-file")?));
+                }
+                "--corpus-manifest" => {
+                    parsed.corpus_manifest =
+                        Some(PathBuf::from(next_arg(&mut args, "--corpus-manifest")?));
                 }
                 "--assume-valid-height" => {
                     parsed.assume_valid_height =
@@ -363,6 +625,9 @@ impl Args {
                 other => bail!("unknown argument: {other}"),
             }
         }
+        if parsed.blocks_file.is_some() != parsed.corpus_manifest.is_some() {
+            bail!("--blocks-file and --corpus-manifest must be provided together");
+        }
         Ok(parsed)
     }
 }
@@ -371,6 +636,16 @@ impl Args {
 /// utxo — and anything added later), sorted by total time descending.
 /// Deliberately unfiltered: a surprise entry in this list is diagnostic
 /// signal, not noise.
+fn counter_value(
+    snapshot: &hashbrown::HashMap<String, bitcoin_rs_node::metrics::MetricValue>,
+    name: &str,
+) -> u64 {
+    match snapshot.get(name) {
+        Some(bitcoin_rs_node::metrics::MetricValue::Counter(value)) => *value,
+        _ => 0,
+    }
+}
+
 fn stage_decomposition(
     handle: Option<bitcoin_rs_node::metrics::MetricsHandle>,
 ) -> Vec<serde_json::Value> {
@@ -407,106 +682,36 @@ fn parse_height(value: &str) -> Result<u32> {
         .with_context(|| format!("parse height {value:?}"))
 }
 
-/// Minimal keep-alive HTTP/1.1 client for the local `bitcoind -rest` interface.
-///
-/// Exists because spawning `bitcoin-cli` per block costs ~11 ms/call — 28 minutes of
-/// pure harness overhead over a 150k-block replay window, drowning the measurement.
-/// One persistent localhost connection brings the fetch cost below a millisecond.
-struct RestClient {
-    host: String,
-    stream: BufReader<TcpStream>,
-}
-
-impl RestClient {
-    /// Upper bound on an accepted response body. The largest legitimate body is
-    /// one serialized block (≤4 MB by consensus weight); anything bigger means
-    /// the URL points at something that is not a bitcoind REST endpoint.
-    const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
-
-    fn connect(host: &str) -> Result<Self> {
-        let stream = TcpStream::connect(host).with_context(|| format!("connect to {host}"))?;
-        // A stalled server must fail the replay loudly, not freeze a
-        // multi-hour run inside a blocking read.
-        stream.set_read_timeout(Some(Duration::from_secs(30)))?;
-        stream.set_write_timeout(Some(Duration::from_secs(30)))?;
-        Ok(Self {
-            host: host.to_owned(),
-            stream: BufReader::new(stream),
-        })
-    }
-
-    fn get(&mut self, path: &str) -> Result<Vec<u8>> {
-        let first_err = match self.request(path) {
-            Ok(body) => return Ok(body),
-            Err(err) => err,
-        };
-        // The server may close a kept-alive connection between requests;
-        // reconnect once before giving up, keeping the first failure's cause.
-        *self =
-            Self::connect(&self.host).with_context(|| format!("reconnect after: {first_err:#}"))?;
-        self.request(path)
-            .with_context(|| format!("retry after: {first_err:#}"))
-    }
-
-    fn request(&mut self, path: &str) -> Result<Vec<u8>> {
-        let request = format!(
-            "GET {path} HTTP/1.1\r\nHost: {}\r\nConnection: keep-alive\r\n\r\n",
-            self.host
-        );
-        self.stream.get_mut().write_all(request.as_bytes())?;
-        let mut line = String::new();
-        self.stream.read_line(&mut line)?;
-        let status = line.trim_end().to_owned();
-        let mut content_length: Option<usize> = None;
-        loop {
-            line.clear();
-            self.stream.read_line(&mut line)?;
-            let header = line.trim_end();
-            if header.is_empty() {
-                break;
-            }
-            if let Some(value) = header
-                .to_ascii_lowercase()
-                .strip_prefix("content-length:")
-                .map(str::trim)
-            {
-                content_length = Some(value.parse().context("parse Content-Length")?);
-            }
-        }
-        let length = content_length
-            .with_context(|| format!("REST response without Content-Length: {status}"))?;
-        if length > Self::MAX_BODY_BYTES {
-            bail!("REST GET {path}: Content-Length {length} exceeds sane bound ({status})");
-        }
-        let mut body = vec![0_u8; length];
-        // Drain the body before judging the status so a kept-alive connection
-        // stays in sync after an HTTP error response.
-        self.stream.read_exact(&mut body)?;
-        let status_code = status.split_whitespace().nth(1);
-        if status_code != Some("200") {
-            bail!("REST GET {path} failed: {status}");
-        }
-        Ok(body)
-    }
-}
-
-/// A fetched block: `(block_hash_hex, raw_block_bytes)`.
-type FetchedBlock = (String, Vec<u8>);
-
 /// Where replay blocks come from: per-call `bitcoin-cli` spawns or a prefetch
 /// thread reading ahead over a persistent REST socket.
-/// Picks the block source, preferring a local file over REST.
+/// Picks the block source, preferring a local Core-framed archive over REST.
 ///
 /// The file source must win outright: building the REST source spawns a
 /// prefetch thread, so choosing it first and discarding it would start an
 /// HTTP pipeline the run never reads.
-fn open_block_source(args: &Args) -> Result<BlockSource<'_>> {
+fn open_block_source<'a>(
+    args: &'a Args,
+    network: Network,
+    manifest: Option<&CorpusManifest>,
+) -> Result<BlockSource<'a>> {
     if let Some(path) = args.blocks_file.as_ref() {
-        return Ok(BlockSource::File(std::io::BufReader::with_capacity(
-            1 << 20,
-            std::fs::File::open(path)
-                .with_context(|| format!("open blocks file {}", path.display()))?,
-        )));
+        let manifest = manifest
+            .with_context(|| "file mode requires a corpus manifest")?
+            .clone();
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("open Core-framed archive {}", path.display()))?;
+        let max_payload = u32::try_from(Weight::MAX_BLOCK.to_wu())
+            .context("maximum block weight does not fit u32")?;
+        let reader = CoreFrameReader::new(
+            HashingReader::new(BufReader::with_capacity(1 << 20, file)),
+            network.magic(),
+            max_payload,
+        );
+        return Ok(BlockSource::File {
+            reader: Box::new(reader),
+            manifest,
+            next_index: 0,
+        });
     }
     match &args.rest_url {
         Some(host) => Ok(BlockSource::Rest(spawn_prefetch(
@@ -521,13 +726,17 @@ fn open_block_source(args: &Args) -> Result<BlockSource<'_>> {
 enum BlockSource<'a> {
     Cli(&'a Args),
     Rest(crossbeam_channel::Receiver<Result<FetchedBlock>>),
-    /// Blocks read sequentially from a local length-prefixed file.
+    /// Blocks read sequentially from a local Core-framed archive.
     ///
-    /// Core's `-reindex-chainstate` reads its own `blk*.dat` files, so a REST
-    /// fetch loads the replay with HTTP and a second process's CPU that Core
-    /// never pays. This source removes that asymmetry for engine-to-engine
-    /// comparisons.
-    File(std::io::BufReader<std::fs::File>),
+    /// Each frame is the Bitcoin Core `-loadblock` wire format:
+    /// `network magic + u32 little-endian length + consensus block payload`.
+    /// Core's `-loadblock` reads the same bytes, so this source removes the
+    /// HTTP / second-process CPU overhead that a REST fetch adds.
+    File {
+        reader: Box<CoreFrameReader<HashingReader<BufReader<std::fs::File>>>>,
+        manifest: CorpusManifest,
+        next_index: usize,
+    },
 }
 
 impl BlockSource<'_> {
@@ -547,52 +756,126 @@ impl BlockSource<'_> {
             Self::Rest(receiver) => receiver
                 .recv()
                 .with_context(|| format!("prefetch thread gone before height {height}"))?,
-            Self::File(reader) => {
-                use std::io::Read as _;
-                let mut len_bytes = [0_u8; 4];
-                reader
-                    .read_exact(&mut len_bytes)
-                    .with_context(|| format!("read block length at height {height}"))?;
-                let len = usize::try_from(u32::from_le_bytes(len_bytes))
-                    .with_context(|| format!("block length at height {height} exceeds usize"))?;
-                let mut bytes = vec![0_u8; len];
-                reader
-                    .read_exact(&mut bytes)
-                    .with_context(|| format!("read {len} block bytes at height {height}"))?;
-                // Hash the 80-byte header directly. Deserializing the whole
-                // block here would duplicate the decode the apply loop already
-                // performs and would inflate this source against the REST one,
-                // which gets the hash from the API for free.
+            Self::File {
+                reader,
+                manifest,
+                next_index,
+            } => {
+                let offset = reader.offset();
+                let record = reader.read_next().with_context(|| {
+                    format!("read Core frame at offset {offset} for height {height}")
+                })?;
+                let Some(record) = record else {
+                    bail!("Core-framed archive ended at offset {offset} before height {height}");
+                };
+                let entry_index = *next_index;
+                *next_index += 1;
+                let expected_index =
+                    usize::try_from(height).context("block height does not fit usize")?;
+                if entry_index != expected_index {
+                    bail!("manifest entry index mismatch: expected {height}, got {entry_index}");
+                }
+                let entry = manifest
+                    .entries
+                    .get(entry_index)
+                    .with_context(|| format!("manifest has no entry for height {height}"))?;
+                if entry.height != height {
+                    bail!(
+                        "manifest entry height mismatch: expected {height}, got {}",
+                        entry.height
+                    );
+                }
+                if record.metadata.offset != entry.offset {
+                    bail!(
+                        "frame offset mismatch at height {height}: manifest {}, archive {}",
+                        entry.offset,
+                        record.metadata.offset
+                    );
+                }
+                if record.metadata.len != entry.payload_length {
+                    bail!(
+                        "frame payload length mismatch at height {height}: manifest {}, archive {}",
+                        entry.payload_length,
+                        record.metadata.len
+                    );
+                }
+                let bytes = record.payload;
                 let header = bytes
                     .get(..80)
-                    .with_context(|| format!("block at height {height} shorter than a header"))?;
-                let hash = {
-                    use bitcoin::hashes::Hash as _;
-                    bitcoin::BlockHash::from_byte_array(
-                        bitcoin::hashes::sha256d::Hash::hash(header).to_byte_array(),
-                    )
-                    .to_string()
-                };
-                Ok((hash, bytes))
+                    .with_context(|| format!("Core frame payload at height {height} is {} bytes, shorter than a block header", bytes.len()))?;
+                let hash = bitcoin::BlockHash::from_byte_array(
+                    bitcoin::hashes::sha256d::Hash::hash(header).to_byte_array(),
+                );
+                let expected = bitcoin::BlockHash::from_byte_array(*entry.hash.as_byte_array());
+                if hash != expected {
+                    bail!(
+                        "frame header hash mismatch at height {height}: manifest {expected}, archive {hash}"
+                    );
+                }
+                Ok((hash.to_string(), bytes))
             }
+        }
+    }
+
+    /// Fails if a Core-framed file source has more frames than the requested range
+    /// or if the bytes consumed do not match the manifest's archive digest.
+    fn ensure_eof(&mut self) -> Result<()> {
+        match self {
+            Self::File {
+                reader, manifest, ..
+            } => {
+                let offset = reader.offset();
+                match reader
+                    .read_next()
+                    .with_context(|| format!("trailing Core frame at offset {offset}"))?
+                {
+                    None => {
+                        let hashing = reader.get_ref();
+                        let archive_bytes = hashing.bytes_read();
+                        if archive_bytes != manifest.archive.size {
+                            bail!(
+                                "archive size mismatch at EOF: manifest {}, read {}",
+                                manifest.archive.size,
+                                archive_bytes
+                            );
+                        }
+                        let archive_digest = hashing.digest();
+                        if archive_digest != manifest.archive.sha256 {
+                            bail!(
+                                "archive SHA-256 mismatch at EOF: manifest {}, read {}",
+                                manifest.archive.sha256.as_slice().to_lower_hex_string(),
+                                archive_digest.as_slice().to_lower_hex_string()
+                            );
+                        }
+                        Ok(())
+                    }
+                    Some(record) => bail!(
+                        "Core-framed archive has an extra frame at offset {} past --stop-height",
+                        record.metadata.offset
+                    ),
+                }
+            }
+            _ => Ok(()),
         }
     }
 }
 
 /// Reads blocks ahead of the apply loop so fetch latency overlaps validation —
 /// the serial round-trip-per-block fetch otherwise accounts for ~24% of replay
-/// wall-clock (96s of 397s over 0..150k), time a real node spends overlapped
-/// with download or disk reads on other threads.
+/// wall-clock (96s of 397s over 0..150k); a real node spends less waiting on
+/// download or disk reads than other threads.
 fn spawn_prefetch(
     host: &str,
     start_height: u32,
     stop_height: u32,
 ) -> Result<crossbeam_channel::Receiver<Result<FetchedBlock>>> {
-    let mut client = RestClient::connect(host)?;
+    let mut client =
+        CoreRestClient::connect(host).map_err(|e: CoreRestError| anyhow::Error::from(e))?;
     let (sender, receiver) = crossbeam_channel::bounded(32);
     std::thread::spawn(move || {
         for height in start_height..=stop_height {
-            let item = fetch_rest_block(&mut client, height);
+            let item = fetch_rest_block(&mut client, height)
+                .map_err(|e: CoreRestError| anyhow::Error::from(e));
             let failed = item.is_err();
             // A send error means the apply loop dropped the receiver; stop.
             if sender.send(item).is_err() || failed {
@@ -601,20 +884,6 @@ fn spawn_prefetch(
         }
     });
     Ok(receiver)
-}
-
-fn fetch_rest_block(client: &mut RestClient, height: u32) -> Result<FetchedBlock> {
-    let hash_bytes = client
-        .get(&format!("/rest/blockhashbyheight/{height}.hex"))
-        .with_context(|| format!("get block hash at height {height}"))?;
-    let hash = String::from_utf8(hash_bytes)
-        .context("block hash response is not UTF-8")?
-        .trim()
-        .to_owned();
-    let bytes = client
-        .get(&format!("/rest/block/{hash}.bin"))
-        .with_context(|| format!("get block {hash} at height {height}"))?;
-    Ok((hash, bytes))
 }
 
 fn bitcoin_cli(args: &Args, command_args: impl IntoIterator<Item = String>) -> Result<String> {
@@ -662,6 +931,350 @@ fn rss_high_water_bytes() -> Option<u64> {
 
 fn print_usage() {
     println!(
-        "usage: mainnet_prefix_replay --stop-height <height> [--blocks-file <path> | --rest-url <host:port> | --bitcoin-cli <path>] [--assume-valid-height <height>] [--bitcoin-cli-arg <arg>]... [--data-dir <path>] [--output <path>] [--validation-output <path>] [--txindex] [--blockfilterindex]"
+        "usage: mainnet_prefix_replay --stop-height <height> [--blocks-file <core-framed-archive> --corpus-manifest <manifest> | --rest-url <host:port> | --bitcoin-cli <path>] [--assume-valid-height <height>] [--bitcoin-cli-arg <arg>]... [--data-dir <path>] [--output <path>] [--validation-output <path>] [--txindex] [--blockfilterindex]"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::consensus::encode::serialize;
+    use bitcoin_rs_node::corpus::{ArchiveInfo, CorpusEntry, CorpusManifest};
+    use bitcoin_rs_primitives::Hash256;
+
+    fn regtest_genesis_bytes() -> Vec<u8> {
+        serialize(&bitcoin::blockdata::constants::genesis_block(
+            bitcoin::Network::Regtest,
+        ))
+    }
+
+    fn write_archive(magic: [u8; 4], payloads: &[&[u8]]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut writer = bitcoin_rs_storage::CoreFrameWriter::new(&mut buf, magic);
+        for payload in payloads {
+            writer.write(payload).unwrap();
+        }
+        buf
+    }
+
+    fn manifest_for_archive(
+        network: Network,
+        archive: &[u8],
+        payloads: &[&[u8]],
+    ) -> CorpusManifest {
+        let mut entries = Vec::new();
+        let mut offset = 0_u64;
+        for (height, payload) in payloads.iter().enumerate() {
+            let header = payload
+                .get(..80)
+                .expect("payload must include a block header");
+            let hash = Hash256::from_le_bytes(
+                &bitcoin::hashes::sha256d::Hash::hash(header).to_byte_array(),
+            );
+            entries.push(CorpusEntry {
+                height: height as u32,
+                hash,
+                offset,
+                payload_length: payload.len() as u32,
+            });
+            offset = offset
+                .checked_add(bitcoin_rs_storage::CORE_FRAME_HEADER_LEN)
+                .unwrap()
+                .checked_add(payload.len() as u64)
+                .unwrap();
+        }
+        let archive_digest = {
+            use sha2::Digest as _;
+            let digest = Sha256::digest(archive);
+            let mut bytes = [0_u8; 32];
+            bytes.copy_from_slice(digest.as_ref());
+            bytes
+        };
+        CorpusManifest::new(
+            network,
+            ArchiveInfo::new(archive.len() as u64, archive_digest),
+            entries,
+        )
+        .expect("test manifest is valid")
+    }
+
+    fn write_manifest(manifest: &CorpusManifest, path: &Path) {
+        manifest.save(path).expect("save manifest")
+    }
+
+    fn args_for_file(archive_path: &Path, manifest_path: &Path) -> Args {
+        let mut args = Args::parse(std::iter::empty::<OsString>()).unwrap();
+        args.blocks_file = Some(archive_path.to_path_buf());
+        args.corpus_manifest = Some(manifest_path.to_path_buf());
+        args
+    }
+
+    #[test]
+    fn file_source_reads_core_framed_blocks() {
+        let magic = Network::Regtest.magic();
+        let payload = regtest_genesis_bytes();
+        let archive = write_archive(magic, &[&payload[..]]);
+        let manifest = manifest_for_archive(Network::Regtest, &archive, &[&payload[..]]);
+
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &archive).unwrap();
+        let manifest_temp = tempfile::NamedTempFile::new().unwrap();
+        write_manifest(&manifest, manifest_temp.path());
+
+        let args = args_for_file(archive_temp.path(), manifest_temp.path());
+        let mut source = open_block_source(&args, Network::Regtest, Some(&manifest)).unwrap();
+        let (hash, bytes) = source.fetch(0).unwrap();
+        let expected = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest)
+            .block_hash()
+            .to_string();
+        assert_eq!(hash, expected);
+        assert_eq!(bytes, payload);
+        let err = source.fetch(1).unwrap_err();
+        assert!(err.to_string().contains("archive ended"), "{err}");
+    }
+
+    #[test]
+    fn file_source_rejects_wrong_magic() {
+        let archive = write_archive(Network::Mainnet.magic(), &[&regtest_genesis_bytes()[..]]);
+        let manifest =
+            manifest_for_archive(Network::Regtest, &archive, &[&regtest_genesis_bytes()[..]]);
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &archive).unwrap();
+
+        let args = args_for_file(archive_temp.path(), Path::new("/nonexistent/manifest.json"));
+        let mut source = open_block_source(&args, Network::Regtest, Some(&manifest)).unwrap();
+        let err = source.fetch(0).unwrap_err();
+        assert!(
+            format!("{err:?}").to_lowercase().contains("wrong magic"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn file_source_rejects_truncated_frame() {
+        let magic = Network::Regtest.magic();
+        let payload = regtest_genesis_bytes();
+        let full_archive = write_archive(magic, &[&payload[..]]);
+        let manifest = manifest_for_archive(Network::Regtest, &full_archive, &[&payload[..]]);
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        let mut truncated = full_archive.clone();
+        truncated.truncate(truncated.len() - 10);
+        std::fs::write(archive_temp.path(), &truncated).unwrap();
+
+        let args = args_for_file(archive_temp.path(), Path::new("/nonexistent/manifest.json"));
+        let mut source = open_block_source(&args, Network::Regtest, Some(&manifest)).unwrap();
+        let err = source.fetch(0).unwrap_err();
+        assert!(
+            format!("{err:?}")
+                .to_lowercase()
+                .contains("partial payload"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn file_source_rejects_old_length_only_file() {
+        let payload = regtest_genesis_bytes();
+        let magic = Network::Regtest.magic();
+        let valid_archive = write_archive(magic, &[&payload[..]]);
+        let manifest = manifest_for_archive(Network::Regtest, &valid_archive, &[&payload[..]]);
+        let mut archive = Vec::new();
+        archive.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        archive.extend_from_slice(&payload);
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &archive).unwrap();
+
+        let args = args_for_file(archive_temp.path(), Path::new("/nonexistent/manifest.json"));
+        let mut source = open_block_source(&args, Network::Regtest, Some(&manifest)).unwrap();
+        let err = source.fetch(0).unwrap_err();
+        assert!(
+            format!("{err:?}").to_lowercase().contains("wrong magic"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn file_source_rejects_extra_frames() {
+        let magic = Network::Regtest.magic();
+        let payload = regtest_genesis_bytes();
+        // Archive with two frames, manifest expecting one.
+        let two_frame_archive = write_archive(magic, &[&payload[..], &payload[..]]);
+        let one_frame_archive = write_archive(magic, &[&payload[..]]);
+        let manifest = manifest_for_archive(Network::Regtest, &one_frame_archive, &[&payload[..]]);
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &two_frame_archive).unwrap();
+
+        let args = args_for_file(archive_temp.path(), Path::new("/nonexistent/manifest.json"));
+        let mut source = open_block_source(&args, Network::Regtest, Some(&manifest)).unwrap();
+        source.fetch(0).unwrap();
+        let err = source.ensure_eof().unwrap_err();
+        assert!(err.to_string().contains("extra frame"), "{err}");
+    }
+
+    #[test]
+    fn file_source_rejects_hash_mismatch() {
+        let magic = Network::Regtest.magic();
+        let payload = regtest_genesis_bytes();
+        let archive = write_archive(magic, &[&payload[..]]);
+        let mut manifest = manifest_for_archive(Network::Regtest, &archive, &[&payload[..]]);
+        manifest.entries[0].hash = Hash256::from_le_bytes(&[0xab; 32]);
+
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &archive).unwrap();
+
+        let args = args_for_file(archive_temp.path(), Path::new("/nonexistent/manifest.json"));
+        let mut source = open_block_source(&args, Network::Regtest, Some(&manifest)).unwrap();
+        let err = source.fetch(0).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("hash mismatch"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn file_source_rejects_offset_mismatch() {
+        let magic = Network::Regtest.magic();
+        let payload = regtest_genesis_bytes();
+        let archive = write_archive(magic, &[&payload[..]]);
+        let mut manifest = manifest_for_archive(Network::Regtest, &archive, &[&payload[..]]);
+        manifest.entries[0].offset = 1;
+
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &archive).unwrap();
+
+        let args = args_for_file(archive_temp.path(), Path::new("/nonexistent/manifest.json"));
+        let mut source = open_block_source(&args, Network::Regtest, Some(&manifest)).unwrap();
+        let err = source.fetch(0).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("offset mismatch"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn file_source_rejects_length_mismatch() {
+        let magic = Network::Regtest.magic();
+        let payload = regtest_genesis_bytes();
+        let archive = write_archive(magic, &[&payload[..]]);
+        let mut manifest = manifest_for_archive(Network::Regtest, &archive, &[&payload[..]]);
+        manifest.entries[0].payload_length = 1;
+
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &archive).unwrap();
+
+        let args = args_for_file(archive_temp.path(), Path::new("/nonexistent/manifest.json"));
+        let mut source = open_block_source(&args, Network::Regtest, Some(&manifest)).unwrap();
+        let err = source.fetch(0).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("length mismatch"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn file_source_rejects_archive_digest_mismatch() {
+        let magic = Network::Regtest.magic();
+        let payload = regtest_genesis_bytes();
+        let archive = write_archive(magic, &[&payload[..]]);
+        let mut manifest = manifest_for_archive(Network::Regtest, &archive, &[&payload[..]]);
+        manifest.archive.sha256 = [0xcd; 32];
+
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &archive).unwrap();
+
+        let args = args_for_file(archive_temp.path(), Path::new("/nonexistent/manifest.json"));
+        let mut source = open_block_source(&args, Network::Regtest, Some(&manifest)).unwrap();
+        source.fetch(0).unwrap();
+        let err = source.ensure_eof().unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("sha-256 mismatch"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn file_mode_requires_paired_arguments() {
+        let mut args = vec![
+            OsString::from("--blocks-file"),
+            OsString::from("/tmp/archive"),
+        ];
+        let err = Args::parse(args.drain(..)).unwrap_err();
+        assert!(
+            err.to_string()
+                .to_lowercase()
+                .contains("must be provided together"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn file_preflight_rejects_regtest_manifest() {
+        let payload = regtest_genesis_bytes();
+        let archive = write_archive(Network::Regtest.magic(), &[&payload[..]]);
+        let manifest = manifest_for_archive(Network::Regtest, &archive, &[&payload[..]]);
+
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &archive).unwrap();
+        let manifest_temp = tempfile::NamedTempFile::new().unwrap();
+        write_manifest(&manifest, manifest_temp.path());
+
+        let mut args = Args::parse(std::iter::empty::<OsString>()).unwrap();
+        args.stop_height = 0;
+        args.blocks_file = Some(archive_temp.path().to_path_buf());
+        args.corpus_manifest = Some(manifest_temp.path().to_path_buf());
+
+        let err = prepare_file_inputs(&args).unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("mainnet"), "{err}");
+    }
+
+    #[test]
+    fn file_preflight_rejects_stop_height_mismatch() {
+        let payload = regtest_genesis_bytes();
+        let archive = write_archive(Network::Mainnet.magic(), &[&payload[..]]);
+        let manifest = {
+            let mut m = manifest_for_archive(Network::Mainnet, &archive, &[&payload[..]]);
+            m
+        };
+
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(archive_temp.path(), &archive).unwrap();
+        let manifest_temp = tempfile::NamedTempFile::new().unwrap();
+        write_manifest(&manifest, manifest_temp.path());
+
+        let mut args = Args::parse(std::iter::empty::<OsString>()).unwrap();
+        args.stop_height = 1; // manifest has stop_height 0
+        args.blocks_file = Some(archive_temp.path().to_path_buf());
+        args.corpus_manifest = Some(manifest_temp.path().to_path_buf());
+
+        let err = prepare_file_inputs(&args).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("stop height"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn file_preflight_rejects_archive_size_mismatch() {
+        let payload = regtest_genesis_bytes();
+        let full_archive = write_archive(Network::Mainnet.magic(), &[&payload[..]]);
+        let manifest = manifest_for_archive(Network::Mainnet, &full_archive, &[&payload[..]]);
+
+        let archive_temp = tempfile::NamedTempFile::new().unwrap();
+        let mut truncated = full_archive.clone();
+        truncated.truncate(truncated.len() - 1);
+        std::fs::write(archive_temp.path(), &truncated).unwrap();
+        let manifest_temp = tempfile::NamedTempFile::new().unwrap();
+        write_manifest(&manifest, manifest_temp.path());
+
+        let mut args = Args::parse(std::iter::empty::<OsString>()).unwrap();
+        args.stop_height = 0;
+        args.blocks_file = Some(archive_temp.path().to_path_buf());
+        args.corpus_manifest = Some(manifest_temp.path().to_path_buf());
+
+        let err = prepare_file_inputs(&args).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("archive size"),
+            "{err}"
+        );
+    }
 }

--- a/crates/node/examples/mainnet_prefix_replay.rs
+++ b/crates/node/examples/mainnet_prefix_replay.rs
@@ -6,7 +6,11 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::ffi::OsString;
+#[cfg(feature = "checksig-census")]
+use std::fs::OpenOptions;
 use std::io::BufReader;
+#[cfg(feature = "checksig-census")]
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -17,6 +21,8 @@ use bitcoin::consensus::Decodable as _;
 use bitcoin::hashes::Hash as _;
 use bitcoin::hex::{DisplayHex as _, FromHex as _};
 use bitcoin::{Block, BlockHash, Weight};
+#[cfg(feature = "checksig-census")]
+use bitcoin_rs_consensus::census_checkpoint;
 use bitcoin_rs_node::Network;
 use bitcoin_rs_node::config::Config;
 use bitcoin_rs_node::corpus::CorpusManifest;
@@ -333,6 +339,9 @@ fn main() -> Result<()> {
         bail!("mainnet prefix replay currently requires --start-height 0");
     }
 
+    #[cfg(feature = "checksig-census")]
+    validate_diagnostic_args(&args)?;
+
     let mut config = Config::default_for_network(Network::Mainnet);
     config.data_dir.clone_from(&args.data_dir);
     config.storage_backend.clone_from(&args.storage_backend);
@@ -365,6 +374,13 @@ fn main() -> Result<()> {
     // keeps its height-only shortcut semantics for every height.
     apply_handles.assume_valid_gate =
         Arc::new(bitcoin_rs_node::apply::AssumeValidGate::with_anchor(None));
+
+    #[cfg(feature = "checksig-census")]
+    if args.census_diagnostic {
+        run_census_diagnostic(&args, &apply_handles)?;
+        return Ok(());
+    }
+
     let ReplayTotals {
         start_hash,
         stop_hash,
@@ -555,6 +571,8 @@ struct Args {
     storage_backend: String,
     txindex: bool,
     blockfilterindex: bool,
+    #[cfg(feature = "checksig-census")]
+    census_diagnostic: bool,
 }
 
 impl Args {
@@ -575,6 +593,8 @@ impl Args {
             storage_backend: "fjall".to_owned(),
             txindex: false,
             blockfilterindex: false,
+            #[cfg(feature = "checksig-census")]
+            census_diagnostic: false,
         };
         let mut args = args.into_iter();
         while let Some(arg) = args.next() {
@@ -622,6 +642,12 @@ impl Args {
                 }
                 "--txindex" => parsed.txindex = true,
                 "--blockfilterindex" => parsed.blockfilterindex = true,
+                #[cfg(feature = "checksig-census")]
+                "--cmodern-diagnostic-protocol" => parsed.census_diagnostic = true,
+                #[cfg(not(feature = "checksig-census"))]
+                "--cmodern-diagnostic-protocol" => {
+                    bail!("--cmodern-diagnostic-protocol requires the checksig-census feature")
+                }
                 other => bail!("unknown argument: {other}"),
             }
         }
@@ -929,6 +955,413 @@ fn rss_high_water_bytes() -> Option<u64> {
     None
 }
 
+#[cfg(feature = "checksig-census")]
+const DIAGNOSTIC_ROW_MAGIC: &[u8; 8] = b"BRSHGT1\0";
+#[cfg(feature = "checksig-census")]
+const DIAGNOSTIC_VERSION: u32 = 1;
+#[cfg(feature = "checksig-census")]
+const DIAGNOSTIC_ROW_SIZE: u32 = 84;
+
+#[cfg(feature = "checksig-census")]
+fn validate_diagnostic_args(args: &Args) -> Result<()> {
+    if !args.census_diagnostic {
+        return Ok(());
+    }
+    if args.rest_url.is_none() {
+        bail!("--cmodern-diagnostic-protocol requires --rest-url");
+    }
+    if args.blocks_file.is_some() || args.corpus_manifest.is_some() {
+        bail!("--cmodern-diagnostic-protocol cannot use --blocks-file or --corpus-manifest");
+    }
+    if args.start_height != 0 {
+        bail!("--cmodern-diagnostic-protocol requires --start-height 0");
+    }
+    if args.assume_valid_height != 0 {
+        bail!("--cmodern-diagnostic-protocol requires --assume-valid-height 0");
+    }
+    if args.window != 1 {
+        bail!("--cmodern-diagnostic-protocol requires --window 1");
+    }
+    if args.output.is_none() {
+        bail!(
+            "--cmodern-diagnostic-protocol requires --output because stdout is the binary protocol"
+        );
+    }
+    if args.validation_output.is_some() {
+        bail!("--cmodern-diagnostic-protocol does not support --validation-output");
+    }
+    for var in [
+        "BRS_CENSUS_CONTEXTS",
+        "BRS_CENSUS_RECORDS",
+        "BRS_CENSUS_JOURNAL",
+    ] {
+        if std::env::var(var).is_err() {
+            bail!("--cmodern-diagnostic-protocol requires the {var} environment variable");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "checksig-census")]
+fn decode_and_validate_block(
+    height: u32,
+    hash_str: &str,
+    bytes: &[u8],
+    prev_hash: &mut Option<BlockHash>,
+    network: Network,
+) -> Result<Block> {
+    let mut cursor = std::io::Cursor::new(bytes);
+    let block = Block::consensus_decode(&mut cursor)
+        .with_context(|| format!("decode block bytes at height {height}"))?;
+    let consumed =
+        usize::try_from(cursor.position()).context("decoded block length exceeds usize")?;
+    if consumed != bytes.len() {
+        bail!(
+            "block payload at height {height} has {} trailing bytes",
+            bytes.len() - consumed
+        );
+    }
+    let actual_hash = block.block_hash();
+    if actual_hash.to_string() != hash_str {
+        bail!("block hash mismatch at height {height}: source {hash_str}, decoded {actual_hash}");
+    }
+    if height == 0 {
+        if block.header.prev_blockhash != BlockHash::from_byte_array([0; 32]) {
+            bail!(
+                "genesis block at height 0 has non-zero prev_blockhash {}",
+                block.header.prev_blockhash
+            );
+        }
+        if actual_hash.to_string() != network.genesis_block_hash().to_string_be() {
+            bail!(
+                "genesis block hash mismatch at height 0: expected {}, got {actual_hash}",
+                network.genesis_block_hash().to_string_be()
+            );
+        }
+    } else if let Some(prev) = prev_hash {
+        if block.header.prev_blockhash != *prev {
+            bail!(
+                "prev_blockhash mismatch at height {height}: expected {prev}, got {}",
+                block.header.prev_blockhash
+            );
+        }
+    }
+    *prev_hash = Some(actual_hash);
+    Ok(block)
+}
+
+#[cfg(feature = "checksig-census")]
+fn apply_one_block(
+    handles: &bitcoin_rs_node::apply::ApplyHandles,
+    block: Block,
+    raw: Vec<u8>,
+) -> Result<()> {
+    let mut blocks = vec![block];
+    let mut raw: Vec<bytes::Bytes> = vec![bytes::Bytes::from(raw)];
+    apply_window(handles, &mut blocks, &mut raw)
+}
+
+#[cfg(feature = "checksig-census")]
+fn write_diagnostic_preface(out: &mut impl Write) -> Result<()> {
+    out.write_all(DIAGNOSTIC_ROW_MAGIC)
+        .context("write diagnostic row magic")?;
+    out.write_all(&DIAGNOSTIC_VERSION.to_le_bytes())
+        .context("write diagnostic version")?;
+    out.write_all(&DIAGNOSTIC_ROW_SIZE.to_le_bytes())
+        .context("write diagnostic row size")?;
+    out.flush().context("flush diagnostic preface")?;
+    Ok(())
+}
+
+#[cfg(feature = "checksig-census")]
+fn write_checkpoint_row(
+    out: &mut impl Write,
+    height: u32,
+    hash: BlockHash,
+    checkpoint: &census_checkpoint::CensusCheckpoint,
+) -> Result<()> {
+    out.write_all(&height.to_le_bytes())
+        .context("write checkpoint height")?;
+    out.write_all(hash.as_byte_array())
+        .context("write checkpoint block hash")?;
+    out.write_all(&checkpoint.context_rows.to_le_bytes())
+        .context("write checkpoint context_rows")?;
+    out.write_all(&checkpoint.context_end.to_le_bytes())
+        .context("write checkpoint context_end")?;
+    out.write_all(&checkpoint.record_rows.to_le_bytes())
+        .context("write checkpoint record_rows")?;
+    out.write_all(&checkpoint.record_end.to_le_bytes())
+        .context("write checkpoint record_end")?;
+    out.write_all(&checkpoint.journal_rows.to_le_bytes())
+        .context("write checkpoint journal_rows")?;
+    out.write_all(&checkpoint.journal_end.to_le_bytes())
+        .context("write checkpoint journal_end")?;
+    Ok(())
+}
+
+#[cfg(feature = "checksig-census")]
+fn read_control_byte(stdin: &mut impl Read) -> Result<u8> {
+    let mut buf = [0_u8; 1];
+    stdin
+        .read_exact(&mut buf)
+        .context("controller closed stdin (EOF) or I/O error while reading control byte")?;
+    Ok(buf[0])
+}
+
+#[cfg(feature = "checksig-census")]
+fn write_diagnostic_artifact(
+    args: &Args,
+    actual_stop_height: u32,
+    actual_stop_hash: &str,
+    elapsed: Duration,
+) -> Result<()> {
+    let output = args.output.as_deref().context("--output is required")?;
+    let artifact = json!({
+        "schema": "mainnet-prefix-replay-diagnostic-v1",
+        "non_certifying": true,
+        "block_source": "rest",
+        "start_height": args.start_height,
+        "requested_stop_height_ceiling": args.stop_height,
+        "actual_stop_height": actual_stop_height,
+        "actual_stop_hash": actual_stop_hash,
+        "window": 1,
+        "assume_valid_height": 0,
+        "stop_reason": "controller-request",
+        "storage_backend": args.storage_backend,
+        "txindex": args.txindex,
+        "blockfilterindex": args.blockfilterindex,
+        "data_dir": args.data_dir,
+        "elapsed_seconds": elapsed.as_secs_f64(),
+    });
+    let rendered =
+        serde_json::to_string_pretty(&artifact).context("render diagnostic artifact JSON")?;
+
+    ensure_diagnostic_output_absent(output)?;
+    let (mut temp, mut file) = DiagnosticTempOutput::create(output)?;
+    file.write_all(rendered.as_bytes()).with_context(|| {
+        format!(
+            "write temporary diagnostic artifact {}",
+            temp.path.display()
+        )
+    })?;
+    file.write_all(b"\n").with_context(|| {
+        format!(
+            "terminate temporary diagnostic artifact {}",
+            temp.path.display()
+        )
+    })?;
+    file.flush().with_context(|| {
+        format!(
+            "flush temporary diagnostic artifact {}",
+            temp.path.display()
+        )
+    })?;
+    file.sync_all().with_context(|| {
+        format!(
+            "fsync temporary diagnostic artifact {}",
+            temp.path.display()
+        )
+    })?;
+    drop(file);
+
+    temp.publish(output)?;
+    let parent = output
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    OpenOptions::new()
+        .read(true)
+        .open(parent)
+        .with_context(|| format!("open diagnostic output directory {}", parent.display()))?
+        .sync_all()
+        .with_context(|| format!("fsync diagnostic output directory {}", parent.display()))?;
+
+    Ok(())
+}
+
+#[cfg(feature = "checksig-census")]
+fn ensure_diagnostic_output_absent(path: &Path) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => bail!(
+            "refusing to replace existing diagnostic output {}",
+            path.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .with_context(|| format!("inspect diagnostic output destination {}", path.display())),
+    }
+}
+
+#[cfg(feature = "checksig-census")]
+struct DiagnosticTempOutput {
+    path: PathBuf,
+    armed: bool,
+}
+
+#[cfg(feature = "checksig-census")]
+impl DiagnosticTempOutput {
+    fn create(target: &Path) -> Result<(Self, std::fs::File)> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+        let file_name = target.file_name().with_context(|| {
+            format!(
+                "diagnostic output path {} has no file name",
+                target.display()
+            )
+        })?;
+        let parent = target
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create diagnostic output directory {}", parent.display()))?;
+
+        for _ in 0..128 {
+            let id = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+            let mut temp_name = file_name.to_os_string();
+            temp_name.push(format!(".tmp.{}.{id}", std::process::id()));
+            let path = parent.join(&temp_name);
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(file) => return Ok((Self { path, armed: true }, file)),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("create temporary diagnostic artifact {}", path.display())
+                    });
+                }
+            }
+        }
+        bail!(
+            "could not reserve a temporary diagnostic artifact name beside {} after 128 attempts",
+            target.display()
+        )
+    }
+
+    fn publish(&mut self, target: &Path) -> Result<()> {
+        rename_noreplace(&self.path, target).with_context(|| {
+            format!(
+                "atomically publish {} without replacing {}",
+                self.path.display(),
+                target.display()
+            )
+        })?;
+        self.armed = false;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "checksig-census")]
+impl Drop for DiagnosticTempOutput {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+#[cfg(feature = "checksig-census")]
+#[cfg(any(
+    target_vendor = "apple",
+    target_os = "linux",
+    target_os = "android",
+    target_os = "redox"
+))]
+fn rename_noreplace(from: &Path, to: &Path) -> std::io::Result<()> {
+    rustix::fs::renameat_with(
+        rustix::fs::CWD,
+        from,
+        rustix::fs::CWD,
+        to,
+        rustix::fs::RenameFlags::NOREPLACE,
+    )
+    .map_err(Into::into)
+}
+
+#[cfg(feature = "checksig-census")]
+#[cfg(not(any(
+    target_vendor = "apple",
+    target_os = "linux",
+    target_os = "android",
+    target_os = "redox"
+)))]
+fn rename_noreplace(from: &Path, to: &Path) -> std::io::Result<()> {
+    std::fs::hard_link(from, to)?;
+    std::fs::remove_file(from)
+}
+
+#[cfg(feature = "checksig-census")]
+fn run_census_diagnostic(
+    args: &Args,
+    apply_handles: &bitcoin_rs_node::apply::ApplyHandles,
+) -> Result<()> {
+    let rest_url = args.rest_url.as_deref().context("--rest-url is required")?;
+    let mut client =
+        CoreRestClient::connect(rest_url).map_err(|e: CoreRestError| anyhow::Error::from(e))?;
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let stdin = std::io::stdin();
+    let mut stdin = stdin.lock();
+
+    write_diagnostic_preface(&mut stdout)?;
+
+    let mut prev_hash = None;
+    let started = Instant::now();
+    let mut prev_checkpoint: Option<census_checkpoint::CensusCheckpoint> = None;
+
+    for height in args.start_height..=args.stop_height {
+        let (hash, raw) = fetch_rest_block(&mut client, height)
+            .map_err(|e: CoreRestError| anyhow::Error::from(e))?;
+        let block =
+            decode_and_validate_block(height, &hash, &raw, &mut prev_hash, apply_handles.network)?;
+        let block_hash = block.block_hash();
+        apply_one_block(apply_handles, block, raw)?;
+        let checkpoint = census_checkpoint::capture().context("census checkpoint")?;
+
+        update_prev_checkpoint(&mut prev_checkpoint, checkpoint, height)
+            .context("monotonicity check before checkpoint row")?;
+
+        write_checkpoint_row(&mut stdout, height, block_hash, &checkpoint)
+            .context("write checkpoint row")?;
+        stdout.flush().context("flush checkpoint row to stdout")?;
+
+        let control = read_control_byte(&mut stdin)?;
+        match control {
+            0x01 => {
+                let actual_stop_hash = block_hash.to_string();
+                census_checkpoint::flush().context("terminal flush after diagnostic stop")?;
+                write_diagnostic_artifact(args, height, &actual_stop_hash, started.elapsed())?;
+                return Ok(());
+            }
+            0x00 => {
+                if height == args.stop_height {
+                    census_checkpoint::flush().context("terminal flush at safety ceiling")?;
+                    bail!("safety ceiling exhausted without controller selection");
+                }
+            }
+            b => bail!("invalid control byte 0x{b:02x} from controller"),
+        }
+    }
+
+    census_checkpoint::flush().context("terminal flush at safety ceiling")?;
+    bail!("safety ceiling exhausted without controller selection");
+}
+
+#[cfg(feature = "checksig-census")]
+fn update_prev_checkpoint(
+    prev: &mut Option<census_checkpoint::CensusCheckpoint>,
+    next: census_checkpoint::CensusCheckpoint,
+    height: u32,
+) -> Result<()> {
+    if let Some(prev) = prev.as_ref() {
+        if !census_checkpoint::is_monotonic(prev, &next) {
+            bail!("checkpoint at height {height} is not monotonic relative to the previous row");
+        }
+    }
+    *prev = Some(next);
+    Ok(())
+}
+
 fn print_usage() {
     println!(
         "usage: mainnet_prefix_replay --stop-height <height> [--blocks-file <core-framed-archive> --corpus-manifest <manifest> | --rest-url <host:port> | --bitcoin-cli <path>] [--assume-valid-height <height>] [--bitcoin-cli-arg <arg>]... [--data-dir <path>] [--output <path>] [--validation-output <path>] [--txindex] [--blockfilterindex]"
@@ -938,14 +1371,16 @@ fn print_usage() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitcoin::consensus::encode::serialize;
+    use bitcoin::consensus::Encodable as _;
     use bitcoin_rs_node::corpus::{ArchiveInfo, CorpusEntry, CorpusManifest};
     use bitcoin_rs_primitives::Hash256;
+    use std::io::Cursor;
 
     fn regtest_genesis_bytes() -> Vec<u8> {
-        serialize(&bitcoin::blockdata::constants::genesis_block(
-            bitcoin::Network::Regtest,
-        ))
+        let block = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest);
+        let mut bytes = Vec::new();
+        block.consensus_encode(&mut bytes).unwrap();
+        bytes
     }
 
     fn write_archive(magic: [u8; 4], payloads: &[&[u8]]) -> Vec<u8> {
@@ -1089,7 +1524,7 @@ mod tests {
         let err = source.fetch(0).unwrap_err();
         assert!(
             format!("{err:?}").to_lowercase().contains("wrong magic"),
-            "{err:?}"
+            "{err}"
         );
     }
 
@@ -1232,7 +1667,7 @@ mod tests {
         let payload = regtest_genesis_bytes();
         let archive = write_archive(Network::Mainnet.magic(), &[&payload[..]]);
         let manifest = {
-            let mut m = manifest_for_archive(Network::Mainnet, &archive, &[&payload[..]]);
+            let m = manifest_for_archive(Network::Mainnet, &archive, &[&payload[..]]);
             m
         };
 
@@ -1276,5 +1711,217 @@ mod tests {
             err.to_string().to_lowercase().contains("archive size"),
             "{err}"
         );
+    }
+
+    #[cfg(feature = "checksig-census")]
+    #[test]
+    fn diagnostic_preface_and_row_encoding() {
+        let mut out: Vec<u8> = Vec::new();
+        write_diagnostic_preface(&mut out).unwrap();
+        assert_eq!(out.len(), 16);
+        assert_eq!(&out[0..8], b"BRSHGT1\0");
+        assert_eq!(
+            u32::from_le_bytes(out[8..12].try_into().unwrap()),
+            DIAGNOSTIC_VERSION
+        );
+        assert_eq!(
+            u32::from_le_bytes(out[12..16].try_into().unwrap()),
+            DIAGNOSTIC_ROW_SIZE
+        );
+
+        let checkpoint = census_checkpoint::CensusCheckpoint {
+            abi_version: 1,
+            struct_size: 56,
+            context_rows: 1,
+            context_end: 16 + 56,
+            record_rows: 2,
+            record_end: 16 + 2 * 224,
+            journal_rows: 3,
+            journal_end: 16 + 3 * 56,
+        };
+        let hash = BlockHash::from_byte_array([0x42; 32]);
+        write_checkpoint_row(&mut out, 7, hash, &checkpoint).unwrap();
+
+        let row_start = 16;
+        assert_eq!(out.len(), row_start + 84);
+        assert_eq!(
+            u32::from_le_bytes(out[row_start..row_start + 4].try_into().unwrap()),
+            7
+        );
+        assert_eq!(&out[row_start + 4..row_start + 36], &[0x42; 32]);
+        let read_hash = <[u8; 32]>::try_from(&out[row_start + 4..row_start + 36]).unwrap();
+        assert_eq!(read_hash, [0x42; 32]);
+    }
+
+    #[cfg(feature = "checksig-census")]
+    #[test]
+    fn diagnostic_artifact_records_actual_stop_and_controller_reason() {
+        let mut args = Args::parse(std::iter::empty::<OsString>()).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("diagnostic.json");
+        args.output = Some(output.clone());
+        write_diagnostic_artifact(
+            &args,
+            11,
+            "000000000000000000000000000000000000000000000000000000000000000a",
+            Duration::from_secs(3),
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(&output).unwrap();
+        let artifact: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            artifact["schema"].as_str(),
+            Some("mainnet-prefix-replay-diagnostic-v1")
+        );
+        assert_eq!(artifact["non_certifying"].as_bool(), Some(true));
+        assert_eq!(artifact["block_source"].as_str(), Some("rest"));
+        assert_eq!(artifact["actual_stop_height"].as_u64(), Some(11));
+        assert_eq!(artifact["requested_stop_height_ceiling"].as_u64(), Some(0));
+        assert_eq!(artifact["stop_reason"].as_str(), Some("controller-request"));
+        assert!(!content.contains("all-11-observed"));
+    }
+
+    #[cfg(feature = "checksig-census")]
+    #[test]
+    fn diagnostic_artifact_refuses_preexisting_destination() {
+        let mut args = Args::parse(std::iter::empty::<OsString>()).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("diagnostic.json");
+        std::fs::write(&output, b"already here").unwrap();
+        args.output = Some(output.clone());
+        let err = write_diagnostic_artifact(
+            &args,
+            11,
+            "000000000000000000000000000000000000000000000000000000000000000a",
+            Duration::from_secs(3),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .to_lowercase()
+                .contains("refusing to replace existing"),
+            "{err}"
+        );
+        let content = std::fs::read_to_string(&output).unwrap();
+        assert_eq!(content, "already here");
+    }
+
+    #[cfg(feature = "checksig-census")]
+    #[test]
+    fn diagnostic_artifact_publishes_dot_tmp_destination_safely() {
+        let mut args = Args::parse(std::iter::empty::<OsString>()).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("diagnostic.json.tmp");
+        args.output = Some(output.clone());
+        write_diagnostic_artifact(
+            &args,
+            7,
+            "0000000000000000000000000000000000000000000000000000000000000007",
+            Duration::from_secs(1),
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(&output).unwrap();
+        let artifact: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(artifact["actual_stop_height"].as_u64(), Some(7));
+
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect();
+        assert!(
+            entries
+                .iter()
+                .any(|n| n.to_string_lossy() == "diagnostic.json.tmp"),
+            "{entries:?}"
+        );
+    }
+
+    #[cfg(feature = "checksig-census")]
+    #[test]
+    fn diagnostic_artifact_leaves_no_debris_on_failure() {
+        let mut args = Args::parse(std::iter::empty::<OsString>()).unwrap();
+        // /nonexistent is guaranteed to fail directory creation.
+        args.output = Some(PathBuf::from("/nonexistent/graveyard/diagnostic.json"));
+        let err = write_diagnostic_artifact(
+            &args,
+            11,
+            "000000000000000000000000000000000000000000000000000000000000000a",
+            Duration::from_secs(3),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("diagnostic output"),
+            "{err}"
+        );
+    }
+
+    #[cfg(feature = "checksig-census")]
+    #[test]
+    fn read_control_byte_interprets_bytes() {
+        let mut zero = Cursor::new([0x00]);
+        assert_eq!(read_control_byte(&mut zero).unwrap(), 0x00);
+        let mut one = Cursor::new([0x01]);
+        assert_eq!(read_control_byte(&mut one).unwrap(), 0x01);
+        let mut empty: Cursor<&[u8]> = Cursor::new(&[]);
+        assert!(read_control_byte(&mut empty).is_err());
+    }
+
+    #[cfg(feature = "checksig-census")]
+    #[test]
+    fn validate_diagnostic_args_rejects_window_and_missing_env() {
+        let mut args = Args::parse(std::iter::empty::<OsString>()).unwrap();
+        args.census_diagnostic = true;
+        args.rest_url = Some("127.0.0.1:18443".into());
+        args.output = Some(PathBuf::from("/tmp/diagnostic.json"));
+        args.window = 2;
+        assert!(
+            validate_diagnostic_args(&args)
+                .unwrap_err()
+                .to_string()
+                .contains("--window 1")
+        );
+
+        args.window = 1;
+        // SAFETY: test-only environment mutation.
+        unsafe {
+            std::env::set_var("BRS_CENSUS_CONTEXTS", "/tmp/ctx");
+            std::env::set_var("BRS_CENSUS_RECORDS", "/tmp/rec");
+            std::env::set_var("BRS_CENSUS_JOURNAL", "/tmp/jrn");
+        }
+        validate_diagnostic_args(&args).unwrap();
+
+        // SAFETY: test-only environment mutation.
+        unsafe {
+            std::env::remove_var("BRS_CENSUS_JOURNAL");
+        }
+    }
+
+    #[cfg(feature = "checksig-census")]
+    #[test]
+    fn checkpoint_monotonicity_rejects_decreasing_successor() {
+        let mut prev = None;
+        let first = census_checkpoint::CensusCheckpoint {
+            context_rows: 1,
+            context_end: 100,
+            record_rows: 1,
+            record_end: 100,
+            journal_rows: 1,
+            journal_end: 100,
+            ..Default::default()
+        };
+        update_prev_checkpoint(&mut prev, first, 0).unwrap();
+
+        let second = census_checkpoint::CensusCheckpoint {
+            context_rows: 0,
+            context_end: 100,
+            record_rows: 1,
+            record_end: 100,
+            journal_rows: 1,
+            journal_end: 100,
+            ..Default::default()
+        };
+        let err = update_prev_checkpoint(&mut prev, second, 1).unwrap_err();
+        assert!(err.to_string().contains("not monotonic"), "{err}");
     }
 }

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -1644,6 +1644,9 @@ fn prove_window(
         if verdict.is_err() {
             return Vec::new();
         }
+        if !units.is_empty() {
+            metrics::counter!("node.window.verify_success_total").increment(1);
+        }
     }
 
     prepared
@@ -6147,6 +6150,7 @@ mod consensus_rule_tests {
     fn a_window_skips_scripts_for_assume_valid_blocks_and_proves_nothing_for_them()
     -> Result<(), Box<dyn std::error::Error>> {
         use bitcoin::opcodes::all::OP_EQUAL;
+        let (recorder, metrics_handle) = crate::metrics::test_recorder();
 
         let genesis = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest);
         let prevout = bitcoin::OutPoint {
@@ -6201,7 +6205,8 @@ mod consensus_rule_tests {
 
         // Height 1 is covered, and with no anchor pinned the gate is trusted.
         let (handles, block, raw) = build(100)?;
-        let proven = prove_window(&handles, &[&block], &[raw]);
+        let proven =
+            metrics::with_local_recorder(&recorder, || prove_window(&handles, &[&block], &[raw]));
         assert_eq!(
             proven.len(),
             1,
@@ -6215,6 +6220,13 @@ mod consensus_rule_tests {
             "a skipped block must carry no script proof: the proof branch bypasses the \
              trust-gate re-read at commit, so a gate that flips in between would let an \
              unverified block through"
+        );
+        assert_eq!(
+            metrics_handle
+                .snapshot()
+                .get("node.window.verify_success_total"),
+            None,
+            "an empty verification dispatch must not count as script verification",
         );
 
         // Full verification must be completely unaffected.

--- a/crates/node/src/corpus.rs
+++ b/crates/node/src/corpus.rs
@@ -1,0 +1,2196 @@
+//! Versioned corpus manifest and active-chain Core-frame exporter.
+//!
+//! A `CorpusManifest` names a single network, a single contiguous block range
+//! `[0, stop]`, and the offset/length table for every block in the archive.
+//! The manifest is the durable integrity contract; `export_active_chain_corpus`
+//! streams the matching archive through [`bitcoin_rs_storage::CoreFrameWriter`]
+//! and publishes it before the validated manifest.
+
+use std::fs;
+use std::io::{self, BufRead as _, BufReader, BufWriter, Read as _, Write as _};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use bitcoin::Block;
+use bitcoin::consensus::deserialize;
+use bitcoin::hashes::Hash as _;
+use bitcoin::hashes::sha256d;
+use bitcoin_rs_chain::BlockTree;
+use bitcoin_rs_primitives::{Hash256, Network};
+use bitcoin_rs_rpc::BlockBodySource;
+use bitcoin_rs_storage::{CORE_FRAME_HEADER_LEN, CoreFrameError, CoreFrameWriter};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+pub(crate) const SCHEMA: &str = "bitcoin-rs-corpus-manifest";
+pub(crate) const VERSION: u32 = 1;
+const MAGIC_HEX_LEN: usize = 8;
+const HASH_HEX_LEN: usize = 64;
+const SHA256_HEX_LEN: usize = 64;
+const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+const MAX_HTTP_LINE_BYTES: u64 = 8 * 1024;
+const REST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Consensus-maximum serialized block size in bytes.
+pub(crate) const MAX_PAYLOAD_BYTES: u32 = 4_000_000;
+
+/// A validated corpus manifest.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CorpusManifest {
+    /// Bitcoin network the archive belongs to.
+    pub network: Network,
+    /// P2P message-start bytes for `network` in wire order.
+    pub network_magic: [u8; 4],
+    /// Genesis block hash for `network` in canonical displayed form.
+    pub genesis_hash: Hash256,
+    /// Inclusive start height; always `0` for a valid manifest.
+    pub start_height: u32,
+    /// Inclusive stop height.
+    pub stop_height: u32,
+    /// Archive payload metadata.
+    pub archive: ArchiveInfo,
+    /// One entry per height, contiguous from `start_height` to `stop_height`.
+    pub entries: Vec<CorpusEntry>,
+}
+
+/// Archive-level metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ArchiveInfo {
+    /// Total archive size in bytes.
+    pub size: u64,
+    /// SHA-256 digest of the entire archive.
+    pub sha256: [u8; 32],
+}
+
+/// One block's position and identity inside the archive.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CorpusEntry {
+    /// Block height.
+    pub height: u32,
+    /// Block hash in canonical displayed Bitcoin form.
+    pub hash: Hash256,
+    /// Byte offset of the frame's magic in the archive.
+    pub offset: u64,
+    /// Length in bytes of the block's consensus-serialized payload.
+    pub payload_length: u32,
+}
+
+/// Errors from manifest parsing, validation, or persistence.
+#[derive(Debug, Error)]
+pub enum CorpusError {
+    /// Underlying I/O failure.
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    /// JSON parse or out-of-range integer failure.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    /// Top-level `schema` field did not match the expected value.
+    #[error("schema mismatch: expected {expected}, got {actual}")]
+    SchemaMismatch {
+        /// Supported schema name.
+        expected: &'static str,
+        /// Schema name from the manifest.
+        actual: String,
+    },
+    /// `version` field did not match the supported value.
+    #[error("version mismatch: expected {expected}, got {actual}")]
+    VersionMismatch {
+        /// Supported schema version.
+        expected: u32,
+        /// Version from the manifest.
+        actual: u32,
+    },
+    /// Network name is not one of the supported names.
+    #[error("unknown network: {name}")]
+    UnknownNetwork {
+        /// Unrecognized network name.
+        name: String,
+    },
+    /// Stored network magic does not match the configured network.
+    #[error("network magic mismatch: expected {expected}, got {actual}")]
+    NetworkMagicMismatch {
+        /// Magic derived from the configured network.
+        expected: String,
+        /// Magic from the manifest.
+        actual: String,
+    },
+    /// Stored genesis hash does not match the configured network.
+    #[error("genesis hash mismatch for {network:?}: expected {expected}, got {actual}")]
+    GenesisMismatch {
+        /// Configured network.
+        network: Network,
+        /// Genesis hash derived from the network.
+        expected: String,
+        /// Genesis hash from the manifest.
+        actual: String,
+    },
+    /// The manifest does not start at height 0.
+    #[error("corpus must start at height 0, got {start}")]
+    NonZeroStart {
+        /// Declared start height.
+        start: u32,
+    },
+    /// The manifest has no entries.
+    #[error("empty corpus entries")]
+    EmptyEntries,
+    /// The inclusive stop height cannot be represented as a vector capacity.
+    #[error("entry capacity for stop height {stop} does not fit this platform")]
+    EntryCapacityOverflow {
+        /// Declared inclusive stop height.
+        stop: u32,
+    },
+    /// The entry count does not match the declared stop height.
+    #[error("expected {expected} entries for stop height {stop}, got {count}")]
+    EntryCountMismatch {
+        /// Declared inclusive stop height.
+        stop: u32,
+        /// Entry count implied by the inclusive range.
+        expected: u64,
+        /// Actual number of entries.
+        count: usize,
+    },
+    /// Heights are duplicated, gapped, or out of order.
+    #[error("height mismatch at index {index}: expected {expected}, got {actual}")]
+    HeightMismatch {
+        /// Entry index in the manifest.
+        index: usize,
+        /// Contiguous height required at this index.
+        expected: u32,
+        /// Height stored in the entry.
+        actual: u32,
+    },
+    /// An offset is not the expected continuation of the previous frame.
+    #[error("offset mismatch at index {index}: expected {expected}, got {actual}")]
+    OffsetMismatch {
+        /// Entry index in the manifest.
+        index: usize,
+        /// Contiguous frame offset required at this index.
+        expected: u64,
+        /// Offset stored in the entry.
+        actual: u64,
+    },
+    /// Computing the next frame end overflowed `u64`.
+    #[error("offset arithmetic overflow at index {index}")]
+    OffsetOverflow {
+        /// Entry index whose frame end overflowed.
+        index: usize,
+    },
+    /// A payload length exceeds the consensus maximum block size.
+    #[error("oversized payload length {length} at index {index}")]
+    OversizedPayload {
+        /// Entry index in the manifest.
+        index: usize,
+        /// Declared payload length.
+        length: u32,
+    },
+    /// The final frame end does not match the declared archive size.
+    #[error("archive size mismatch: final frame ends at {computed}, manifest declares {declared}")]
+    ArchiveSizeMismatch {
+        /// Archive size implied by the final frame.
+        computed: u64,
+        /// Archive size stored in the manifest.
+        declared: u64,
+    },
+    /// A hex string is not composed of lowercase hexadecimal characters.
+    #[error("invalid hex: {0}")]
+    InvalidHex(String),
+    /// A hash or digest is not exactly 64 lowercase hex characters.
+    #[error("invalid hash length: expected {expected}, got {length}")]
+    InvalidHashLength {
+        /// Required hexadecimal string length.
+        expected: usize,
+        /// Actual string length.
+        length: usize,
+    },
+    /// The network magic is not exactly 8 lowercase hex characters.
+    #[error("invalid magic length: expected {MAGIC_HEX_LEN}, got {length}")]
+    InvalidMagicLength {
+        /// Actual string length.
+        length: usize,
+    },
+    /// Archive and manifest resolve to the same destination.
+    #[error("archive and manifest paths collide: {path}")]
+    PathCollision {
+        /// Colliding destination.
+        path: PathBuf,
+    },
+    /// A final output already exists and will not be replaced.
+    #[error("output already exists: {path}")]
+    OutputExists {
+        /// Existing destination.
+        path: PathBuf,
+    },
+    /// An output path has no final file name.
+    #[error("output path has no file name: {path}")]
+    InvalidOutputPath {
+        /// Invalid destination.
+        path: PathBuf,
+    },
+    /// The requested stop height is beyond the active tip.
+    #[error("stop height {stop} exceeds active tip {tip:?}")]
+    StopAboveTip {
+        /// Requested inclusive stop height.
+        stop: u32,
+        /// Active tip height, absent when the tree has no active tip.
+        tip: Option<u32>,
+    },
+    /// The active-chain lookup returned an entry at the wrong height.
+    #[error("noncontiguous active entry: requested height {expected}, got {actual}")]
+    NoncontiguousActiveEntry {
+        /// Requested height.
+        expected: u32,
+        /// Height stored in the returned node.
+        actual: u32,
+    },
+    /// The active chain has no entry at a required height.
+    #[error("missing active-chain entry at height {height}")]
+    MissingActiveEntry {
+        /// Missing height.
+        height: u32,
+    },
+    /// The durable block-body source has no bytes for an active block.
+    #[error("missing block body at height {height} for {hash}")]
+    MissingBody {
+        /// Active-chain height.
+        height: u32,
+        /// Expected active-chain hash.
+        hash: Hash256,
+    },
+    /// Stored consensus bytes did not decode as one complete block.
+    #[error("invalid block body at height {height}: {source}")]
+    InvalidBody {
+        /// Active-chain height.
+        height: u32,
+        /// Consensus decoding failure.
+        #[source]
+        source: bitcoin::consensus::encode::Error,
+    },
+    /// The stored body's block hash differs from the active-chain hash.
+    #[error("block body hash mismatch at height {height}: expected {expected}, got {actual}")]
+    BodyHashMismatch {
+        /// Active-chain height.
+        height: u32,
+        /// Active-chain hash.
+        expected: Hash256,
+        /// Decoded body's hash.
+        actual: Hash256,
+    },
+    /// Core-frame streaming failed.
+    #[error("Core frame error: {0}")]
+    CoreFrame(#[from] CoreFrameError),
+    /// Core REST transport or protocol failure.
+    #[error("Core REST error: {0}")]
+    Rest(#[from] CoreRestError),
+    /// A REST payload is too short to contain a block header.
+    #[error("REST block payload at height {height} is only {len} bytes; expected at least 80")]
+    RestShortPayload {
+        /// Requested height.
+        height: u32,
+        /// Received payload length.
+        len: usize,
+    },
+    /// The hash reported by Core differs from the payload header hash.
+    #[error(
+        "REST block hash mismatch at height {height}: reported {reported}, computed {computed}"
+    )]
+    RestHashMismatch {
+        /// Requested height.
+        height: u32,
+        /// Hash returned by `blockhashbyheight`.
+        reported: String,
+        /// Hash computed from the received header.
+        computed: String,
+    },
+    /// The first REST block is not the configured network's genesis block.
+    #[error("REST genesis mismatch: expected {expected}, got {actual}")]
+    RestGenesisMismatch {
+        /// Configured network genesis.
+        expected: String,
+        /// Received height-zero hash.
+        actual: String,
+    },
+    /// Consecutive REST blocks do not form one chain.
+    #[error(
+        "REST chain discontinuity at height {height}: expected parent {expected_prev}, got {actual_prev}"
+    )]
+    RestContinuity {
+        /// Discontinuous block height.
+        height: u32,
+        /// Previously fetched block hash.
+        expected_prev: String,
+        /// Parent named by this block.
+        actual_prev: String,
+    },
+    /// A temporary output name could not be reserved.
+    #[error("could not reserve a sibling temporary file for {path}")]
+    TempNameExhausted {
+        /// Final destination.
+        path: PathBuf,
+    },
+}
+
+/// Errors from the synchronous Bitcoin Core REST client.
+#[derive(Debug, Error)]
+pub enum CoreRestError {
+    /// Opening the TCP connection failed.
+    #[error("connect to {host}: {source}")]
+    Connect {
+        /// REST host in `host:port` form.
+        host: String,
+        /// Socket error.
+        #[source]
+        source: io::Error,
+    },
+    /// Reading or writing the REST connection failed.
+    #[error("REST I/O error: {0}")]
+    Io(#[from] io::Error),
+    /// The response status was not HTTP 200.
+    #[error("REST GET {path} failed: {status}")]
+    HttpStatus {
+        /// Requested path.
+        path: String,
+        /// Complete status line.
+        status: String,
+    },
+    /// No Content-Length header was present.
+    #[error("REST response without Content-Length: {status}")]
+    MissingContentLength {
+        /// Complete status line.
+        status: String,
+    },
+    /// Content-Length was not a non-negative decimal integer.
+    #[error("invalid Content-Length {value:?}")]
+    InvalidContentLength {
+        /// Header value.
+        value: String,
+    },
+    /// A status or header line exceeded the protocol bound.
+    #[error("REST response line exceeds {MAX_HTTP_LINE_BYTES} bytes")]
+    OversizedHeaderLine,
+    /// A response body exceeded the configured safety bound.
+    #[error("REST GET {path}: Content-Length {len} exceeds sane bound")]
+    OversizedBody {
+        /// Requested path.
+        path: String,
+        /// Declared response length.
+        len: usize,
+    },
+    /// The block-hash response was not UTF-8.
+    #[error("block hash response is not UTF-8")]
+    NonUtf8Hash,
+    /// The block-hash response was not a canonical hash.
+    #[error("invalid block hash hex: {0}")]
+    InvalidHashHex(String),
+}
+
+/// Minimal synchronous keep-alive client for Bitcoin Core's REST interface.
+pub struct CoreRestClient {
+    host: String,
+    stream: BufReader<TcpStream>,
+}
+
+impl CoreRestClient {
+    /// Opens a bounded blocking connection to `host` in `host:port` form.
+    pub fn connect(host: &str) -> Result<Self, CoreRestError> {
+        let stream = TcpStream::connect(host).map_err(|source| CoreRestError::Connect {
+            host: host.to_owned(),
+            source,
+        })?;
+        stream.set_read_timeout(Some(REST_TIMEOUT))?;
+        stream.set_write_timeout(Some(REST_TIMEOUT))?;
+        Ok(Self {
+            host: host.to_owned(),
+            stream: BufReader::new(stream),
+        })
+    }
+
+    /// Fetches one bounded response, reconnecting once if the keep-alive socket failed.
+    pub fn get(&mut self, path: &str) -> Result<Vec<u8>, CoreRestError> {
+        match self.request(path) {
+            Ok(body) => Ok(body),
+            // A keep-alive socket may close between requests; retry once for I/O
+            // failures only. Protocol/logic errors are final.
+            Err(CoreRestError::Io(_)) => {
+                *self = Self::connect(&self.host)?;
+                self.request(path)
+            }
+            Err(other) => Err(other),
+        }
+    }
+
+    fn request(&mut self, path: &str) -> Result<Vec<u8>, CoreRestError> {
+        let request = format!(
+            "GET {path} HTTP/1.1\r\nHost: {}\r\nConnection: keep-alive\r\n\r\n",
+            self.host
+        );
+        self.stream.get_mut().write_all(request.as_bytes())?;
+        let status = read_http_line(&mut self.stream)?;
+        let mut content_length = None;
+        loop {
+            let header = read_http_line(&mut self.stream)?;
+            if header.is_empty() {
+                break;
+            }
+            if let Some(value) = header
+                .to_ascii_lowercase()
+                .strip_prefix("content-length:")
+                .map(str::trim)
+            {
+                let length = value
+                    .parse()
+                    .map_err(|_| CoreRestError::InvalidContentLength {
+                        value: value.to_owned(),
+                    })?;
+                content_length = Some(length);
+            }
+        }
+        let length = content_length.ok_or_else(|| CoreRestError::MissingContentLength {
+            status: status.clone(),
+        })?;
+        if length > MAX_BODY_BYTES {
+            return Err(CoreRestError::OversizedBody {
+                path: path.to_owned(),
+                len: length,
+            });
+        }
+        let mut body = vec![0_u8; length];
+        self.stream.read_exact(&mut body)?;
+        if status.split_whitespace().nth(1) != Some("200") {
+            return Err(CoreRestError::HttpStatus {
+                path: path.to_owned(),
+                status,
+            });
+        }
+        Ok(body)
+    }
+}
+
+fn read_http_line(stream: &mut BufReader<TcpStream>) -> Result<String, CoreRestError> {
+    let mut bytes = Vec::new();
+    let read = stream
+        .take(MAX_HTTP_LINE_BYTES + 1)
+        .read_until(b'\n', &mut bytes)?;
+    if read == 0 {
+        return Err(CoreRestError::Io(io::ErrorKind::UnexpectedEof.into()));
+    }
+    let max_line = usize::try_from(MAX_HTTP_LINE_BYTES).unwrap_or(usize::MAX);
+    if read > max_line || !bytes.ends_with(b"\n") {
+        return Err(CoreRestError::OversizedHeaderLine);
+    }
+    while matches!(bytes.last(), Some(b'\n' | b'\r')) {
+        bytes.pop();
+    }
+    String::from_utf8(bytes).map_err(|_| CoreRestError::OversizedHeaderLine)
+}
+
+/// A fetched block's canonical displayed hash and raw consensus bytes.
+pub type FetchedBlock = (String, Vec<u8>);
+
+/// Fetches a height's hash and raw block bytes from Bitcoin Core REST.
+pub fn fetch_rest_block(
+    client: &mut CoreRestClient,
+    height: u32,
+) -> Result<FetchedBlock, CoreRestError> {
+    let hash_bytes = client.get(&format!("/rest/blockhashbyheight/{height}.hex"))?;
+    let hash = String::from_utf8(hash_bytes)
+        .map_err(|_| CoreRestError::NonUtf8Hash)?
+        .trim()
+        .to_owned();
+    Hash256::from_str_be(&hash).map_err(|_| CoreRestError::InvalidHashHex(hash.clone()))?;
+    let bytes = client.get(&format!("/rest/block/{hash}.bin"))?;
+    Ok((hash, bytes))
+}
+
+struct CorpusBlock {
+    hash: Hash256,
+    payload: Vec<u8>,
+}
+
+trait CorpusBlockSource {
+    fn next_block(&mut self, height: u32) -> Result<CorpusBlock, CorpusError>;
+}
+
+struct BlockTreeSource<'a> {
+    tree: &'a BlockTree,
+    body: &'a dyn BlockBodySource,
+}
+
+impl CorpusBlockSource for BlockTreeSource<'_> {
+    fn next_block(&mut self, height: u32) -> Result<CorpusBlock, CorpusError> {
+        let node = self
+            .tree
+            .active_node_at_height(height)
+            .ok_or(CorpusError::MissingActiveEntry { height })?;
+        if node.height != height {
+            return Err(CorpusError::NoncontiguousActiveEntry {
+                expected: height,
+                actual: node.height,
+            });
+        }
+        let hash = node.hash;
+        let payload = self
+            .body
+            .block_body(height, hash)
+            .ok_or(CorpusError::MissingBody { height, hash })?;
+        Ok(CorpusBlock { hash, payload })
+    }
+}
+
+struct RestCorpusSource {
+    fetcher: Box<dyn FnMut(u32) -> Result<FetchedBlock, CoreRestError>>,
+    network: Network,
+    prev: Option<Hash256>,
+}
+
+impl CorpusBlockSource for RestCorpusSource {
+    fn next_block(&mut self, height: u32) -> Result<CorpusBlock, CorpusError> {
+        let (reported, payload) = (self.fetcher)(height)?;
+        if payload.len() < 80 {
+            return Err(CorpusError::RestShortPayload {
+                height,
+                len: payload.len(),
+            });
+        }
+        let hash = Hash256::from_str_be(&reported)
+            .map_err(|_| CoreRestError::InvalidHashHex(reported.clone()))?;
+        let computed = Hash256::from_le_bytes(sha256d::Hash::hash(&payload[..80]).as_byte_array());
+        if computed != hash {
+            return Err(CorpusError::RestHashMismatch {
+                height,
+                reported,
+                computed: computed.to_string_be(),
+            });
+        }
+        let mut actual_prev_bytes = [0_u8; 32];
+        actual_prev_bytes.copy_from_slice(&payload[4..36]);
+        let actual_prev = Hash256::from_le_bytes(&actual_prev_bytes);
+        if height == 0 {
+            let expected = self.network.genesis_block_hash();
+            if computed != expected {
+                return Err(CorpusError::RestGenesisMismatch {
+                    expected: expected.to_string_be(),
+                    actual: computed.to_string_be(),
+                });
+            }
+        } else if self.prev != Some(actual_prev) {
+            return Err(CorpusError::RestContinuity {
+                height,
+                expected_prev: self
+                    .prev
+                    .map_or_else(String::new, bitcoin_rs_primitives::Hash256::to_string_be),
+                actual_prev: actual_prev.to_string_be(),
+            });
+        }
+        self.prev = Some(computed);
+        Ok(CorpusBlock { hash, payload })
+    }
+}
+
+/// Streams heights `0..=stop_height` directly from Bitcoin Core REST.
+pub fn export_corpus_from_rest(
+    rest_url: &str,
+    network: Network,
+    stop_height: u32,
+    archive_path: impl AsRef<Path>,
+    manifest_path: impl AsRef<Path>,
+) -> Result<CorpusManifest, CorpusError> {
+    let (archive_path, manifest_path) =
+        prepare_corpus_destinations(archive_path.as_ref(), manifest_path.as_ref())?;
+    let mut client = CoreRestClient::connect(rest_url)?;
+    let mut source = RestCorpusSource {
+        fetcher: Box::new(move |height| fetch_rest_block(&mut client, height)),
+        network,
+        prev: None,
+    };
+    write_corpus_archive(
+        &mut source,
+        network,
+        stop_height,
+        &archive_path,
+        &manifest_path,
+    )
+}
+
+/// Exports heights `0..=stop_height` from an opened production node state.
+///
+/// The archive contains Bitcoin Core `-loadblock` frames. Stored consensus body
+/// bytes are decoded only to verify their hash and are written without
+/// re-encoding. The archive is durably published before the validated manifest.
+pub fn export_active_chain_corpus(
+    state: &crate::state::NodeState,
+    network: Network,
+    stop_height: u32,
+    archive_path: impl AsRef<Path>,
+    manifest_path: impl AsRef<Path>,
+) -> Result<CorpusManifest, CorpusError> {
+    let block_tree = state.block_tree();
+    let block_tree = block_tree.read();
+    let body_source = state.block_body_source();
+    export_from_sources(
+        &block_tree,
+        body_source.as_ref(),
+        network,
+        stop_height,
+        archive_path.as_ref(),
+        manifest_path.as_ref(),
+    )
+}
+
+pub(crate) fn export_from_sources(
+    block_tree: &BlockTree,
+    body_source: &dyn BlockBodySource,
+    network: Network,
+    stop_height: u32,
+    archive_path: &Path,
+    manifest_path: &Path,
+) -> Result<CorpusManifest, CorpusError> {
+    let (archive_path, manifest_path) = prepare_corpus_destinations(archive_path, manifest_path)?;
+    let tip = block_tree.tip_height();
+    match tip {
+        Some(tip_height) if stop_height <= tip_height => {}
+        _ => {
+            return Err(CorpusError::StopAboveTip {
+                stop: stop_height,
+                tip,
+            });
+        }
+    }
+    let mut source = BlockTreeSource {
+        tree: block_tree,
+        body: body_source,
+    };
+    write_corpus_archive(
+        &mut source,
+        network,
+        stop_height,
+        &archive_path,
+        &manifest_path,
+    )
+}
+
+fn prepare_corpus_destinations(
+    archive_path: &Path,
+    manifest_path: &Path,
+) -> Result<(PathBuf, PathBuf), CorpusError> {
+    let archive_path = prepare_destination(archive_path)?;
+    let manifest_path = prepare_destination(manifest_path)?;
+    if archive_path == manifest_path {
+        return Err(CorpusError::PathCollision { path: archive_path });
+    }
+    Ok((archive_path, manifest_path))
+}
+
+fn write_corpus_archive(
+    source: &mut dyn CorpusBlockSource,
+    network: Network,
+    stop_height: u32,
+    archive_path: &Path,
+    manifest_path: &Path,
+) -> Result<CorpusManifest, CorpusError> {
+    ensure_absent(archive_path)?;
+    ensure_absent(manifest_path)?;
+
+    let (mut archive_temp, archive_file) = TempFile::create(archive_path)?;
+    let mut hashing_writer = HashingWriter::new(BufWriter::new(archive_file));
+    let entry_capacity = usize::try_from(u64::from(stop_height) + 1)
+        .map_err(|_| CorpusError::EntryCapacityOverflow { stop: stop_height })?;
+    let mut entries = Vec::with_capacity(entry_capacity);
+    let archive_size;
+    {
+        let mut frames = CoreFrameWriter::new(&mut hashing_writer, network.magic());
+        for height in 0..=stop_height {
+            let CorpusBlock { hash, payload } = source.next_block(height)?;
+            let block: Block = deserialize(&payload)
+                .map_err(|source| CorpusError::InvalidBody { height, source })?;
+            let actual = Hash256::from_le_bytes(block.block_hash().as_byte_array());
+            if actual != hash {
+                return Err(CorpusError::BodyHashMismatch {
+                    height,
+                    expected: hash,
+                    actual,
+                });
+            }
+            let metadata = frames.write(&payload)?;
+            entries.push(CorpusEntry {
+                height,
+                hash,
+                offset: metadata.offset,
+                payload_length: metadata.len,
+            });
+        }
+        archive_size = frames.offset();
+    }
+    let (mut buf, hasher) = hashing_writer.into_parts();
+    buf.flush()?;
+    let file = buf
+        .into_inner()
+        .map_err(std::io::IntoInnerError::into_error)?;
+    file.sync_all()?;
+    let archive_digest: [u8; 32] = hasher.finalize().into();
+    drop(file);
+    let stored_size = fs::metadata(archive_temp.path())?.len();
+    if stored_size != archive_size {
+        return Err(CorpusError::ArchiveSizeMismatch {
+            computed: archive_size,
+            declared: stored_size,
+        });
+    }
+
+    let manifest = CorpusManifest::new(
+        network,
+        ArchiveInfo::new(archive_size, archive_digest),
+        entries,
+    )?;
+    let manifest_bytes = serde_json::to_vec(&CorpusManifestV1::from(&manifest))?;
+    let (mut manifest_temp, mut manifest_file) = TempFile::create(manifest_path)?;
+    manifest_file.write_all(&manifest_bytes)?;
+    manifest_file.flush()?;
+    manifest_file.sync_all()?;
+    drop(manifest_file);
+
+    ensure_absent(archive_path)?;
+    ensure_absent(manifest_path)?;
+    archive_temp.publish(archive_path)?;
+    sync_parent(archive_path)?;
+    manifest_temp.publish(manifest_path)?;
+    sync_parent(manifest_path)?;
+    Ok(manifest)
+}
+
+struct HashingWriter<W> {
+    inner: W,
+    hasher: Sha256,
+}
+
+impl<W> HashingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            hasher: Sha256::new(),
+        }
+    }
+
+    fn into_parts(self) -> (W, Sha256) {
+        (self.inner, self.hasher)
+    }
+}
+
+impl<W: io::Write> io::Write for HashingWriter<W> {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(bytes)?;
+        self.hasher.update(&bytes[..written]);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+struct TempFile {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFile {
+    fn create(target: &Path) -> Result<(Self, fs::File), CorpusError> {
+        static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+        let file_name = target
+            .file_name()
+            .ok_or_else(|| CorpusError::InvalidOutputPath {
+                path: target.to_owned(),
+            })?;
+        for _ in 0..128 {
+            let id = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+            let mut temp_name = file_name.to_os_string();
+            temp_name.push(format!(".tmp.{}.{id}", std::process::id()));
+            let path = target.with_file_name(temp_name);
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(file) => {
+                    return Ok((Self { path, armed: true }, file));
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(CorpusError::TempNameExhausted {
+            path: target.to_owned(),
+        })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn publish(&mut self, target: &Path) -> Result<(), CorpusError> {
+        rename_noreplace(&self.path, target).map_err(|error| {
+            if error.kind() == io::ErrorKind::AlreadyExists {
+                CorpusError::OutputExists {
+                    path: target.to_owned(),
+                }
+            } else {
+                CorpusError::Io(error)
+            }
+        })?;
+        self.armed = false;
+        Ok(())
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+fn prepare_destination(path: &Path) -> Result<PathBuf, CorpusError> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| CorpusError::InvalidOutputPath {
+            path: path.to_owned(),
+        })?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    Ok(fs::canonicalize(parent)?.join(file_name))
+}
+
+fn ensure_absent(path: &Path) -> Result<(), CorpusError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Err(CorpusError::OutputExists {
+            path: path.to_owned(),
+        }),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn sync_parent(path: &Path) -> io::Result<()> {
+    fs::File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()
+}
+
+#[cfg(any(
+    target_vendor = "apple",
+    target_os = "linux",
+    target_os = "android",
+    target_os = "redox"
+))]
+fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+    rustix::fs::renameat_with(
+        rustix::fs::CWD,
+        from,
+        rustix::fs::CWD,
+        to,
+        rustix::fs::RenameFlags::NOREPLACE,
+    )
+    .map_err(Into::into)
+}
+
+#[cfg(not(any(
+    target_vendor = "apple",
+    target_os = "linux",
+    target_os = "android",
+    target_os = "redox"
+)))]
+fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+    fs::hard_link(from, to)?;
+    fs::remove_file(from)
+}
+
+impl CorpusManifest {
+    /// Schema identifier for the v1 manifest.
+    pub const SCHEMA: &'static str = SCHEMA;
+    /// Version number for the v1 manifest.
+    pub const VERSION: u32 = VERSION;
+
+    /// Constructs and validates a manifest from its constituent parts.
+    ///
+    /// `network_magic` and `genesis_hash` are derived from `network`; the
+    /// caller is responsible for ensuring `entries` are contiguous and the
+    /// archive size matches the final frame.
+    pub fn new(
+        network: Network,
+        archive: ArchiveInfo,
+        entries: Vec<CorpusEntry>,
+    ) -> Result<Self, CorpusError> {
+        let start_height = 0;
+        let stop_height = match entries.len() {
+            0 => return Err(CorpusError::EmptyEntries),
+            n => u32::try_from(n - 1).map_err(|_| CorpusError::OffsetOverflow { index: 0 })?,
+        };
+
+        let manifest = Self {
+            network,
+            network_magic: network.magic(),
+            genesis_hash: network.genesis_block_hash(),
+            start_height,
+            stop_height,
+            archive,
+            entries,
+        };
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// Loads a manifest from a JSON file and validates every field.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, CorpusError> {
+        let bytes = fs::read(path.as_ref())?;
+        Self::from_bytes(&bytes)
+    }
+
+    /// Parses and validates a manifest from its in-memory JSON bytes.
+    ///
+    /// Keeps the read and the parse in one call so a caller can hash the same
+    /// bytes it validated, avoiding a second file read.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, CorpusError> {
+        let wire: CorpusManifestV1 = serde_json::from_slice(bytes)?;
+        wire.try_into()
+    }
+
+    /// Validates a manifest from a path and returns the parsed manifest plus
+    /// the raw bytes that produced it, so the caller can compute the manifest
+    /// file's own digest without reading it a second time.
+    pub fn load_with_bytes(path: impl AsRef<Path>) -> Result<(Self, Vec<u8>), CorpusError> {
+        let bytes = fs::read(path.as_ref())?;
+        let manifest = Self::from_bytes(&bytes)?;
+        Ok((manifest, bytes))
+    }
+
+    /// Saves this manifest to `path` atomically via a temp file, fsync, and
+    /// rename, followed by a parent-directory fsync.
+    pub fn save(&self, path: impl AsRef<Path>) -> Result<(), CorpusError> {
+        self.validate()?;
+        let wire = CorpusManifestV1::from(self);
+        let bytes = serde_json::to_vec(&wire)?;
+
+        let path = path.as_ref();
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        fs::create_dir_all(parent)?;
+        let tmp = path.with_extension("tmp");
+
+        {
+            let mut file = fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&tmp)?;
+            file.write_all(&bytes)?;
+            file.flush()?;
+            file.sync_all()?;
+        }
+
+        fs::rename(&tmp, path)?;
+        fs::File::open(parent)?.sync_all()?;
+
+        Ok(())
+    }
+
+    /// Re-validates the in-memory manifest.
+    pub fn validate(&self) -> Result<(), CorpusError> {
+        if self.start_height != 0 {
+            return Err(CorpusError::NonZeroStart {
+                start: self.start_height,
+            });
+        }
+        if self.network_magic != self.network.magic() {
+            return Err(CorpusError::NetworkMagicMismatch {
+                expected: hex_encode(&self.network.magic()),
+                actual: hex_encode(&self.network_magic),
+            });
+        }
+        if self.genesis_hash != self.network.genesis_block_hash() {
+            return Err(CorpusError::GenesisMismatch {
+                network: self.network,
+                expected: self.network.genesis_block_hash().to_string_be(),
+                actual: self.genesis_hash.to_string_be(),
+            });
+        }
+
+        if self.entries.is_empty() {
+            return Err(CorpusError::EmptyEntries);
+        }
+
+        let expected_count = u64::from(self.stop_height)
+            .checked_add(1)
+            .ok_or(CorpusError::OffsetOverflow { index: 0 })?;
+        let entry_count =
+            u64::try_from(self.entries.len()).map_err(|_| CorpusError::EntryCountMismatch {
+                stop: self.stop_height,
+                expected: expected_count,
+                count: self.entries.len(),
+            })?;
+        if entry_count != expected_count {
+            return Err(CorpusError::EntryCountMismatch {
+                stop: self.stop_height,
+                expected: expected_count,
+                count: self.entries.len(),
+            });
+        }
+
+        let mut expected_offset = 0_u64;
+        let last_index = self.entries.len().saturating_sub(1);
+        for (index, entry) in self.entries.iter().enumerate() {
+            let height_offset = u32::try_from(index).map_err(|_| CorpusError::HeightMismatch {
+                index,
+                expected: self.stop_height,
+                actual: entry.height,
+            })?;
+            let expected_height = self.start_height.wrapping_add(height_offset);
+            if entry.height != expected_height {
+                return Err(CorpusError::HeightMismatch {
+                    index,
+                    expected: expected_height,
+                    actual: entry.height,
+                });
+            }
+            if entry.payload_length > MAX_PAYLOAD_BYTES {
+                return Err(CorpusError::OversizedPayload {
+                    index,
+                    length: entry.payload_length,
+                });
+            }
+            if index == 0 {
+                if entry.offset != 0 {
+                    return Err(CorpusError::OffsetMismatch {
+                        index,
+                        expected: 0,
+                        actual: entry.offset,
+                    });
+                }
+            } else if entry.offset != expected_offset {
+                return Err(CorpusError::OffsetMismatch {
+                    index,
+                    expected: expected_offset,
+                    actual: entry.offset,
+                });
+            }
+
+            expected_offset = entry
+                .offset
+                .checked_add(CORE_FRAME_HEADER_LEN)
+                .and_then(|o| o.checked_add(u64::from(entry.payload_length)))
+                .ok_or(CorpusError::OffsetOverflow { index })?;
+
+            if index == last_index && expected_offset != self.archive.size {
+                return Err(CorpusError::ArchiveSizeMismatch {
+                    computed: expected_offset,
+                    declared: self.archive.size,
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ArchiveInfo {
+    /// Constructs archive metadata from the file size and SHA-256 digest.
+    pub const fn new(size: u64, sha256: [u8; 32]) -> Self {
+        Self { size, sha256 }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CorpusManifestV1 {
+    schema: String,
+    version: u32,
+    network: String,
+    network_magic: String,
+    genesis_hash: String,
+    range: RangeV1,
+    archive: ArchiveInfoV1,
+    entries: Vec<CorpusEntryV1>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RangeV1 {
+    start_height: u32,
+    stop_height: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ArchiveInfoV1 {
+    size: u64,
+    sha256: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CorpusEntryV1 {
+    height: u32,
+    hash: String,
+    offset: u64,
+    payload_length: u32,
+}
+
+impl TryFrom<CorpusManifestV1> for CorpusManifest {
+    type Error = CorpusError;
+
+    fn try_from(wire: CorpusManifestV1) -> Result<Self, Self::Error> {
+        if wire.schema != SCHEMA {
+            return Err(CorpusError::SchemaMismatch {
+                expected: SCHEMA,
+                actual: wire.schema,
+            });
+        }
+        if wire.version != VERSION {
+            return Err(CorpusError::VersionMismatch {
+                expected: VERSION,
+                actual: wire.version,
+            });
+        }
+
+        let network = parse_network_name(&wire.network)?;
+
+        let magic = decode_magic(&wire.network_magic)?;
+        if magic != network.magic() {
+            return Err(CorpusError::NetworkMagicMismatch {
+                expected: hex_encode(&network.magic()),
+                actual: wire.network_magic,
+            });
+        }
+
+        let genesis = parse_hash256(&wire.genesis_hash)?;
+        let expected_genesis = network.genesis_block_hash();
+        if genesis != expected_genesis {
+            return Err(CorpusError::GenesisMismatch {
+                network,
+                expected: expected_genesis.to_string_be(),
+                actual: wire.genesis_hash,
+            });
+        }
+
+        if wire.range.start_height != 0 {
+            return Err(CorpusError::NonZeroStart {
+                start: wire.range.start_height,
+            });
+        }
+
+        let archive = ArchiveInfo {
+            size: wire.archive.size,
+            sha256: decode_sha256(&wire.archive.sha256)?,
+        };
+
+        let mut entries = Vec::with_capacity(wire.entries.len());
+        for wire_entry in wire.entries {
+            entries.push(CorpusEntry {
+                height: wire_entry.height,
+                hash: parse_hash256(&wire_entry.hash)?,
+                offset: wire_entry.offset,
+                payload_length: wire_entry.payload_length,
+            });
+        }
+
+        let manifest = Self {
+            network,
+            network_magic: magic,
+            genesis_hash: genesis,
+            start_height: wire.range.start_height,
+            stop_height: wire.range.stop_height,
+            archive,
+            entries,
+        };
+        manifest.validate()?;
+        Ok(manifest)
+    }
+}
+
+impl From<&CorpusManifest> for CorpusManifestV1 {
+    fn from(manifest: &CorpusManifest) -> Self {
+        Self {
+            schema: SCHEMA.to_owned(),
+            version: VERSION,
+            network: network_name(manifest.network).to_owned(),
+            network_magic: hex_encode(&manifest.network_magic),
+            genesis_hash: manifest.genesis_hash.to_string_be(),
+            range: RangeV1 {
+                start_height: manifest.start_height,
+                stop_height: manifest.stop_height,
+            },
+            archive: ArchiveInfoV1 {
+                size: manifest.archive.size,
+                sha256: hex_encode(&manifest.archive.sha256),
+            },
+            entries: manifest
+                .entries
+                .iter()
+                .map(|entry| CorpusEntryV1 {
+                    height: entry.height,
+                    hash: entry.hash.to_string_be(),
+                    offset: entry.offset,
+                    payload_length: entry.payload_length,
+                })
+                .collect(),
+        }
+    }
+}
+
+fn network_name(network: Network) -> &'static str {
+    match network {
+        Network::Mainnet => "mainnet",
+        Network::Testnet3 => "testnet",
+        Network::Testnet4 => "testnet4",
+        Network::Signet => "signet",
+        Network::Regtest => "regtest",
+    }
+}
+
+fn parse_network_name(name: &str) -> Result<Network, CorpusError> {
+    match name {
+        "mainnet" => Ok(Network::Mainnet),
+        "testnet" => Ok(Network::Testnet3),
+        "testnet4" => Ok(Network::Testnet4),
+        "signet" => Ok(Network::Signet),
+        "regtest" => Ok(Network::Regtest),
+        _ => Err(CorpusError::UnknownNetwork {
+            name: name.to_owned(),
+        }),
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len().saturating_mul(2));
+    for byte in bytes {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+fn is_lower_hex(s: &str, expected_len: usize) -> Result<(), CorpusError> {
+    if s.len() != expected_len {
+        return Err(CorpusError::InvalidHashLength {
+            expected: expected_len,
+            length: s.len(),
+        });
+    }
+    if !s
+        .bytes()
+        .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return Err(CorpusError::InvalidHex(s.to_owned()));
+    }
+    Ok(())
+}
+
+fn decode_hex<const N: usize>(s: &str) -> Result<[u8; N], CorpusError> {
+    is_lower_hex(s, N.saturating_mul(2))?;
+    let mut out = [0_u8; N];
+    for (i, pair) in s.as_bytes().chunks_exact(2).enumerate() {
+        let hi = decode_nibble(pair[0]);
+        let lo = decode_nibble(pair[1]);
+        out[i] = (hi << 4) | lo;
+    }
+    Ok(out)
+}
+
+fn decode_nibble(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => 0,
+    }
+}
+
+fn decode_magic(s: &str) -> Result<[u8; 4], CorpusError> {
+    if s.len() != MAGIC_HEX_LEN {
+        return Err(CorpusError::InvalidMagicLength { length: s.len() });
+    }
+    decode_hex::<4>(s)
+}
+
+fn decode_sha256(s: &str) -> Result<[u8; 32], CorpusError> {
+    is_lower_hex(s, SHA256_HEX_LEN)?;
+    decode_hex::<32>(s)
+}
+
+fn parse_hash256(s: &str) -> Result<Hash256, CorpusError> {
+    is_lower_hex(s, HASH_HEX_LEN)?;
+    Hash256::from_str_be(s).map_err(|_| CorpusError::InvalidHex(s.to_owned()))
+}
+
+#[cfg(test)]
+// Test fixtures fail at the assertion site; production parsing stays fallible.
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use hashbrown::HashMap;
+    use std::io::{BufRead as _, BufReader, Cursor, Write as _};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::{fs, path::Path};
+
+    use bitcoin::Block;
+    use bitcoin::block::{Header as BlockHeader, Version};
+    use bitcoin::consensus::serialize;
+    use bitcoin::hashes::Hash as _;
+    use bitcoin::{BlockHash, CompactTarget, TxMerkleNode};
+    use bitcoin_rs_chain::{BlockTree, NodeStatus};
+    use bitcoin_rs_primitives::{Hash256, Network};
+    use bitcoin_rs_rpc::BlockBodySource;
+    use bitcoin_rs_storage::CoreFrameReader;
+    use sha2::{Digest as _, Sha256};
+
+    use super::{
+        ArchiveInfo, BlockTreeSource, CoreRestClient, CoreRestError, CorpusEntry, CorpusError,
+        CorpusManifest, CorpusManifestV1, HASH_HEX_LEN, MAX_BODY_BYTES, MAX_PAYLOAD_BYTES,
+        RestCorpusSource, SCHEMA, VERSION, export_from_sources, write_corpus_archive,
+    };
+
+    fn sample_archive() -> ArchiveInfo {
+        ArchiveInfo::new(22, [1; 32])
+    }
+
+    fn sample_entries() -> Vec<CorpusEntry> {
+        vec![
+            CorpusEntry {
+                height: 0,
+                hash: Hash256::from_le_bytes(&[0; 32]),
+                offset: 0,
+                payload_length: 2,
+            },
+            CorpusEntry {
+                height: 1,
+                hash: Hash256::from_le_bytes(&[1; 32]),
+                offset: 10,
+                payload_length: 4,
+            },
+        ]
+    }
+
+    fn sample_manifest() -> CorpusManifest {
+        CorpusManifest::new(Network::Regtest, sample_archive(), sample_entries()).unwrap()
+    }
+
+    #[test]
+    fn roundtrip_saves_and_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corpus-manifest-v1.json");
+
+        let manifest = sample_manifest();
+        manifest.save(&path).unwrap();
+        let loaded = CorpusManifest::load(&path).unwrap();
+
+        assert_eq!(loaded, manifest);
+    }
+
+    #[test]
+    fn rejects_wrong_schema() {
+        let json = r#"{"schema":"other","version":1,"network":"regtest","network_magic":"fabfb5da","genesis_hash":"0000000000000000000000000000000000000000000000000000000000000000","range":{"start_height":0,"stop_height":0},"archive":{"size":8,"sha256":"0000000000000000000000000000000000000000000000000000000000000000"},"entries":[{"height":0,"hash":"0000000000000000000000000000000000000000000000000000000000000000","offset":0,"payload_length":0}]}"#;
+        let err = CorpusManifest::try_from(serde_json::from_str::<CorpusManifestV1>(json).unwrap())
+            .unwrap_err();
+        assert!(matches!(err, CorpusError::SchemaMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_wrong_version() {
+        let json = r#"{"schema":"bitcoin-rs-corpus-manifest","version":2,"network":"regtest","network_magic":"fabfb5da","genesis_hash":"0000000000000000000000000000000000000000000000000000000000000000","range":{"start_height":0,"stop_height":0},"archive":{"size":8,"sha256":"0000000000000000000000000000000000000000000000000000000000000000"},"entries":[{"height":0,"hash":"0000000000000000000000000000000000000000000000000000000000000000","offset":0,"payload_length":0}]}"#;
+        let err = CorpusManifest::try_from(serde_json::from_str::<CorpusManifestV1>(json).unwrap())
+            .unwrap_err();
+        assert!(matches!(err, CorpusError::VersionMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_unknown_network() {
+        let manifest = sample_manifest();
+        // Inject a bad network name through the wire path by hand-editing JSON.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("manifest.json");
+        manifest.save(&path).unwrap();
+
+        let text = fs::read_to_string(&path)
+            .unwrap()
+            .replace("regtest", "unknown");
+        fs::write(&path, text).unwrap();
+
+        let err = CorpusManifest::load(&path).unwrap_err();
+        assert!(matches!(err, CorpusError::UnknownNetwork { .. }));
+    }
+
+    #[test]
+    fn rejects_network_magic_mismatch() {
+        let mut manifest = sample_manifest();
+        manifest.network_magic = [0xde, 0xad, 0xbe, 0xef];
+        manifest.network = Network::Regtest;
+        manifest.genesis_hash = Network::Regtest.genesis_block_hash();
+        let err = manifest.save(Path::new("/dev/null")).unwrap_err();
+        assert!(matches!(err, CorpusError::NetworkMagicMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_genesis_mismatch() {
+        let mut manifest = sample_manifest();
+        manifest.genesis_hash = Hash256::from_le_bytes(&[0xff; 32]);
+        let err = manifest.save(Path::new("/dev/null")).unwrap_err();
+        assert!(matches!(err, CorpusError::GenesisMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_nonzero_start() {
+        let mut wire = CorpusManifestV1::from(&sample_manifest());
+        wire.range.start_height = 1;
+        let err = CorpusManifest::try_from(wire).unwrap_err();
+        assert!(matches!(err, CorpusError::NonZeroStart { .. }));
+    }
+
+    #[test]
+    fn rejects_empty_entries() {
+        let err = CorpusManifest::new(Network::Regtest, sample_archive(), Vec::new()).unwrap_err();
+        assert!(matches!(err, CorpusError::EmptyEntries));
+    }
+
+    #[test]
+    fn rejects_gapped_heights() {
+        let mut entries = sample_entries();
+        entries[1].height = 2;
+        let err = CorpusManifest::new(Network::Regtest, sample_archive(), entries).unwrap_err();
+        assert!(matches!(err, CorpusError::HeightMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_duplicate_heights() {
+        let mut entries = sample_entries();
+        entries[1].height = 0;
+        let err = CorpusManifest::new(Network::Regtest, sample_archive(), entries).unwrap_err();
+        assert!(matches!(err, CorpusError::HeightMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_nonzero_first_offset() {
+        let mut entries = sample_entries();
+        entries[0].offset = 1;
+        let err = CorpusManifest::new(Network::Regtest, sample_archive(), entries).unwrap_err();
+        assert!(matches!(err, CorpusError::OffsetMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_inconsistent_offset() {
+        let mut entries = sample_entries();
+        entries[1].offset = 11;
+        let err = CorpusManifest::new(Network::Regtest, sample_archive(), entries).unwrap_err();
+        assert!(matches!(err, CorpusError::OffsetMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_oversized_payload() {
+        let mut entries = sample_entries();
+        entries[0].payload_length = MAX_PAYLOAD_BYTES + 1;
+        let err = CorpusManifest::new(Network::Regtest, sample_archive(), entries).unwrap_err();
+        assert!(matches!(err, CorpusError::OversizedPayload { .. }));
+    }
+
+    #[test]
+    fn rejects_archive_size_mismatch() {
+        let entries = sample_entries();
+        let archive = ArchiveInfo::new(13, [1; 32]);
+        let err = CorpusManifest::new(Network::Regtest, archive, entries).unwrap_err();
+        assert!(matches!(err, CorpusError::ArchiveSizeMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_invalid_magic_length() {
+        let manifest = sample_manifest();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("manifest.json");
+        manifest.save(&path).unwrap();
+
+        let text = fs::read_to_string(&path).unwrap().replace(
+            "\"network_magic\":\"fabfb5da\"",
+            "\"network_magic\":\"fabfb5\"",
+        );
+        fs::write(&path, text).unwrap();
+
+        let err = CorpusManifest::load(&path).unwrap_err();
+        assert!(matches!(err, CorpusError::InvalidMagicLength { .. }));
+    }
+
+    #[test]
+    fn rejects_invalid_hex() {
+        let mut wire = CorpusManifestV1::from(&sample_manifest());
+        wire.entries[0].hash = "g".repeat(HASH_HEX_LEN);
+        let err = CorpusManifest::try_from(wire).unwrap_err();
+        assert!(matches!(err, CorpusError::InvalidHex { .. }));
+    }
+
+    #[test]
+    fn rejects_invalid_hash_length() {
+        let mut wire = CorpusManifestV1::from(&sample_manifest());
+        wire.archive.sha256.pop();
+        let err = CorpusManifest::try_from(wire).unwrap_err();
+        assert!(matches!(err, CorpusError::InvalidHashLength { .. }));
+    }
+
+    #[test]
+    fn rejects_out_of_range_version_integer() {
+        let json = r#"{"schema":"bitcoin-rs-corpus-manifest","version":4294967296,"network":"regtest","network_magic":"fabfb5da","genesis_hash":"0000000000000000000000000000000000000000000000000000000000000000","range":{"start_height":0,"stop_height":0},"archive":{"size":8,"sha256":"0000000000000000000000000000000000000000000000000000000000000000"},"entries":[{"height":0,"hash":"0000000000000000000000000000000000000000000000000000000000000000","offset":0,"payload_length":0}]}"#;
+        assert!(serde_json::from_str::<CorpusManifestV1>(json).is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_payload_length_integer() {
+        let json = r#"{"schema":"bitcoin-rs-corpus-manifest","version":1,"network":"regtest","network_magic":"fabfb5da","genesis_hash":"0000000000000000000000000000000000000000000000000000000000000000","range":{"start_height":0,"stop_height":0},"archive":{"size":8,"sha256":"0000000000000000000000000000000000000000000000000000000000000000"},"entries":[{"height":0,"hash":"0000000000000000000000000000000000000000000000000000000000000000","offset":0,"payload_length":4294967296}]}"#;
+        assert!(serde_json::from_str::<CorpusManifestV1>(json).is_err());
+    }
+
+    #[test]
+    fn single_entry_archive_size_is_frame_length() {
+        let entries = vec![CorpusEntry {
+            height: 0,
+            hash: Hash256::from_le_bytes(&[0; 32]),
+            offset: 0,
+            payload_length: 10,
+        }];
+        let archive = ArchiveInfo::new(18, [0; 32]);
+        let manifest = CorpusManifest::new(Network::Regtest, archive, entries).unwrap();
+        assert_eq!(manifest.stop_height, 0);
+        assert_eq!(manifest.archive.size, 18);
+    }
+
+    #[test]
+    fn boundary_max_u32_stop_height_roundtrips() {
+        // One entry at height u32::MAX is not practical to allocate, so just
+        // validate the wire form for the boundary value.
+        let json = format!(
+            r#"{{"schema":"{}","version":{},"network":"regtest","network_magic":"fabfb5da","genesis_hash":"0000000000000000000000000000000000000000000000000000000000000000","range":{{"start_height":0,"stop_height":{}}},"archive":{{"size":8,"sha256":"0000000000000000000000000000000000000000000000000000000000000000"}},"entries":[{{"height":{},"hash":"0000000000000000000000000000000000000000000000000000000000000000","offset":0,"payload_length":0}}]}}"#,
+            SCHEMA,
+            VERSION,
+            u32::MAX,
+            u32::MAX
+        );
+        assert!(serde_json::from_str::<CorpusManifestV1>(&json).is_ok());
+    }
+
+    fn block_hash256(block: &Block) -> Hash256 {
+        Hash256::from_le_bytes(block.block_hash().as_byte_array())
+    }
+
+    fn make_test_chain(stop: u32) -> (BlockTree, Vec<Block>) {
+        let mut tree = BlockTree::new();
+        let mut blocks = Vec::new();
+        let mut prev_hash = BlockHash::all_zeros();
+        for height in 0..=stop {
+            let header = BlockHeader {
+                version: Version::ONE,
+                prev_blockhash: prev_hash,
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 1_000_000 + height * 600,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
+                nonce: 0,
+            };
+            let next_hash = header.block_hash();
+            tree.insert_header(header, NodeStatus::HeaderValid)
+                .expect("test chain inserts must succeed");
+            let block = Block {
+                header,
+                txdata: Vec::new(),
+            };
+            blocks.push(block);
+            prev_hash = next_hash;
+        }
+        (tree, blocks)
+    }
+
+    struct MockBodySource {
+        bodies: HashMap<(u32, Hash256), Vec<u8>>,
+    }
+
+    impl MockBodySource {
+        fn empty() -> Self {
+            Self {
+                bodies: HashMap::new(),
+            }
+        }
+
+        fn from_blocks(blocks: &[Block]) -> Self {
+            let mut bodies = HashMap::new();
+            for (height, block) in blocks.iter().enumerate() {
+                let hash = block_hash256(block);
+                let height = u32::try_from(height).expect("test chain height fits u32");
+                bodies.insert((height, hash), serialize(block));
+            }
+            Self { bodies }
+        }
+    }
+
+    impl BlockBodySource for MockBodySource {
+        fn block_body(&self, height: u32, hash: Hash256) -> Option<Vec<u8>> {
+            self.bodies.get(&(height, hash)).cloned()
+        }
+    }
+
+    fn sha256_of(bytes: &[u8]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        hasher.finalize().into()
+    }
+
+    #[test]
+    fn exports_active_chain_corpus() -> Result<(), CorpusError> {
+        let (tree, blocks) = make_test_chain(2);
+        let body_source = MockBodySource::from_blocks(&blocks);
+        let dir = tempfile::tempdir()?;
+        let archive_path = dir.path().join("archive.dat");
+        let manifest_path = dir.path().join("manifest.json");
+
+        let manifest = export_from_sources(
+            &tree,
+            &body_source,
+            Network::Regtest,
+            2,
+            &archive_path,
+            &manifest_path,
+        )?;
+
+        assert_eq!(manifest.network, Network::Regtest);
+        assert_eq!(manifest.start_height, 0);
+        assert_eq!(manifest.stop_height, 2);
+        assert_eq!(manifest.entries.len(), 3);
+
+        let archive_bytes = fs::read(&archive_path)?;
+        assert_eq!(
+            u64::try_from(archive_bytes.len()).expect("archive length fits u64"),
+            manifest.archive.size
+        );
+        assert_eq!(sha256_of(&archive_bytes), manifest.archive.sha256);
+
+        assert_eq!(&archive_bytes[..4], Network::Regtest.magic());
+        let payload_len = u32::from_le_bytes([
+            archive_bytes[4],
+            archive_bytes[5],
+            archive_bytes[6],
+            archive_bytes[7],
+        ]);
+        assert_eq!(
+            payload_len,
+            u32::try_from(serialize(&blocks[0]).len()).expect("payload length fits u32")
+        );
+
+        let mut reader = CoreFrameReader::new(
+            Cursor::new(archive_bytes.as_slice()),
+            Network::Regtest.magic(),
+            MAX_PAYLOAD_BYTES,
+        );
+        for (i, block) in blocks.iter().enumerate() {
+            let record = reader
+                .read_next()?
+                .ok_or_else(|| std::io::Error::other("expected a frame"))?;
+            let expected = serialize(block);
+            assert_eq!(record.payload, expected, "payload mismatch at height {i}");
+            let entry = &manifest.entries[i];
+            assert_eq!(
+                entry.height,
+                u32::try_from(i).expect("test height fits u32")
+            );
+            assert_eq!(entry.hash, block_hash256(block));
+            assert_eq!(entry.offset, record.metadata.offset);
+            assert_eq!(entry.payload_length, record.metadata.len);
+            assert_eq!(
+                entry.payload_length,
+                u32::try_from(expected.len()).expect("payload length fits u32")
+            );
+        }
+        assert!(reader.read_next()?.is_none());
+
+        let loaded = CorpusManifest::load(&manifest_path)?;
+        assert_eq!(loaded, manifest);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_stop_above_active_tip() -> Result<(), CorpusError> {
+        let (tree, blocks) = make_test_chain(1);
+        let body_source = MockBodySource::from_blocks(&blocks);
+        let dir = tempfile::tempdir()?;
+        let archive_path = dir.path().join("archive.dat");
+        let manifest_path = dir.path().join("manifest.json");
+
+        let err = export_from_sources(
+            &tree,
+            &body_source,
+            Network::Regtest,
+            5,
+            &archive_path,
+            &manifest_path,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            CorpusError::StopAboveTip {
+                stop: 5,
+                tip: Some(1),
+            }
+        ));
+        assert!(!archive_path.exists());
+        assert!(!manifest_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_missing_body_before_manifest() -> Result<(), CorpusError> {
+        let (tree, blocks) = make_test_chain(1);
+        let hash0 = block_hash256(&blocks[0]);
+        let mut source = MockBodySource::from_blocks(&blocks);
+        source.bodies.remove(&(0, hash0));
+
+        let dir = tempfile::tempdir()?;
+        let archive_path = dir.path().join("archive.dat");
+        let manifest_path = dir.path().join("manifest.json");
+
+        let err = export_from_sources(
+            &tree,
+            &source,
+            Network::Regtest,
+            0,
+            &archive_path,
+            &manifest_path,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, CorpusError::MissingBody { height: 0, .. }));
+        assert!(!manifest_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_body_hash_mismatch_before_manifest() -> Result<(), CorpusError> {
+        let (tree, blocks) = make_test_chain(1);
+        let hash1 = block_hash256(&blocks[1]);
+        let mut source = MockBodySource::from_blocks(&blocks);
+        // Replace the body at height 1 with the serialized block from height 0;
+        // it decodes cleanly but its hash does not match the active chain.
+        source.bodies.insert((1, hash1), serialize(&blocks[0]));
+
+        let dir = tempfile::tempdir()?;
+        let archive_path = dir.path().join("archive.dat");
+        let manifest_path = dir.path().join("manifest.json");
+
+        let err = export_from_sources(
+            &tree,
+            &source,
+            Network::Regtest,
+            1,
+            &archive_path,
+            &manifest_path,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            CorpusError::BodyHashMismatch { height: 1, .. }
+        ));
+        assert!(!manifest_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_archive_manifest_path_collision() {
+        let tree = BlockTree::new();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("same.dat");
+
+        let err = export_from_sources(
+            &tree,
+            &MockBodySource::empty(),
+            Network::Regtest,
+            0,
+            &path,
+            &path,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, CorpusError::PathCollision { .. }));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn rejects_existing_archive_output() -> Result<(), CorpusError> {
+        let (tree, blocks) = make_test_chain(0);
+        let body_source = MockBodySource::from_blocks(&blocks);
+        let dir = tempfile::tempdir()?;
+        let archive_path = dir.path().join("archive.dat");
+        let manifest_path = dir.path().join("manifest.json");
+        fs::write(&archive_path, b"do not overwrite")?;
+
+        let err = export_from_sources(
+            &tree,
+            &body_source,
+            Network::Regtest,
+            0,
+            &archive_path,
+            &manifest_path,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, CorpusError::OutputExists { .. }));
+        assert_eq!(fs::read(&archive_path)?, b"do not overwrite");
+        assert!(!manifest_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn write_corpus_archive_matches_export_from_sources() -> Result<(), CorpusError> {
+        let (tree, blocks) = make_test_chain(2);
+        let body_source = MockBodySource::from_blocks(&blocks);
+        let dir = tempfile::tempdir()?;
+        let archive_path = dir.path().join("archive.dat");
+        let manifest_path = dir.path().join("manifest.json");
+
+        let direct = export_from_sources(
+            &tree,
+            &body_source,
+            Network::Regtest,
+            2,
+            &archive_path,
+            &manifest_path,
+        )?;
+        let direct_archive = fs::read(&archive_path)?;
+        let direct_manifest = fs::read(&manifest_path)?;
+
+        // Remove the published files and rerun through the shared writer only.
+        fs::remove_file(&archive_path)?;
+        fs::remove_file(&manifest_path)?;
+
+        let mut source = BlockTreeSource {
+            tree: &tree,
+            body: &body_source,
+        };
+        let via_writer = write_corpus_archive(
+            &mut source,
+            Network::Regtest,
+            2,
+            &archive_path,
+            &manifest_path,
+        )?;
+        let writer_archive = fs::read(&archive_path)?;
+        let writer_manifest = fs::read(&manifest_path)?;
+
+        assert_eq!(direct, via_writer);
+        assert_eq!(direct_archive, writer_archive);
+        assert_eq!(direct_manifest, writer_manifest);
+        Ok(())
+    }
+
+    fn make_rest_blocks(stop: u32) -> (Vec<Block>, Vec<(String, Vec<u8>)>) {
+        let genesis = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest);
+        let mut blocks = vec![genesis.clone()];
+        let mut records = vec![(genesis.block_hash().to_string(), serialize(&genesis))];
+        let mut prev_hash = genesis.block_hash();
+        for height in 1..=stop {
+            let header = BlockHeader {
+                version: Version::ONE,
+                prev_blockhash: prev_hash,
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 1_000_000 + height * 600,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
+                nonce: 0,
+            };
+            let next_hash = header.block_hash();
+            let block = Block {
+                header,
+                txdata: Vec::new(),
+            };
+            records.push((next_hash.to_string(), serialize(&block)));
+            blocks.push(block);
+            prev_hash = next_hash;
+        }
+        (blocks, records)
+    }
+
+    fn make_regtest_tree(blocks: &[Block]) -> BlockTree {
+        let mut tree = BlockTree::new();
+        for block in blocks {
+            tree.insert_header(block.header, NodeStatus::HeaderValid)
+                .expect("regtest chain inserts must succeed");
+        }
+        tree
+    }
+
+    fn make_rest_source(records: Vec<(String, Vec<u8>)>, network: Network) -> RestCorpusSource {
+        let mut iter = records.into_iter();
+        RestCorpusSource {
+            fetcher: Box::new(move |height| {
+                let (hash, payload) = iter.next().ok_or_else(|| CoreRestError::HttpStatus {
+                    path: format!("/rest/blockhashbyheight/{height}.hex"),
+                    status: "HTTP/1.1 404 Not Found".to_owned(),
+                })?;
+                Ok((hash, payload))
+            }),
+            network,
+            prev: None,
+        }
+    }
+
+    #[test]
+    fn rest_corpus_source_matches_blocktree_output() -> Result<(), CorpusError> {
+        let (blocks, records) = make_rest_blocks(2);
+        let tree = make_regtest_tree(&blocks);
+        let body_source = MockBodySource::from_blocks(&blocks);
+        let dir = tempfile::tempdir()?;
+        let archive_path = dir.path().join("archive.dat");
+        let manifest_path = dir.path().join("manifest.json");
+
+        let mut rest = make_rest_source(records, Network::Regtest);
+        let rest_manifest = write_corpus_archive(
+            &mut rest,
+            Network::Regtest,
+            2,
+            &archive_path,
+            &manifest_path,
+        )?;
+        let rest_archive = fs::read(&archive_path)?;
+
+        fs::remove_file(&archive_path)?;
+        fs::remove_file(&manifest_path)?;
+
+        let direct = export_from_sources(
+            &tree,
+            &body_source,
+            Network::Regtest,
+            2,
+            &archive_path,
+            &manifest_path,
+        )?;
+        let direct_archive = fs::read(&archive_path)?;
+
+        assert_eq!(rest_manifest, direct);
+        assert_eq!(rest_archive, direct_archive);
+        Ok(())
+    }
+
+    #[test]
+    fn rest_corpus_rejects_genesis_mismatch() -> Result<(), CorpusError> {
+        let (_, records) = make_rest_blocks(0);
+        // Use mainnet expectation; the real regtest genesis will not match.
+        let mut source = make_rest_source(records, Network::Mainnet);
+        let dir = tempfile::tempdir()?;
+        let archive = dir.path().join("archive.dat");
+        let manifest = dir.path().join("manifest.json");
+
+        let err = write_corpus_archive(&mut source, Network::Mainnet, 0, &archive, &manifest)
+            .unwrap_err();
+
+        assert!(matches!(err, CorpusError::RestGenesisMismatch { .. }));
+        assert!(!archive.exists());
+        assert!(!manifest.exists());
+        assert!(no_tmp_files(&dir));
+        Ok(())
+    }
+
+    #[test]
+    fn rest_corpus_rejects_continuity_break() -> Result<(), CorpusError> {
+        let (_, mut records) = make_rest_blocks(2);
+        // Make height 2 claim a bogus parent while keeping a valid header hash.
+        let mut tampered = bitcoin::consensus::deserialize::<Block>(&records[2].1).unwrap();
+        tampered.header.prev_blockhash = BlockHash::from_byte_array([0xff; 32]);
+        tampered.header.nonce += 1; // re-mine to a new hash
+        let new_hash = tampered.block_hash().to_string();
+        records[2] = (new_hash, serialize(&tampered));
+
+        let mut source = make_rest_source(records, Network::Regtest);
+        let dir = tempfile::tempdir()?;
+        let archive = dir.path().join("archive.dat");
+        let manifest = dir.path().join("manifest.json");
+
+        let err = write_corpus_archive(&mut source, Network::Regtest, 2, &archive, &manifest)
+            .unwrap_err();
+
+        assert!(matches!(err, CorpusError::RestContinuity { height: 2, .. }));
+        assert!(!archive.exists());
+        assert!(!manifest.exists());
+        assert!(no_tmp_files(&dir));
+        Ok(())
+    }
+
+    #[test]
+    fn rest_corpus_rejects_hash_mismatch() -> Result<(), CorpusError> {
+        let (_, mut records) = make_rest_blocks(1);
+        // Reported hash stays the same but payload is the genesis block;
+        // computed hash will differ.
+        records[1].1 = records[0].1.clone();
+
+        let mut source = make_rest_source(records, Network::Regtest);
+        let dir = tempfile::tempdir()?;
+        let archive = dir.path().join("archive.dat");
+        let manifest = dir.path().join("manifest.json");
+
+        let err = write_corpus_archive(&mut source, Network::Regtest, 1, &archive, &manifest)
+            .unwrap_err();
+
+        assert!(matches!(err, CorpusError::RestHashMismatch { .. }));
+        assert!(!archive.exists());
+        assert!(!manifest.exists());
+        assert!(no_tmp_files(&dir));
+        Ok(())
+    }
+
+    #[test]
+    fn rest_corpus_rejects_short_payload() -> Result<(), CorpusError> {
+        let (_, mut records) = make_rest_blocks(0);
+        records[0].1 = vec![0; 79];
+        let mut source = make_rest_source(records, Network::Regtest);
+        let dir = tempfile::tempdir()?;
+        let archive = dir.path().join("archive.dat");
+        let manifest = dir.path().join("manifest.json");
+
+        let err = write_corpus_archive(&mut source, Network::Regtest, 0, &archive, &manifest)
+            .unwrap_err();
+
+        assert!(matches!(err, CorpusError::RestShortPayload { .. }));
+        assert!(!archive.exists());
+        assert!(!manifest.exists());
+        assert!(no_tmp_files(&dir));
+        Ok(())
+    }
+
+    fn no_tmp_files(dir: &tempfile::TempDir) -> bool {
+        dir.path()
+            .read_dir()
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.file_type().is_ok_and(|t| t.is_file()))
+            .all(|e| {
+                let name = e.file_name();
+                let s = name.to_string_lossy();
+                !s.contains(".tmp.")
+            })
+    }
+
+    fn http_response(status: &str, body: &[u8]) -> Vec<u8> {
+        let mut out = format!(
+            "HTTP/1.1 {}\r\nContent-Length: {}\r\n\r\n",
+            status,
+            body.len()
+        )
+        .into_bytes();
+        out.extend_from_slice(body);
+        out
+    }
+
+    fn http_no_content_length(status: &str, body: &[u8]) -> Vec<u8> {
+        let mut out = format!("HTTP/1.1 {status}\r\n\r\n").into_bytes();
+        out.extend_from_slice(body);
+        out
+    }
+
+    fn http_oversized_content_length() -> Vec<u8> {
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n",
+            MAX_BODY_BYTES + 1
+        )
+        .into_bytes()
+    }
+
+    fn serve_http(responses: Vec<Vec<u8>>) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            for response in responses {
+                // consume one request
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    reader.read_line(&mut line).unwrap();
+                    if line.trim().is_empty() {
+                        break;
+                    }
+                }
+                reader.get_mut().write_all(&response).unwrap();
+                reader.get_mut().flush().unwrap();
+            }
+        });
+        (addr, handle)
+    }
+
+    #[test]
+    fn core_rest_client_gets_body_and_rejects_non_200() {
+        let body = b"hello".to_vec();
+        let ok = http_response("200 OK", &body);
+        let not_found = http_response("404 Not Found", b"missing");
+        let (addr, _handle) = serve_http(vec![ok, not_found]);
+
+        let mut client = CoreRestClient::connect(&addr).unwrap();
+        assert_eq!(client.get("/a").unwrap(), body);
+
+        let err = client.get("/b").unwrap_err();
+        assert!(
+            matches!(err, CoreRestError::HttpStatus { status, .. } if status.starts_with("HTTP/1.1 404"))
+        );
+    }
+
+    #[test]
+    fn core_rest_client_rejects_missing_content_length() {
+        let body = b"hello".to_vec();
+        let (addr, _handle) = serve_http(vec![http_no_content_length("200 OK", &body)]);
+
+        let mut client = CoreRestClient::connect(&addr).unwrap();
+        let err = client.get("/a").unwrap_err();
+        assert!(matches!(err, CoreRestError::MissingContentLength { .. }));
+    }
+
+    #[test]
+    fn core_rest_client_rejects_oversized_content_length() {
+        let (addr, _handle) = serve_http(vec![http_oversized_content_length()]);
+
+        let mut client = CoreRestClient::connect(&addr).unwrap();
+        let err = client.get("/a").unwrap_err();
+        assert!(matches!(err, CoreRestError::OversizedBody { .. }));
+    }
+
+    fn serve_http_with_close_then_response(
+        response: Vec<u8>,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let handle = thread::spawn(move || {
+            // first connection: accept, read request, drop.
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                if reader.read_line(&mut line).unwrap() == 0 {
+                    break;
+                }
+                if line.trim().is_empty() {
+                    break;
+                }
+            }
+            drop(reader);
+
+            // second connection: serve the real response.
+            let (mut stream, _) = listener.accept().unwrap();
+            stream.write_all(&response).unwrap();
+            stream.flush().unwrap();
+        });
+        (addr, handle)
+    }
+
+    #[test]
+    fn core_rest_client_reconnects_once() {
+        let response = http_response("200 OK", b"body");
+        let (addr, _handle) = serve_http_with_close_then_response(response);
+
+        let mut client = CoreRestClient::connect(&addr).unwrap();
+        let body = client.get("/a").unwrap();
+        assert_eq!(body, b"body");
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -22,6 +22,8 @@ mod checkpoint;
 mod checkpoint_fs;
 /// Layered node configuration.
 pub mod config;
+/// Block corpus manifest for contiguous archive integrity.
+pub mod corpus;
 /// Startup crash recovery.
 pub mod crash_recovery;
 /// Central synchronous event loop.

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -214,6 +214,15 @@ fn install_metrics_with(
 }
 
 #[cfg(test)]
+pub(crate) fn test_recorder() -> (impl Recorder, MetricsHandle) {
+    let recorder = InMemoryRecorder::default();
+    let handle = MetricsHandle {
+        bind: SocketAddr::from(([127, 0, 0, 1], 0)),
+        recorder: recorder.clone(),
+    };
+    (recorder, handle)
+}
+#[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
@@ -282,14 +291,5 @@ mod tests {
             snapshot.get("node.test.repeat_histogram"),
             Some(&MetricValue::Histogram { count: 2, sum: 5.0 })
         );
-    }
-
-    fn test_recorder() -> (InMemoryRecorder, MetricsHandle) {
-        let recorder = InMemoryRecorder::default();
-        let handle = MetricsHandle {
-            bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-            recorder: recorder.clone(),
-        };
-        (recorder, handle)
     }
 }

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1207,6 +1207,21 @@ impl NodeState {
         self.resume_source
     }
 
+    /// Publishes a durable clean checkpoint and returns the published
+    /// generation, or an error if there is no applied tip.
+    ///
+    /// This is the public boundary for the private checkpoint machinery; it
+    /// keeps `CheckpointWrite`, `CheckpointError`, and the checkpoint module
+    /// internal to the crate.
+    pub fn publish_checkpoint(&self) -> Result<u64> {
+        match self.write_clean_checkpoint()? {
+            crate::checkpoint::CheckpointWrite::Published { generation } => Ok(generation),
+            crate::checkpoint::CheckpointWrite::SkippedNoAppliedTip => {
+                bail!("checkpoint refused: no applied tip to publish")
+            }
+        }
+    }
+
     pub(crate) fn write_clean_checkpoint(
         &self,
     ) -> core::result::Result<crate::checkpoint::CheckpointWrite, crate::checkpoint::CheckpointError>
@@ -2617,6 +2632,51 @@ mod tests {
                 path.display()
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn publish_checkpoint_refuses_when_no_applied_tip() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut config = crate::Config::default_for_network(crate::Network::Regtest);
+        config.data_dir = dir.path().join("node");
+        config.p2p_listen.clear();
+        let state = NodeState::open(config)?;
+        let Err(error) = state.publish_checkpoint() else {
+            anyhow::bail!("checkpoint publication unexpectedly succeeded");
+        };
+        assert!(
+            error.to_string().contains("no applied tip"),
+            "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn publish_checkpoint_returns_generation_and_reopens() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let data_dir = dir.path().join("node");
+        let mut config = crate::Config::default_for_network(crate::Network::Regtest);
+        config.data_dir = data_dir;
+        config.p2p_listen.clear();
+        let state = NodeState::open(config.clone())?;
+        let genesis = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest);
+        let tip = state.apply_block(&genesis)?;
+        let generation = state.publish_checkpoint()?;
+        assert!(
+            generation > 0,
+            "published checkpoint must have a positive generation"
+        );
+        drop(state);
+
+        let resumed = NodeState::open(config)?;
+        assert_eq!(resumed.resume_source(), ResumeSource::Checkpoint);
+        let applied = resumed
+            .applied_tip()
+            .load_full()
+            .ok_or_else(|| std::io::Error::other("checkpoint did not publish applied tip"))?;
+        assert_eq!(applied.height, tip.height);
+        assert_eq!(applied.hash, tip.hash);
         Ok(())
     }
 

--- a/crates/storage/src/corpus.rs
+++ b/crates/storage/src/corpus.rs
@@ -1,0 +1,465 @@
+//! Streaming length-prefixed Core frames for contiguous archives.
+//!
+//! A Core frame is a self-describing record:
+//!
+//! ```text
+//! magic     [u8; CORE_FRAME_MAGIC_LEN]   caller-supplied magic, e.g. a network's P2P message-start bytes
+//! length    u32 little-endian            payload length in bytes
+//! payload   [u8; length]                 exactly `length` payload bytes
+//! ```
+//!
+//! Record offsets point at the first byte of `magic`. The writer returns the
+//! exact offset of each record it writes. The reader, given an expected magic
+//! and a caller-configured maximum payload length, streams records and returns
+//! `Ok(None)` exactly when a clean end-of-file boundary is reached at the start
+//! of a record. Any partial magic, partial length, or partial payload is an
+//! error.
+//!
+//! All arithmetic on offsets and lengths is checked; overflow produces
+//! [`CoreFrameError::Overflow`].
+
+use std::io::{self, Read, Write};
+
+use thiserror::Error;
+
+/// Byte length of the magic field in a Core frame.
+pub const CORE_FRAME_MAGIC_LEN: usize = 4;
+/// Total byte length of a Core frame header (magic + length).
+pub const CORE_FRAME_HEADER_LEN: u64 = 8;
+
+const LENGTH_LEN: usize = 4;
+const HEADER_LEN: usize = CORE_FRAME_MAGIC_LEN + LENGTH_LEN;
+
+/// Errors that can occur when reading or writing Core frames.
+#[derive(Debug, Error)]
+pub enum CoreFrameError {
+    /// The magic bytes in the stream did not match the expected value.
+    #[error("wrong magic: expected {expected:?}, got {got:?}")]
+    WrongMagic {
+        /// Magic expected by the reader.
+        expected: [u8; CORE_FRAME_MAGIC_LEN],
+        /// Magic read from the stream.
+        got: [u8; CORE_FRAME_MAGIC_LEN],
+    },
+    /// The header was truncated before the full 8 bytes could be read.
+    #[error("partial header: needed {needed} bytes, got {got}")]
+    PartialHeader {
+        /// Number of bytes required for a complete header.
+        needed: usize,
+        /// Number of bytes actually read.
+        got: usize,
+    },
+    /// The payload was truncated before the declared length could be read.
+    #[error("partial payload: expected {expected} bytes, got {got}")]
+    PartialPayload {
+        /// Declared payload length.
+        expected: u32,
+        /// Number of payload bytes actually read.
+        got: usize,
+    },
+    /// The declared payload length exceeds the caller's configured maximum.
+    #[error("payload too large: length {length}, maximum {max}")]
+    PayloadTooLarge {
+        /// Declared payload length.
+        length: u32,
+        /// Caller-configured maximum payload length.
+        max: u32,
+    },
+    /// Offset or length arithmetic overflowed `u64`.
+    #[error("offset/length overflow: {context}")]
+    Overflow {
+        /// Context describing which arithmetic operation overflowed.
+        context: &'static str,
+    },
+    /// Underlying I/O failure.
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+}
+
+/// Metadata describing one Core frame.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CoreFrameMetadata {
+    /// Byte offset of the record's magic in the stream.
+    pub offset: u64,
+    /// Payload length in bytes, not including the 8-byte header.
+    pub len: u32,
+}
+
+/// A complete Core frame returned by [`CoreFrameReader::read_next`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CoreFrameRecord {
+    /// Position and size metadata for this record.
+    pub metadata: CoreFrameMetadata,
+    /// Owned payload bytes.
+    pub payload: Vec<u8>,
+}
+
+/// Streaming writer for Core frames.
+///
+/// Each call to [`Self::write`] appends one `magic + u32 LE length + payload`
+/// record and returns the exact offset of that record's magic. The payload is
+/// borrowed for the write, so the caller retains ownership of the bytes.
+pub struct CoreFrameWriter<W> {
+    inner: W,
+    magic: [u8; CORE_FRAME_MAGIC_LEN],
+    offset: u64,
+}
+
+impl<W: Write> CoreFrameWriter<W> {
+    /// Creates a writer starting at offset `0`.
+    pub fn new(inner: W, magic: [u8; CORE_FRAME_MAGIC_LEN]) -> Self {
+        Self::with_offset(inner, magic, 0)
+    }
+
+    /// Creates a writer with an explicit starting offset.
+    ///
+    /// `offset` is the byte position of the next record's magic in the stream.
+    pub fn with_offset(inner: W, magic: [u8; CORE_FRAME_MAGIC_LEN], offset: u64) -> Self {
+        Self {
+            inner,
+            magic,
+            offset,
+        }
+    }
+
+    /// Returns the byte offset of the next record to be written.
+    #[must_use]
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    /// Writes one Core frame with the given payload.
+    ///
+    /// The payload is borrowed, not copied, before being written to the
+    /// underlying stream. Returns the metadata of the record written.
+    pub fn write(&mut self, payload: &[u8]) -> Result<CoreFrameMetadata, CoreFrameError> {
+        let payload_len = u32::try_from(payload.len()).map_err(|_| CoreFrameError::Overflow {
+            context: "payload length does not fit u32",
+        })?;
+        let record_len = CORE_FRAME_HEADER_LEN
+            .checked_add(u64::from(payload_len))
+            .ok_or(CoreFrameError::Overflow {
+                context: "record length overflow",
+            })?;
+        let record_offset = self.offset;
+        let record_end = record_offset
+            .checked_add(record_len)
+            .ok_or(CoreFrameError::Overflow {
+                context: "record offset overflow",
+            })?;
+
+        let mut header = [0_u8; HEADER_LEN];
+        header[..CORE_FRAME_MAGIC_LEN].copy_from_slice(&self.magic);
+        header[CORE_FRAME_MAGIC_LEN..].copy_from_slice(&payload_len.to_le_bytes());
+
+        self.inner.write_all(&header)?;
+        self.inner.write_all(payload)?;
+
+        self.offset = record_end;
+        Ok(CoreFrameMetadata {
+            offset: record_offset,
+            len: payload_len,
+        })
+    }
+}
+
+/// Streaming reader for Core frames.
+///
+/// The reader expects every record to begin with the caller-supplied `magic`,
+/// followed by a little-endian `u32` payload length, followed by that many
+/// payload bytes. It returns `Ok(None)` when it reaches a clean end-of-file
+/// boundary at the start of a record. Any partial frame is an error.
+pub struct CoreFrameReader<R> {
+    inner: R,
+    expected_magic: [u8; CORE_FRAME_MAGIC_LEN],
+    max_payload: u32,
+    offset: u64,
+}
+
+impl<R: Read> CoreFrameReader<R> {
+    /// Creates a reader that expects `expected_magic` and rejects payloads
+    /// larger than `max_payload` bytes.
+    ///
+    /// The initial offset is `0`. Use [`Self::with_offset`] to start elsewhere.
+    pub fn new(inner: R, expected_magic: [u8; CORE_FRAME_MAGIC_LEN], max_payload: u32) -> Self {
+        Self::with_offset(inner, expected_magic, max_payload, 0)
+    }
+
+    /// Creates a reader with an explicit starting offset.
+    ///
+    /// `offset` is the byte position of the next record's magic in the stream.
+    pub fn with_offset(
+        inner: R,
+        expected_magic: [u8; CORE_FRAME_MAGIC_LEN],
+        max_payload: u32,
+        offset: u64,
+    ) -> Self {
+        Self {
+            inner,
+            expected_magic,
+            max_payload,
+            offset,
+        }
+    }
+
+    /// Returns the byte offset of the next record to be read.
+    #[must_use]
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    /// Returns a shared reference to the underlying reader.
+    ///
+    /// This lets a wrapping [`HashingReader`] expose its current digest
+    /// without consuming or bypassing the frame parser.
+    #[must_use]
+    pub const fn get_ref(&self) -> &R {
+        &self.inner
+    }
+
+    /// Reads the next complete Core frame.
+    ///
+    /// Returns `Ok(None)` when the stream ends exactly at a record boundary.
+    /// Any partial magic, length, or payload is an error.
+    pub fn read_next(&mut self) -> Result<Option<CoreFrameRecord>, CoreFrameError> {
+        let record_offset = self.offset;
+
+        let mut header = [0_u8; HEADER_LEN];
+        let mut total = 0;
+        while total < HEADER_LEN {
+            match self.inner.read(&mut header[total..])? {
+                0 if total == 0 => return Ok(None),
+                0 => {
+                    return Err(CoreFrameError::PartialHeader {
+                        needed: HEADER_LEN,
+                        got: total,
+                    });
+                }
+                n => total += n,
+            }
+        }
+
+        let mut magic = [0_u8; CORE_FRAME_MAGIC_LEN];
+        magic.copy_from_slice(&header[..CORE_FRAME_MAGIC_LEN]);
+        if magic != self.expected_magic {
+            return Err(CoreFrameError::WrongMagic {
+                expected: self.expected_magic,
+                got: magic,
+            });
+        }
+
+        let mut length_bytes = [0_u8; LENGTH_LEN];
+        length_bytes.copy_from_slice(&header[CORE_FRAME_MAGIC_LEN..]);
+        let length = u32::from_le_bytes(length_bytes);
+
+        if length > self.max_payload {
+            return Err(CoreFrameError::PayloadTooLarge {
+                length,
+                max: self.max_payload,
+            });
+        }
+
+        let record_end = record_offset
+            .checked_add(CORE_FRAME_HEADER_LEN)
+            .and_then(|o| o.checked_add(u64::from(length)))
+            .ok_or(CoreFrameError::Overflow {
+                context: "record end overflow",
+            })?;
+
+        let payload_len = usize::try_from(length).map_err(|_| CoreFrameError::Overflow {
+            context: "payload length does not fit usize",
+        })?;
+        let mut payload = vec![0_u8; payload_len];
+        if payload_len > 0 {
+            let mut got = 0;
+            while got < payload_len {
+                match self.inner.read(&mut payload[got..])? {
+                    0 if got == 0 => {
+                        return Err(CoreFrameError::PartialPayload {
+                            expected: length,
+                            got: 0,
+                        });
+                    }
+                    0 => {
+                        return Err(CoreFrameError::PartialPayload {
+                            expected: length,
+                            got,
+                        });
+                    }
+                    n => got += n,
+                }
+            }
+        }
+
+        self.offset = record_end;
+        Ok(Some(CoreFrameRecord {
+            metadata: CoreFrameMetadata {
+                offset: record_offset,
+                len: length,
+            },
+            payload,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    const MAGIC: [u8; 4] = *b"TEST";
+
+    #[test]
+    fn round_trips_multiple_records_and_exact_bytes() -> Result<(), CoreFrameError> {
+        let mut buf = Vec::new();
+        let mut writer = CoreFrameWriter::new(&mut buf, MAGIC);
+
+        let first = writer.write(b"")?;
+        let second = writer.write(b"second")?;
+
+        assert_eq!(first, CoreFrameMetadata { offset: 0, len: 0 });
+        assert_eq!(second, CoreFrameMetadata { offset: 8, len: 6 });
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&MAGIC);
+        expected.extend_from_slice(&0_u32.to_le_bytes());
+        expected.extend_from_slice(&MAGIC);
+        expected.extend_from_slice(&6_u32.to_le_bytes());
+        expected.extend_from_slice(b"second");
+        assert_eq!(buf, expected);
+
+        let mut reader = CoreFrameReader::new(Cursor::new(&buf[..]), MAGIC, u32::MAX);
+
+        let Some(first_record) = reader.read_next()? else {
+            panic!("expected first record");
+        };
+        assert_eq!(
+            first_record.metadata,
+            CoreFrameMetadata { offset: 0, len: 0 }
+        );
+        assert_eq!(first_record.payload, b"");
+
+        let Some(second_record) = reader.read_next()? else {
+            panic!("expected second record");
+        };
+        assert_eq!(
+            second_record.metadata,
+            CoreFrameMetadata { offset: 8, len: 6 }
+        );
+        assert_eq!(second_record.payload, b"second");
+
+        assert_eq!(reader.read_next()?, None);
+        assert_eq!(reader.get_ref().position(), reader.offset());
+        Ok(())
+    }
+
+    #[test]
+    fn get_ref_peeks_underlying_reader_without_consuming_parser() -> Result<(), CoreFrameError> {
+        let mut buf = Vec::new();
+        let mut writer = CoreFrameWriter::new(&mut buf, MAGIC);
+        writer.write(b"peek")?;
+        let mut reader = CoreFrameReader::new(Cursor::new(&buf[..]), MAGIC, u32::MAX);
+        let Some(_record) = reader.read_next()? else {
+            panic!("expected one record");
+        };
+        // The frame reader owns the cursor, but get_ref still lets callers
+        // observe the exact byte position the parser reached.
+        assert_eq!(reader.get_ref().position(), reader.offset());
+        assert_eq!(reader.read_next()?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn empty_input() -> Result<(), CoreFrameError> {
+        let mut reader = CoreFrameReader::new(Cursor::new(b""), MAGIC, u32::MAX);
+        assert_eq!(reader.read_next()?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn wrong_magic() -> Result<(), CoreFrameError> {
+        let mut buf = Vec::new();
+        CoreFrameWriter::new(&mut buf, *b"GOOD").write(b"payload")?;
+
+        let mut reader = CoreFrameReader::new(Cursor::new(&buf[..]), *b"BADS", u32::MAX);
+        match reader.read_next() {
+            Err(CoreFrameError::WrongMagic { expected, got }) => {
+                assert_eq!(expected, *b"BADS");
+                assert_eq!(got, *b"GOOD");
+            }
+            other => panic!("expected WrongMagic, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn short_header() {
+        let mut reader = CoreFrameReader::new(Cursor::new(&[1u8, 2, 3]), MAGIC, u32::MAX);
+        match reader.read_next() {
+            Err(CoreFrameError::PartialHeader { needed, got }) => {
+                assert_eq!(needed, HEADER_LEN);
+                assert_eq!(got, 3);
+            }
+            other => panic!("expected PartialHeader, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn short_payload() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&MAGIC);
+        data.extend_from_slice(&10_u32.to_le_bytes());
+        data.extend_from_slice(b"hello");
+
+        let mut reader = CoreFrameReader::new(Cursor::new(&data[..]), MAGIC, u32::MAX);
+        match reader.read_next() {
+            Err(CoreFrameError::PartialPayload { expected, got }) => {
+                assert_eq!(expected, 10);
+                assert_eq!(got, 5);
+            }
+            other => panic!("expected PartialPayload, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn size_limit() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&MAGIC);
+        data.extend_from_slice(&8_u32.to_le_bytes());
+        data.extend_from_slice(b"12345678");
+
+        let mut reader = CoreFrameReader::new(Cursor::new(&data[..]), MAGIC, 4);
+        match reader.read_next() {
+            Err(CoreFrameError::PayloadTooLarge { length, max }) => {
+                assert_eq!(length, 8);
+                assert_eq!(max, 4);
+            }
+            other => panic!("expected PayloadTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reader_offset_overflow() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&MAGIC);
+        data.extend_from_slice(&4_u32.to_le_bytes());
+        data.extend_from_slice(b"1234");
+
+        let mut reader =
+            CoreFrameReader::with_offset(Cursor::new(&data[..]), MAGIC, 4, u64::MAX - 7);
+        match reader.read_next() {
+            Err(CoreFrameError::Overflow { .. }) => {}
+            other => panic!("expected Overflow, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn writer_offset_overflow() {
+        let mut writer = CoreFrameWriter::with_offset(std::io::sink(), MAGIC, u64::MAX - 7);
+        match writer.write(b"1234") {
+            Err(CoreFrameError::Overflow { .. }) => {}
+            other => panic!("expected Overflow, got {other:?}"),
+        }
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -5,6 +5,8 @@
 pub mod block_file;
 /// Logical column-family names shared by all storage backends.
 pub mod column_families;
+/// Streaming length-prefixed Core frame reader and writer.
+pub mod corpus;
 /// Storage error type.
 pub mod error;
 /// Backend-neutral key-value store traits.
@@ -28,6 +30,10 @@ pub use block_file::{
     block_file_max_height_key, decode_block_file_max_height, encode_block_file_max_height,
 };
 pub use column_families::ColumnFamily;
+pub use corpus::{
+    CORE_FRAME_HEADER_LEN, CORE_FRAME_MAGIC_LEN, CoreFrameError, CoreFrameMetadata,
+    CoreFrameReader, CoreFrameRecord, CoreFrameWriter,
+};
 pub use error::StorageError;
 pub use trait_::{KvIter, KvPair, KvSnapshot, KvStore, WriteBatch};
 

--- a/tools/checksig-census/README.md
+++ b/tools/checksig-census/README.md
@@ -59,7 +59,7 @@ if [ -e "$EXP/libbitcoinkernel-sys-0.3.0" ]; then
 fi
 
 cp -a "$PRISTINE" "$EXP/libbitcoinkernel-sys-0.3.0"
-patch -p2 -d "$EXP/libbitcoinkernel-sys-0.3.0" < "$EXP/instrumentation.diff"
+patch --fuzz=0 -p1 -d "$EXP/libbitcoinkernel-sys-0.3.0" < "$EXP/instrumentation.diff"
 ```
 
 ## Build
@@ -103,28 +103,50 @@ Binaries produced:
 
 ## Run sequence
 
-### Run A — full census (0..150k, counters + journal only)
+### Run A — authoritative C150 cumulative evidence
 
 ```bash
 REPO=/home/alpha/exp/bitcoin-rs
 EXP=$REPO/tools/checksig-census
+C150=/home/alpha/bench-g14/corpora/c150
 
 mkdir -p "$EXP/out"
 
-BRS_CENSUS_COUNTERS=$EXP/out/census-0-150k.counters.json \
-BRS_CENSUS_JOURNAL=$EXP/out/census-0-150k.journal.bin \
-BRS_CENSUS_LABEL=census-0-150k \
+BRS_CENSUS_COUNTERS=$EXP/out/c150.counters.json \
+BRS_CENSUS_CONTEXTS=$EXP/out/c150.contexts.bin \
+BRS_CENSUS_JOURNAL=$EXP/out/c150.journal.bin \
+BRS_CENSUS_RECORDS=$EXP/out/c150.records.bin \
+BRS_CENSUS_LABEL=c150 \
 taskset -c 0-31 \
 "$EXP/target/release/examples/mainnet_prefix_replay" \
   --stop-height 150000 \
-  --rest-url 127.0.0.1:18443 \
+  --blocks-file "$C150/blocks.dat" \
+  --corpus-manifest "$C150/manifest.json" \
   --assume-valid-height 0 \
-  --data-dir "$EXP/out/census-datadir" \
-  --output "$EXP/out/census-replay.json"
+  --data-dir "$EXP/out/c150-datadir" \
+  --output "$EXP/out/c150.replay.json"
+
+cd "$EXP"
+python3 analyze.py classify-corpus \
+  --counters out/c150.counters.json \
+  --contexts out/c150.contexts.bin \
+  --records out/c150.records.bin \
+  --journal out/c150.journal.bin \
+  --replay out/c150.replay.json \
+  --corpus-manifest "$C150/manifest.json" \
+  --archive "$C150/blocks.dat" \
+  --output out/c150.classification.json \
+  --contract c150
 ```
 
+The replay produces the authoritative `c150.counters.json`, `c150.contexts.bin`,
+`c150.journal.bin`, and `c150.records.bin` artifacts in one process. The strict
+classifier validates each stream's magic and framing, the exact native count
+equations, and every context, record, and journal join.
+
 Expected: `ffi_verify_entries == 2,868,199`, all verdicts true, pre-taproot
-counters (`op_checksigadd`, `checkschnorr_entries`, `schnorr_verify_calls`) zero.
+counters (`op_checksigadd`, `checkschnorr_entries`, `schnorr_verify_calls`,
+`schnorr_verify_ok`, `schnorr_verify_fail`) zero.
 Any sink open, write, stream, or close failure forces a nonzero process exit.
 
 ### Run B — KSPIKE1 capture (counters + journal + records, run twice)
@@ -149,6 +171,9 @@ BRS_CENSUS_RECORDS=$EXP/out/kspike1-repeat.records.bin \
 BRS_CENSUS_LABEL=kspike1 \
 "$CAPTURE" --corpus "$CORPUS" --output "$EXP/out/kspike1-repeat.summary.json"
 ```
+
+`BRS_CENSUS_CONTEXTS` is mandatory for authoritative Run A. It is optional for
+the separate KSPIKE1 diagnostic in Run B.
 
 Expected: `ffi_verify_entries == 159,259`, all inputs verify successfully.
 
@@ -196,7 +221,7 @@ spike inputs. Each file also contains:
 - `inv_8` (native correctness: `mismatches == 0`, `ok_count == expected_true_count`,
   `expected_true_count` equal to the capture count, `ok_equals_count_outcome_1 == true`,
   and `passed == true`);
-- `inv_15` (exactly the 22 named post-timing counters, each integer zero,
+- `inv_15` (exactly the 24 named post-timing counters, each integer zero,
   plus `all_counters_zero == true` and `passed == true`);
 - `rust_secp_diagnostic` — a 2-record parser incompatibility between Rust
   secp256k1 0.31.1/libsecp 0.6.0 and the native tree (Bitcoin Core 31.99.0
@@ -374,7 +399,7 @@ removable gain.
 | Full census `ffi_verify_entries` | 2,868,199 |
 | KSPIKE1 `ffi_verify_entries` | 159,259 |
 | KSPIKE1 corpus SHA256 | `16cbaf17feb16ad9b567b4680a5eaf449699037f9696ccb2366af3f48b756fa2` |
-| Pre-taproot counters | `op_checksigadd`, `checkschnorr_entries`, `schnorr_verify_calls` all zero |
+| Pre-taproot counters | `op_checksigadd`, `checkschnorr_entries`, `schnorr_verify_calls`, `schnorr_verify_ok`, `schnorr_verify_fail` all zero |
 
 ## Output artifacts
 
@@ -407,13 +432,24 @@ magic + u64 count.
 
 **Records** (magic `BRSREC1\0`, 224 bytes each):
 spend_txid[32], input_index u32, op_seq u32, op_kind u8, sig_version u8,
-outcome u8 (0=false, 1=true, 2=pre-secp reject), der_len u8, pubkey_len u8,
-sighash_type u8, reject_reason u8, pad u8, sighash[32], der_sig[72],
-pubkey[65], pad[7].
+outcome u8 (0=false, 1=true, 2=pre-verification reject), der_len u8,
+pubkey_len u8, sighash_type u8, reject_reason u8, pad u8, sighash[32],
+der_sig[72], pubkey[65], pad[7]. Reject reasons are: 0 none; 1 invalid
+ECDSA pubkey; 2 empty ECDSA signature; 3 missing ECDSA transaction data;
+4 invalid Schnorr signature size; 5 explicit-default Schnorr hash type;
+6 missing Schnorr transaction data; 7 Schnorr sighash failure; 8 empty
+Tapscript Schnorr signature skipped before `CheckSchnorrSignature`.
 
 **Journal** (magic `BRSJRN1\0`, 56 bytes each):
 spend_txid[32], input_index u32, checksig_ops u32, checkmultisig_ops u32,
 ecdsa_verify_calls u32, ecdsa_verify_ok u32, verdict u8, pad[3].
 
-**Counters JSON**: schema=1, label, 22 named u64 counters, record_count,
-journal_count.
+**Contexts** (magic `BRSCTX1\0`, variable-length rows):
+row_len u32; spend_txid_le[32]; input_index u32; verify_flags u32;
+prevout_script_len u32; script_sig_len u32; witness_count u32;
+exact prevout scriptPubKey bytes; exact scriptSig bytes;
+for each witness item u32 item_len + exact item bytes.
+`row_len` counts the bytes after the `row_len` field itself.
+
+**Counters JSON**: schema=1, label, 24 named u64 counters, record_count,
+journal_count, context_count.

--- a/tools/checksig-census/README.md
+++ b/tools/checksig-census/README.md
@@ -440,6 +440,14 @@ ECDSA pubkey; 2 empty ECDSA signature; 3 missing ECDSA transaction data;
 6 missing Schnorr transaction data; 7 Schnorr sighash failure; 8 empty
 Tapscript Schnorr signature skipped before `CheckSchnorrSignature`.
 
+The on-disk 224-byte layout is fixed: `pubkey_len` preserves the low 8 bits of
+the source public-key stack element. A semantic reader may accept `pubkey_len >
+65` only for the exact native reason-1 pre-verification reject shape: `outcome
+== 2`, `reject_reason == 1`, `op_kind` in 1..4, `sig_version` in {0, 1},
+`der_len == 0`, `sighash_type == 0`, and all `sighash`, `der_sig`, `pubkey`,
+and padding bytes zero. Every other over-capacity record keeps the existing
+`pubkey_len ... exceeds 65` rejection.
+
 **Journal** (magic `BRSJRN1\0`, 56 bytes each):
 spend_txid[32], input_index u32, checksig_ops u32, checkmultisig_ops u32,
 ecdsa_verify_calls u32, ecdsa_verify_ok u32, verdict u8, pad[3].

--- a/tools/checksig-census/analyze.py
+++ b/tools/checksig-census/analyze.py
@@ -340,6 +340,26 @@ class Record:
             self.pubkey,
             _pad1,
         ) = unpacked
+        # Exact over-capacity ECDSA reject shape accepted by both BRSREC1 readers.
+        # Native reason-1 records may preserve the original (>=66) pubkey_len only
+        # for outcome 2 with a null payload and unchanged padding.
+        _is_exact_over_capacity_reject = (
+            self.outcome == 2
+            and self.reject_reason == 1
+            and 1 <= self.op_kind <= 4
+            and self.sig_version in (0, 1)
+            and self.der_len == 0
+            and self.sighash_type == 0
+            and _pad0 == 0
+            and _pad1 == b"\x00" * 7
+            and self.sighash == b"\x00" * 32
+            and self.der_sig == b"\x00" * 72
+            and self.pubkey == b"\x00" * 65
+        )
+        if self.pubkey_len > 65 and not _is_exact_over_capacity_reject:
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: record pubkey_len {self.pubkey_len} exceeds 65"
+            )
         # ── Canonical field-range validation ──
         if self.op_kind > 5:
             raise AnalyzerError(
@@ -416,10 +436,6 @@ class Record:
             effective_der_len = 72
         else:
             effective_der_len = self.der_len
-        if self.pubkey_len > 65:
-            raise AnalyzerError(
-                f"CTX-OPERATIONS: record pubkey_len {self.pubkey_len} exceeds 65"
-            )
         # ── Padding must be all-zero ──
         if _pad0 != 0:
             raise AnalyzerError("CTX-OPERATIONS: record _pad0 is not all-zero")

--- a/tools/checksig-census/analyze.py
+++ b/tools/checksig-census/analyze.py
@@ -16,11 +16,21 @@ import hashlib
 import json
 import math
 import re
+import sqlite3
 import statistics
 import struct
 import sys
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import BinaryIO
+
+from context import (
+    ContextError,
+    SpendContext,
+    classify_input,
+    iter_context_inputs,
+)
 
 # ── Constants ───────────────────────────────────────────────────────────────
 
@@ -56,7 +66,49 @@ COUNTER_NAMES: list[str] = [
     "sighash_midstate_hit",
     "checkschnorr_entries",
     "schnorr_verify_calls",
+    "schnorr_verify_ok",
+    "schnorr_verify_fail",
 ]
+
+
+CONTEXT_INPUT_SCHEMA = "census-context-input-v1"
+
+CONTEXT_COUNTER_NAMES: list[str] = [
+    "p2sh_redeem_spends",
+    "native_witness_v0_spends",
+    "p2sh_wrapped_witness_v0_spends",
+    "bare_multisig_checks",
+    "p2sh_multisig_checks",
+    "native_witness_v0_multisig_checks",
+    "p2sh_wrapped_witness_v0_multisig_checks",
+    "taproot_key_path_spends",
+    "tapscript_spends",
+    "tapscript_schnorr_checks",
+    "tapscript_checksigadd_checks",
+]
+
+CONTEXT_COUNTER_DEFINITIONS: dict[str, str] = {
+    "p2sh_redeem_spends": "non-coinbase inputs whose prevout is P2SH and whose redeem script is not a witness-v0 program",
+    "native_witness_v0_spends": "non-coinbase inputs whose prevout is a native witness-v0 program (P2WPKH or P2WSH)",
+    "p2sh_wrapped_witness_v0_spends": "non-coinbase inputs whose prevout is P2SH and whose redeem script is a witness-v0 program",
+    "bare_multisig_checks": "BRSREC1 executed-operation records with op_kind CHECKMULTISIG or CHECKMULTISIGVERIFY joined to a bare legacy input",
+    "p2sh_multisig_checks": "BRSREC1 executed-operation records with op_kind CHECKMULTISIG or CHECKMULTISIGVERIFY joined to a P2SH input",
+    "native_witness_v0_multisig_checks": "BRSREC1 executed-operation records with op_kind CHECKMULTISIG or CHECKMULTISIGVERIFY joined to a native witness-v0 input",
+    "p2sh_wrapped_witness_v0_multisig_checks": "BRSREC1 executed-operation records with op_kind CHECKMULTISIG or CHECKMULTISIGVERIFY joined to a P2SH-wrapped witness-v0 input",
+    "taproot_key_path_spends": "P2TR inputs with one witness element after optional annex removal",
+    "tapscript_spends": "P2TR inputs with at least two witness elements after optional annex removal",
+    "tapscript_schnorr_checks": "BRSREC1 executed-operation records with sig_version TAPSCRIPT and op_kind CHECKSIG, CHECKSIGVERIFY, or CHECKSIGADD",
+    "tapscript_checksigadd_checks": "BRSREC1 executed-operation records with sig_version TAPSCRIPT and op_kind CHECKSIGADD",
+}
+
+MULTISIG_ELIGIBLE_CONTEXTS: frozenset[SpendContext] = frozenset(
+    (
+        SpendContext.BARE,
+        SpendContext.P2SH,
+        SpendContext.NATIVE_WITNESS_V0,
+        SpendContext.P2SH_WRAPPED_WITNESS_V0,
+    )
+)
 
 HEADER_STRUCT = struct.Struct("<8sQ")
 RECORD_STRUCT = struct.Struct("<32sIIBBBBBBBB32s72s65s7s")
@@ -65,6 +117,15 @@ JOURNAL_STRUCT = struct.Struct("<32sIIIIIB3s")
 assert HEADER_STRUCT.size == HEADER_SIZE
 assert RECORD_STRUCT.size == RECORD_SIZE
 assert JOURNAL_STRUCT.size == JOURNAL_SIZE
+
+# ── Canonical mainnet constants ─────────────────────────────────────────────
+
+MAINNET_MAGIC = "f9beb4d9"
+MAINNET_GENESIS_HASH = (
+    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+)
+C150_STOP_HEIGHT = 150_000
+C150_STOP_HASH = "0000000000000a3290f20e75860d505ce0e948a1d1d846bec7e39015d242884b"
 
 
 # ── Exceptions ──────────────────────────────────────────────────────────────
@@ -98,6 +159,74 @@ def _require_non_bool_int(value: object, field: str) -> int:
     return value
 
 
+def _require_exact_keys(d: dict[str, object], expected: set[str], label: str) -> None:
+    """Reject unknown or missing keys in *d* against *expected*."""
+    actual = set(d.keys())
+    unknown = actual - expected
+    if unknown:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: {label} has unknown key(s): {sorted(unknown)}"
+        )
+    missing = expected - actual
+    if missing:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: {label} missing required key(s): {sorted(missing)}"
+        )
+
+
+def _require_u32(value: object, field: str) -> int:
+    """Validate a u32 (0 ..= 2**32-1)."""
+    v = _require_non_bool_int(value, field)
+    if v < 0 or v > 0xFFFFFFFF:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: {field} must be u32 (0..{0xFFFFFFFF}), got {v}"
+        )
+    return v
+
+
+def _require_u64(value: object, field: str) -> int:
+    """Validate a u64 (0 ..= 2**64-1)."""
+    v = _require_non_bool_int(value, field)
+    if v < 0 or v > 0xFFFFFFFFFFFFFFFF:
+        raise AnalyzerError(f"CTX-CUSTODY: {field} must be u64, got {v}")
+    return v
+
+
+def _require_custody_ref(
+    value: object, label: str, *, with_schema: bool = False
+) -> dict[str, object]:
+    """Validate a custody reference object (path/bytes/sha256, optionally schema/version)."""
+    if not isinstance(value, dict):
+        raise AnalyzerError(f"CTX-CUSTODY: {label} must be an object")
+    expected = {"path", "bytes", "sha256"}
+    if with_schema:
+        expected |= {"schema", "version"}
+    _require_exact_keys(value, expected, label)
+    path = value["path"]
+    if not isinstance(path, str) or len(path) == 0:
+        raise AnalyzerError(f"CTX-CUSTODY: {label}.path must be a nonempty string")
+    bytes_val = _require_non_bool_int(value["bytes"], f"{label}.bytes")
+    if bytes_val < 0:
+        raise AnalyzerError(f"CTX-CUSTODY: {label}.bytes must be >= 0, got {bytes_val}")
+    sha = _require_hex_str(value["sha256"], f"{label}.sha256", 64)
+    result: dict[str, object] = {"path": path, "bytes": bytes_val, "sha256": sha}
+    if with_schema:
+        schema = value["schema"]
+        if schema != "bitcoin-rs-corpus-manifest":
+            raise AnalyzerError(
+                f"CTX-CUSTODY: {label}.schema is {schema!r}, "
+                f"expected 'bitcoin-rs-corpus-manifest'"
+            )
+        version = _require_int_field(value["version"], f"{label}.version")
+        if version != 1:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: {label}.version must be 1, got {version}"
+            )
+        result["schema"] = schema
+        result["version"] = version
+    return result
+
+
 # ── Data classes ────────────────────────────────────────────────────────────
 
 
@@ -126,8 +255,11 @@ class Counters:
     sighash_midstate_hit: int
     checkschnorr_entries: int
     schnorr_verify_calls: int
+    schnorr_verify_ok: int
+    schnorr_verify_fail: int
+    context_count: int
 
-    def __init__(self, raw: dict[str, Any]) -> None:
+    def __init__(self, raw: dict[str, object]) -> None:
         self._raw = raw
         self.schema: int = int(raw.get("schema", 0))
         self.label: str = str(raw.get("label", ""))
@@ -144,27 +276,44 @@ class Counters:
                     f"counters JSON: field {name!r} must be >= 0, got {value}"
                 )
             setattr(self, name, value)
-        self.record_count: int = int(raw.get("record_count", 0))
-        self.journal_count: int = int(raw.get("journal_count", 0))
+        # ── Reconciliation count fields: required, strict non-bool nonnegative int ──
+        for _rc_field in ("record_count", "journal_count", "context_count"):
+            if _rc_field not in raw:
+                raise AnalyzerError(
+                    f"counters JSON: missing required field {_rc_field!r}"
+                )
+            _rc_val = raw[_rc_field]
+            if isinstance(_rc_val, bool) or not isinstance(_rc_val, int):
+                raise AnalyzerError(
+                    f"counters JSON: field {_rc_field!r} must be int, "
+                    f"got {type(_rc_val).__name__}"
+                )
+            if _rc_val < 0:
+                raise AnalyzerError(
+                    f"counters JSON: field {_rc_field!r} must be >= 0, got {_rc_val}"
+                )
+        self.record_count: int = raw["record_count"]
+        self.journal_count: int = raw["journal_count"]
+        self.context_count: int = raw["context_count"]
 
 
 class Record:
     """Parsed 224-byte record."""
 
     __slots__ = (
-        "spend_txid",
-        "input_index",
-        "op_seq",
-        "op_kind",
-        "sig_version",
-        "outcome",
         "der_len",
-        "pubkey_len",
-        "sighash_type",
-        "reject_reason",
-        "sighash",
         "der_sig",
+        "input_index",
+        "op_kind",
+        "op_seq",
+        "outcome",
         "pubkey",
+        "pubkey_len",
+        "reject_reason",
+        "sig_version",
+        "sighash",
+        "sighash_type",
+        "spend_txid",
     )
 
     def __init__(self, raw: bytes) -> None:
@@ -186,12 +335,100 @@ class Record:
             self.pubkey,
             _pad1,
         ) = unpacked
+        # ── Canonical field-range validation ──
+        if self.op_kind > 5:
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: record op_kind {self.op_kind} exceeds 5"
+            )
+        if self.sig_version > 3:
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: record sig_version {self.sig_version} exceeds 3"
+            )
         if self.outcome > 2:
-            raise AnalyzerError(f"record outcome {self.outcome} exceeds 2")
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: record outcome {self.outcome} exceeds 2"
+            )
+        if self.reject_reason > 8:
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: record reject_reason {self.reject_reason} exceeds 8"
+            )
+        # Canonical outcome/reject combinations:
+        # outcome 0/1 (post-verification) must not carry a reject reason.
+        # outcome 2 (pre-verification reject) must have a valid reason and no sighash.
+        if self.outcome in (0, 1) and self.reject_reason != 0:
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: outcome {self.outcome} must have reject_reason 0, "
+                f"got {self.reject_reason}"
+            )
+        if self.outcome == 2:
+            if self.reject_reason == 0:
+                raise AnalyzerError(
+                    "CTX-OPERATIONS: outcome 2 (pre-verification reject) must have a non-zero reject_reason"
+                )
+            if self.sighash != b"\x00" * 32:
+                raise AnalyzerError(
+                    "CTX-OPERATIONS: pre-verification reject must have an all-zero sighash"
+                )
+            # ── Reject-family compatibility: exact native emission ──
+            _is_ecdsa_rec = self.sig_version in (0, 1) and self.op_kind in (1, 2, 3, 4)
+            _is_schnorr_rec = (self.sig_version == 2 and self.op_kind in (1, 2, 5)) or (
+                self.sig_version == 3 and self.op_kind == 0
+            )
+            _is_tapscript_skip = (
+                self.sig_version == 2
+                and self.op_kind in (1, 2, 5)
+                and self.der_len == 0
+            )
+            if self.reject_reason in (1, 2, 3):
+                if not _is_ecdsa_rec:
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: reject_reason {self.reject_reason} "
+                        f"requires ECDSA record (sig_version 0/1, op_kind 1..4), "
+                        f"got sig_version {self.sig_version}, op_kind {self.op_kind}"
+                    )
+            elif self.reject_reason in (4, 5, 6, 7):
+                if not _is_schnorr_rec:
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: reject_reason {self.reject_reason} "
+                        f"requires Schnorr record (sig_version 2 op 1/2/5, "
+                        f"or sig_version 3 op 0), got sig_version "
+                        f"{self.sig_version}, op_kind {self.op_kind}"
+                    )
+            elif self.reject_reason == 8 and not _is_tapscript_skip:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: reject_reason 8 requires Tapscript "
+                    f"skipped call (sig_version 2, op_kind 1/2/5, "
+                    f"empty signature), got sig_version "
+                    f"{self.sig_version}, op_kind {self.op_kind}, "
+                    f"der_len {self.der_len}"
+                )
         if self.der_len > 72:
-            raise AnalyzerError(f"record der_len {self.der_len} exceeds 72")
+            # The native instrumented kernel stores the original vchSig length in
+            # der_len but only copies up to 72 bytes into the fixed-size der_sig
+            # field.  Lengths > 72 therefore mean the signature was truncated; the
+            # record still contains at most 72 meaningful bytes, so we clamp the
+            # padding check to the field size.
+            effective_der_len = 72
+        else:
+            effective_der_len = self.der_len
         if self.pubkey_len > 65:
-            raise AnalyzerError(f"record pubkey_len {self.pubkey_len} exceeds 65")
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: record pubkey_len {self.pubkey_len} exceeds 65"
+            )
+        # ── Padding must be all-zero ──
+        if _pad0 != 0:
+            raise AnalyzerError("CTX-OPERATIONS: record _pad0 is not all-zero")
+        if _pad1 != b"\x00" * 7:
+            raise AnalyzerError("CTX-OPERATIONS: record _pad1 is not all-zero")
+        # ── Trailing bytes in der_sig / pubkey beyond their lengths must be zero ──
+        if self.der_sig[effective_der_len:] != b"\x00" * (72 - effective_der_len):
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: record der_sig has non-zero padding beyond der_len={self.der_len}"
+            )
+        if self.pubkey[self.pubkey_len :] != b"\x00" * (65 - self.pubkey_len):
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: record pubkey has non-zero padding beyond pubkey_len={self.pubkey_len}"
+            )
 
     @property
     def sort_key(self) -> tuple[bytes, int, int]:
@@ -202,12 +439,12 @@ class JournalEntry:
     """Parsed 56-byte journal entry."""
 
     __slots__ = (
-        "spend_txid",
-        "input_index",
-        "checksig_ops",
         "checkmultisig_ops",
+        "checksig_ops",
         "ecdsa_verify_calls",
         "ecdsa_verify_ok",
+        "input_index",
+        "spend_txid",
         "verdict",
     )
 
@@ -223,6 +460,18 @@ class JournalEntry:
             self.verdict,
             _pad,
         ) = unpacked
+        # ── Canonical field-range validation ──
+        if self.verdict not in (0, 1):
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: journal verdict {self.verdict} must be 0 or 1"
+            )
+        if _pad != b"\x00" * 3:
+            raise AnalyzerError("CTX-OPERATIONS: journal padding is not all-zero")
+        if self.ecdsa_verify_ok > self.ecdsa_verify_calls:
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: ecdsa_verify_ok {self.ecdsa_verify_ok} > "
+                f"ecdsa_verify_calls {self.ecdsa_verify_calls}"
+            )
 
     @property
     def key(self) -> tuple[bytes, int]:
@@ -266,13 +515,148 @@ def parse_journal(path: Path) -> list[JournalEntry]:
     return [JournalEntry(r) for r in raws]
 
 
-def parse_counters(path: Path) -> Counters:
-    raw = json.loads(path.read_text())
+def _iter_binary_entries(
+    path: Path, magic: bytes, entry_size: int, name: str
+) -> Iterator[tuple[int, bytes]]:
+    """Stream fixed-size entries from a magic+u64-count binary file.
+
+    Yields ``(index, raw_bytes)`` pairs without loading the whole file.
+    Raises ``AnalyzerError`` on short reads, bad magic, or size mismatch.
+    """
+    file_size = path.stat().st_size
+    if file_size < HEADER_SIZE:
+        raise AnalyzerError(
+            f"{name}: file too short ({file_size} bytes < {HEADER_SIZE} header)"
+        )
+    with path.open("rb") as stream:
+        header = _read_exact_bytes(stream, HEADER_SIZE, f"{name} header")
+        file_magic, count = HEADER_STRUCT.unpack(header)
+        if file_magic != magic:
+            raise AnalyzerError(f"{name}: bad magic {file_magic!r}, expected {magic!r}")
+        expected_payload = count * entry_size
+        available = file_size - HEADER_SIZE
+        if available < expected_payload:
+            raise AnalyzerError(
+                f"{name}: declared {count} entries need {expected_payload} bytes "
+                f"but only {available} remain after header"
+            )
+        for index in range(count):
+            raw = _read_exact_bytes(stream, entry_size, f"{name} entry {index}")
+            yield index, raw
+        trailing = stream.read(1)
+        if trailing:
+            raise AnalyzerError(
+                f"{name}: {len(trailing)} trailing byte(s) after declared entries"
+            )
+
+
+def _read_exact_bytes(
+    stream: BinaryIO, length: int, field: str, scope: str = ""
+) -> bytes:
+    """Read exactly *length* bytes from *stream* or raise AnalyzerError."""
+    data = stream.read(length)
+    if data is None or len(data) < length:
+        prefix = f"{scope}: " if scope else ""
+        raise AnalyzerError(f"{prefix}{field}: short read (expected {length} bytes)")
+    return data
+
+
+def iter_records(path: Path) -> Iterator[Record]:
+    """Stream BRSREC1 records one at a time without materializing the file."""
+    for _index, raw in _iter_binary_entries(path, RECORD_MAGIC, RECORD_SIZE, "records"):
+        yield Record(raw)
+
+
+def _iter_binary_entries_with_custody(
+    path: Path, magic: bytes, entry_size: int, name: str
+) -> tuple[Iterator[tuple[int, bytes]], dict[str, int]]:
+    """Stream fixed-size entries and compute custody (size + sha256) on the
+    exact single open used for parsing.  Returns ``(iterator, custody)``
+    where *custody* is populated once the iterator is fully consumed.
+    """
+    file_size = path.stat().st_size
+    if file_size < HEADER_SIZE:
+        raise AnalyzerError(
+            f"{name}: file too short ({file_size} bytes < {HEADER_SIZE} header)"
+        )
+    custody: dict[str, int] = {"bytes": 0, "sha256": 0}
+    stream = path.open("rb")
+    running_hash = hashlib.sha256()
+    try:
+        header = _read_exact_bytes(stream, HEADER_SIZE, f"{name} header")
+        running_hash.update(header)
+        file_magic, count = HEADER_STRUCT.unpack(header)
+        if file_magic != magic:
+            raise AnalyzerError(f"{name}: bad magic {file_magic!r}, expected {magic!r}")
+        expected_payload = count * entry_size
+        available = file_size - HEADER_SIZE
+        if available < expected_payload:
+            raise AnalyzerError(
+                f"{name}: declared {count} entries need {expected_payload} bytes "
+                f"but only {available} remain after header"
+            )
+
+        def _gen() -> Iterator[tuple[int, bytes]]:
+            try:
+                for index in range(count):
+                    raw = _read_exact_bytes(stream, entry_size, f"{name} entry {index}")
+                    running_hash.update(raw)
+                    yield index, raw
+                trailing = stream.read(1)
+                if trailing:
+                    raise AnalyzerError(
+                        f"{name}: {len(trailing)} trailing byte(s) after declared entries"
+                    )
+                custody["bytes"] = file_size
+                custody["sha256"] = int(running_hash.hexdigest(), 16)
+            finally:
+                stream.close()
+
+        return _gen(), custody
+    except BaseException:
+        stream.close()
+        raise
+
+
+def iter_records_with_custody(path: Path) -> tuple[Iterator[Record], dict[str, int]]:
+    """Stream BRSREC1 records and compute custody on the single open."""
+    gen, custody = _iter_binary_entries_with_custody(
+        path, RECORD_MAGIC, RECORD_SIZE, "records"
+    )
+    return ((Record(raw) for _idx, raw in gen), custody)
+
+
+def iter_journal_with_custody(
+    path: Path,
+) -> tuple[Iterator[JournalEntry], dict[str, int]]:
+    """Stream BRSJRN1 journal entries and compute custody on the single open."""
+    gen, custody = _iter_binary_entries_with_custody(
+        path, JOURNAL_MAGIC, JOURNAL_SIZE, "journal entries"
+    )
+    return ((JournalEntry(raw) for _idx, raw in gen), custody)
+
+
+def iter_journal(path: Path) -> Iterator[JournalEntry]:
+    """Stream BRSJRN1 journal entries one at a time without materializing the file."""
+    for _index, raw in _iter_binary_entries(
+        path, JOURNAL_MAGIC, JOURNAL_SIZE, "journal entries"
+    ):
+        yield JournalEntry(raw)
+
+
+def parse_counters(path: Path) -> tuple[Counters, dict[str, int]]:
+    """Parse counters JSON and return (Counters, custody) from the single read."""
+    counters_bytes = path.read_bytes()
+    raw = json.loads(counters_bytes)
     if not isinstance(raw, dict):
         raise AnalyzerError(f"{path}: JSON root is not an object")
     if raw.get("schema") != 1:
         raise AnalyzerError(f"{path}: schema is {raw.get('schema')}, expected 1")
-    return Counters(raw)
+    custody = {
+        "bytes": len(counters_bytes),
+        "sha256": int(hashlib.sha256(counters_bytes).hexdigest(), 16),
+    }
+    return Counters(raw), custody
 
 
 # ── Sorting and hashing ─────────────────────────────────────────────────────
@@ -294,15 +678,33 @@ def sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _sha256_file(path: Path) -> tuple[int, str]:
+    """Return (size in bytes, lowercase hex sha256) for a file."""
+    h = hashlib.sha256()
+    size = 0
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(64 * 1024)
+            if not chunk:
+                break
+            h.update(chunk)
+            size += len(chunk)
+    return size, h.hexdigest()
+
+
 # ── Invariant checks ────────────────────────────────────────────────────────
 
 
-def check_counter_arithmetic(c: Counters) -> list[dict[str, Any]]:
+def check_counter_arithmetic(c: Counters) -> list[dict[str, object]]:
     """INV-1 through INV-7."""
-    results: list[dict[str, Any]] = []
+    results: list[dict[str, object]] = []
 
-    def inv(inv_id: str, passed: bool, statement: str, **extra: Any) -> None:
-        entry: dict[str, Any] = {"id": inv_id, "passed": passed, "statement": statement}
+    def inv(inv_id: str, passed: bool, statement: str, **extra: object) -> None:
+        entry: dict[str, object] = {
+            "id": inv_id,
+            "passed": passed,
+            "statement": statement,
+        }
         entry.update(extra)
         results.append(entry)
 
@@ -373,7 +775,7 @@ def check_counter_arithmetic(c: Counters) -> list[dict[str, Any]]:
     return results
 
 
-def check_record_counts(records: list[Record], c: Counters) -> dict[str, Any]:
+def check_record_counts(records: list[Record], c: Counters) -> dict[str, object]:
     """INV-9: record count reconciliation."""
     outcome_01 = sum(1 for r in records if r.outcome in (0, 1))
     total = len(records)
@@ -388,7 +790,7 @@ def check_record_counts(records: list[Record], c: Counters) -> dict[str, Any]:
     }
 
 
-def check_journal_sums(journal: list[JournalEntry], c: Counters) -> dict[str, Any]:
+def check_journal_sums(journal: list[JournalEntry], c: Counters) -> dict[str, object]:
     """INV-10: journal sums reconcile with counters."""
     s_checksig = sum(e.checksig_ops for e in journal)
     s_checkmultisig = sum(e.checkmultisig_ops for e in journal)
@@ -415,7 +817,7 @@ def check_journal_sums(journal: list[JournalEntry], c: Counters) -> dict[str, An
     }
 
 
-def check_duplicate_keys(records: list[Record]) -> dict[str, Any]:
+def check_duplicate_keys(records: list[Record]) -> dict[str, object]:
     """INV-11: no duplicate (spend_txid, input_index, op_seq) after sorting."""
     seen: set[tuple[bytes, int, int]] = set()
     duplicates = 0
@@ -432,7 +834,7 @@ def check_duplicate_keys(records: list[Record]) -> dict[str, Any]:
     }
 
 
-def check_all_verdicts_true(journal: list[JournalEntry]) -> dict[str, Any]:
+def check_all_verdicts_true(journal: list[JournalEntry]) -> dict[str, object]:
     """INV-2 for census: all journal verdicts are true (1)."""
     false_count = sum(1 for e in journal if e.verdict != 1)
     return {
@@ -446,7 +848,7 @@ def check_all_verdicts_true(journal: list[JournalEntry]) -> dict[str, Any]:
 
 def check_count_repeat(
     c1: Counters, c2: Counters, sha1: str, sha2: str
-) -> dict[str, Any]:
+) -> dict[str, object]:
     """INV-13: two Run-B executions produce identical counters and sorted records SHA256."""
     counters_identical = (
         all(getattr(c1, name) == getattr(c2, name) for name in COUNTER_NAMES)
@@ -468,7 +870,7 @@ def check_count_repeat(
 def check_census_capture_agreement(
     census_journal: list[JournalEntry],
     capture_journal: list[JournalEntry],
-) -> dict[str, Any]:
+) -> dict[str, object]:
     """INV-12: census ∩ capture journal agreement (anti-triple-count)."""
     census_map: dict[tuple[bytes, int], JournalEntry] = {}
     for e in census_journal:
@@ -487,7 +889,7 @@ def check_census_capture_agreement(
         capture_map[e.key] = e
 
     intersection = set(census_map.keys()) & set(capture_map.keys())
-    discrepancies: list[dict[str, Any]] = []
+    discrepancies: list[dict[str, object]] = []
     max_ratio = 1.0
 
     for key in sorted(intersection):
@@ -512,8 +914,7 @@ def check_census_capture_agreement(
                 )
                 if field_name == "ecdsa_verify_calls" and bv > 0:
                     ratio = cv / bv
-                    if ratio > max_ratio:
-                        max_ratio = ratio
+                    max_ratio = max(max_ratio, ratio)
 
     width_multiplier: int | None = None
     if max_ratio > 2.5 and max_ratio < 3.5:
@@ -537,7 +938,7 @@ def check_census_capture_agreement(
 # ── Bare JSON extraction ────────────────────────────────────────────────────
 
 
-def extract_bare_mode0(bare: dict[str, Any]) -> dict[str, Any]:
+def extract_bare_mode0(bare: dict[str, object]) -> dict[str, object]:
     """Extract mode-0 results from bare-secp JSON per the binding contract.
 
     Requires top-level ``native_mode0`` with all exact fields:
@@ -701,7 +1102,7 @@ def extract_bare_mode0(bare: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def extract_spike_width1(spike: dict[str, Any]) -> float:
+def extract_spike_width1(spike: dict[str, object]) -> float:
     """Extract width-1 us_per_input from a spike run JSON."""
     if "runs" in spike and isinstance(spike["runs"], list):
         for run in spike["runs"]:
@@ -733,7 +1134,7 @@ def extract_spike_width1(spike: dict[str, Any]) -> float:
             )
         return _require_positive_finite_float(
             spike["us_per_input"], "spike JSON: top-level us_per_input"
-            )
+        )
     raise AnalyzerError("spike JSON: no us_per_input found")
 
 
@@ -741,11 +1142,11 @@ def extract_spike_width1(spike: dict[str, Any]) -> float:
 
 
 def cmd_validate_capture(args: argparse.Namespace) -> int:
-    counters = parse_counters(Path(args.counters))
+    counters, _ = parse_counters(Path(args.counters))
     records = parse_records(Path(args.records))
     journal = parse_journal(Path(args.journal))
 
-    repeat_counters = parse_counters(Path(args.repeat_counters))
+    repeat_counters, _ = parse_counters(Path(args.repeat_counters))
     parse_records(Path(args.repeat_records))
     parse_journal(Path(args.repeat_journal))
 
@@ -764,7 +1165,7 @@ def cmd_validate_capture(args: argparse.Namespace) -> int:
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_bytes(HEADER_STRUCT.pack(RECORD_MAGIC, len(raw1)) + sorted1)
 
-    inv_results: list[dict[str, Any]] = []
+    inv_results: list[dict[str, object]] = []
     inv_results.extend(check_counter_arithmetic(counters))
     inv_results.append(check_record_counts(records, counters))
     inv_results.append(check_journal_sums(journal, counters))
@@ -776,8 +1177,8 @@ def cmd_validate_capture(args: argparse.Namespace) -> int:
         and counters.ffi_verify_entries == EXPECTED_FFI_VERIFY_ENTRIES_KSPIKE1
     )
 
-    report = {
-        "schema": "validate-capture-v1",
+    report: dict[str, object] = {
+        "schema": "census-capture-v2",
         "counters_label": counters.label,
         "record_count": len(records),
         "journal_count": len(journal),
@@ -786,6 +1187,12 @@ def cmd_validate_capture(args: argparse.Namespace) -> int:
         "invariants": inv_results,
         "all_passed": all_passed,
     }
+
+    context_inputs = getattr(args, "context_inputs", None)
+    if context_inputs:
+        corpus_size, corpus_sha256 = _sha256_file(Path(context_inputs))
+        report["corpus_size"] = corpus_size
+        report["corpus_sha256"] = corpus_sha256
 
     out_path = Path(args.output)
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -805,11 +1212,11 @@ def cmd_validate_capture(args: argparse.Namespace) -> int:
 
 
 def cmd_validate_census(args: argparse.Namespace) -> int:
-    counters = parse_counters(Path(args.counters))
+    counters, _ = parse_counters(Path(args.counters))
     journal = parse_journal(Path(args.journal))
     capture_journal = parse_journal(Path(args.capture_journal))
 
-    inv_results: list[dict[str, Any]] = []
+    inv_results: list[dict[str, object]] = []
     inv_results.extend(check_counter_arithmetic(counters))
     inv_results.append(check_all_verdicts_true(journal))
     inv_results.append(check_journal_sums(journal, counters))
@@ -817,7 +1224,7 @@ def cmd_validate_census(args: argparse.Namespace) -> int:
 
     # EXP-1: expected input count
     exp1_passed = counters.ffi_verify_entries == EXPECTED_FFI_VERIFY_ENTRIES_FULL
-    exp1: dict[str, Any] = {
+    exp1: dict[str, object] = {
         "id": "EXP-1",
         "passed": exp1_passed,
         "statement": f"C_FFI_VERIFY_ENTRIES == {EXPECTED_FFI_VERIFY_ENTRIES_FULL}",
@@ -844,7 +1251,7 @@ def cmd_validate_census(args: argparse.Namespace) -> int:
     else:
         ratio = 0.0
         exp4_passed = False
-    exp4: dict[str, Any] = {
+    exp4: dict[str, object] = {
         "id": "EXP-4",
         "passed": exp4_passed,
         "statement": "attempts-per-check on KSPIKE1 vs 0..150k differ by <= 10%",
@@ -898,7 +1305,7 @@ def cmd_verdict(args: argparse.Namespace) -> int:
         raise AnalyzerError(
             f"verdict requires exactly three spike-runs, got {len(args.spike_runs)}"
         )
-    capture_counters = parse_counters(Path(args.capture_counters))
+    capture_counters, _ = parse_counters(Path(args.capture_counters))
     k_entries = capture_counters.ffi_verify_entries
     if k_entries == 0:
         raise AnalyzerError("capture counters: ffi_verify_entries == 0")
@@ -920,7 +1327,7 @@ def cmd_verdict(args: argparse.Namespace) -> int:
     )
 
     # Extract and validate every bare timing run.
-    run_records: list[dict[str, Any]] = []
+    run_records: list[dict[str, object]] = []
     run_medians: list[float] = []
     all_per_attempt_ns: list[float] = []
     for bare_path in args.bare_runs:
@@ -1220,6 +1627,1440 @@ def cmd_verdict(args: argparse.Namespace) -> int:
     return 0 if verdict != "INVALID" else 2
 
 
+# ── Subcommand: classify-corpus ──────────────────────────────────────────────
+
+
+def _op_kind_name(op_kind: int) -> str:
+    return {
+        1: "CHECKSIG",
+        2: "CHECKSIGVERIFY",
+        3: "CHECKMULTISIG",
+        4: "CHECKMULTISIGVERIFY",
+        5: "CHECKSIGADD",
+    }.get(op_kind, f"UNKNOWN({op_kind})")
+
+
+def _sig_version_name(sig_version: int) -> str:
+    return {
+        0: "BASE",
+        1: "WITNESS_V0",
+        2: "TAPSCRIPT",
+        3: "TAPROOT",
+    }.get(sig_version, f"UNKNOWN({sig_version})")
+
+
+def _require_hex_str(value: object, field: str, length: int) -> str:
+    """Validate that *value* is a lowercase hex string of exactly *length* chars."""
+    if not isinstance(value, str) or len(value) != length:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: {field} must be a {length}-character hex string"
+        )
+    if not re.fullmatch(r"[0-9a-f]{" + str(length) + r"}", value):
+        raise AnalyzerError(
+            f"CTX-CUSTODY: {field} must be lowercase hex, got {value!r}"
+        )
+    return value
+
+
+def _require_int_field(value: object, field: str) -> int:
+    """Validate that *value* is a non-bool int."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AnalyzerError(
+            f"CTX-CUSTODY: {field} must be an integer, got {type(value).__name__}"
+        )
+    return value
+
+
+def _validate_replay_artifact(path: Path) -> dict[str, object]:
+    """Validate a mainnet-prefix-replay-v2 JSON artifact and return flat fields.
+
+    Required root keys (exactly): schema, network, network_magic, genesis_hash,
+    start_height, start_hash, stop_height, stop_hash, block_count, window,
+    assume_valid_height, window_verify_success_total, corpus_manifest, archive.
+    Raises ``AnalyzerError`` with CTX-CUSTODY or CTX-WINDOW prefix on any
+    schema, field, or invariant violation.
+    """
+    replay_bytes = path.read_bytes()
+    raw = json.loads(replay_bytes)
+    if not isinstance(raw, dict):
+        raise AnalyzerError("CTX-CUSTODY: replay artifact root is not an object")
+
+    _REPLAY_KEYS = {
+        "schema",
+        "network",
+        "network_magic",
+        "genesis_hash",
+        "start_height",
+        "start_hash",
+        "stop_height",
+        "stop_hash",
+        "block_count",
+        "window",
+        "assume_valid_height",
+        "window_verify_success_total",
+        "corpus_manifest",
+        "archive",
+        "block_bytes",
+        "block_source",
+        "blockfilterindex",
+        "blocks_per_second",
+        "checkpoint_generation",
+        "data_dir",
+        "decode_seconds",
+        "elapsed_seconds",
+        "fetch_seconds",
+        "git_head",
+        "measurement_target",
+        "rss_high_water_bytes",
+        "stage_seconds",
+        "storage_backend",
+        "tx_count",
+        "txindex",
+    }
+    _require_exact_keys(raw, _REPLAY_KEYS, "replay artifact root")
+
+    if raw["schema"] != "mainnet-prefix-replay-v2":
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay schema is {raw['schema']!r}, "
+            f"expected 'mainnet-prefix-replay-v2'"
+        )
+
+    network = raw["network"]
+    if network != "mainnet":
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.network must be 'mainnet', got {network!r}"
+        )
+
+    network_magic = _require_hex_str(raw["network_magic"], "replay.network_magic", 8)
+    if network_magic != MAINNET_MAGIC:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.network_magic must be {MAINNET_MAGIC!r}, "
+            f"got {network_magic!r}"
+        )
+
+    genesis_hash = _require_hex_str(raw["genesis_hash"], "replay.genesis_hash", 64)
+    if genesis_hash != MAINNET_GENESIS_HASH:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.genesis_hash must be the canonical mainnet "
+            f"genesis {MAINNET_GENESIS_HASH!r}, got {genesis_hash!r}"
+        )
+
+    start_height = _require_int_field(raw["start_height"], "replay.start_height")
+    if start_height != 0:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.start_height must be 0, got {start_height}"
+        )
+    start_hash = _require_hex_str(raw["start_hash"], "replay.start_hash", 64)
+    if start_hash != genesis_hash:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.start_hash must equal genesis_hash, "
+            f"got {start_hash!r}"
+        )
+
+    stop_height = _require_int_field(raw["stop_height"], "replay.stop_height")
+    stop_hash = _require_hex_str(raw["stop_hash"], "replay.stop_hash", 64)
+    block_count = _require_int_field(raw["block_count"], "replay.block_count")
+    if block_count != stop_height + 1:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.block_count must equal stop_height+1 "
+            f"({stop_height + 1}), got {block_count}"
+        )
+
+    window = _require_int_field(raw["window"], "replay.window")
+    if window <= 1:
+        raise AnalyzerError(f"CTX-WINDOW: replay.window must be > 1, got {window}")
+
+    assume_valid_height = _require_int_field(
+        raw["assume_valid_height"], "replay.assume_valid_height"
+    )
+    if assume_valid_height != 0:
+        raise AnalyzerError(
+            f"CTX-WINDOW: replay.assume_valid_height must be 0, "
+            f"got {assume_valid_height}"
+        )
+
+    window_verify_success_total = _require_int_field(
+        raw["window_verify_success_total"], "replay.window_verify_success_total"
+    )
+    if window_verify_success_total < 1:
+        raise AnalyzerError(
+            f"CTX-WINDOW: replay.window_verify_success_total must be >= 1, "
+            f"got {window_verify_success_total}"
+        )
+
+    corpus_manifest = _require_custody_ref(
+        raw["corpus_manifest"], "replay.corpus_manifest", with_schema=True
+    )
+    archive = _require_custody_ref(raw["archive"], "replay.archive", with_schema=False)
+
+    # ── Optional timing/metadata fields emitted by the Rust replay binary.
+    # These are not load-bearing for the contract, but the schema is frozen,
+    # so we validate type and canonical range for each.
+    def _require_float(value: object, field: str, *, ge: float | None = None) -> float:
+        if isinstance(value, bool) or not isinstance(value, float):
+            raise AnalyzerError(f"CTX-CUSTODY: {field} must be a float")
+        if ge is not None and value < ge:
+            raise AnalyzerError(f"CTX-CUSTODY: {field} must be >= {ge}, got {value}")
+        return value
+
+    block_bytes = _require_non_bool_int(raw["block_bytes"], "replay.block_bytes")
+    if block_bytes < 0:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.block_bytes must be >= 0, got {block_bytes}"
+        )
+
+    block_source = raw["block_source"]
+    if not isinstance(block_source, str) or block_source not in ("file", "rest"):
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.block_source must be 'file' or 'rest', got {block_source!r}"
+        )
+
+    if not isinstance(raw["blockfilterindex"], bool):
+        raise AnalyzerError("CTX-CUSTODY: replay.blockfilterindex must be a boolean")
+    if not isinstance(raw["txindex"], bool):
+        raise AnalyzerError("CTX-CUSTODY: replay.txindex must be a boolean")
+
+    blocks_per_second = _require_float(
+        raw["blocks_per_second"], "replay.blocks_per_second", ge=0.0
+    )
+    checkpoint_generation = _require_non_bool_int(
+        raw["checkpoint_generation"], "replay.checkpoint_generation"
+    )
+    if checkpoint_generation < 1:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.checkpoint_generation must be >= 1, got {checkpoint_generation}"
+        )
+
+    data_dir = raw["data_dir"]
+    if not isinstance(data_dir, str) or len(data_dir) == 0:
+        raise AnalyzerError("CTX-CUSTODY: replay.data_dir must be a nonempty string")
+
+    decode_seconds = _require_float(
+        raw["decode_seconds"], "replay.decode_seconds", ge=0.0
+    )
+    elapsed_seconds = _require_float(
+        raw["elapsed_seconds"], "replay.elapsed_seconds", ge=0.0
+    )
+    fetch_seconds = _require_float(raw["fetch_seconds"], "replay.fetch_seconds", ge=0.0)
+
+    git_head = _require_hex_str(raw["git_head"], "replay.git_head", 40)
+
+    measurement_target = raw["measurement_target"]
+    if not isinstance(measurement_target, str) or len(measurement_target) == 0:
+        raise AnalyzerError(
+            "CTX-CUSTODY: replay.measurement_target must be a nonempty string"
+        )
+
+    rss_high_water_bytes = _require_non_bool_int(
+        raw["rss_high_water_bytes"], "replay.rss_high_water_bytes"
+    )
+    if rss_high_water_bytes < 0:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.rss_high_water_bytes must be >= 0, got {rss_high_water_bytes}"
+        )
+
+    stage_seconds = raw["stage_seconds"]
+    if not isinstance(stage_seconds, list):
+        raise AnalyzerError("CTX-CUSTODY: replay.stage_seconds must be a list")
+    _STAGE_ENTRY_KEYS = {"count", "stage", "sum_seconds"}
+    for _stage_entry in stage_seconds:
+        if not isinstance(_stage_entry, dict):
+            raise AnalyzerError(
+                "CTX-CUSTODY: replay.stage_seconds entries must be objects with "
+                "count, stage, and sum_seconds"
+            )
+        _require_exact_keys(
+            _stage_entry, _STAGE_ENTRY_KEYS, "replay.stage_seconds entry"
+        )
+        _stage_count = _stage_entry["count"]
+        if isinstance(_stage_count, bool) or not isinstance(_stage_count, int):
+            raise AnalyzerError(
+                "CTX-CUSTODY: replay.stage_seconds count must be a non-bool integer"
+            )
+        if _stage_count < 0:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: replay.stage_seconds count must be >= 0, got {_stage_count}"
+            )
+        _stage_name = _stage_entry["stage"]
+        if not isinstance(_stage_name, str):
+            raise AnalyzerError(
+                "CTX-CUSTODY: replay.stage_seconds stage must be a string"
+            )
+        _stage_sum = _stage_entry["sum_seconds"]
+        if isinstance(_stage_sum, bool) or not isinstance(_stage_sum, float):
+            raise AnalyzerError(
+                "CTX-CUSTODY: replay.stage_seconds sum_seconds must be a float"
+            )
+        if not math.isfinite(_stage_sum) or _stage_sum < 0.0:
+            raise AnalyzerError(
+                "CTX-CUSTODY: replay.stage_seconds sum_seconds must be finite and "
+                f">= 0, got {_stage_sum}"
+            )
+
+    storage_backend = raw["storage_backend"]
+    if not isinstance(storage_backend, str) or len(storage_backend) == 0:
+        raise AnalyzerError(
+            "CTX-CUSTODY: replay.storage_backend must be a nonempty string"
+        )
+
+    tx_count = _require_non_bool_int(raw["tx_count"], "replay.tx_count")
+    if tx_count < 0:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: replay.tx_count must be >= 0, got {tx_count}"
+        )
+
+    return {
+        "schema": "mainnet-prefix-replay-v2",
+        "network": network,
+        "network_magic": network_magic,
+        "genesis_hash": genesis_hash,
+        "start_height": start_height,
+        "start_hash": start_hash,
+        "stop_height": stop_height,
+        "stop_hash": stop_hash,
+        "block_count": block_count,
+        "window": window,
+        "assume_valid_height": assume_valid_height,
+        "window_verify_success_total": window_verify_success_total,
+        "corpus_manifest": corpus_manifest,
+        "archive": archive,
+        "block_bytes": block_bytes,
+        "block_source": block_source,
+        "blockfilterindex": raw["blockfilterindex"],
+        "blocks_per_second": blocks_per_second,
+        "checkpoint_generation": checkpoint_generation,
+        "data_dir": data_dir,
+        "decode_seconds": decode_seconds,
+        "elapsed_seconds": elapsed_seconds,
+        "fetch_seconds": fetch_seconds,
+        "git_head": git_head,
+        "measurement_target": measurement_target,
+        "rss_high_water_bytes": rss_high_water_bytes,
+        "stage_seconds": stage_seconds,
+        "storage_backend": storage_backend,
+        "tx_count": tx_count,
+        "txindex": raw["txindex"],
+        "custody": {
+            "bytes": len(replay_bytes),
+            "sha256": hashlib.sha256(replay_bytes).hexdigest(),
+        },
+    }
+
+
+def _validate_corpus_manifest(
+    manifest_path: Path, archive_path: Path, replay: dict[str, object]
+) -> dict[str, object]:
+    """Validate corpus manifest JSON, cross-check against replay, and
+    stream-validate every Core-frame in the archive in a single open pass.
+
+    The archive is opened exactly once.  A running SHA-256 is updated
+    incrementally with every byte read (magic + length + payload), replacing
+    the separate ``_sha256_file`` call.  The computed hash and byte count
+    must match the manifest's declared archive size and sha256.
+
+    Returns the manifest summary **without** ``entries``.  Raises
+    ``AnalyzerError`` with CTX-CUSTODY prefix on any mismatch.
+    """
+    # ── Load and validate manifest JSON ──
+    manifest_bytes = manifest_path.read_bytes()
+    raw = json.loads(manifest_bytes)
+    if not isinstance(raw, dict):
+        raise AnalyzerError("CTX-CUSTODY: corpus manifest root is not an object")
+
+    _MANIFEST_KEYS = {
+        "schema",
+        "version",
+        "network",
+        "network_magic",
+        "genesis_hash",
+        "range",
+        "archive",
+        "entries",
+    }
+    _require_exact_keys(raw, _MANIFEST_KEYS, "corpus manifest root")
+
+    if raw["schema"] != "bitcoin-rs-corpus-manifest":
+        raise AnalyzerError(
+            f"CTX-CUSTODY: corpus manifest schema is {raw['schema']!r}, "
+            f"expected 'bitcoin-rs-corpus-manifest'"
+        )
+    version = _require_int_field(raw["version"], "manifest.version")
+    if version != 1:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: corpus manifest version must be 1, got {version}"
+        )
+
+    network = raw["network"]
+    if network != "mainnet":
+        raise AnalyzerError(
+            f"CTX-CUSTODY: manifest.network must be 'mainnet', got {network!r}"
+        )
+    network_magic = _require_hex_str(raw["network_magic"], "manifest.network_magic", 8)
+    if network_magic != MAINNET_MAGIC:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: manifest.network_magic must be {MAINNET_MAGIC!r}, "
+            f"got {network_magic!r}"
+        )
+    genesis_hash = _require_hex_str(raw["genesis_hash"], "manifest.genesis_hash", 64)
+    if genesis_hash != MAINNET_GENESIS_HASH:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: manifest.genesis_hash must be the canonical mainnet "
+            f"genesis {MAINNET_GENESIS_HASH!r}, got {genesis_hash!r}"
+        )
+
+    # ── range ──
+    range_obj = raw["range"]
+    if not isinstance(range_obj, dict):
+        raise AnalyzerError("CTX-CUSTODY: manifest.range must be an object")
+    _require_exact_keys(range_obj, {"start_height", "stop_height"}, "manifest.range")
+    range_start = _require_u32(range_obj["start_height"], "manifest.range.start_height")
+    range_stop = _require_u32(range_obj["stop_height"], "manifest.range.stop_height")
+    if range_start != 0:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: manifest.range.start_height must be 0, got {range_start}"
+        )
+
+    # ── archive ──
+    archive_obj = raw["archive"]
+    if not isinstance(archive_obj, dict):
+        raise AnalyzerError("CTX-CUSTODY: manifest.archive must be an object")
+    _require_exact_keys(archive_obj, {"size", "sha256"}, "manifest.archive")
+    archive_size = _require_u64(archive_obj["size"], "manifest.archive.size")
+    archive_sha256 = _require_hex_str(
+        archive_obj["sha256"], "manifest.archive.sha256", 64
+    )
+
+    # ── entries ──
+    entries = raw["entries"]
+    if not isinstance(entries, list) or len(entries) == 0:
+        raise AnalyzerError("CTX-CUSTODY: manifest.entries must be a non-empty array")
+
+    # ── Cross-check manifest file bytes/SHA-256 against replay ──
+    replay_cm = replay["corpus_manifest"]
+    replay_cm_bytes = replay_cm["bytes"]
+    replay_cm_sha256 = replay_cm["sha256"]
+    actual_cm_size = len(manifest_bytes)
+    actual_cm_sha = hashlib.sha256(manifest_bytes).hexdigest()
+    if actual_cm_size != replay_cm_bytes:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: manifest file size mismatch: replay={replay_cm_bytes}, "
+            f"actual={actual_cm_size}"
+        )
+    if actual_cm_sha != replay_cm_sha256:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: manifest file sha256 mismatch: replay={replay_cm_sha256}, "
+            f"actual={actual_cm_sha}"
+        )
+
+    # ── Cross-check manifest fields against replay ──
+    replay_network = replay["network"]
+    replay_magic = replay["network_magic"]
+    replay_genesis = replay["genesis_hash"]
+    replay_start = replay["start_height"]
+    replay_stop = replay["stop_height"]
+    replay_stop_hash = replay["stop_hash"]
+    replay_arch_bytes = replay["archive"]["bytes"]
+    replay_arch_sha256 = replay["archive"]["sha256"]
+
+    if network != replay_network:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: network mismatch: manifest={network!r}, "
+            f"replay={replay_network!r}"
+        )
+    if network_magic != replay_magic:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: network_magic mismatch: manifest={network_magic!r}, "
+            f"replay={replay_magic!r}"
+        )
+    if genesis_hash != replay_genesis:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: genesis_hash mismatch: manifest={genesis_hash!r}, "
+            f"replay={replay_genesis!r}"
+        )
+    if range_start != replay_start:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: start_height mismatch: manifest={range_start}, "
+            f"replay={replay_start}"
+        )
+    if range_stop != replay_stop:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: stop_height mismatch: manifest={range_stop}, "
+            f"replay={replay_stop}"
+        )
+    if archive_size != replay_arch_bytes:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: archive size mismatch: manifest={archive_size}, "
+            f"replay={replay_arch_bytes}"
+        )
+    if archive_sha256 != replay_arch_sha256:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: archive sha256 mismatch: manifest={archive_sha256}, "
+            f"replay={replay_arch_sha256!r}"
+        )
+
+    # ── Validate manifest entries: exact keys, types, duplicates, contiguity ──
+    expected_entry_count = range_stop + 1
+    if len(entries) != expected_entry_count:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: manifest entries count {len(entries)} != "
+            f"stop_height+1 ({expected_entry_count})"
+        )
+
+    _ENTRY_KEYS = {"height", "hash", "offset", "payload_length"}
+    seen_heights: set[int] = set()
+    seen_hashes: set[str] = set()
+    expected_offset = 0
+    last_index = len(entries) - 1
+    magic_bytes = bytes.fromhex(network_magic)
+
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise AnalyzerError(
+                f"CTX-CUSTODY: manifest.entries[{index}] is not an object"
+            )
+        _require_exact_keys(entry, _ENTRY_KEYS, f"manifest.entries[{index}]")
+        entry_height = _require_u32(
+            entry["height"], f"manifest.entries[{index}].height"
+        )
+        entry_hash = _require_hex_str(
+            entry["hash"], f"manifest.entries[{index}].hash", 64
+        )
+        entry_offset = _require_u64(
+            entry["offset"], f"manifest.entries[{index}].offset"
+        )
+        entry_payload_length = _require_u32(
+            entry["payload_length"], f"manifest.entries[{index}].payload_length"
+        )
+        if entry_payload_length < 80 or entry_payload_length > 4_000_000:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: manifest.entries[{index}].payload_length "
+                f"{entry_payload_length} out of range [80, 4000000]"
+            )
+
+        if entry_height in seen_heights:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: duplicate height {entry_height} in manifest entries"
+            )
+        if entry_hash in seen_hashes:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: duplicate hash {entry_hash} in manifest entries"
+            )
+        seen_heights.add(entry_height)
+        seen_hashes.add(entry_hash)
+
+        if entry_height != range_start + index:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: manifest.entries[{index}].height {entry_height} "
+                f"!= expected {range_start + index} (gapped heights)"
+            )
+        if entry_offset != expected_offset:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: manifest.entries[{index}].offset {entry_offset} "
+                f"!= expected {expected_offset} (inconsistent offset)"
+            )
+        expected_offset = entry_offset + 8 + entry_payload_length
+        if index == last_index and expected_offset != archive_size:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: final frame end {expected_offset} != "
+                f"archive.size {archive_size}"
+            )
+
+    # ── Single-open archive pass: stream frames, hash incrementally ──
+    prev_block_hash_raw: bytes | None = None
+    running_hash = hashlib.sha256()
+    bytes_consumed = 0
+
+    with archive_path.open("rb") as stream:
+        for index, entry in enumerate(entries):
+            assert isinstance(entry, dict)
+            entry_payload_length = int(entry["payload_length"])
+            entry_hash = str(entry["hash"])
+
+            # Read frame header: 4-byte magic + 4-byte LE u32 length.
+            frame_header = _read_exact_bytes(
+                stream, 8, f"archive frame {index} header", scope="CTX-CUSTODY"
+            )
+            running_hash.update(frame_header)
+            bytes_consumed += 8
+            frame_magic = frame_header[0:4]
+            frame_length = struct.unpack_from("<I", frame_header, 4)[0]
+
+            if frame_magic != magic_bytes:
+                raise AnalyzerError(
+                    f"CTX-CUSTODY: archive frame {index} magic "
+                    f"{frame_magic.hex()} != manifest network_magic "
+                    f"{magic_bytes.hex()} (frame magic mismatch)"
+                )
+            if frame_length != entry_payload_length:
+                raise AnalyzerError(
+                    f"CTX-CUSTODY: archive frame {index} length {frame_length} "
+                    f"!= manifest payload_length {entry_payload_length} "
+                    f"(payload_length mismatch)"
+                )
+
+            # Read the 80-byte block header first.
+            header_bytes = _read_exact_bytes(
+                stream, 80, f"archive frame {index} block header", scope="CTX-CUSTODY"
+            )
+            running_hash.update(header_bytes)
+            bytes_consumed += 80
+
+            # Double-SHA256 of the 80-byte header → internal LE hash.
+            hash_raw = hashlib.sha256(hashlib.sha256(header_bytes).digest()).digest()
+            hash_display = hash_raw[::-1].hex()
+
+            if hash_display != entry_hash:
+                raise AnalyzerError(
+                    f"CTX-CUSTODY: archive frame {index} header double-SHA256 "
+                    f"{hash_display} != manifest hash {entry_hash} "
+                    f"(header hash mismatch)"
+                )
+
+            # prev_blockhash is bytes 4..36 of the header (internal LE order).
+            prev_blockhash = header_bytes[4:36]
+
+            if index == 0:
+                if entry_hash != genesis_hash:
+                    raise AnalyzerError(
+                        f"CTX-CUSTODY: first block hash {entry_hash} != "
+                        f"manifest genesis_hash {genesis_hash}"
+                    )
+                if prev_blockhash != b"\x00" * 32:
+                    raise AnalyzerError(
+                        f"CTX-CUSTODY: genesis block prev_blockhash is not "
+                        f"all-zero (genesis prev_blockhash nonzero: "
+                        f"got {prev_blockhash[::-1].hex()})"
+                    )
+            else:
+                if prev_block_hash_raw is None:
+                    raise AnalyzerError(
+                        "CTX-CUSTODY: internal error: prev_block_hash_raw is None"
+                    )
+                if prev_blockhash != prev_block_hash_raw:
+                    raise AnalyzerError(
+                        f"CTX-CUSTODY: block {index} prev_blockhash "
+                        f"{prev_blockhash[::-1].hex()} != previous block hash "
+                        f"{prev_block_hash_raw[::-1].hex()} (chain break)"
+                    )
+
+            # Last block hash must equal replay stop_hash.
+            if index == last_index and entry_hash != replay_stop_hash:
+                raise AnalyzerError(
+                    f"CTX-CUSTODY: last block hash {entry_hash} != "
+                    f"replay stop_hash {replay_stop_hash}"
+                )
+
+            prev_block_hash_raw = hash_raw
+
+            # Consume the remainder of the payload in 64 KiB chunks.
+            remaining = entry_payload_length - 80
+            chunk_size = 65536
+            while remaining > 0:
+                to_read = min(remaining, chunk_size)
+                chunk = _read_exact_bytes(
+                    stream,
+                    to_read,
+                    f"archive frame {index} payload chunk",
+                    scope="CTX-CUSTODY",
+                )
+                running_hash.update(chunk)
+                bytes_consumed += to_read
+                remaining -= to_read
+
+        # Archive must be exhausted exactly at archive.size.
+        trailing = stream.read(1)
+        if trailing:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: archive has {len(trailing)} trailing byte(s) "
+                f"after final frame (trailing bytes)"
+            )
+
+    if bytes_consumed != archive_size:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: archive bytes consumed {bytes_consumed} != "
+            f"archive.size {archive_size}"
+        )
+    computed_sha256 = running_hash.hexdigest()
+    if computed_sha256 != archive_sha256:
+        raise AnalyzerError(
+            f"CTX-CUSTODY: archive streaming sha256 {computed_sha256} != "
+            f"manifest archive sha256 {archive_sha256}"
+        )
+
+    return {
+        "schema": "bitcoin-rs-corpus-manifest",
+        "version": version,
+        "network": network,
+        "network_magic": network_magic,
+        "genesis_hash": genesis_hash,
+        "range": {"start_height": range_start, "stop_height": range_stop},
+        "archive": {"size": archive_size, "sha256": archive_sha256},
+        "custody": {
+            "bytes": len(manifest_bytes),
+            "sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+        },
+    }
+
+
+def _count_context_records_disk(
+    contexts_path: Path,
+    records_path: Path,
+    journal_path: Path,
+    counters: Counters,
+) -> tuple[dict[str, int], int, dict[str, dict[str, int]]]:
+    """Disk-backed streaming computation of context counters.
+
+    Uses a temporary on-disk sqlite3 database to join BRSCTX1 contexts,
+    BRSJRN1 journal entries, and BRSREC1 records without materializing
+    any of the binary files in memory.
+
+    Returns ``(counts, context_count, custody)`` where *custody* maps
+    ``"contexts"``, ``"records"``, ``"journal"`` to ``{bytes, sha256}``
+    computed on the single open used for parsing.
+    """
+    counts: dict[str, int] = {name: 0 for name in CONTEXT_COUNTER_NAMES}
+
+    with tempfile.TemporaryDirectory(prefix="classify-corpus-") as tmpdir:
+        db_path = Path(tmpdir) / "contexts.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                "CREATE TABLE contexts ("
+                "txid_le BLOB, input_index INTEGER, spend_context TEXT, "
+                "prevout BLOB, script_sig BLOB, witness_count INTEGER, "
+                "PRIMARY KEY(txid_le, input_index))"
+            )
+            conn.execute(
+                "CREATE TABLE journal ("
+                "txid_le BLOB, input_index INTEGER, verdict INTEGER, "
+                "checksig_ops INTEGER, checkmultisig_ops INTEGER, "
+                "ecdsa_verify_calls INTEGER, ecdsa_verify_ok INTEGER, "
+                "PRIMARY KEY(txid_le, input_index))"
+            )
+            conn.execute(
+                "CREATE TABLE record_keys ("
+                "txid_le BLOB, input_index INTEGER, op_seq INTEGER, "
+                "PRIMARY KEY(txid_le, input_index, op_seq))"
+            )
+            conn.execute(
+                "CREATE TABLE record_seq ("
+                "txid_le BLOB, input_index INTEGER, last_op_seq INTEGER, "
+                "PRIMARY KEY(txid_le, input_index))"
+            )
+            conn.execute(
+                "CREATE TABLE record_ecdsa ("
+                "txid_le BLOB, input_index INTEGER, calls INTEGER, ok INTEGER, "
+                "PRIMARY KEY(txid_le, input_index))"
+            )
+
+            # ── Stream BRSCTX1 → classify → INSERT ──
+            context_count = 0
+            context_iter = iter_context_inputs(contexts_path, dedup=False)
+            try:
+                for evidence in context_iter:
+                    classified = classify_input(evidence)
+                    ctx = classified.spend_context
+                    conn.execute(
+                        "INSERT INTO contexts VALUES (?, ?, ?, ?, ?, ?)",
+                        (
+                            evidence.identity.txid_le,
+                            evidence.identity.input_index,
+                            ctx.value,
+                            evidence.prevout_script_pubkey,
+                            evidence.script_sig,
+                            len(evidence.witness),
+                        ),
+                    )
+                    context_count += 1
+                contexts_custody = context_iter.custody()
+            except ContextError as exc:
+                raise AnalyzerError(f"CTX-RAW: BRSCTX1 stream failed: {exc}") from exc
+            except sqlite3.IntegrityError as exc:
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: duplicate context execution identity in BRSCTX1: {exc}"
+                ) from exc
+            # ── Stream BRSJRN1 → INSERT, verify all verdicts == 1 ──
+            journal_count = 0
+            journal_iter, journal_custody = iter_journal_with_custody(journal_path)
+            try:
+                for entry in journal_iter:
+                    if entry.verdict != 1:
+                        display_txid = entry.spend_txid[::-1].hex()
+                        raise AnalyzerError(
+                            f"CTX-EXECUTION: journal verdict {entry.verdict} != 1 "
+                            f"for txid={display_txid}, input_index={entry.input_index}"
+                        )
+                    conn.execute(
+                        "INSERT INTO journal VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            entry.spend_txid,
+                            entry.input_index,
+                            entry.verdict,
+                            entry.checksig_ops,
+                            entry.checkmultisig_ops,
+                            entry.ecdsa_verify_calls,
+                            entry.ecdsa_verify_ok,
+                        ),
+                    )
+                    journal_count += 1
+            except sqlite3.IntegrityError as exc:
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: duplicate journal key in BRSJRN1: {exc}"
+                ) from exc
+
+            # ── Count reconciliation: contexts == journal == ffi_verify_entries ──
+            if context_count != journal_count:
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: context count {context_count} != "
+                    f"journal count {journal_count}"
+                )
+            if context_count != counters.ffi_verify_entries:
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: context count {context_count} != "
+                    f"counters.ffi_verify_entries {counters.ffi_verify_entries}"
+                )
+            if journal_count != counters.ffi_verify_entries:
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: journal count {journal_count} != "
+                    f"counters.ffi_verify_entries {counters.ffi_verify_entries}"
+                )
+            if context_count != counters.context_count:
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: context count {context_count} != "
+                    f"counters.context_count {counters.context_count}"
+                )
+            if journal_count != counters.journal_count:
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: journal count {journal_count} != "
+                    f"counters.journal_count {counters.journal_count}"
+                )
+
+            # ── Key equality: contexts ↔ journal via EXCEPT both directions ──
+            except_ctx_not_in_journal = conn.execute(
+                "SELECT COUNT(*) FROM ("
+                "  SELECT txid_le, input_index FROM contexts "
+                "  EXCEPT "
+                "  SELECT txid_le, input_index FROM journal"
+                ")"
+            ).fetchone()[0]
+            if except_ctx_not_in_journal:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: {except_ctx_not_in_journal} context key(s) "
+                    f"not present in journal"
+                )
+            except_jrn_not_in_ctx = conn.execute(
+                "SELECT COUNT(*) FROM ("
+                "  SELECT txid_le, input_index FROM journal "
+                "  EXCEPT "
+                "  SELECT txid_le, input_index FROM contexts"
+                ")"
+            ).fetchone()[0]
+            if except_jrn_not_in_ctx:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: {except_jrn_not_in_ctx} journal key(s) "
+                    f"not present in contexts"
+                )
+
+            # ── Tally spend-context counts from the contexts table ──
+            ctx_rows = conn.execute(
+                "SELECT spend_context, COUNT(*) FROM contexts GROUP BY spend_context"
+            ).fetchall()
+            for ctx_name, cnt in ctx_rows:
+                ctx_enum = SpendContext(ctx_name)
+                if ctx_enum == SpendContext.P2SH:
+                    counts["p2sh_redeem_spends"] += cnt
+                elif ctx_enum == SpendContext.NATIVE_WITNESS_V0:
+                    counts["native_witness_v0_spends"] += cnt
+                elif ctx_enum == SpendContext.P2SH_WRAPPED_WITNESS_V0:
+                    counts["p2sh_wrapped_witness_v0_spends"] += cnt
+                elif ctx_enum == SpendContext.TAPROOT_KEY_PATH:
+                    counts["taproot_key_path_spends"] += cnt
+                elif ctx_enum == SpendContext.TAPSCRIPT:
+                    counts["tapscript_spends"] += cnt
+
+            # ── Global aggregate counters for reconciliation (running ints) ──
+            agg_ecdsa_calls = 0
+            agg_ecdsa_ok = 0
+            agg_ecdsa_fail = 0
+            agg_schnorr_calls = 0
+            agg_schnorr_ok = 0
+            agg_schnorr_fail = 0
+            agg_checkecdsa_entries = 0
+            agg_checkschnorr_entries = 0
+            # Eight reject counters (reject_reason 0..7; 8 = unknown/distinct)
+            agg_rejects = [0] * 9
+
+            # ── Stream BRSREC1 → insert key, look up context, tally op counts ──
+            record_streamed_count = 0
+            record_iter, record_custody = iter_records_with_custody(records_path)
+            try:
+                for record in record_iter:
+                    conn.execute(
+                        "INSERT INTO record_keys VALUES (?, ?, ?)",
+                        (record.spend_txid, record.input_index, record.op_seq),
+                    )
+                    row = conn.execute(
+                        "SELECT spend_context FROM contexts "
+                        "WHERE txid_le = ? AND input_index = ?",
+                        (record.spend_txid, record.input_index),
+                    ).fetchone()
+                    if row is None:
+                        display_txid = record.spend_txid[::-1].hex()
+                        raise AnalyzerError(
+                            f"CTX-OPERATIONS: BRSREC1 record has no matching "
+                            f"context identity: txid={display_txid}, "
+                            f"input_index={record.input_index}"
+                        )
+                    ctx = SpendContext(row[0])
+                    op = record.op_kind
+                    sig = record.sig_version
+                    display_txid = record.spend_txid[::-1].hex()
+                    identity_str = (
+                        f"txid={display_txid}, input_index={record.input_index}"
+                    )
+                    # ── Per-key contiguous op_seq via SQLite record_seq ──
+                    conn.execute(
+                        "INSERT INTO record_seq (txid_le, input_index, last_op_seq) "
+                        "VALUES (?, ?, ?) "
+                        "ON CONFLICT(txid_le, input_index) DO UPDATE SET "
+                        "last_op_seq = excluded.last_op_seq "
+                        "WHERE record_seq.last_op_seq + 1 = excluded.last_op_seq",
+                        (record.spend_txid, record.input_index, record.op_seq),
+                    )
+                    seq_row = conn.execute(
+                        "SELECT last_op_seq FROM record_seq "
+                        "WHERE txid_le = ? AND input_index = ?",
+                        (record.spend_txid, record.input_index),
+                    ).fetchone()
+                    if seq_row is None or seq_row[0] != record.op_seq:
+                        expected = (seq_row[0] + 1) if seq_row else 0
+                        raise AnalyzerError(
+                            f"CTX-OPERATIONS: op_seq contiguity violation for "
+                            f"txid={display_txid}, input_index={record.input_index}: "
+                            f"expected {expected}, got {record.op_seq}"
+                        )
+                    if op in (3, 4):
+                        if sig not in (0, 1):
+                            raise AnalyzerError(
+                                f"CTX-OPERATIONS: multisig record must have "
+                                f"sig_version BASE or WITNESS_V0, "
+                                f"got {_sig_version_name(sig)} for {identity_str}"
+                            )
+                        if ctx == SpendContext.BARE:
+                            if sig != 0:
+                                raise AnalyzerError(
+                                    f"CTX-OPERATIONS: bare multisig record has "
+                                    f"sig_version {_sig_version_name(sig)}, "
+                                    f"expected BASE for {identity_str}"
+                                )
+                            counts["bare_multisig_checks"] += 1
+                        elif ctx == SpendContext.P2SH:
+                            if sig != 0:
+                                raise AnalyzerError(
+                                    f"CTX-OPERATIONS: P2SH multisig record has "
+                                    f"sig_version {_sig_version_name(sig)}, "
+                                    f"expected BASE for {identity_str}"
+                                )
+                            counts["p2sh_multisig_checks"] += 1
+                        elif ctx == SpendContext.NATIVE_WITNESS_V0:
+                            if sig != 1:
+                                raise AnalyzerError(
+                                    f"CTX-OPERATIONS: native witness-v0 multisig "
+                                    f"record has sig_version "
+                                    f"{_sig_version_name(sig)}, "
+                                    f"expected WITNESS_V0 for {identity_str}"
+                                )
+                            counts["native_witness_v0_multisig_checks"] += 1
+                        elif ctx == SpendContext.P2SH_WRAPPED_WITNESS_V0:
+                            if sig != 1:
+                                raise AnalyzerError(
+                                    f"CTX-OPERATIONS: P2SH-wrapped witness-v0 "
+                                    f"multisig record has sig_version "
+                                    f"{_sig_version_name(sig)}, "
+                                    f"expected WITNESS_V0 for {identity_str}"
+                                )
+                            counts["p2sh_wrapped_witness_v0_multisig_checks"] += 1
+                        elif ctx in (
+                            SpendContext.TAPROOT_KEY_PATH,
+                            SpendContext.TAPSCRIPT,
+                        ):
+                            raise AnalyzerError(
+                                f"CTX-OPERATIONS: multisig record joined to a "
+                                f"Taproot input {identity_str}"
+                            )
+                        else:
+                            raise AnalyzerError(
+                                f"CTX-OPERATIONS: unknown spend context {ctx!r}"
+                            )
+                    elif op == 5:
+                        if sig != 2:
+                            raise AnalyzerError(
+                                f"CTX-OPERATIONS: CHECKSIGADD record must have "
+                                f"sig_version TAPSCRIPT, got "
+                                f"{_sig_version_name(sig)} for {identity_str}"
+                            )
+                        if ctx != SpendContext.TAPSCRIPT:
+                            raise AnalyzerError(
+                                f"CTX-OPERATIONS: CHECKSIGADD record joined to a "
+                                f"non-Tapscript input {identity_str}"
+                            )
+                        counts["tapscript_schnorr_checks"] += 1
+                        counts["tapscript_checksigadd_checks"] += 1
+                    elif op == 0:
+                        if sig != 3:
+                            raise AnalyzerError(
+                                f"CTX-OPERATIONS: key-path record must have "
+                                f"sig_version TAPROOT, got {_sig_version_name(sig)} "
+                                f"for {identity_str}"
+                            )
+                        if ctx != SpendContext.TAPROOT_KEY_PATH:
+                            raise AnalyzerError(
+                                f"CTX-OPERATIONS: key-path record joined to a "
+                                f"non-key-path input {identity_str}"
+                            )
+                    elif op in (1, 2):
+                        if sig == 2:
+                            if ctx != SpendContext.TAPSCRIPT:
+                                raise AnalyzerError(
+                                    f"CTX-OPERATIONS: Tapscript CHECKSIG record "
+                                    f"joined to a non-Tapscript input {identity_str}"
+                                )
+                            counts["tapscript_schnorr_checks"] += 1
+                        elif sig == 1:
+                            if ctx not in (
+                                SpendContext.NATIVE_WITNESS_V0,
+                                SpendContext.P2SH_WRAPPED_WITNESS_V0,
+                            ):
+                                raise AnalyzerError(
+                                    f"CTX-OPERATIONS: WITNESS_V0 CHECKSIG record "
+                                    f"joined to a non-witness-v0 input {identity_str}"
+                                )
+                        elif sig == 0:
+                            if ctx not in (SpendContext.BARE, SpendContext.P2SH):
+                                raise AnalyzerError(
+                                    f"CTX-OPERATIONS: BASE CHECKSIG record joined "
+                                    f"to a non-legacy input {identity_str}"
+                                )
+                        else:
+                            raise AnalyzerError(
+                                f"CTX-OPERATIONS: CHECKSIG record has unknown "
+                                f"sig_version {sig} for {identity_str}"
+                            )
+                    else:
+                        raise AnalyzerError(
+                            f"CTX-OPERATIONS: unknown op_kind {op} for {identity_str}"
+                        )
+                    record_streamed_count += 1
+                    # ── Global aggregate reconciliation ──
+                    outcome = record.outcome
+                    reject = record.reject_reason
+                    # ECDSA: op in (1,2,3,4) with sig in (0,1) → ECDSA verify
+                    is_ecdsa = op in (1, 2, 3, 4) and sig in (0, 1)
+                    is_schnorr = (op in (1, 2, 5) and sig == 2) or (
+                        op == 0 and sig == 3
+                    )
+                    # Native emission (instrumentation.diff): CheckECDSASignature
+                    # increments C_CHECKECDSA_ENTRIES on every entry; the bad-pubkey
+                    # (reject_reason 1), empty-sig (2), and missing-data (3) guards
+                    # return before C_ECDSA_VERIFY_CALLS. Only outcome 0/1 are
+                    # verify calls, with C_ECDSA_VERIFY_FAIL on outcome 0 (crypto
+                    # false) and C_ECDSA_VERIFY_OK on outcome 1.
+                    if is_ecdsa:
+                        agg_checkecdsa_entries += 1
+                        if outcome != 2:
+                            agg_ecdsa_calls += 1
+                            if outcome == 1:
+                                agg_ecdsa_ok += 1
+                            else:  # outcome == 0: verifier returned false
+                                agg_ecdsa_fail += 1
+                            # Per-key ECDSA verify-call tracking (verify calls
+                            # only; pre-verification rejects never reach the
+                            # verifier so they emit no record_ecdsa row).
+                            conn.execute(
+                                "INSERT INTO record_ecdsa (txid_le, input_index, calls, ok) "
+                                "VALUES (?, ?, 1, ?) "
+                                "ON CONFLICT(txid_le, input_index) DO UPDATE SET "
+                                "calls = calls + 1, ok = ok + excluded.ok",
+                                (
+                                    record.spend_txid,
+                                    record.input_index,
+                                    1 if outcome == 1 else 0,
+                                ),
+                            )
+                    # Native emission: CheckSchnorrSignature increments
+                    # C_CHECKSCHNORR_ENTRIES on entry (reject_reason 4..7 are rejects
+                    # inside it), but reject_reason 8 is a Tapscript empty-sig skip
+                    # emitted in EvalChecksigTapscript before the function is called,
+                    # so it is neither an entry nor a verify call. Verify calls are
+                    # outcome 0/1 with fail on outcome 0.
+                    if is_schnorr:
+                        if reject != 8:
+                            agg_checkschnorr_entries += 1
+                        if outcome != 2:
+                            agg_schnorr_calls += 1
+                            if outcome == 1:
+                                agg_schnorr_ok += 1
+                            else:  # outcome == 0
+                                agg_schnorr_fail += 1
+                    if outcome == 2 and reject <= 8:
+                        agg_rejects[reject] += 1
+
+            except sqlite3.IntegrityError as exc:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: duplicate record key in BRSREC1: {exc}"
+                ) from exc
+
+            if record_streamed_count != counters.record_count:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: BRSREC1 record count "
+                    f"{record_streamed_count} != counters.record_count "
+                    f"{counters.record_count}"
+                )
+            # ── Per-key op_seq contiguity proof via SQL ──
+            # For every (txid, input_index), count of record_keys must equal
+            # max(op_seq)+1 and min(op_seq) must be 0.
+            gap_count = conn.execute(
+                "SELECT COUNT(*) FROM ("
+                "  SELECT txid_le, input_index "
+                "  FROM record_keys "
+                "  GROUP BY txid_le, input_index "
+                "  HAVING COUNT(*) != MAX(op_seq) + 1 OR MIN(op_seq) != 0"
+                ")"
+            ).fetchone()[0]
+            if gap_count:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: op_seq contiguity proof failed: "
+                    f"{gap_count} key(s) with non-contiguous op_seq"
+                )
+            # Keys in record_ecdsa with mismatched journal values
+            ecdsa_mismatch = conn.execute(
+                "SELECT r.txid_le, r.input_index, r.calls, r.ok, "
+                "j.ecdsa_verify_calls, j.ecdsa_verify_ok "
+                "FROM record_ecdsa r "
+                "JOIN journal j "
+                "ON r.txid_le = j.txid_le AND r.input_index = j.input_index "
+                "WHERE r.calls != j.ecdsa_verify_calls "
+                "OR r.ok != j.ecdsa_verify_ok "
+                "LIMIT 1"
+            ).fetchone()
+            if ecdsa_mismatch is not None:
+                r_txid, r_idx, r_calls, r_ok, j_calls, j_ok = ecdsa_mismatch
+                display_txid = r_txid[::-1].hex()
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: ECDSA mismatch for "
+                    f"txid={display_txid}, input_index={r_idx}: "
+                    f"records calls={r_calls} ok={r_ok}, "
+                    f"journal calls={j_calls} ok={j_ok}"
+                )
+            # Keys in journal with ecdsa but missing from record_ecdsa
+            jrn_only_ecdsa = conn.execute(
+                "SELECT j.txid_le, j.input_index, j.ecdsa_verify_calls, "
+                "j.ecdsa_verify_ok "
+                "FROM journal j "
+                "WHERE (j.ecdsa_verify_calls > 0 OR j.ecdsa_verify_ok > 0) "
+                "AND NOT EXISTS ("
+                "  SELECT 1 FROM record_ecdsa r "
+                "  WHERE r.txid_le = j.txid_le AND r.input_index = j.input_index) "
+                "LIMIT 1"
+            ).fetchone()
+            if jrn_only_ecdsa is not None:
+                j_txid, j_idx, j_calls, j_ok = jrn_only_ecdsa
+                display_txid = j_txid[::-1].hex()
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: journal has ECDSA calls for "
+                    f"txid={display_txid}, input_index={j_idx} "
+                    f"but no ECDSA records found"
+                )
+
+            # ── Journal-sum reconciliation: SUM(checksig_ops) and SUM(checkmultisig_ops) ──
+            sum_checksig = conn.execute(
+                "SELECT COALESCE(SUM(checksig_ops), 0) FROM journal"
+            ).fetchone()[0]
+            if sum_checksig != counters.op_checksig + counters.op_checksigverify:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: SUM(checksig_ops) {sum_checksig} != "
+                    f"op_checksig + op_checksigverify "
+                    f"{counters.op_checksig + counters.op_checksigverify}"
+                )
+            sum_checkmultisig = conn.execute(
+                "SELECT COALESCE(SUM(checkmultisig_ops), 0) FROM journal"
+            ).fetchone()[0]
+            if (
+                sum_checkmultisig
+                != counters.op_checkmultisig + counters.op_checkmultisigverify
+            ):
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: SUM(checkmultisig_ops) {sum_checkmultisig} != "
+                    f"op_checkmultisig + op_checkmultisigverify "
+                    f"{counters.op_checkmultisig + counters.op_checkmultisigverify}"
+                )
+            # ── Global ECDSA/Schnorr/reject aggregate reconciliation ──
+            if agg_ecdsa_calls != counters.ecdsa_verify_calls:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: ecdsa_verify_calls mismatch: "
+                    f"records={agg_ecdsa_calls}, counters={counters.ecdsa_verify_calls}"
+                )
+            if agg_ecdsa_ok != counters.ecdsa_verify_ok:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: ecdsa_verify_ok mismatch: "
+                    f"records={agg_ecdsa_ok}, counters={counters.ecdsa_verify_ok}"
+                )
+            if agg_ecdsa_fail != counters.ecdsa_verify_fail:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: ecdsa_verify_fail mismatch: "
+                    f"records={agg_ecdsa_fail}, counters={counters.ecdsa_verify_fail}"
+                )
+            if agg_schnorr_calls != counters.schnorr_verify_calls:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: schnorr_verify_calls mismatch: "
+                    f"records={agg_schnorr_calls}, counters={counters.schnorr_verify_calls}"
+                )
+            if agg_schnorr_ok != counters.schnorr_verify_ok:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: schnorr_verify_ok mismatch: "
+                    f"records={agg_schnorr_ok}, counters={counters.schnorr_verify_ok}"
+                )
+            if agg_schnorr_fail != counters.schnorr_verify_fail:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: schnorr_verify_fail mismatch: "
+                    f"records={agg_schnorr_fail}, counters={counters.schnorr_verify_fail}"
+                )
+            if agg_checkecdsa_entries != counters.checkecdsa_entries:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: checkecdsa_entries mismatch: "
+                    f"records={agg_checkecdsa_entries}, counters={counters.checkecdsa_entries}"
+                )
+            if agg_checkschnorr_entries != counters.checkschnorr_entries:
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: checkschnorr_entries mismatch: "
+                    f"records={agg_checkschnorr_entries}, counters={counters.checkschnorr_entries}"
+                )
+            # Eight reject counters reconciliation
+            _reject_names = [
+                "checkecdsa_reject_pubkey",
+                "checkecdsa_reject_empty_sig",
+                "checkecdsa_reject_missing_data",
+            ]
+            # reject_reason 1..3 (1=bad pubkey, 2=empty sig, 3=missing data per
+            # instrumentation.diff) map to the three named ECDSA reject counters.
+            for i, name in enumerate(_reject_names):
+                if agg_rejects[i + 1] != getattr(counters, name):
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: {name} mismatch: "
+                        f"records={agg_rejects[i + 1]}, counters={getattr(counters, name)}"
+                    )
+
+            conn.commit()
+        finally:
+            conn.close()
+
+    # Contexts custody comes from the same single-open parse stream.
+    custody_meta: dict[str, dict[str, int]] = {
+        "contexts": contexts_custody,
+        "records": record_custody,
+        "journal": journal_custody,
+    }
+    return counts, context_count, custody_meta
+
+
+def _c150_passed(counts: dict[str, int], counters: Counters) -> bool:
+    """Exact C150 product predicate.
+
+    All 11 CONTEXT_COUNTER_NAMES are zero; the six ordinary equality-chain
+    counters all equal EXPECTED_FFI_VERIFY_ENTRIES_FULL (2_868_199); all
+    complementary counters are zero.
+
+    ``eval_script_entries`` is checked separately and must equal exactly twice
+    the canonical total (2 * 2_868_199 == 5_736_398), not the one-times total.
+    Every ordinary C150 spend is a bare P2PKH whose VerifyScript runs two
+    EvalScript passes -- one over the scriptSig and one over the scriptPubKey --
+    so the instrumented kernel emits two EvalScript entries per VerifyScript
+    call. It is therefore deliberately excluded from the one-times equality
+    tuple and pinned to ``2 * expected`` on its own line.
+    """
+    # All 11 context counters must be zero
+    if any(counts[name] != 0 for name in CONTEXT_COUNTER_NAMES):
+        return False
+    # Equality chain: all must equal 2_868_199
+    expected = EXPECTED_FFI_VERIFY_ENTRIES_FULL
+    equality_chain = (
+        counters.ffi_verify_entries,
+        counters.op_checksig,
+        counters.ecdsa_from_checksig,
+        counters.checkecdsa_entries,
+        counters.ecdsa_verify_calls,
+        counters.ecdsa_verify_ok,
+    )
+    if any(v != expected for v in equality_chain):
+        return False
+    # eval_script_entries is exactly twice the ordinary total: two EvalScript
+    # passes (scriptSig + scriptPubKey) per ordinary P2PKH VerifyScript call.
+    if counters.eval_script_entries != 2 * expected:
+        return False
+    # Complementary counters must be zero
+    complementary_zero = (
+        counters.op_checksigverify,
+        counters.op_checkmultisig,
+        counters.op_checkmultisigverify,
+        counters.op_checksigadd,
+        counters.ecdsa_from_checkmultisig,
+        counters.checkecdsa_reject_pubkey,
+        counters.checkecdsa_reject_empty_sig,
+        counters.checkecdsa_reject_missing_data,
+        counters.ecdsa_verify_fail,
+        counters.checkschnorr_entries,
+        counters.schnorr_verify_calls,
+        counters.schnorr_verify_ok,
+        counters.schnorr_verify_fail,
+    )
+    return not any(v != 0 for v in complementary_zero)
+
+
+def cmd_classify_corpus(args: argparse.Namespace) -> int:
+    counters_path = Path(args.counters)
+    contexts_path = Path(args.contexts)
+    records_path = Path(args.records)
+    journal_path = Path(args.journal)
+    replay_path = Path(args.replay)
+    manifest_path = Path(args.corpus_manifest)
+    archive_path = Path(args.archive)
+    output_path = Path(args.output)
+
+    # ── Parse counters (single read, custody from same buffer) ──
+    counters, counters_custody = parse_counters(counters_path)
+
+    # ── Validate replay artifact and corpus manifest/archive ──
+    # Each parser computes custody (size + sha256) from the exact buffer it
+    # parses, eliminating TOCTOU from a separate prehash pass.
+    replay = _validate_replay_artifact(replay_path)
+    manifest = _validate_corpus_manifest(manifest_path, archive_path, replay)
+
+    # ── Run disk-backed counter computation (returns custody for ctx/rec/jrn) ──
+    counts, context_count, bin_custody = _count_context_records_disk(
+        contexts_path, records_path, journal_path, counters
+    )
+
+    # ── Assemble custody from parser-returned metadata ──
+    custody: dict[str, dict[str, object]] = {
+        "counters": {
+            "path": str(counters_path),
+            "bytes": counters_custody["bytes"],
+            "sha256": format(counters_custody["sha256"], "064x"),
+        },
+        "contexts": {
+            "path": str(contexts_path),
+            "bytes": bin_custody["contexts"]["bytes"],
+            "sha256": format(bin_custody["contexts"]["sha256"], "064x"),
+        },
+        "records": {
+            "path": str(records_path),
+            "bytes": bin_custody["records"]["bytes"],
+            "sha256": format(bin_custody["records"]["sha256"], "064x"),
+        },
+        "journal": {
+            "path": str(journal_path),
+            "bytes": bin_custody["journal"]["bytes"],
+            "sha256": format(bin_custody["journal"]["sha256"], "064x"),
+        },
+        "replay": {
+            "path": str(replay_path),
+            "bytes": replay["custody"]["bytes"],
+            "sha256": replay["custody"]["sha256"],
+        },
+        "corpus_manifest": {
+            "path": str(manifest_path),
+            "bytes": manifest["custody"]["bytes"],
+            "sha256": manifest["custody"]["sha256"],
+        },
+        "archive": {
+            "path": str(archive_path),
+            "bytes": manifest["archive"]["size"],
+            "sha256": manifest["archive"]["sha256"],
+        },
+    }
+
+    # ── Counter arithmetic invariants (INV-1 through INV-7) ──
+    inv_results = check_counter_arithmetic(counters)
+    inv_all_passed = all(r["passed"] for r in inv_results)
+
+    # ── Zero-input evidence precedence: validate counts > 0 before contract logic ──
+    if (
+        counters.context_count == 0
+        or counters.journal_count == 0
+        or counters.record_count == 0
+    ):
+        raise AnalyzerError(
+            "CTX-EXECUTION: zero-input evidence rejected: "
+            f"context_count={counters.context_count}, "
+            f"journal_count={counters.journal_count}, "
+            f"record_count={counters.record_count}"
+        )
+
+    # ── Apply c150 / cmodern contract logic ──
+    if args.contract == "cmodern":
+        # cmodern is not frozen until the exact tip is empirically recorded.
+        cmodern_frozen = False
+        all_passed = False
+        report_error = (
+            "CTX-CUSTODY: cmodern contract is not frozen until the exact "
+            "tip is empirically recorded"
+        )
+    elif args.contract == "c150":
+        # c150 pin: stop_height must be exactly 150000 and stop_hash must match.
+        if replay["stop_height"] != C150_STOP_HEIGHT:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: c150 requires stop_height {C150_STOP_HEIGHT}, "
+                f"got {replay['stop_height']}"
+            )
+        if replay["stop_hash"] != C150_STOP_HASH:
+            raise AnalyzerError(
+                f"CTX-CUSTODY: c150 requires stop_hash {C150_STOP_HASH!r}, "
+                f"got {replay['stop_hash']!r}"
+            )
+        c150_passed = _c150_passed(counts, counters) and inv_all_passed
+        all_passed = c150_passed
+    else:
+        raise AnalyzerError(
+            f"contract must be 'c150' or 'cmodern', got {args.contract!r}"
+        )
+
+    # ── Build report ──
+    report: dict[str, object] = {
+        "schema": "classify-corpus-v2",
+        "contract": args.contract,
+        "input_count": context_count,
+        "context_counts": counts,
+        "definitions": CONTEXT_COUNTER_DEFINITIONS,
+        "all_passed": all_passed,
+        "custody": custody,
+        "replay": replay,
+        "corpus_manifest": manifest,
+        "counter_arithmetic": inv_results,
+    }
+    if args.contract == "cmodern":
+        report["cmodern_frozen"] = cmodern_frozen
+        report["error"] = report_error
+    else:
+        report["c150_passed"] = c150_passed
+
+    # Optional cross-check: --input-count if provided.
+    input_count_opt = getattr(args, "input_count", None)
+    if input_count_opt is not None and input_count_opt != context_count:
+        raise AnalyzerError(
+            f"CTX-SOURCE: --input-count {input_count_opt} != "
+            f"BRSCTX1 context count {context_count}"
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2) + "\n")
+
+    if all_passed:
+        print(f"classify-corpus: PASSED — {args.contract}")
+        return 0
+    print(f"classify-corpus: FAILED — {args.contract}", file=sys.stderr)
+    return 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="analyze.py",
@@ -1245,6 +3086,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--sorted-records-output",
         default=None,
         help="optional: write sorted records binary here",
+    )
+    vc.add_argument(
+        "--context-inputs",
+        default=None,
+        help="optional: census-context-input-v1 JSONL to bind corpus_size and corpus_sha256",
     )
     vc.set_defaults(func=cmd_validate_capture)
 
@@ -1294,6 +3140,64 @@ def build_parser() -> argparse.ArgumentParser:
         help="integrity JSON (INV-14 source-identity proof: pubkey.cpp and secp256k1 tree hashes)",
     )
     vd.set_defaults(func=cmd_verdict)
+
+    cc = sub.add_parser(
+        "classify-corpus",
+        help="classify verified inputs by spend context and join BRSREC1 records (v2)",
+    )
+    cc.add_argument(
+        "--counters",
+        required=True,
+        help="counters JSON (schema 1) with ffi_verify_entries and record_count",
+    )
+    cc.add_argument(
+        "--contexts",
+        required=True,
+        help="BRSCTX1 binary context evidence file (one row per verified non-coinbase input)",
+    )
+    cc.add_argument(
+        "--records",
+        required=True,
+        help="BRSREC1 executed-operation records binary",
+    )
+    cc.add_argument(
+        "--journal",
+        required=True,
+        help="BRSJRN1 journal binary",
+    )
+    cc.add_argument(
+        "--replay",
+        required=True,
+        help="mainnet-prefix-replay-v2 JSON artifact",
+    )
+    cc.add_argument(
+        "--corpus-manifest",
+        required=True,
+        help="bitcoin-rs-corpus-manifest v1 JSON",
+    )
+    cc.add_argument(
+        "--archive",
+        required=True,
+        help="Core-framed corpus archive binary",
+    )
+    cc.add_argument(
+        "--output",
+        required=True,
+        help="output classification report JSON",
+    )
+    cc.add_argument(
+        "--contract",
+        required=True,
+        choices=("c150", "cmodern"),
+        help="classification contract: c150 (C150 bare-multisig only) or cmodern (all context counters nonzero)",
+    )
+    cc.add_argument(
+        "--input-count",
+        default=None,
+        type=int,
+        help="optional cross-check: expected BRSCTX1 row count (BRSCTX1 file is authoritative)",
+    )
+    cc.set_defaults(func=cmd_classify_corpus)
 
     return parser
 

--- a/tools/checksig-census/analyze.py
+++ b/tools/checksig-census/analyze.py
@@ -20,17 +20,21 @@ import re
 import sqlite3
 import statistics
 import struct
+import subprocess
 import sys
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
-from typing import BinaryIO
+from typing import BinaryIO, NamedTuple
 
 from context import (
+    CONTEXT_MIN_ROW_SIZE,
+    ClassifiedInput,
     ContextError,
     SpendContext,
     classify_input,
     iter_context_inputs,
+    read_bounded_context_rows,
 )
 
 # ── Constants ───────────────────────────────────────────────────────────────
@@ -477,6 +481,1275 @@ class JournalEntry:
     @property
     def key(self) -> tuple[bytes, int]:
         return (self.spend_txid, self.input_index)
+
+
+# ── Canonical BRSREC1 interpretation (shared by disk classifier and diagnostic scanner)
+
+
+# Each rule is a list of (op_kind, sig_version, spend_context) triples.
+# Used both by the diagnostic per-block loop and the set-based disk classifier.
+_RECORD_COUNTER_RULES: list[tuple[str, list[tuple[int, int, str]]]] = [
+    ("bare_multisig_checks", [(3, 0, "bare"), (4, 0, "bare")]),
+    ("p2sh_multisig_checks", [(3, 0, "p2sh"), (4, 0, "p2sh")]),
+    (
+        "native_witness_v0_multisig_checks",
+        [(3, 1, "native_witness_v0"), (4, 1, "native_witness_v0")],
+    ),
+    (
+        "p2sh_wrapped_witness_v0_multisig_checks",
+        [(3, 1, "p2sh_wrapped_witness_v0"), (4, 1, "p2sh_wrapped_witness_v0")],
+    ),
+    (
+        "tapscript_schnorr_checks",
+        [(5, 2, "tapscript"), (1, 2, "tapscript"), (2, 2, "tapscript")],
+    ),
+    ("tapscript_checksigadd_checks", [(5, 2, "tapscript")]),
+]
+
+
+def _record_matches_rule(
+    record: Record,
+    spend_context: str,
+    rule: list[tuple[int, int, str]],
+) -> bool:
+    """Test a BRSREC1 record against one counter rule."""
+    return (record.op_kind, record.sig_version, spend_context) in rule
+
+
+def _record_legality_error(record: Record, spend_context: str) -> str | None:
+    """Return the canonical CTX-OPERATIONS error code for a record, or None.
+
+    This must match the SQL CASE in ``_count_context_records_disk`` exactly;
+    it is the single source of truth for BRSREC1 op/sig/context legality.
+    """
+    op, sig, ctx = record.op_kind, record.sig_version, spend_context
+
+    if op in (3, 4):
+        if sig not in (0, 1):
+            return "multisig_sig"
+        if ctx == "bare" and sig != 0:
+            return "bare_multisig"
+        if ctx == "p2sh" and sig != 0:
+            return "p2sh_multisig"
+        if ctx == "native_witness_v0" and sig != 1:
+            return "native_multisig"
+        if ctx == "p2sh_wrapped_witness_v0" and sig != 1:
+            return "wrapped_multisig"
+        if ctx in ("taproot_key_path", "tapscript"):
+            return "taproot_multisig"
+
+    if op == 5:
+        if sig != 2:
+            return "checksigadd_sig"
+        if ctx != "tapscript":
+            return "checksigadd_context"
+
+    if op == 0:
+        if sig != 3:
+            return "keypath_sig"
+        if ctx != "taproot_key_path":
+            return "keypath_context"
+
+    if op in (1, 2):
+        if sig == 2 and ctx != "tapscript":
+            return "tapscript_checksig"
+        if sig == 1 and ctx not in ("native_witness_v0", "p2sh_wrapped_witness_v0"):
+            return "witness_checksig"
+        if sig == 0 and ctx not in ("bare", "p2sh"):
+            return "base_checksig"
+        if sig not in (0, 1, 2):
+            return "unknown_checksig"
+
+    if op not in (0, 1, 2, 3, 4, 5):
+        return "unknown_op"
+
+    return None
+
+
+def _diagnostic_spend_counts(classified: list[ClassifiedInput]) -> dict[str, int]:
+    """Derive the five spend-context counters from classified BRSCTX1 inputs."""
+    counts: dict[str, int] = {
+        "p2sh_redeem_spends": 0,
+        "native_witness_v0_spends": 0,
+        "p2sh_wrapped_witness_v0_spends": 0,
+        "taproot_key_path_spends": 0,
+        "tapscript_spends": 0,
+    }
+    for evidence in classified:
+        sc = evidence.spend_context.value
+        if sc == SpendContext.P2SH.value:
+            counts["p2sh_redeem_spends"] += 1
+        elif sc == SpendContext.NATIVE_WITNESS_V0.value:
+            counts["native_witness_v0_spends"] += 1
+        elif sc == SpendContext.P2SH_WRAPPED_WITNESS_V0.value:
+            counts["p2sh_wrapped_witness_v0_spends"] += 1
+        elif sc == SpendContext.TAPROOT_KEY_PATH.value:
+            counts["taproot_key_path_spends"] += 1
+        elif sc == SpendContext.TAPSCRIPT.value:
+            counts["tapscript_spends"] += 1
+    return counts
+
+
+def _diagnostic_record_counts(
+    records: list[Record],
+    context_map: dict[tuple[bytes, int], str],
+) -> tuple[dict[str, int], dict[tuple[bytes, int, int], int]]:
+    """Derive the six record-derived context counters from one block's records.
+
+    Validates each record in stream order, checking:
+      1. the record's context identity exists (orphan),
+      2. the (txid, input_index, op_seq) key is not a duplicate,
+      3. the per-identity op_seq matches the next expected value,
+      4. the (op_kind, sig_version, spend_context) triple is legal,
+    before incrementing the relevant context counter.
+
+    Returns (counts, op_seq_by_identity) where op_seq_by_identity is the
+    set of exact record keys seen during the stream.
+    """
+    counts: dict[str, int] = {
+        "bare_multisig_checks": 0,
+        "p2sh_multisig_checks": 0,
+        "native_witness_v0_multisig_checks": 0,
+        "p2sh_wrapped_witness_v0_multisig_checks": 0,
+        "tapscript_schnorr_checks": 0,
+        "tapscript_checksigadd_checks": 0,
+    }
+    op_seq_by_identity: dict[tuple[bytes, int, int], int] = {}
+    next_op_seq: dict[tuple[bytes, int], int] = {}
+
+    for record in records:
+        key = (record.spend_txid, record.input_index)
+        if key not in context_map:
+            display_txid = record.spend_txid[::-1].hex()
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: BRSREC1 record has no matching context identity: "
+                f"txid={display_txid}, input_index={record.input_index}"
+            )
+
+        ctx = context_map[key]
+
+        seq_key = (record.spend_txid, record.input_index, record.op_seq)
+        if seq_key in op_seq_by_identity:
+            display_txid = record.spend_txid[::-1].hex()
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: duplicate record key in BRSREC1: "
+                f"txid={display_txid}, input_index={record.input_index}, op_seq={record.op_seq}"
+            )
+        op_seq_by_identity[seq_key] = 1
+
+        expected_op_seq = next_op_seq.get(key, 0)
+        if record.op_seq != expected_op_seq:
+            display_txid = record.spend_txid[::-1].hex()
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: op_seq contiguity violation for {display_txid}:{record.input_index}: "
+                f"expected {expected_op_seq}, got {record.op_seq}"
+            )
+
+        error = _record_legality_error(record, ctx)
+        if error is not None:
+            sig_name = _sig_version_name(record.sig_version)
+            op_name = _op_kind_name(record.op_kind)
+            display_txid = record.spend_txid[::-1].hex()
+            identity = f"txid={display_txid}, input_index={record.input_index}"
+            message = _record_legality_message(error, op_name, sig_name, identity)
+            raise AnalyzerError(f"CTX-OPERATIONS: {message}")
+
+        next_op_seq[key] = record.op_seq + 1
+
+        for name, rule in _RECORD_COUNTER_RULES:
+            if _record_matches_rule(record, ctx, rule):
+                counts[name] += 1
+
+    return counts, op_seq_by_identity
+
+
+def _record_legality_message(
+    error: str, op_name: str, sig_name: str, identity: str
+) -> str:
+    """Human-readable message for a BRSREC1 legality error code."""
+    if error == "multisig_sig":
+        return f"multisig record must have sig_version BASE or WITNESS_V0, got {sig_name} for {identity}"
+    if error == "bare_multisig":
+        return f"bare multisig record has sig_version {sig_name}, expected BASE for {identity}"
+    if error == "p2sh_multisig":
+        return f"P2SH multisig record has sig_version {sig_name}, expected BASE for {identity}"
+    if error == "native_multisig":
+        return f"native witness-v0 multisig record has sig_version {sig_name}, expected WITNESS_V0 for {identity}"
+    if error == "wrapped_multisig":
+        return f"P2SH-wrapped witness-v0 multisig record has sig_version {sig_name}, expected WITNESS_V0 for {identity}"
+    if error == "taproot_multisig":
+        return f"multisig record joined to a Taproot input {identity}"
+    if error == "checksigadd_sig":
+        return f"CHECKSIGADD record must have sig_version TAPSCRIPT, got {sig_name} for {identity}"
+    if error == "checksigadd_context":
+        return f"CHECKSIGADD record joined to a non-Tapscript input {identity}"
+    if error == "keypath_sig":
+        return f"key-path record must have sig_version TAPROOT, got {sig_name} for {identity}"
+    if error == "keypath_context":
+        return f"key-path record joined to a non-key-path input {identity}"
+    if error == "tapscript_checksig":
+        return f"Tapscript CHECKSIG record joined to a non-Tapscript input {identity}"
+    if error == "witness_checksig":
+        return f"WITNESS_V0 CHECKSIG record joined to a non-witness-v0 input {identity}"
+    if error == "base_checksig":
+        return f"BASE CHECKSIG record joined to a non-legacy input {identity}"
+    if error == "unknown_checksig":
+        return f"CHECKSIG record has unknown sig_version {sig_name} for {identity}"
+    if error == "unknown_op":
+        return f"unknown op_kind {op_name} for {identity}"
+    return f"unknown error code {error} for {identity}"
+
+
+def _diagnostic_counter_totals(
+    classified: list[ClassifiedInput],
+    records: list[Record],
+    context_map: dict[tuple[bytes, int], str],
+) -> dict[str, int]:
+    """Combine spend-context and record-derived counters into the 11 canonical values."""
+    spend_counts = _diagnostic_spend_counts(classified)
+    record_counts, _ = _diagnostic_record_counts(records, context_map)
+    return {**spend_counts, **record_counts}
+
+
+# ── Cmodern diagnostic checkpoint protocol
+
+
+DIAGNOSTIC_PREFACE_SIZE = 16
+DIAGNOSTIC_ROW_SIZE = 84
+DIAGNOSTIC_MAGIC = b"BRSHGT1\x00"
+DIAGNOSTIC_VERSION = 1
+
+BRSHGT1_HEADER_STRUCT = struct.Struct("<8sQ")
+BRSHGT1_ROW_STRUCT = struct.Struct("<I32sQQQQQQ")
+
+
+class DiagnosticCheckpoint(NamedTuple):
+    height: int
+    block_hash_le: bytes
+    context_rows: int
+    context_end: int
+    record_rows: int
+    record_end: int
+    journal_rows: int
+    journal_end: int
+
+
+def _read_exact_stream(stream: BinaryIO, length: int, field: str) -> bytes:
+    """Read exactly *length* bytes from the child protocol stream.
+
+    Python's read(n) may return fewer than n bytes before EOF (e.g. when
+    the kernel has not yet delivered the rest of a pipe frame).  We
+    accumulate short reads into a single bounded buffer and only stop
+    at the exact requested length or at a true EOF (empty read).
+    """
+    if length < 0:
+        raise AnalyzerError(f"DIAG-PROTO: invalid read length {length} for {field}")
+    out = bytearray(length)
+    received = 0
+    while received < length:
+        chunk = stream.read(length - received)
+        if not chunk:
+            raise AnalyzerError(
+                f"DIAG-PROTO: short {field}: expected {length} bytes, got {received}"
+            )
+        got = len(chunk)
+        if got > length - received:
+            raise AnalyzerError(
+                f"DIAG-PROTO: overlong {field}: expected {length - received} bytes, got {got}"
+            )
+        out[received : received + got] = chunk
+        received += got
+    return bytes(out)
+
+
+def _read_diagnostic_preface(stream: BinaryIO) -> None:
+    """Validate the 16-byte preface on child stdout."""
+    preface = _read_exact_stream(stream, DIAGNOSTIC_PREFACE_SIZE, "preface")
+    magic = preface[:8]
+    version = struct.unpack_from("<I", preface, 8)[0]
+    row_size = struct.unpack_from("<I", preface, 12)[0]
+    if magic != DIAGNOSTIC_MAGIC:
+        raise AnalyzerError(f"DIAG-PROTO: wrong preface magic {magic!r}")
+    if version != DIAGNOSTIC_VERSION:
+        raise AnalyzerError(f"DIAG-PROTO: unsupported protocol version {version}")
+    if row_size != DIAGNOSTIC_ROW_SIZE:
+        raise AnalyzerError(
+            f"DIAG-PROTO: unsupported row size {row_size}, expected {DIAGNOSTIC_ROW_SIZE}"
+        )
+
+
+def _read_checkpoint_row(stream: BinaryIO) -> DiagnosticCheckpoint:
+    """Read one 84-byte BRSHGT1 row from the child protocol stream."""
+    raw = _read_exact_stream(stream, DIAGNOSTIC_ROW_SIZE, "checkpoint row")
+    (
+        height,
+        block_hash_le,
+        context_rows,
+        context_end,
+        record_rows,
+        record_end,
+        journal_rows,
+        journal_end,
+    ) = BRSHGT1_ROW_STRUCT.unpack(raw)
+    return DiagnosticCheckpoint(
+        height=height,
+        block_hash_le=block_hash_le,
+        context_rows=context_rows,
+        context_end=context_end,
+        record_rows=record_rows,
+        record_end=record_end,
+        journal_rows=journal_rows,
+        journal_end=journal_end,
+    )
+
+
+def _write_brshgt1_preface(fd: int) -> None:
+    """Write the 16-byte BRSHGT1 placeholder header."""
+    header = BRSHGT1_HEADER_STRUCT.pack(DIAGNOSTIC_MAGIC, 0)
+    written = os.write(fd, header)
+    if written != len(header):
+        raise AnalyzerError("DIAG-SIDECAR: short write of BRSHGT1 placeholder header")
+    os.fsync(fd)
+
+
+def _write_brshgt1_row(fd: int, row: DiagnosticCheckpoint) -> None:
+    """Append one 84-byte row and fsync the sidecar."""
+    raw = BRSHGT1_ROW_STRUCT.pack(*row)
+    written = os.write(fd, raw)
+    if written != len(raw):
+        raise AnalyzerError("DIAG-SIDECAR: short write of BRSHGT1 row")
+    os.fsync(fd)
+
+
+def _patch_brshgt1_count(sidecar_path: Path, count: int) -> None:
+    """Patch the row count in the sidecar header, fsync, then sync parent dir."""
+    fd = os.open(sidecar_path, os.O_RDWR)
+    try:
+        header = os.pread(fd, BRSHGT1_HEADER_STRUCT.size, 0)
+        if len(header) != BRSHGT1_HEADER_STRUCT.size:
+            raise AnalyzerError("DIAG-SIDECAR: cannot read header for count patch")
+        magic, _old = BRSHGT1_HEADER_STRUCT.unpack(header)
+        if magic != DIAGNOSTIC_MAGIC:
+            raise AnalyzerError("DIAG-SIDECAR: wrong magic while patching count")
+        os.pwrite(fd, struct.pack("<Q", count), 8)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    dir_fd = os.open(sidecar_path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def _brshgt1_count(sidecar_path: Path) -> int:
+    """Return the declared row count from a finalized BRSHGT1 sidecar."""
+    fd = os.open(sidecar_path, os.O_RDONLY)
+    try:
+        header = os.pread(fd, BRSHGT1_HEADER_STRUCT.size, 0)
+        if len(header) != BRSHGT1_HEADER_STRUCT.size:
+            raise AnalyzerError("DIAG-SIDECAR: short header")
+        magic, count = BRSHGT1_HEADER_STRUCT.unpack(header)
+        if magic != DIAGNOSTIC_MAGIC:
+            raise AnalyzerError("DIAG-SIDECAR: wrong magic")
+        return count
+    finally:
+        os.close(fd)
+
+
+def _open_brshgt1_read_fd(sidecar_path: Path) -> int:
+    """Open a BRSHGT1 sidecar and validate its preface/header."""
+    fd = os.open(sidecar_path, os.O_RDONLY)
+    valid = False
+    try:
+        header = os.pread(fd, BRSHGT1_HEADER_STRUCT.size, 0)
+        if len(header) != BRSHGT1_HEADER_STRUCT.size:
+            raise AnalyzerError("DIAG-SIDECAR: short header")
+        magic, count = BRSHGT1_HEADER_STRUCT.unpack(header)
+        if magic != DIAGNOSTIC_MAGIC:
+            raise AnalyzerError(f"DIAG-SIDECAR: wrong magic {magic!r}")
+        file_size = os.fstat(fd).st_size
+        expected = BRSHGT1_HEADER_STRUCT.size + count * DIAGNOSTIC_ROW_SIZE
+        if file_size != expected:
+            raise AnalyzerError(
+                f"DIAG-SIDECAR: size {file_size} != header {BRSHGT1_HEADER_STRUCT.size} + "
+                f"{count} x {DIAGNOSTIC_ROW_SIZE} = {expected}"
+            )
+        valid = True
+        return fd
+    finally:
+        if not valid:
+            os.close(fd)
+
+
+def _read_brshgt1_row(fd: int, row_number: int) -> DiagnosticCheckpoint:
+    """Read the Nth 84-byte row from a sidecar (1-indexed)."""
+    offset = BRSHGT1_HEADER_STRUCT.size + (row_number - 1) * DIAGNOSTIC_ROW_SIZE
+    raw = os.pread(fd, DIAGNOSTIC_ROW_SIZE, offset)
+    if len(raw) != DIAGNOSTIC_ROW_SIZE:
+        raise AnalyzerError(f"DIAG-SIDECAR: short row {row_number}")
+    (
+        height,
+        block_hash_le,
+        context_rows,
+        context_end,
+        record_rows,
+        record_end,
+        journal_rows,
+        journal_end,
+    ) = BRSHGT1_ROW_STRUCT.unpack(raw)
+    return DiagnosticCheckpoint(
+        height=height,
+        block_hash_le=block_hash_le,
+        context_rows=context_rows,
+        context_end=context_end,
+        record_rows=record_rows,
+        record_end=record_end,
+        journal_rows=journal_rows,
+        journal_end=journal_end,
+    )
+
+
+def _read_fixed_entries_slice(
+    fd: int,
+    start_offset: int,
+    end_offset: int,
+    start_row: int,
+    committed_rows: int,
+    entry_size: int,
+    name: str,
+) -> list[bytes]:
+    """Read a committed slice of fixed-size entries using pread."""
+    if start_row < 0 or committed_rows < start_row:
+        raise AnalyzerError(
+            f"DIAG-PROTO: invalid {name} row range {start_row}..{committed_rows}"
+        )
+    if start_offset < HEADER_SIZE or end_offset < start_offset:
+        raise AnalyzerError(
+            f"DIAG-PROTO: invalid {name} byte range {start_offset}..{end_offset}"
+        )
+    expected_start = HEADER_SIZE + start_row * entry_size
+    expected_end = HEADER_SIZE + committed_rows * entry_size
+    if start_offset != expected_start or end_offset != expected_end:
+        raise AnalyzerError(
+            f"DIAG-PROTO: {name} endpoint mismatch: "
+            f"expected {expected_start}..{expected_end}, got {start_offset}..{end_offset}"
+        )
+    file_size = os.fstat(fd).st_size
+    if end_offset > file_size:
+        raise AnalyzerError(
+            f"DIAG-PROTO: {name} endpoint {end_offset} exceeds file size {file_size}"
+        )
+    slice_size = end_offset - start_offset
+    if slice_size != (committed_rows - start_row) * entry_size:
+        raise AnalyzerError(
+            f"DIAG-PROTO: {name} slice size {slice_size} does not match row delta"
+        )
+    raw = os.pread(fd, slice_size, start_offset)
+    if len(raw) != slice_size:
+        raise AnalyzerError(f"DIAG-PROTO: short pread for {name}")
+    return [
+        raw[i * entry_size : (i + 1) * entry_size]
+        for i in range(committed_rows - start_row)
+    ]
+
+
+def _read_diagnostic_streams(
+    row: DiagnosticCheckpoint,
+    prev: DiagnosticCheckpoint | None,
+    paths: dict[str, Path],
+) -> tuple[
+    list[ClassifiedInput],
+    list[Record],
+    list[JournalEntry],
+    dict[tuple[bytes, int], str],
+    dict[str, int],
+]:
+    """Parse the three committed prefixes for one block.
+
+    Returns (classified, records, journal, context_map, record_counts).
+    """
+    ctx_fd = os.open(paths["contexts"], os.O_RDONLY)
+    rec_fd = os.open(paths["records"], os.O_RDONLY)
+    jrn_fd = os.open(paths["journal"], os.O_RDONLY)
+    try:
+        prev_ctx = prev.context_rows if prev is not None else 0
+        prev_ctx_end = prev.context_end if prev is not None else HEADER_SIZE
+        prev_rec = prev.record_rows if prev is not None else 0
+        prev_rec_end = prev.record_end if prev is not None else HEADER_SIZE
+        prev_jrn = prev.journal_rows if prev is not None else 0
+        prev_jrn_end = prev.journal_end if prev is not None else HEADER_SIZE
+
+        context_inputs = read_bounded_context_rows(
+            ctx_fd,
+            start_offset=prev_ctx_end,
+            end_offset=row.context_end,
+            start_row=prev_ctx,
+            committed_rows=row.context_rows,
+        )
+        classified: list[ClassifiedInput] = []
+        context_map: dict[tuple[bytes, int], str] = {}
+        for inp in context_inputs:
+            ci = classify_input(inp)
+            key = (inp.identity.txid_le, inp.identity.input_index)
+            if key in context_map:
+                display_txid = inp.identity.txid_le[::-1].hex()
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: duplicate context execution identity "
+                    f"{display_txid}:{inp.identity.input_index}"
+                )
+            context_map[key] = ci.spend_context.value
+            classified.append(ci)
+
+        journal_raws = _read_fixed_entries_slice(
+            jrn_fd,
+            prev_jrn_end,
+            row.journal_end,
+            prev_jrn,
+            row.journal_rows,
+            JOURNAL_SIZE,
+            "journal",
+        )
+        journal = [JournalEntry(raw) for raw in journal_raws]
+        journal_keys: set[tuple[bytes, int]] = set()
+        for entry in journal:
+            if entry.verdict != 1:
+                display_txid = entry.spend_txid[::-1].hex()
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: journal verdict {entry.verdict} != 1 for {display_txid}:{entry.input_index}"
+                )
+            key = (entry.spend_txid, entry.input_index)
+            if key in journal_keys:
+                display_txid = entry.spend_txid[::-1].hex()
+                raise AnalyzerError(
+                    f"CTX-EXECUTION: duplicate journal key in BRSJRN1: {display_txid}:{entry.input_index}"
+                )
+            journal_keys.add(key)
+
+        context_keys = set(context_map.keys())
+        if context_keys != journal_keys:
+            missing = journal_keys - context_keys
+            extra = context_keys - journal_keys
+            raise AnalyzerError(
+                f"CTX-OPERATIONS: context/journal key-set mismatch: "
+                f"missing={len(missing)} extra={len(extra)}"
+            )
+
+        record_raws = _read_fixed_entries_slice(
+            rec_fd,
+            prev_rec_end,
+            row.record_end,
+            prev_rec,
+            row.record_rows,
+            RECORD_SIZE,
+            "records",
+        )
+        records = [Record(raw) for raw in record_raws]
+        record_counts, _ = _diagnostic_record_counts(records, context_map)
+
+        # Record-level orphan/duplicate/sequence/legality checks are now
+        # performed inside _diagnostic_record_counts.  This loop only
+        # derives the per-key ECDSA verify calls/ok needed for the
+        # diagnostic journal reconciliation.
+        record_sums: dict[tuple[bytes, int], list[int]] = {}
+        for record in records:
+            key = (record.spend_txid, record.input_index)
+            sums = record_sums.setdefault(key, [0, 0, 0, 0])
+            if record.sig_version in (0, 1) and record.op_kind in (1, 2, 3, 4):
+                if record.outcome != 2:
+                    sums[2] += 1
+                if record.outcome == 1:
+                    sums[3] += 1
+
+        for entry in journal:
+            actual = record_sums.get(entry.key, [0, 0, 0, 0])
+            # CHECKMULTISIG may emit multiple ECDSA records for one opcode;
+            # reconcile only record-derived ECDSA calls/ok to the journal per key.
+            actual_ecdsa = [actual[2], actual[3]]
+            expected_ecdsa = [entry.ecdsa_verify_calls, entry.ecdsa_verify_ok]
+            if actual_ecdsa != expected_ecdsa:
+                display_txid = entry.spend_txid[::-1].hex()
+                raise AnalyzerError(
+                    f"CTX-OPERATIONS: journal/record ECDSA totals mismatch for "
+                    f"{display_txid}:{entry.input_index}: expected {expected_ecdsa}, got {actual_ecdsa}"
+                )
+
+        return classified, records, journal, context_map, record_counts
+    finally:
+        os.close(ctx_fd)
+        os.close(rec_fd)
+        os.close(jrn_fd)
+
+
+def _validate_checkpoint_bounds(
+    row: DiagnosticCheckpoint,
+    prev: DiagnosticCheckpoint | None,
+    file_sizes: dict[str, int],
+) -> None:
+    """Validate checkpoint ordering, framing, hashes, and committed endpoints."""
+    if prev is None:
+        if row.height != 0:
+            raise AnalyzerError("DIAG-PROTO: first checkpoint row must have height 0")
+        genesis_le = bytes.fromhex(MAINNET_GENESIS_HASH)[::-1]
+        if row.block_hash_le != genesis_le:
+            raise AnalyzerError(
+                "DIAG-PROTO: height 0 checkpoint hash is not mainnet genesis"
+            )
+    else:
+        if row.height != prev.height + 1:
+            raise AnalyzerError(
+                f"DIAG-PROTO: height {row.height} does not follow {prev.height}"
+            )
+        if row.block_hash_le == prev.block_hash_le:
+            raise AnalyzerError(
+                f"DIAG-PROTO: checkpoint hash repeated at height {row.height}"
+            )
+
+    if row.block_hash_le == bytes(32):
+        raise AnalyzerError(f"DIAG-PROTO: zero block hash at height {row.height}")
+
+    for name in ("context", "record", "journal"):
+        end = getattr(row, f"{name}_end")
+        count = getattr(row, f"{name}_rows")
+        previous_end = (
+            getattr(prev, f"{name}_end", HEADER_SIZE) if prev else HEADER_SIZE
+        )
+        previous_count = getattr(prev, f"{name}_rows", 0) if prev else 0
+        if count < previous_count:
+            raise AnalyzerError(
+                f"DIAG-PROTO: {name}_rows decreased from {previous_count} to {count}"
+            )
+        if end < previous_end:
+            raise AnalyzerError(
+                f"DIAG-PROTO: {name}_end decreased from {previous_end} to {end}"
+            )
+        if end > file_sizes[name]:
+            raise AnalyzerError(
+                f"DIAG-PROTO: {name}_end {end} exceeds current file size {file_sizes[name]}"
+            )
+
+    expected_record_end = HEADER_SIZE + row.record_rows * RECORD_SIZE
+    if row.record_end != expected_record_end:
+        raise AnalyzerError(
+            f"DIAG-PROTO: record_end {row.record_end} != {expected_record_end}"
+        )
+    expected_journal_end = HEADER_SIZE + row.journal_rows * JOURNAL_SIZE
+    if row.journal_end != expected_journal_end:
+        raise AnalyzerError(
+            f"DIAG-PROTO: journal_end {row.journal_end} != {expected_journal_end}"
+        )
+    minimum_context_end = HEADER_SIZE + row.context_rows * CONTEXT_MIN_ROW_SIZE
+    if row.context_end < minimum_context_end:
+        raise AnalyzerError(
+            f"DIAG-PROTO: context_end {row.context_end} is below minimum {minimum_context_end}"
+        )
+
+
+_ATOMIC_PUBLISH_COUNTER = 0
+
+
+def _atomic_publish_no_replace(path: Path, content: bytes) -> None:
+    """Fsync an exclusive sibling temp and hard-link it without replacement."""
+    parent = path.parent if str(path.parent) else Path(".")
+    parent.mkdir(parents=True, exist_ok=True)
+    global _ATOMIC_PUBLISH_COUNTER
+    _ATOMIC_PUBLISH_COUNTER += 1
+    temp = parent / f".{path.name}.tmp.{os.getpid()}.{_ATOMIC_PUBLISH_COUNTER}"
+    link_created = False
+    dir_fd: int | None = None
+
+    def _unlink_temp() -> None:
+        try:
+            temp.unlink()
+        except FileNotFoundError:
+            pass
+
+    try:
+        fd = os.open(temp, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(fd, view)
+                if written == 0:
+                    raise AnalyzerError(
+                        "DIAG-OUTPUT: zero-byte write to temporary file"
+                    )
+                view = view[written:]
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+        dir_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.link(temp, path)
+        except FileExistsError as exc:
+            raise AnalyzerError(f"DIAG-OUTPUT: output already exists: {path}") from exc
+        except OSError as exc:
+            raise AnalyzerError(
+                f"DIAG-OUTPUT: atomic no-replace publication failed: {exc}"
+            ) from exc
+        link_created = True
+        os.fsync(dir_fd)
+        _unlink_temp()
+        os.fsync(dir_fd)
+    except BaseException as publish_error:
+        rollback_error: BaseException | None = None
+        if link_created:
+            try:
+                path.unlink()
+                if dir_fd is None:
+                    dir_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+                os.fsync(dir_fd)
+            # Rollback must finish even when cleanup receives an interrupt.
+            except BaseException as exc:  # noqa: BLE001
+                rollback_error = exc
+        try:
+            _unlink_temp()
+        except BaseException as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+        if rollback_error is not None:
+            raise rollback_error from publish_error
+        raise
+    finally:
+        if dir_fd is not None:
+            os.close(dir_fd)
+        _unlink_temp()
+
+    if not link_created:
+        raise AnalyzerError("DIAG-OUTPUT: publication did not create a link")
+
+
+def _write_json_atomic(path: Path, content: dict[str, object]) -> None:
+    rendered = json.dumps(content, indent=2).encode("utf-8") + b"\n"
+    _atomic_publish_no_replace(path, rendered)
+
+
+def _close_stream(stream: BinaryIO | None) -> None:
+    if stream is None or stream.closed:
+        return
+    try:
+        stream.close()
+    except OSError:
+        return
+
+
+def _reap_child(
+    proc: subprocess.Popen, stderr_file: BinaryIO, *, timeout: float = 5.0
+) -> None:
+    """Close stdin, wait, kill only on timeout, then close remaining handles."""
+    _close_stream(proc.stdin)
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            raise AnalyzerError("DIAG-PROTO: child did not exit after kill") from exc
+    finally:
+        _close_stream(proc.stdout)
+        _close_stream(proc.stderr)
+        _close_stream(stderr_file)
+
+
+def _launch_diagnostic_child(
+    binary: Path,
+    rest_url: str,
+    ceiling: int,
+    work_dir: Path,
+    replay_json: Path,
+    data_dir: Path,
+    stderr_path: Path,
+    counters_path: Path,
+    storage_backend: str,
+    txindex: bool,
+    blockfilterindex: bool,
+) -> tuple[subprocess.Popen, BinaryIO]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "BRS_CENSUS_COUNTERS": str(counters_path),
+            "BRS_CENSUS_CONTEXTS": str(work_dir / "brsctx1.bin"),
+            "BRS_CENSUS_RECORDS": str(work_dir / "brsrec1.bin"),
+            "BRS_CENSUS_JOURNAL": str(work_dir / "brsjrn1.bin"),
+            "BRS_CENSUS_LABEL": "cmodern-diagnostic",
+        }
+    )
+    command = [
+        str(binary),
+        "--cmodern-diagnostic-protocol",
+        "--rest-url",
+        rest_url,
+        "--start-height",
+        "0",
+        "--assume-valid-height",
+        "0",
+        "--window",
+        "1",
+        "--stop-height",
+        str(ceiling),
+        "--data-dir",
+        str(data_dir),
+        "--output",
+        str(replay_json),
+        "--storage-backend",
+        storage_backend,
+    ]
+    if txindex:
+        command.append("--txindex")
+    if blockfilterindex:
+        command.append("--blockfilterindex")
+
+    stderr_file = stderr_path.open("xb")
+    try:
+        proc = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=stderr_file,
+            env=env,
+            bufsize=0,
+            close_fds=True,
+        )
+    except OSError as exc:
+        stderr_file.close()
+        raise AnalyzerError(f"DIAG-SETUP: failed to launch child: {exc}") from exc
+    return proc, stderr_file
+
+
+def _validate_replay_diagnostic(
+    path: Path,
+    final: DiagnosticCheckpoint,
+    ceiling: int,
+    storage_backend: str,
+    txindex: bool,
+    blockfilterindex: bool,
+    data_dir: str,
+) -> None:
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AnalyzerError(f"DIAG-CUSTODY: invalid child replay JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise AnalyzerError("DIAG-CUSTODY: child replay JSON root is not an object")
+
+    expected_keys = {
+        "schema",
+        "non_certifying",
+        "block_source",
+        "start_height",
+        "requested_stop_height_ceiling",
+        "actual_stop_height",
+        "actual_stop_hash",
+        "window",
+        "assume_valid_height",
+        "stop_reason",
+        "storage_backend",
+        "txindex",
+        "blockfilterindex",
+        "data_dir",
+        "elapsed_seconds",
+    }
+    _require_exact_keys(raw, expected_keys, "child replay")
+
+    if raw["schema"] != "mainnet-prefix-replay-diagnostic-v1":
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: child replay schema {raw['schema']!r} "
+            "!= 'mainnet-prefix-replay-diagnostic-v1'"
+        )
+    if raw["non_certifying"] is not True:
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: child replay non_certifying {raw['non_certifying']!r} != True"
+        )
+    if raw["block_source"] != "rest":
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: child replay block_source {raw['block_source']!r} != 'rest'"
+        )
+    start_height = _require_u32(raw["start_height"], "start_height")
+    if start_height != 0:
+        raise AnalyzerError(f"DIAG-CUSTODY: start_height {start_height} != 0")
+    requested = _require_u32(
+        raw["requested_stop_height_ceiling"], "requested_stop_height_ceiling"
+    )
+    if requested != ceiling:
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: requested_stop_height_ceiling {requested} != {ceiling}"
+        )
+    actual = _require_u32(raw["actual_stop_height"], "actual_stop_height")
+    if actual != final.height:
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: actual_stop_height {actual} != {final.height}"
+        )
+    actual_hash = _require_hex_str(raw["actual_stop_hash"], "actual_stop_hash", 64)
+    expected_hash = final.block_hash_le[::-1].hex()
+    if actual_hash != expected_hash:
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: actual_stop_hash {actual_hash} != {expected_hash}"
+        )
+    window = _require_u32(raw["window"], "window")
+    if window != 1:
+        raise AnalyzerError(f"DIAG-CUSTODY: child replay window {window} != 1")
+    assume = _require_u32(raw["assume_valid_height"], "assume_valid_height")
+    if assume != 0:
+        raise AnalyzerError(f"DIAG-CUSTODY: assume_valid_height {assume} != 0")
+    if raw["stop_reason"] != "controller-request":
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: stop_reason {raw['stop_reason']!r} != 'controller-request'"
+        )
+
+    if raw["storage_backend"] != storage_backend:
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: storage_backend {raw['storage_backend']!r} "
+            f"!= {storage_backend!r}"
+        )
+    if raw["txindex"] is not txindex:
+        raise AnalyzerError(f"DIAG-CUSTODY: txindex {raw['txindex']!r} != {txindex!r}")
+    if raw["blockfilterindex"] is not blockfilterindex:
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: blockfilterindex {raw['blockfilterindex']!r} "
+            f"!= {blockfilterindex!r}"
+        )
+    if raw["data_dir"] != data_dir:
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: data_dir {raw['data_dir']!r} != {data_dir!r}"
+        )
+
+    elapsed = raw["elapsed_seconds"]
+    if isinstance(elapsed, bool) or not isinstance(elapsed, (int, float)):
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: elapsed_seconds must be a finite non-negative number, got {elapsed!r}"
+        )
+    elapsed_f = float(elapsed)
+    if math.isnan(elapsed_f) or math.isinf(elapsed_f):
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: elapsed_seconds must be finite, got {elapsed!r}"
+        )
+    if elapsed_f < 0.0:
+        raise AnalyzerError(
+            f"DIAG-CUSTODY: elapsed_seconds must be non-negative, got {elapsed_f}"
+        )
+
+
+def _validate_native_counters(path: Path, final: DiagnosticCheckpoint) -> None:
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AnalyzerError(f"DIAG-CUSTODY: invalid counters JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise AnalyzerError("DIAG-CUSTODY: counters JSON root is not an object")
+    counters = Counters(raw)
+    expected = {
+        "context_count": final.context_rows,
+        "record_count": final.record_rows,
+        "journal_count": final.journal_rows,
+    }
+    for field, value in expected.items():
+        if getattr(counters, field) != value:
+            raise AnalyzerError(
+                f"DIAG-CUSTODY: counters {field} {getattr(counters, field)} != {value}"
+            )
+
+
+def _validate_terminal_streams(
+    paths: dict[str, Path], final: DiagnosticCheckpoint
+) -> dict[str, dict[str, object]]:
+    custody: dict[str, dict[str, object]] = {}
+    context_iter = iter_context_inputs(paths["contexts"])
+    for _ in context_iter:
+        continue
+    context_custody = context_iter.custody()
+    if (
+        context_custody["count"] != final.context_rows
+        or context_custody["bytes"] != final.context_end
+    ):
+        raise AnalyzerError("DIAG-CUSTODY: terminal context header/checkpoint mismatch")
+    custody["contexts"] = {
+        "path": str(paths["contexts"]),
+        "bytes": context_custody["bytes"],
+        "sha256": format(context_custody["sha256"], "064x"),
+    }
+
+    record_iter, record_custody = iter_records_with_custody(paths["records"])
+    for _ in record_iter:
+        continue
+    record_count = (record_custody["bytes"] - HEADER_SIZE) // RECORD_SIZE
+    if record_count != final.record_rows or record_custody["bytes"] != final.record_end:
+        raise AnalyzerError("DIAG-CUSTODY: terminal record header/checkpoint mismatch")
+    custody["records"] = {
+        "path": str(paths["records"]),
+        "bytes": record_custody["bytes"],
+        "sha256": format(record_custody["sha256"], "064x"),
+    }
+
+    journal_iter, journal_custody = iter_journal_with_custody(paths["journal"])
+    for _ in journal_iter:
+        continue
+    journal_count = (journal_custody["bytes"] - HEADER_SIZE) // JOURNAL_SIZE
+    if (
+        journal_count != final.journal_rows
+        or journal_custody["bytes"] != final.journal_end
+    ):
+        raise AnalyzerError("DIAG-CUSTODY: terminal journal header/checkpoint mismatch")
+    custody["journal"] = {
+        "path": str(paths["journal"]),
+        "bytes": journal_custody["bytes"],
+        "sha256": format(journal_custody["sha256"], "064x"),
+    }
+    return custody
+
+
+def _finalize_candidate(
+    paths: dict[str, Path],
+    sidecar_row_count: int,
+    final: DiagnosticCheckpoint,
+    cumulative_counts: dict[str, int],
+    first_heights: dict[str, int],
+    rest_url: str,
+    ceiling: int,
+    output_path: Path,
+    storage_backend: str,
+    txindex: bool,
+    blockfilterindex: bool,
+    data_dir: str,
+) -> None:
+    _patch_brshgt1_count(paths["sidecar"], sidecar_row_count)
+    if _brshgt1_count(paths["sidecar"]) != sidecar_row_count:
+        raise AnalyzerError("DIAG-SIDECAR: finalized row count mismatch")
+    sidecar_read_fd = _open_brshgt1_read_fd(paths["sidecar"])
+    try:
+        terminal_row = _read_brshgt1_row(sidecar_read_fd, sidecar_row_count)
+    finally:
+        os.close(sidecar_read_fd)
+    if terminal_row != final:
+        raise AnalyzerError("DIAG-SIDECAR: terminal row mismatch")
+
+    stream_custody = _validate_terminal_streams(paths, final)
+    _validate_replay_diagnostic(
+        paths["replay"],
+        final,
+        ceiling,
+        storage_backend,
+        txindex,
+        blockfilterindex,
+        data_dir,
+    )
+    _validate_native_counters(paths["counters"], final)
+    custody: dict[str, dict[str, object]] = {}
+    for name in ("sidecar", "replay", "counters"):
+        size, digest = _sha256_file(paths[name])
+        custody[name] = {
+            "path": str(paths[name]),
+            "bytes": size,
+            "sha256": digest,
+        }
+
+    candidate: dict[str, object] = {
+        "schema": "cmodern-candidate-diagnostic-v1",
+        "non_certifying": True,
+        "certifying_replay_required": True,
+        "network": "mainnet",
+        "block_source": "rest",
+        "rest_url": rest_url,
+        "start_height": 0,
+        "assume_valid_height": 0,
+        "window": 1,
+        "stop_height_ceiling": ceiling,
+        "earliest_defensible_height_h": final.height,
+        "block_hash_h": final.block_hash_le[::-1].hex(),
+        "first_occurrence_heights": {
+            name: first_heights[name] for name in CONTEXT_COUNTER_NAMES
+        },
+        "context_counts": {
+            name: cumulative_counts[name] for name in CONTEXT_COUNTER_NAMES
+        },
+        "context_counter_definitions": CONTEXT_COUNTER_DEFINITIONS,
+        "final_stream_counts": {
+            "context_rows": final.context_rows,
+            "record_rows": final.record_rows,
+            "journal_rows": final.journal_rows,
+        },
+        "final_stream_endpoints": {
+            "context_end": final.context_end,
+            "record_end": final.record_end,
+            "journal_end": final.journal_end,
+        },
+        "child_exit_status": 0,
+        "child_replay_schema": "mainnet-prefix-replay-diagnostic-v1",
+        "custody": {
+            "brshgt1_sidecar": custody["sidecar"],
+            "child_replay_json": custody["replay"],
+            "counters_json": custody["counters"],
+            "brsctx1": stream_custody["contexts"],
+            "brsrec1": stream_custody["records"],
+            "brsjrn1": stream_custody["journal"],
+        },
+    }
+    _write_json_atomic(output_path, candidate)
+
+
+def _send_control(proc: subprocess.Popen, control: bytes) -> None:
+    if proc.stdin is None:
+        raise AnalyzerError("DIAG-SETUP: child stdin is not piped")
+    try:
+        proc.stdin.write(control)
+        proc.stdin.flush()
+    except (BrokenPipeError, OSError) as exc:
+        raise AnalyzerError(f"DIAG-PROTO: failed to send control byte: {exc}") from exc
+
+
+def _run_diagnostic_scan(
+    binary: Path,
+    rest_url: str,
+    ceiling: int,
+    work_dir: Path,
+    output_path: Path,
+    storage_backend: str = "fjall",
+    txindex: bool = False,
+    blockfilterindex: bool = False,
+) -> None:
+    paths = {
+        "contexts": work_dir / "brsctx1.bin",
+        "records": work_dir / "brsrec1.bin",
+        "journal": work_dir / "brsjrn1.bin",
+        "sidecar": work_dir / "brshgt1.bin",
+        "replay": work_dir / "replay_diagnostic.json",
+        "stderr": work_dir / "stderr.log",
+        "counters": work_dir / "counters.json",
+    }
+    data_dir = work_dir / "state"
+    data_dir.mkdir(exist_ok=False)
+    sidecar_fd: int | None = os.open(
+        paths["sidecar"], os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
+    )
+    _write_brshgt1_preface(sidecar_fd)
+    proc: subprocess.Popen | None = None
+    stderr_file: BinaryIO | None = None
+    child_closed = False
+    try:
+        proc, stderr_file = _launch_diagnostic_child(
+            binary,
+            rest_url,
+            ceiling,
+            work_dir,
+            paths["replay"],
+            data_dir,
+            paths["stderr"],
+            paths["counters"],
+            storage_backend,
+            txindex,
+            blockfilterindex,
+        )
+        if proc.stdout is None:
+            raise AnalyzerError("DIAG-SETUP: child stdout is not piped")
+        _read_diagnostic_preface(proc.stdout)
+        previous: DiagnosticCheckpoint | None = None
+        cumulative_counts = {name: 0 for name in CONTEXT_COUNTER_NAMES}
+        first_heights: dict[str, int] = {}
+        row_count = 0
+
+        while True:
+            row = _read_checkpoint_row(proc.stdout)
+            file_sizes = {
+                "context": paths["contexts"].stat().st_size,
+                "record": paths["records"].stat().st_size,
+                "journal": paths["journal"].stat().st_size,
+            }
+            _validate_checkpoint_bounds(row, previous, file_sizes)
+            classified, _records, _journal, _context_map, record_counts = (
+                _read_diagnostic_streams(row, previous, paths)
+            )
+            block_counts = {**_diagnostic_spend_counts(classified), **record_counts}
+            for name in CONTEXT_COUNTER_NAMES:
+                cumulative_counts[name] += block_counts[name]
+                if block_counts[name] > 0 and name not in first_heights:
+                    first_heights[name] = row.height
+
+            _write_brshgt1_row(sidecar_fd, row)
+            row_count += 1
+            if len(first_heights) == len(CONTEXT_COUNTER_NAMES):
+                expected_h = max(first_heights.values())
+                if row.height != expected_h:
+                    raise AnalyzerError(
+                        f"DIAG-PROTO: current height {row.height} != derived H {expected_h}"
+                    )
+                _send_control(proc, b"\x01")
+                break
+            if row.height >= ceiling:
+                raise AnalyzerError(
+                    f"DIAG-PROTO: safety ceiling {ceiling} exhausted without all 11 types"
+                )
+            _send_control(proc, b"\x00")
+            previous = row
+
+        _close_stream(proc.stdin)
+        try:
+            exit_code = proc.wait(timeout=10)
+        except subprocess.TimeoutExpired as exc:
+            raise AnalyzerError("DIAG-PROTO: child did not exit after STOP") from exc
+        if exit_code != 0:
+            raise AnalyzerError(f"DIAG-PROTO: child exited with status {exit_code}")
+        if proc.stdout.read(1) != b"":
+            raise AnalyzerError("DIAG-PROTO: trailing bytes after terminal checkpoint")
+        _close_stream(proc.stdout)
+        _close_stream(proc.stderr)
+        _close_stream(stderr_file)
+        child_closed = True
+
+        os.fsync(sidecar_fd)
+        os.close(sidecar_fd)
+        sidecar_fd = None
+        _finalize_candidate(
+            paths,
+            row_count,
+            row,
+            cumulative_counts,
+            first_heights,
+            rest_url,
+            ceiling,
+            output_path,
+            storage_backend,
+            txindex,
+            blockfilterindex,
+            str(data_dir),
+        )
+    finally:
+        if proc is not None and stderr_file is not None and not child_closed:
+            _reap_child(proc, stderr_file)
+        if sidecar_fd is not None:
+            os.close(sidecar_fd)
+
+
+def cmd_find_cmodern_height(args: argparse.Namespace) -> int:
+    binary = Path(args.binary)
+    work_dir = Path(args.work_dir)
+    output = Path(args.output)
+    if not binary.is_file():
+        raise AnalyzerError(f"DIAG-SETUP: binary not found: {binary}")
+    if not args.rest_url or ":" not in args.rest_url:
+        raise AnalyzerError(
+            f"DIAG-SETUP: invalid rest_url {args.rest_url!r}; expected host:port"
+        )
+    if not (0 <= args.stop_height <= 0xFFFFFFFF):
+        raise AnalyzerError(
+            f"DIAG-SETUP: stop-height must be a u32, got {args.stop_height}"
+        )
+    if work_dir.exists():
+        raise AnalyzerError(f"DIAG-SETUP: work directory already exists: {work_dir}")
+    if output.exists():
+        raise AnalyzerError(f"DIAG-SETUP: output already exists: {output}")
+    work_dir.mkdir(parents=True, exist_ok=False)
+    _run_diagnostic_scan(
+        binary,
+        args.rest_url,
+        args.stop_height,
+        work_dir,
+        output,
+        storage_backend=args.storage_backend,
+        txindex=args.txindex,
+        blockfilterindex=args.blockfilterindex,
+    )
+    return 0
 
 
 # ── Binary parsing ──────────────────────────────────────────────────────────
@@ -3200,6 +4473,37 @@ def build_parser() -> argparse.ArgumentParser:
         help="optional writable directory for the classifier database and SQLite temporary files",
     )
     cc.set_defaults(func=cmd_classify_corpus)
+
+    fc = sub.add_parser(
+        "find-cmodern-height",
+        help="launch a diagnostic replay to find the first mainnet height with all 11 special contexts",
+    )
+    fc.add_argument(
+        "--binary", required=True, help="feature-built mainnet_prefix_replay binary"
+    )
+    fc.add_argument("--rest-url", required=True, help="frozen REST URL (host:port)")
+    fc.add_argument(
+        "--stop-height", required=True, type=int, help="safety ceiling (inclusive u32)"
+    )
+    fc.add_argument(
+        "--work-dir",
+        required=True,
+        help="new work directory for BRS streams and scratch state",
+    )
+    fc.add_argument("--output", required=True, help="candidate output JSON path")
+    fc.add_argument(
+        "--storage-backend", default="fjall", help="storage backend for replay state"
+    )
+    fc.add_argument(
+        "--txindex", action="store_true", default=False, help="enable txindex"
+    )
+    fc.add_argument(
+        "--blockfilterindex",
+        action="store_true",
+        default=False,
+        help="enable blockfilterindex",
+    )
+    fc.set_defaults(func=cmd_find_cmodern_height)
 
     return parser
 

--- a/tools/checksig-census/analyze.py
+++ b/tools/checksig-census/analyze.py
@@ -15,6 +15,7 @@ import argparse
 import hashlib
 import json
 import math
+import os
 import re
 import sqlite3
 import statistics
@@ -2307,560 +2308,552 @@ def _count_context_records_disk(
     records_path: Path,
     journal_path: Path,
     counters: Counters,
+    scratch_dir: Path | None = None,
 ) -> tuple[dict[str, int], int, dict[str, dict[str, int]]]:
-    """Disk-backed streaming computation of context counters.
+    """Join the three native streams using bounded SQLite bulk loading.
 
-    Uses a temporary on-disk sqlite3 database to join BRSCTX1 contexts,
-    BRSJRN1 journal entries, and BRSREC1 records without materializing
-    any of the binary files in memory.
-
-    Returns ``(counts, context_count, custody)`` where *custody* maps
-    ``"contexts"``, ``"records"``, ``"journal"`` to ``{bytes, sha256}``
-    computed on the single open used for parsing.
+    Each evidence stream is parsed and hashed from one open. Rows are inserted
+    lazily, so memory is bounded by SQLite's executemany machinery rather than
+    the evidence size, and an already-seen duplicate is reported before a later
+    malformed row is requested from the iterator.
     """
     counts: dict[str, int] = {name: 0 for name in CONTEXT_COUNTER_NAMES}
+    chunk_size = 4096
 
-    with tempfile.TemporaryDirectory(prefix="classify-corpus-") as tmpdir:
-        db_path = Path(tmpdir) / "contexts.db"
-        conn = sqlite3.connect(str(db_path))
+    if scratch_dir is not None:
+        scratch_dir = Path(scratch_dir)
+        if not scratch_dir.is_dir():
+            raise AnalyzerError(
+                f"CTX-EXECUTION: scratch-dir is not a writable directory: {scratch_dir}"
+            )
         try:
-            conn.execute(
-                "CREATE TABLE contexts ("
-                "txid_le BLOB, input_index INTEGER, spend_context TEXT, "
-                "prevout BLOB, script_sig BLOB, witness_count INTEGER, "
-                "PRIMARY KEY(txid_le, input_index))"
-            )
-            conn.execute(
-                "CREATE TABLE journal ("
-                "txid_le BLOB, input_index INTEGER, verdict INTEGER, "
-                "checksig_ops INTEGER, checkmultisig_ops INTEGER, "
-                "ecdsa_verify_calls INTEGER, ecdsa_verify_ok INTEGER, "
-                "PRIMARY KEY(txid_le, input_index))"
-            )
-            conn.execute(
-                "CREATE TABLE record_keys ("
-                "txid_le BLOB, input_index INTEGER, op_seq INTEGER, "
-                "PRIMARY KEY(txid_le, input_index, op_seq))"
-            )
-            conn.execute(
-                "CREATE TABLE record_seq ("
-                "txid_le BLOB, input_index INTEGER, last_op_seq INTEGER, "
-                "PRIMARY KEY(txid_le, input_index))"
-            )
-            conn.execute(
-                "CREATE TABLE record_ecdsa ("
-                "txid_le BLOB, input_index INTEGER, calls INTEGER, ok INTEGER, "
-                "PRIMARY KEY(txid_le, input_index))"
-            )
+            with tempfile.NamedTemporaryFile(
+                prefix="classify-corpus-write-test-", dir=scratch_dir
+            ):
+                pass
+        except OSError as exc:
+            raise AnalyzerError(
+                f"CTX-EXECUTION: scratch-dir is not a writable directory: "
+                f"{scratch_dir}: {exc}"
+            ) from exc
 
-            # ── Stream BRSCTX1 → classify → INSERT ──
-            context_count = 0
-            context_iter = iter_context_inputs(contexts_path, dedup=False)
+    saved_sqlite_tmpdir = os.environ.get("SQLITE_TMPDIR")
+    saved_tmpdir = os.environ.get("TMPDIR")
+    if scratch_dir is not None:
+        os.environ["SQLITE_TMPDIR"] = str(scratch_dir)
+        os.environ["TMPDIR"] = str(scratch_dir)
+
+    conn: sqlite3.Connection | None = None
+
+    def insert_bounded(sql: str, rows: Iterator[tuple[object, ...]]) -> int:
+        inserted = 0
+        exhausted = False
+        while not exhausted:
+
+            def next_chunk() -> Iterator[tuple[object, ...]]:
+                nonlocal exhausted, inserted
+                for _ in range(chunk_size):
+                    try:
+                        row = next(rows)
+                    except StopIteration:
+                        exhausted = True
+                        return
+                    inserted += 1
+                    yield row
+
+            conn.executemany(sql, next_chunk())
+        return inserted
+
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix="classify-corpus-", dir=scratch_dir
+        ) as tmpdir:
+            db_path = Path(tmpdir) / "contexts.db"
+            conn = sqlite3.connect(str(db_path))
             try:
-                for evidence in context_iter:
-                    classified = classify_input(evidence)
-                    ctx = classified.spend_context
-                    conn.execute(
-                        "INSERT INTO contexts VALUES (?, ?, ?, ?, ?, ?)",
-                        (
+                if scratch_dir is not None:
+                    conn.execute("PRAGMA temp_store = FILE")
+                conn.execute(
+                    "CREATE TABLE contexts ("
+                    "txid_le BLOB NOT NULL, input_index INTEGER NOT NULL, "
+                    "spend_context TEXT NOT NULL, "
+                    "PRIMARY KEY(txid_le, input_index)"
+                    ") WITHOUT ROWID"
+                )
+                conn.execute(
+                    "CREATE TABLE journal ("
+                    "txid_le BLOB NOT NULL, input_index INTEGER NOT NULL, "
+                    "checksig_ops INTEGER NOT NULL, checkmultisig_ops INTEGER NOT NULL, "
+                    "ecdsa_verify_calls INTEGER NOT NULL, ecdsa_verify_ok INTEGER NOT NULL, "
+                    "PRIMARY KEY(txid_le, input_index)"
+                    ") WITHOUT ROWID"
+                )
+                conn.execute(
+                    "CREATE TABLE records ("
+                    "txid_le BLOB NOT NULL, input_index INTEGER NOT NULL, "
+                    "op_seq INTEGER NOT NULL, stream_pos INTEGER NOT NULL, "
+                    "op_kind INTEGER NOT NULL, sig_version INTEGER NOT NULL, "
+                    "outcome INTEGER NOT NULL, reject_reason INTEGER NOT NULL, "
+                    "PRIMARY KEY(txid_le, input_index, op_seq)"
+                    ") WITHOUT ROWID"
+                )
+                conn.execute("CREATE INDEX records_stream_pos ON records(stream_pos)")
+
+                context_iter = iter_context_inputs(contexts_path, dedup=False)
+
+                def context_rows() -> Iterator[tuple[object, ...]]:
+                    for evidence in context_iter:
+                        classified = classify_input(evidence)
+                        yield (
                             evidence.identity.txid_le,
                             evidence.identity.input_index,
-                            ctx.value,
-                            evidence.prevout_script_pubkey,
-                            evidence.script_sig,
-                            len(evidence.witness),
-                        ),
-                    )
-                    context_count += 1
-                contexts_custody = context_iter.custody()
-            except ContextError as exc:
-                raise AnalyzerError(f"CTX-RAW: BRSCTX1 stream failed: {exc}") from exc
-            except sqlite3.IntegrityError as exc:
-                raise AnalyzerError(
-                    f"CTX-EXECUTION: duplicate context execution identity in BRSCTX1: {exc}"
-                ) from exc
-            # ── Stream BRSJRN1 → INSERT, verify all verdicts == 1 ──
-            journal_count = 0
-            journal_iter, journal_custody = iter_journal_with_custody(journal_path)
-            try:
-                for entry in journal_iter:
-                    if entry.verdict != 1:
-                        display_txid = entry.spend_txid[::-1].hex()
-                        raise AnalyzerError(
-                            f"CTX-EXECUTION: journal verdict {entry.verdict} != 1 "
-                            f"for txid={display_txid}, input_index={entry.input_index}"
+                            classified.spend_context.value,
                         )
-                    conn.execute(
-                        "INSERT INTO journal VALUES (?, ?, ?, ?, ?, ?, ?)",
-                        (
+
+                try:
+                    context_count = insert_bounded(
+                        "INSERT INTO contexts VALUES (?, ?, ?)", context_rows()
+                    )
+                    contexts_custody = context_iter.custody()
+                except ContextError as exc:
+                    raise AnalyzerError(
+                        f"CTX-RAW: BRSCTX1 stream failed: {exc}"
+                    ) from exc
+                except sqlite3.IntegrityError as exc:
+                    raise AnalyzerError(
+                        f"CTX-EXECUTION: duplicate context execution identity in BRSCTX1: {exc}"
+                    ) from exc
+
+                journal_iter, journal_custody = iter_journal_with_custody(journal_path)
+
+                def journal_rows() -> Iterator[tuple[object, ...]]:
+                    for entry in journal_iter:
+                        if entry.verdict != 1:
+                            display_txid = entry.spend_txid[::-1].hex()
+                            raise AnalyzerError(
+                                f"CTX-EXECUTION: journal verdict {entry.verdict} != 1 "
+                                f"for txid={display_txid}, input_index={entry.input_index}"
+                            )
+                        yield (
                             entry.spend_txid,
                             entry.input_index,
-                            entry.verdict,
                             entry.checksig_ops,
                             entry.checkmultisig_ops,
                             entry.ecdsa_verify_calls,
                             entry.ecdsa_verify_ok,
-                        ),
-                    )
-                    journal_count += 1
-            except sqlite3.IntegrityError as exc:
-                raise AnalyzerError(
-                    f"CTX-EXECUTION: duplicate journal key in BRSJRN1: {exc}"
-                ) from exc
-
-            # ── Count reconciliation: contexts == journal == ffi_verify_entries ──
-            if context_count != journal_count:
-                raise AnalyzerError(
-                    f"CTX-EXECUTION: context count {context_count} != "
-                    f"journal count {journal_count}"
-                )
-            if context_count != counters.ffi_verify_entries:
-                raise AnalyzerError(
-                    f"CTX-EXECUTION: context count {context_count} != "
-                    f"counters.ffi_verify_entries {counters.ffi_verify_entries}"
-                )
-            if journal_count != counters.ffi_verify_entries:
-                raise AnalyzerError(
-                    f"CTX-EXECUTION: journal count {journal_count} != "
-                    f"counters.ffi_verify_entries {counters.ffi_verify_entries}"
-                )
-            if context_count != counters.context_count:
-                raise AnalyzerError(
-                    f"CTX-EXECUTION: context count {context_count} != "
-                    f"counters.context_count {counters.context_count}"
-                )
-            if journal_count != counters.journal_count:
-                raise AnalyzerError(
-                    f"CTX-EXECUTION: journal count {journal_count} != "
-                    f"counters.journal_count {counters.journal_count}"
-                )
-
-            # ── Key equality: contexts ↔ journal via EXCEPT both directions ──
-            except_ctx_not_in_journal = conn.execute(
-                "SELECT COUNT(*) FROM ("
-                "  SELECT txid_le, input_index FROM contexts "
-                "  EXCEPT "
-                "  SELECT txid_le, input_index FROM journal"
-                ")"
-            ).fetchone()[0]
-            if except_ctx_not_in_journal:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: {except_ctx_not_in_journal} context key(s) "
-                    f"not present in journal"
-                )
-            except_jrn_not_in_ctx = conn.execute(
-                "SELECT COUNT(*) FROM ("
-                "  SELECT txid_le, input_index FROM journal "
-                "  EXCEPT "
-                "  SELECT txid_le, input_index FROM contexts"
-                ")"
-            ).fetchone()[0]
-            if except_jrn_not_in_ctx:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: {except_jrn_not_in_ctx} journal key(s) "
-                    f"not present in contexts"
-                )
-
-            # ── Tally spend-context counts from the contexts table ──
-            ctx_rows = conn.execute(
-                "SELECT spend_context, COUNT(*) FROM contexts GROUP BY spend_context"
-            ).fetchall()
-            for ctx_name, cnt in ctx_rows:
-                ctx_enum = SpendContext(ctx_name)
-                if ctx_enum == SpendContext.P2SH:
-                    counts["p2sh_redeem_spends"] += cnt
-                elif ctx_enum == SpendContext.NATIVE_WITNESS_V0:
-                    counts["native_witness_v0_spends"] += cnt
-                elif ctx_enum == SpendContext.P2SH_WRAPPED_WITNESS_V0:
-                    counts["p2sh_wrapped_witness_v0_spends"] += cnt
-                elif ctx_enum == SpendContext.TAPROOT_KEY_PATH:
-                    counts["taproot_key_path_spends"] += cnt
-                elif ctx_enum == SpendContext.TAPSCRIPT:
-                    counts["tapscript_spends"] += cnt
-
-            # ── Global aggregate counters for reconciliation (running ints) ──
-            agg_ecdsa_calls = 0
-            agg_ecdsa_ok = 0
-            agg_ecdsa_fail = 0
-            agg_schnorr_calls = 0
-            agg_schnorr_ok = 0
-            agg_schnorr_fail = 0
-            agg_checkecdsa_entries = 0
-            agg_checkschnorr_entries = 0
-            # Eight reject counters (reject_reason 0..7; 8 = unknown/distinct)
-            agg_rejects = [0] * 9
-
-            # ── Stream BRSREC1 → insert key, look up context, tally op counts ──
-            record_streamed_count = 0
-            record_iter, record_custody = iter_records_with_custody(records_path)
-            try:
-                for record in record_iter:
-                    conn.execute(
-                        "INSERT INTO record_keys VALUES (?, ?, ?)",
-                        (record.spend_txid, record.input_index, record.op_seq),
-                    )
-                    row = conn.execute(
-                        "SELECT spend_context FROM contexts "
-                        "WHERE txid_le = ? AND input_index = ?",
-                        (record.spend_txid, record.input_index),
-                    ).fetchone()
-                    if row is None:
-                        display_txid = record.spend_txid[::-1].hex()
-                        raise AnalyzerError(
-                            f"CTX-OPERATIONS: BRSREC1 record has no matching "
-                            f"context identity: txid={display_txid}, "
-                            f"input_index={record.input_index}"
                         )
-                    ctx = SpendContext(row[0])
-                    op = record.op_kind
-                    sig = record.sig_version
-                    display_txid = record.spend_txid[::-1].hex()
-                    identity_str = (
-                        f"txid={display_txid}, input_index={record.input_index}"
-                    )
-                    # ── Per-key contiguous op_seq via SQLite record_seq ──
-                    conn.execute(
-                        "INSERT INTO record_seq (txid_le, input_index, last_op_seq) "
-                        "VALUES (?, ?, ?) "
-                        "ON CONFLICT(txid_le, input_index) DO UPDATE SET "
-                        "last_op_seq = excluded.last_op_seq "
-                        "WHERE record_seq.last_op_seq + 1 = excluded.last_op_seq",
-                        (record.spend_txid, record.input_index, record.op_seq),
-                    )
-                    seq_row = conn.execute(
-                        "SELECT last_op_seq FROM record_seq "
-                        "WHERE txid_le = ? AND input_index = ?",
-                        (record.spend_txid, record.input_index),
-                    ).fetchone()
-                    if seq_row is None or seq_row[0] != record.op_seq:
-                        expected = (seq_row[0] + 1) if seq_row else 0
-                        raise AnalyzerError(
-                            f"CTX-OPERATIONS: op_seq contiguity violation for "
-                            f"txid={display_txid}, input_index={record.input_index}: "
-                            f"expected {expected}, got {record.op_seq}"
-                        )
-                    if op in (3, 4):
-                        if sig not in (0, 1):
-                            raise AnalyzerError(
-                                f"CTX-OPERATIONS: multisig record must have "
-                                f"sig_version BASE or WITNESS_V0, "
-                                f"got {_sig_version_name(sig)} for {identity_str}"
-                            )
-                        if ctx == SpendContext.BARE:
-                            if sig != 0:
-                                raise AnalyzerError(
-                                    f"CTX-OPERATIONS: bare multisig record has "
-                                    f"sig_version {_sig_version_name(sig)}, "
-                                    f"expected BASE for {identity_str}"
-                                )
-                            counts["bare_multisig_checks"] += 1
-                        elif ctx == SpendContext.P2SH:
-                            if sig != 0:
-                                raise AnalyzerError(
-                                    f"CTX-OPERATIONS: P2SH multisig record has "
-                                    f"sig_version {_sig_version_name(sig)}, "
-                                    f"expected BASE for {identity_str}"
-                                )
-                            counts["p2sh_multisig_checks"] += 1
-                        elif ctx == SpendContext.NATIVE_WITNESS_V0:
-                            if sig != 1:
-                                raise AnalyzerError(
-                                    f"CTX-OPERATIONS: native witness-v0 multisig "
-                                    f"record has sig_version "
-                                    f"{_sig_version_name(sig)}, "
-                                    f"expected WITNESS_V0 for {identity_str}"
-                                )
-                            counts["native_witness_v0_multisig_checks"] += 1
-                        elif ctx == SpendContext.P2SH_WRAPPED_WITNESS_V0:
-                            if sig != 1:
-                                raise AnalyzerError(
-                                    f"CTX-OPERATIONS: P2SH-wrapped witness-v0 "
-                                    f"multisig record has sig_version "
-                                    f"{_sig_version_name(sig)}, "
-                                    f"expected WITNESS_V0 for {identity_str}"
-                                )
-                            counts["p2sh_wrapped_witness_v0_multisig_checks"] += 1
-                        elif ctx in (
-                            SpendContext.TAPROOT_KEY_PATH,
-                            SpendContext.TAPSCRIPT,
-                        ):
-                            raise AnalyzerError(
-                                f"CTX-OPERATIONS: multisig record joined to a "
-                                f"Taproot input {identity_str}"
-                            )
-                        else:
-                            raise AnalyzerError(
-                                f"CTX-OPERATIONS: unknown spend context {ctx!r}"
-                            )
-                    elif op == 5:
-                        if sig != 2:
-                            raise AnalyzerError(
-                                f"CTX-OPERATIONS: CHECKSIGADD record must have "
-                                f"sig_version TAPSCRIPT, got "
-                                f"{_sig_version_name(sig)} for {identity_str}"
-                            )
-                        if ctx != SpendContext.TAPSCRIPT:
-                            raise AnalyzerError(
-                                f"CTX-OPERATIONS: CHECKSIGADD record joined to a "
-                                f"non-Tapscript input {identity_str}"
-                            )
-                        counts["tapscript_schnorr_checks"] += 1
-                        counts["tapscript_checksigadd_checks"] += 1
-                    elif op == 0:
-                        if sig != 3:
-                            raise AnalyzerError(
-                                f"CTX-OPERATIONS: key-path record must have "
-                                f"sig_version TAPROOT, got {_sig_version_name(sig)} "
-                                f"for {identity_str}"
-                            )
-                        if ctx != SpendContext.TAPROOT_KEY_PATH:
-                            raise AnalyzerError(
-                                f"CTX-OPERATIONS: key-path record joined to a "
-                                f"non-key-path input {identity_str}"
-                            )
-                    elif op in (1, 2):
-                        if sig == 2:
-                            if ctx != SpendContext.TAPSCRIPT:
-                                raise AnalyzerError(
-                                    f"CTX-OPERATIONS: Tapscript CHECKSIG record "
-                                    f"joined to a non-Tapscript input {identity_str}"
-                                )
-                            counts["tapscript_schnorr_checks"] += 1
-                        elif sig == 1:
-                            if ctx not in (
-                                SpendContext.NATIVE_WITNESS_V0,
-                                SpendContext.P2SH_WRAPPED_WITNESS_V0,
-                            ):
-                                raise AnalyzerError(
-                                    f"CTX-OPERATIONS: WITNESS_V0 CHECKSIG record "
-                                    f"joined to a non-witness-v0 input {identity_str}"
-                                )
-                        elif sig == 0:
-                            if ctx not in (SpendContext.BARE, SpendContext.P2SH):
-                                raise AnalyzerError(
-                                    f"CTX-OPERATIONS: BASE CHECKSIG record joined "
-                                    f"to a non-legacy input {identity_str}"
-                                )
-                        else:
-                            raise AnalyzerError(
-                                f"CTX-OPERATIONS: CHECKSIG record has unknown "
-                                f"sig_version {sig} for {identity_str}"
-                            )
-                    else:
-                        raise AnalyzerError(
-                            f"CTX-OPERATIONS: unknown op_kind {op} for {identity_str}"
-                        )
-                    record_streamed_count += 1
-                    # ── Global aggregate reconciliation ──
-                    outcome = record.outcome
-                    reject = record.reject_reason
-                    # ECDSA: op in (1,2,3,4) with sig in (0,1) → ECDSA verify
-                    is_ecdsa = op in (1, 2, 3, 4) and sig in (0, 1)
-                    is_schnorr = (op in (1, 2, 5) and sig == 2) or (
-                        op == 0 and sig == 3
-                    )
-                    # Native emission (instrumentation.diff): CheckECDSASignature
-                    # increments C_CHECKECDSA_ENTRIES on every entry; the bad-pubkey
-                    # (reject_reason 1), empty-sig (2), and missing-data (3) guards
-                    # return before C_ECDSA_VERIFY_CALLS. Only outcome 0/1 are
-                    # verify calls, with C_ECDSA_VERIFY_FAIL on outcome 0 (crypto
-                    # false) and C_ECDSA_VERIFY_OK on outcome 1.
-                    if is_ecdsa:
-                        agg_checkecdsa_entries += 1
-                        if outcome != 2:
-                            agg_ecdsa_calls += 1
-                            if outcome == 1:
-                                agg_ecdsa_ok += 1
-                            else:  # outcome == 0: verifier returned false
-                                agg_ecdsa_fail += 1
-                            # Per-key ECDSA verify-call tracking (verify calls
-                            # only; pre-verification rejects never reach the
-                            # verifier so they emit no record_ecdsa row).
-                            conn.execute(
-                                "INSERT INTO record_ecdsa (txid_le, input_index, calls, ok) "
-                                "VALUES (?, ?, 1, ?) "
-                                "ON CONFLICT(txid_le, input_index) DO UPDATE SET "
-                                "calls = calls + 1, ok = ok + excluded.ok",
-                                (
-                                    record.spend_txid,
-                                    record.input_index,
-                                    1 if outcome == 1 else 0,
-                                ),
-                            )
-                    # Native emission: CheckSchnorrSignature increments
-                    # C_CHECKSCHNORR_ENTRIES on entry (reject_reason 4..7 are rejects
-                    # inside it), but reject_reason 8 is a Tapscript empty-sig skip
-                    # emitted in EvalChecksigTapscript before the function is called,
-                    # so it is neither an entry nor a verify call. Verify calls are
-                    # outcome 0/1 with fail on outcome 0.
-                    if is_schnorr:
-                        if reject != 8:
-                            agg_checkschnorr_entries += 1
-                        if outcome != 2:
-                            agg_schnorr_calls += 1
-                            if outcome == 1:
-                                agg_schnorr_ok += 1
-                            else:  # outcome == 0
-                                agg_schnorr_fail += 1
-                    if outcome == 2 and reject <= 8:
-                        agg_rejects[reject] += 1
 
-            except sqlite3.IntegrityError as exc:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: duplicate record key in BRSREC1: {exc}"
-                ) from exc
-
-            if record_streamed_count != counters.record_count:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: BRSREC1 record count "
-                    f"{record_streamed_count} != counters.record_count "
-                    f"{counters.record_count}"
-                )
-            # ── Per-key op_seq contiguity proof via SQL ──
-            # For every (txid, input_index), count of record_keys must equal
-            # max(op_seq)+1 and min(op_seq) must be 0.
-            gap_count = conn.execute(
-                "SELECT COUNT(*) FROM ("
-                "  SELECT txid_le, input_index "
-                "  FROM record_keys "
-                "  GROUP BY txid_le, input_index "
-                "  HAVING COUNT(*) != MAX(op_seq) + 1 OR MIN(op_seq) != 0"
-                ")"
-            ).fetchone()[0]
-            if gap_count:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: op_seq contiguity proof failed: "
-                    f"{gap_count} key(s) with non-contiguous op_seq"
-                )
-            # Keys in record_ecdsa with mismatched journal values
-            ecdsa_mismatch = conn.execute(
-                "SELECT r.txid_le, r.input_index, r.calls, r.ok, "
-                "j.ecdsa_verify_calls, j.ecdsa_verify_ok "
-                "FROM record_ecdsa r "
-                "JOIN journal j "
-                "ON r.txid_le = j.txid_le AND r.input_index = j.input_index "
-                "WHERE r.calls != j.ecdsa_verify_calls "
-                "OR r.ok != j.ecdsa_verify_ok "
-                "LIMIT 1"
-            ).fetchone()
-            if ecdsa_mismatch is not None:
-                r_txid, r_idx, r_calls, r_ok, j_calls, j_ok = ecdsa_mismatch
-                display_txid = r_txid[::-1].hex()
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: ECDSA mismatch for "
-                    f"txid={display_txid}, input_index={r_idx}: "
-                    f"records calls={r_calls} ok={r_ok}, "
-                    f"journal calls={j_calls} ok={j_ok}"
-                )
-            # Keys in journal with ecdsa but missing from record_ecdsa
-            jrn_only_ecdsa = conn.execute(
-                "SELECT j.txid_le, j.input_index, j.ecdsa_verify_calls, "
-                "j.ecdsa_verify_ok "
-                "FROM journal j "
-                "WHERE (j.ecdsa_verify_calls > 0 OR j.ecdsa_verify_ok > 0) "
-                "AND NOT EXISTS ("
-                "  SELECT 1 FROM record_ecdsa r "
-                "  WHERE r.txid_le = j.txid_le AND r.input_index = j.input_index) "
-                "LIMIT 1"
-            ).fetchone()
-            if jrn_only_ecdsa is not None:
-                j_txid, j_idx, j_calls, j_ok = jrn_only_ecdsa
-                display_txid = j_txid[::-1].hex()
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: journal has ECDSA calls for "
-                    f"txid={display_txid}, input_index={j_idx} "
-                    f"but no ECDSA records found"
-                )
-
-            # ── Journal-sum reconciliation: SUM(checksig_ops) and SUM(checkmultisig_ops) ──
-            sum_checksig = conn.execute(
-                "SELECT COALESCE(SUM(checksig_ops), 0) FROM journal"
-            ).fetchone()[0]
-            if sum_checksig != counters.op_checksig + counters.op_checksigverify:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: SUM(checksig_ops) {sum_checksig} != "
-                    f"op_checksig + op_checksigverify "
-                    f"{counters.op_checksig + counters.op_checksigverify}"
-                )
-            sum_checkmultisig = conn.execute(
-                "SELECT COALESCE(SUM(checkmultisig_ops), 0) FROM journal"
-            ).fetchone()[0]
-            if (
-                sum_checkmultisig
-                != counters.op_checkmultisig + counters.op_checkmultisigverify
-            ):
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: SUM(checkmultisig_ops) {sum_checkmultisig} != "
-                    f"op_checkmultisig + op_checkmultisigverify "
-                    f"{counters.op_checkmultisig + counters.op_checkmultisigverify}"
-                )
-            # ── Global ECDSA/Schnorr/reject aggregate reconciliation ──
-            if agg_ecdsa_calls != counters.ecdsa_verify_calls:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: ecdsa_verify_calls mismatch: "
-                    f"records={agg_ecdsa_calls}, counters={counters.ecdsa_verify_calls}"
-                )
-            if agg_ecdsa_ok != counters.ecdsa_verify_ok:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: ecdsa_verify_ok mismatch: "
-                    f"records={agg_ecdsa_ok}, counters={counters.ecdsa_verify_ok}"
-                )
-            if agg_ecdsa_fail != counters.ecdsa_verify_fail:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: ecdsa_verify_fail mismatch: "
-                    f"records={agg_ecdsa_fail}, counters={counters.ecdsa_verify_fail}"
-                )
-            if agg_schnorr_calls != counters.schnorr_verify_calls:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: schnorr_verify_calls mismatch: "
-                    f"records={agg_schnorr_calls}, counters={counters.schnorr_verify_calls}"
-                )
-            if agg_schnorr_ok != counters.schnorr_verify_ok:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: schnorr_verify_ok mismatch: "
-                    f"records={agg_schnorr_ok}, counters={counters.schnorr_verify_ok}"
-                )
-            if agg_schnorr_fail != counters.schnorr_verify_fail:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: schnorr_verify_fail mismatch: "
-                    f"records={agg_schnorr_fail}, counters={counters.schnorr_verify_fail}"
-                )
-            if agg_checkecdsa_entries != counters.checkecdsa_entries:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: checkecdsa_entries mismatch: "
-                    f"records={agg_checkecdsa_entries}, counters={counters.checkecdsa_entries}"
-                )
-            if agg_checkschnorr_entries != counters.checkschnorr_entries:
-                raise AnalyzerError(
-                    f"CTX-OPERATIONS: checkschnorr_entries mismatch: "
-                    f"records={agg_checkschnorr_entries}, counters={counters.checkschnorr_entries}"
-                )
-            # Eight reject counters reconciliation
-            _reject_names = [
-                "checkecdsa_reject_pubkey",
-                "checkecdsa_reject_empty_sig",
-                "checkecdsa_reject_missing_data",
-            ]
-            # reject_reason 1..3 (1=bad pubkey, 2=empty sig, 3=missing data per
-            # instrumentation.diff) map to the three named ECDSA reject counters.
-            for i, name in enumerate(_reject_names):
-                if agg_rejects[i + 1] != getattr(counters, name):
+                try:
+                    journal_count = insert_bounded(
+                        "INSERT INTO journal VALUES (?, ?, ?, ?, ?, ?)", journal_rows()
+                    )
+                except sqlite3.IntegrityError as exc:
                     raise AnalyzerError(
-                        f"CTX-OPERATIONS: {name} mismatch: "
-                        f"records={agg_rejects[i + 1]}, counters={getattr(counters, name)}"
+                        f"CTX-EXECUTION: duplicate journal key in BRSJRN1: {exc}"
+                    ) from exc
+
+                if context_count != journal_count:
+                    raise AnalyzerError(
+                        f"CTX-EXECUTION: context count {context_count} != "
+                        f"journal count {journal_count}"
+                    )
+                if context_count != counters.ffi_verify_entries:
+                    raise AnalyzerError(
+                        f"CTX-EXECUTION: context count {context_count} != "
+                        f"counters.ffi_verify_entries {counters.ffi_verify_entries}"
+                    )
+                if journal_count != counters.ffi_verify_entries:
+                    raise AnalyzerError(
+                        f"CTX-EXECUTION: journal count {journal_count} != "
+                        f"counters.ffi_verify_entries {counters.ffi_verify_entries}"
+                    )
+                if context_count != counters.context_count:
+                    raise AnalyzerError(
+                        f"CTX-EXECUTION: context count {context_count} != "
+                        f"counters.context_count {counters.context_count}"
+                    )
+                if journal_count != counters.journal_count:
+                    raise AnalyzerError(
+                        f"CTX-EXECUTION: journal count {journal_count} != "
+                        f"counters.journal_count {counters.journal_count}"
                     )
 
-            conn.commit()
-        finally:
-            conn.close()
+                missing_journal = conn.execute(
+                    "SELECT COUNT(*) FROM ("
+                    " SELECT txid_le, input_index FROM contexts"
+                    " EXCEPT SELECT txid_le, input_index FROM journal"
+                    ")"
+                ).fetchone()[0]
+                if missing_journal:
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: {missing_journal} context key(s) not present in journal"
+                    )
+                missing_context = conn.execute(
+                    "SELECT COUNT(*) FROM ("
+                    " SELECT txid_le, input_index FROM journal"
+                    " EXCEPT SELECT txid_le, input_index FROM contexts"
+                    ")"
+                ).fetchone()[0]
+                if missing_context:
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: {missing_context} journal key(s) not present in contexts"
+                    )
 
-    # Contexts custody comes from the same single-open parse stream.
-    custody_meta: dict[str, dict[str, int]] = {
-        "contexts": contexts_custody,
-        "records": record_custody,
-        "journal": journal_custody,
-    }
-    return counts, context_count, custody_meta
+                spend_counts = dict(
+                    conn.execute(
+                        "SELECT spend_context, COUNT(*) FROM contexts GROUP BY spend_context"
+                    ).fetchall()
+                )
+                counts["p2sh_redeem_spends"] = spend_counts.get(
+                    SpendContext.P2SH.value, 0
+                )
+                counts["native_witness_v0_spends"] = spend_counts.get(
+                    SpendContext.NATIVE_WITNESS_V0.value, 0
+                )
+                counts["p2sh_wrapped_witness_v0_spends"] = spend_counts.get(
+                    SpendContext.P2SH_WRAPPED_WITNESS_V0.value, 0
+                )
+                counts["taproot_key_path_spends"] = spend_counts.get(
+                    SpendContext.TAPROOT_KEY_PATH.value, 0
+                )
+                counts["tapscript_spends"] = spend_counts.get(
+                    SpendContext.TAPSCRIPT.value, 0
+                )
+
+                record_iter, record_custody = iter_records_with_custody(records_path)
+
+                def record_rows() -> Iterator[tuple[object, ...]]:
+                    for stream_pos, record in enumerate(record_iter):
+                        yield (
+                            record.spend_txid,
+                            record.input_index,
+                            record.op_seq,
+                            stream_pos,
+                            record.op_kind,
+                            record.sig_version,
+                            record.outcome,
+                            record.reject_reason,
+                        )
+
+                try:
+                    record_count = insert_bounded(
+                        "INSERT INTO records VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        record_rows(),
+                    )
+                except sqlite3.IntegrityError as exc:
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: duplicate record key in BRSREC1: {exc}"
+                    ) from exc
+
+                # ── Set-based discovery of the earliest per-record semantic failure.
+                #    The old streaming loop checked each record in stream order, then
+                #    within a record in this priority: orphan, then op_seq sequence,
+                #    then op/sig/context legality.  We preserve the same ordering by
+                #    selecting the globally earliest (stream_pos, category_priority)
+                #    candidate from three bounded LIMIT 1 queries.
+                record_failures: list[tuple[int, int, tuple[object, ...], str]] = []
+
+                orphan = conn.execute(
+                    "SELECT r.txid_le, r.input_index, r.stream_pos FROM records r "
+                    "LEFT JOIN contexts c ON c.txid_le=r.txid_le AND c.input_index=r.input_index "
+                    "WHERE c.txid_le IS NULL ORDER BY r.stream_pos LIMIT 1"
+                ).fetchone()
+                if orphan is not None:
+                    record_failures.append((orphan[2], 0, orphan[:2], "orphan"))
+
+                sequence_error = conn.execute(
+                    "WITH ordered AS ("
+                    " SELECT txid_le, input_index, op_seq, stream_pos,"
+                    " ROW_NUMBER() OVER (PARTITION BY txid_le, input_index ORDER BY stream_pos)-1 expected"
+                    " FROM records"
+                    ") SELECT txid_le, input_index, expected, op_seq, stream_pos FROM ordered"
+                    " WHERE op_seq != expected ORDER BY stream_pos LIMIT 1"
+                ).fetchone()
+                if sequence_error is not None:
+                    record_failures.append(
+                        (sequence_error[4], 1, sequence_error[:4], "sequence")
+                    )
+
+                invalid = conn.execute(
+                    "WITH classified AS ("
+                    " SELECT r.*, c.spend_context, CASE"
+                    " WHEN op_kind IN (3,4) AND sig_version NOT IN (0,1) THEN 'multisig_sig'"
+                    " WHEN op_kind IN (3,4) AND spend_context='bare' AND sig_version!=0 THEN 'bare_multisig'"
+                    " WHEN op_kind IN (3,4) AND spend_context='p2sh' AND sig_version!=0 THEN 'p2sh_multisig'"
+                    " WHEN op_kind IN (3,4) AND spend_context='native_witness_v0' AND sig_version!=1 THEN 'native_multisig'"
+                    " WHEN op_kind IN (3,4) AND spend_context='p2sh_wrapped_witness_v0' AND sig_version!=1 THEN 'wrapped_multisig'"
+                    " WHEN op_kind IN (3,4) AND spend_context IN ('taproot_key_path','tapscript') THEN 'taproot_multisig'"
+                    " WHEN op_kind=5 AND sig_version!=2 THEN 'checksigadd_sig'"
+                    " WHEN op_kind=5 AND spend_context!='tapscript' THEN 'checksigadd_context'"
+                    " WHEN op_kind=0 AND sig_version!=3 THEN 'keypath_sig'"
+                    " WHEN op_kind=0 AND spend_context!='taproot_key_path' THEN 'keypath_context'"
+                    " WHEN op_kind IN (1,2) AND sig_version=2 AND spend_context!='tapscript' THEN 'tapscript_checksig'"
+                    " WHEN op_kind IN (1,2) AND sig_version=1 AND spend_context NOT IN ('native_witness_v0','p2sh_wrapped_witness_v0') THEN 'witness_checksig'"
+                    " WHEN op_kind IN (1,2) AND sig_version=0 AND spend_context NOT IN ('bare','p2sh') THEN 'base_checksig'"
+                    " WHEN op_kind IN (1,2) AND sig_version NOT IN (0,1,2) THEN 'unknown_checksig'"
+                    " WHEN op_kind NOT IN (0,1,2,3,4,5) THEN 'unknown_op' END error_code"
+                    " FROM records r JOIN contexts c"
+                    " ON c.txid_le=r.txid_le AND c.input_index=r.input_index"
+                    ") SELECT txid_le,input_index,op_kind,sig_version,spend_context,error_code,stream_pos"
+                    " FROM classified WHERE error_code IS NOT NULL"
+                    " ORDER BY stream_pos LIMIT 1"
+                ).fetchone()
+                if invalid is not None:
+                    record_failures.append((invalid[6], 2, invalid[:6], "invalid"))
+
+                if record_failures:
+                    record_failures.sort(key=lambda row: (row[0], row[1]))
+                    _, _, row, kind = record_failures[0]
+                    if kind == "orphan":
+                        txid_le, input_index = row
+                        raise AnalyzerError(
+                            "CTX-OPERATIONS: BRSREC1 record has no matching "
+                            f"context identity: txid={txid_le[::-1].hex()}, "
+                            f"input_index={input_index}"
+                        )
+                    if kind == "sequence":
+                        txid_le, input_index, expected, actual = row
+                        raise AnalyzerError(
+                            "CTX-OPERATIONS: op_seq contiguity violation for "
+                            f"txid={txid_le[::-1].hex()}, input_index={input_index}: "
+                            f"expected {expected}, got {actual}"
+                        )
+                    # kind == "invalid"
+                    txid_le, input_index, op, sig, _ctx_name, error_code = row
+                    identity = f"txid={txid_le[::-1].hex()}, input_index={input_index}"
+                    sig_name = _sig_version_name(sig)
+                    if error_code == "multisig_sig":
+                        message = f"multisig record must have sig_version BASE or WITNESS_V0, got {sig_name} for {identity}"
+                    elif error_code == "bare_multisig":
+                        message = f"bare multisig record has sig_version {sig_name}, expected BASE for {identity}"
+                    elif error_code == "p2sh_multisig":
+                        message = f"P2SH multisig record has sig_version {sig_name}, expected BASE for {identity}"
+                    elif error_code == "native_multisig":
+                        message = f"native witness-v0 multisig record has sig_version {sig_name}, expected WITNESS_V0 for {identity}"
+                    elif error_code == "wrapped_multisig":
+                        message = f"P2SH-wrapped witness-v0 multisig record has sig_version {sig_name}, expected WITNESS_V0 for {identity}"
+                    elif error_code == "taproot_multisig":
+                        message = (
+                            f"multisig record joined to a Taproot input {identity}"
+                        )
+                    elif error_code == "checksigadd_sig":
+                        message = f"CHECKSIGADD record must have sig_version TAPSCRIPT, got {sig_name} for {identity}"
+                    elif error_code == "checksigadd_context":
+                        message = f"CHECKSIGADD record joined to a non-Tapscript input {identity}"
+                    elif error_code == "keypath_sig":
+                        message = f"key-path record must have sig_version TAPROOT, got {sig_name} for {identity}"
+                    elif error_code == "keypath_context":
+                        message = (
+                            f"key-path record joined to a non-key-path input {identity}"
+                        )
+                    elif error_code == "tapscript_checksig":
+                        message = f"Tapscript CHECKSIG record joined to a non-Tapscript input {identity}"
+                    elif error_code == "witness_checksig":
+                        message = f"WITNESS_V0 CHECKSIG record joined to a non-witness-v0 input {identity}"
+                    elif error_code == "base_checksig":
+                        message = f"BASE CHECKSIG record joined to a non-legacy input {identity}"
+                    elif error_code == "unknown_checksig":
+                        message = f"CHECKSIG record has unknown sig_version {sig} for {identity}"
+                    else:
+                        message = f"unknown op_kind {op} for {identity}"
+                    raise AnalyzerError(f"CTX-OPERATIONS: {message}")
+
+                if record_count != counters.record_count:
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: BRSREC1 record count {record_count} != "
+                        f"counters.record_count {counters.record_count}"
+                    )
+
+                gap_count = conn.execute(
+                    "SELECT COUNT(*) FROM ("
+                    " SELECT txid_le, input_index FROM records"
+                    " GROUP BY txid_le, input_index"
+                    " HAVING COUNT(*) != MAX(op_seq)+1 OR MIN(op_seq) != 0"
+                    ")"
+                ).fetchone()[0]
+                if gap_count:
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: op_seq contiguity proof failed: "
+                        f"{gap_count} key(s) with non-contiguous op_seq"
+                    )
+
+                record_tallies = conn.execute(
+                    "SELECT"
+                    " SUM(op_kind IN (3,4) AND spend_context='bare'),"
+                    " SUM(op_kind IN (3,4) AND spend_context='p2sh'),"
+                    " SUM(op_kind IN (3,4) AND spend_context='native_witness_v0'),"
+                    " SUM(op_kind IN (3,4) AND spend_context='p2sh_wrapped_witness_v0'),"
+                    " SUM((op_kind=5 OR (op_kind IN (1,2) AND sig_version=2)) AND spend_context='tapscript'),"
+                    " SUM(op_kind=5 AND spend_context='tapscript')"
+                    " FROM records JOIN contexts USING(txid_le,input_index)"
+                ).fetchone()
+                for name, value in zip(
+                    (
+                        "bare_multisig_checks",
+                        "p2sh_multisig_checks",
+                        "native_witness_v0_multisig_checks",
+                        "p2sh_wrapped_witness_v0_multisig_checks",
+                        "tapscript_schnorr_checks",
+                        "tapscript_checksigadd_checks",
+                    ),
+                    record_tallies,
+                ):
+                    counts[name] = value or 0
+
+                aggregate = conn.execute(
+                    "SELECT"
+                    " SUM(op_kind IN (1,2,3,4) AND sig_version IN (0,1) AND outcome!=2),"
+                    " SUM(op_kind IN (1,2,3,4) AND sig_version IN (0,1) AND outcome=1),"
+                    " SUM(op_kind IN (1,2,3,4) AND sig_version IN (0,1) AND outcome=0),"
+                    " SUM(((op_kind IN (1,2,5) AND sig_version=2) OR (op_kind=0 AND sig_version=3)) AND outcome!=2),"
+                    " SUM(((op_kind IN (1,2,5) AND sig_version=2) OR (op_kind=0 AND sig_version=3)) AND outcome=1),"
+                    " SUM(((op_kind IN (1,2,5) AND sig_version=2) OR (op_kind=0 AND sig_version=3)) AND outcome=0),"
+                    " SUM(op_kind IN (1,2,3,4) AND sig_version IN (0,1)),"
+                    " SUM(((op_kind IN (1,2,5) AND sig_version=2) OR (op_kind=0 AND sig_version=3)) AND reject_reason!=8),"
+                    " SUM(reject_reason=1), SUM(reject_reason=2), SUM(reject_reason=3)"
+                    " FROM records"
+                ).fetchone()
+                (
+                    agg_ecdsa_calls,
+                    agg_ecdsa_ok,
+                    agg_ecdsa_fail,
+                    agg_schnorr_calls,
+                    agg_schnorr_ok,
+                    agg_schnorr_fail,
+                    agg_checkecdsa_entries,
+                    agg_checkschnorr_entries,
+                    reject_pubkey,
+                    reject_empty_sig,
+                    reject_missing_data,
+                ) = (value or 0 for value in aggregate)
+
+                ecdsa_mismatch = conn.execute(
+                    "WITH e AS ("
+                    " SELECT txid_le,input_index,"
+                    " SUM(outcome!=2) calls,SUM(outcome=1) ok FROM records"
+                    " WHERE op_kind IN (1,2,3,4) AND sig_version IN (0,1)"
+                    " GROUP BY txid_le,input_index"
+                    ") SELECT e.txid_le,e.input_index,e.calls,e.ok,j.ecdsa_verify_calls,j.ecdsa_verify_ok"
+                    " FROM e JOIN journal j USING(txid_le,input_index)"
+                    " WHERE e.calls!=j.ecdsa_verify_calls OR e.ok!=j.ecdsa_verify_ok LIMIT 1"
+                ).fetchone()
+                if ecdsa_mismatch is not None:
+                    txid_le, input_index, r_calls, r_ok, j_calls, j_ok = ecdsa_mismatch
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: ECDSA mismatch for txid={txid_le[::-1].hex()}, "
+                        f"input_index={input_index}: records calls={r_calls} ok={r_ok}, "
+                        f"journal calls={j_calls} ok={j_ok}"
+                    )
+                journal_only_ecdsa = conn.execute(
+                    "WITH e AS ("
+                    " SELECT txid_le,input_index FROM records"
+                    " WHERE op_kind IN (1,2,3,4) AND sig_version IN (0,1)"
+                    " GROUP BY txid_le,input_index"
+                    ") SELECT j.txid_le,j.input_index,j.ecdsa_verify_calls,j.ecdsa_verify_ok"
+                    " FROM journal j LEFT JOIN e USING(txid_le,input_index)"
+                    " WHERE (j.ecdsa_verify_calls>0 OR j.ecdsa_verify_ok>0) AND e.txid_le IS NULL"
+                    " LIMIT 1"
+                ).fetchone()
+                if journal_only_ecdsa is not None:
+                    txid_le, input_index, _calls, _ok = journal_only_ecdsa
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: journal has ECDSA calls for "
+                        f"txid={txid_le[::-1].hex()}, input_index={input_index} "
+                        "but no ECDSA records found"
+                    )
+
+                sum_checksig, sum_checkmultisig = conn.execute(
+                    "SELECT COALESCE(SUM(checksig_ops),0),"
+                    " COALESCE(SUM(checkmultisig_ops),0) FROM journal"
+                ).fetchone()
+                if sum_checksig != counters.op_checksig + counters.op_checksigverify:
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: SUM(checksig_ops) {sum_checksig} != "
+                        f"op_checksig + op_checksigverify "
+                        f"{counters.op_checksig + counters.op_checksigverify}"
+                    )
+                if (
+                    sum_checkmultisig
+                    != counters.op_checkmultisig + counters.op_checkmultisigverify
+                ):
+                    raise AnalyzerError(
+                        f"CTX-OPERATIONS: SUM(checkmultisig_ops) {sum_checkmultisig} != "
+                        f"op_checkmultisig + op_checkmultisigverify "
+                        f"{counters.op_checkmultisig + counters.op_checkmultisigverify}"
+                    )
+
+                reconciliations = (
+                    (
+                        "ecdsa_verify_calls",
+                        agg_ecdsa_calls,
+                        counters.ecdsa_verify_calls,
+                    ),
+                    ("ecdsa_verify_ok", agg_ecdsa_ok, counters.ecdsa_verify_ok),
+                    ("ecdsa_verify_fail", agg_ecdsa_fail, counters.ecdsa_verify_fail),
+                    (
+                        "schnorr_verify_calls",
+                        agg_schnorr_calls,
+                        counters.schnorr_verify_calls,
+                    ),
+                    ("schnorr_verify_ok", agg_schnorr_ok, counters.schnorr_verify_ok),
+                    (
+                        "schnorr_verify_fail",
+                        agg_schnorr_fail,
+                        counters.schnorr_verify_fail,
+                    ),
+                    (
+                        "checkecdsa_entries",
+                        agg_checkecdsa_entries,
+                        counters.checkecdsa_entries,
+                    ),
+                    (
+                        "checkschnorr_entries",
+                        agg_checkschnorr_entries,
+                        counters.checkschnorr_entries,
+                    ),
+                )
+                for name, actual, expected in reconciliations:
+                    if actual != expected:
+                        raise AnalyzerError(
+                            f"CTX-OPERATIONS: {name} mismatch: records={actual}, counters={expected}"
+                        )
+                for name, actual in zip(
+                    (
+                        "checkecdsa_reject_pubkey",
+                        "checkecdsa_reject_empty_sig",
+                        "checkecdsa_reject_missing_data",
+                    ),
+                    (reject_pubkey, reject_empty_sig, reject_missing_data),
+                ):
+                    expected = getattr(counters, name)
+                    if actual != expected:
+                        raise AnalyzerError(
+                            f"CTX-OPERATIONS: {name} mismatch: records={actual}, counters={expected}"
+                        )
+                conn.commit()
+            finally:
+                if conn is not None:
+                    conn.close()
+
+    finally:
+        if saved_sqlite_tmpdir is not None:
+            os.environ["SQLITE_TMPDIR"] = saved_sqlite_tmpdir
+        else:
+            os.environ.pop("SQLITE_TMPDIR", None)
+        if saved_tmpdir is not None:
+            os.environ["TMPDIR"] = saved_tmpdir
+        else:
+            os.environ.pop("TMPDIR", None)
+
+    return (
+        counts,
+        context_count,
+        {
+            "contexts": contexts_custody,
+            "records": record_custody,
+            "journal": journal_custody,
+        },
+    )
 
 
 def _c150_passed(counts: dict[str, int], counters: Counters) -> bool:
@@ -2937,7 +2930,11 @@ def cmd_classify_corpus(args: argparse.Namespace) -> int:
 
     # ── Run disk-backed counter computation (returns custody for ctx/rec/jrn) ──
     counts, context_count, bin_custody = _count_context_records_disk(
-        contexts_path, records_path, journal_path, counters
+        contexts_path,
+        records_path,
+        journal_path,
+        counters,
+        Path(args.scratch_dir) if getattr(args, "scratch_dir", None) else None,
     )
 
     # ── Assemble custody from parser-returned metadata ──
@@ -3196,6 +3193,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         type=int,
         help="optional cross-check: expected BRSCTX1 row count (BRSCTX1 file is authoritative)",
+    )
+    cc.add_argument(
+        "--scratch-dir",
+        default=None,
+        help="optional writable directory for the classifier database and SQLite temporary files",
     )
     cc.set_defaults(func=cmd_classify_corpus)
 

--- a/tools/checksig-census/bare-secp/src/main.rs
+++ b/tools/checksig-census/bare-secp/src/main.rs
@@ -56,6 +56,38 @@ const COUNTER_NAMES: [&str; 24] = [
 
 // ── Entry point ────────────────────────────────────────────────────────────
 
+fn record_to_bare_input(
+    rec: &ParsedRecord,
+) -> Result<Option<libbitcoinkernel_sys::btck_bare_input>> {
+    // Outcome-2 records are pre-verification rejects and carry no sighash.
+    // They must be skipped before any capacity-indexed public-key slice.
+    if rec.outcome == 2 {
+        return Ok(None);
+    }
+    // parse_record already enforces these bounds for non-exempt records,
+    // but the helper keeps the slice contract self-contained.
+    if rec.der_len > 72 {
+        bail!("record: der_len {} exceeds 72", rec.der_len);
+    }
+    if rec.pubkey_len > 65 {
+        bail!("record: pubkey_len {} exceeds 65", rec.pubkey_len);
+    }
+
+    let mut input = libbitcoinkernel_sys::btck_bare_input {
+        sighash: [0u8; 32],
+        der_sig: [0u8; 72],
+        pubkey: [0u8; 65],
+        der_len: rec.der_len,
+        pubkey_len: rec.pubkey_len,
+        expected: rec.outcome, // 1=true, 0=false
+        pad: [0u8; 4],
+    };
+    input.sighash.copy_from_slice(&rec.sighash);
+    input.der_sig[..rec.der_len as usize].copy_from_slice(&rec.der_sig[..rec.der_len as usize]);
+    input.pubkey[..rec.pubkey_len as usize].copy_from_slice(&rec.pubkey[..rec.pubkey_len as usize]);
+    Ok(Some(input))
+}
+
 fn main() -> Result<()> {
     let args = Args::parse(std::env::args_os().skip(1))?;
 
@@ -70,24 +102,10 @@ fn main() -> Result<()> {
     let mut inputs: Vec<libbitcoinkernel_sys::btck_bare_input> = Vec::with_capacity(records.len());
     let mut rejected: u64 = 0;
     for rec in &records {
-        if rec.outcome == 2 {
-            rejected += 1;
-            continue;
+        match record_to_bare_input(rec)? {
+            None => rejected += 1,
+            Some(input) => inputs.push(input),
         }
-        let mut input = libbitcoinkernel_sys::btck_bare_input {
-            sighash: [0u8; 32],
-            der_sig: [0u8; 72],
-            pubkey: [0u8; 65],
-            der_len: rec.der_len,
-            pubkey_len: rec.pubkey_len,
-            expected: rec.outcome, // 1=true, 0=false
-            pad: [0u8; 4],
-        };
-        input.sighash.copy_from_slice(&rec.sighash);
-        input.der_sig[..rec.der_len as usize].copy_from_slice(&rec.der_sig[..rec.der_len as usize]);
-        input.pubkey[..rec.pubkey_len as usize]
-            .copy_from_slice(&rec.pubkey[..rec.pubkey_len as usize]);
-        inputs.push(input);
     }
     let expected_true_count: u64 = inputs.iter().filter(|inp| inp.expected == 1).count() as u64;
 
@@ -351,16 +369,57 @@ struct ParsedRecord {
     pubkey_len: u8,
     outcome: u8,
 }
+
+/// Exact over-capacity ECDSA reject shape accepted by the bare-secp reader.
+/// Native reason-1 records may preserve the original (>=66) pubkey_len only
+/// for outcome 2 with a null payload and unchanged padding.
+fn is_exempt_over_capacity_ecdsa_reject(buf: &[u8; RECORD_SIZE]) -> bool {
+    if !(1..=4).contains(&buf[40]) {
+        return false;
+    } // op_kind
+    if !(0..=1).contains(&buf[41]) {
+        return false;
+    } // sig_version
+    if buf[42] != 2 {
+        return false;
+    } // outcome
+    if buf[43] != 0 {
+        return false;
+    } // der_len
+    if buf[45] != 0 {
+        return false;
+    } // sighash_type
+    if buf[46] != 1 {
+        return false;
+    } // reject_reason
+    if buf[47] != 0 {
+        return false;
+    } // _pad0
+    if buf[48..80] != [0; 32] {
+        return false;
+    } // sighash
+    if buf[80..152] != [0; 72] {
+        return false;
+    } // der_sig
+    if buf[152..217] != [0; 65] {
+        return false;
+    } // pubkey
+    if buf[217..224] != [0; 7] {
+        return false;
+    } // _pad1
+    true
+}
+
 fn parse_record(buf: &[u8; RECORD_SIZE], index: u64) -> Result<ParsedRecord> {
     let outcome = buf[42];
     let der_len = buf[43];
     let pubkey_len = buf[44];
 
+    if pubkey_len > 65 && !is_exempt_over_capacity_ecdsa_reject(buf) {
+        bail!("record {index}: pubkey_len {pubkey_len} exceeds 65");
+    }
     if der_len > 72 {
         bail!("record {index}: der_len {der_len} exceeds 72");
-    }
-    if pubkey_len > 65 {
-        bail!("record {index}: pubkey_len {pubkey_len} exceeds 65");
     }
     if outcome > 2 {
         bail!("record {index}: outcome {outcome} exceeds 2");
@@ -547,5 +606,129 @@ mod tests {
             libbitcoinkernel_sys::btck_bare_verify_bench(&input, 1, 0, 1, 0, &mut result)
         };
         assert_eq!(rc, -1);
+    }
+
+    fn preserved_over_capacity_row() -> [u8; RECORD_SIZE] {
+        let mut buf = [0u8; RECORD_SIZE];
+        let prefix: [u8; 48] = [
+            0xcf, 0x42, 0xbd, 0x87, 0xb9, 0x98, 0x25, 0x95, 0xbf, 0x2d, 0x35, 0x4c, 0x5f, 0x75,
+            0x8c, 0x14, 0x4d, 0x66, 0x33, 0x01, 0xce, 0xfc, 0x3b, 0x31, 0xad, 0x31, 0x32, 0xf8,
+            0x7f, 0x49, 0x18, 0xd1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00,
+            0x02, 0x00, 0x42, 0x00, 0x01, 0x00,
+        ];
+        buf[..48].copy_from_slice(&prefix);
+        buf
+    }
+
+    #[test]
+    fn parse_accepts_preserved_over_capacity_ecdsa_reject() {
+        let buf = preserved_over_capacity_row();
+        let rec = parse_record(&buf, 0).unwrap();
+        assert_eq!(rec.outcome, 2);
+        assert_eq!(rec.der_len, 0);
+        assert_eq!(rec.pubkey_len, 66);
+        assert_eq!(rec.sighash, [0; 32]);
+        assert_eq!(rec.der_sig, [0; 72]);
+        assert_eq!(rec.pubkey, [0; 65]);
+    }
+
+    #[test]
+    fn parse_rejects_over_capacity_near_misses() {
+        let base = preserved_over_capacity_row();
+        let mutations: [(usize, u8, &str); 19] = [
+            (40, 0, "op_kind=0"),
+            (40, 5, "op_kind=5"),
+            (41, 2, "sig_version=2"),
+            (41, 3, "sig_version=3"),
+            (42, 0, "outcome=0"),
+            (42, 1, "outcome=1"),
+            (43, 1, "der_len=1"),
+            (43, 73, "der_len=73"),
+            (45, 1, "sighash_type=1"),
+            (46, 0, "reject_reason=0"),
+            (46, 2, "reject_reason=2"),
+            (46, 3, "reject_reason=3"),
+            (46, 4, "reject_reason=4"),
+            (46, 5, "reject_reason=5"),
+            (46, 6, "reject_reason=6"),
+            (46, 7, "reject_reason=7"),
+            (46, 8, "reject_reason=8"),
+            (47, 1, "nonzero _pad0"),
+            (80, 1, "nonzero der_sig byte"),
+        ];
+        for (offset, value, label) in mutations {
+            let mut buf = base;
+            buf[offset] = value;
+            let err = match parse_record(&buf, 0) {
+                Err(e) => e.to_string(),
+                Ok(_) => panic!("{label} should have failed"),
+            };
+            assert!(
+                err.contains("pubkey_len 66 exceeds 65"),
+                "{label} should fail with length error, got: {err}"
+            );
+        }
+
+        for offset in [48, 79, 80, 151, 152, 216, 217, 223] {
+            let mut buf = base;
+            buf[offset] = 1;
+            let err = match parse_record(&buf, 0) {
+                Err(e) => e.to_string(),
+                Ok(_) => panic!("byte {offset} should have failed"),
+            };
+            assert!(
+                err.contains("pubkey_len 66 exceeds 65"),
+                "byte {offset} should fail with length error, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn load_records_accepts_preserved_over_capacity_reject() {
+        // Build a minimal BRSREC1 fixture with the exact over-capacity row.
+        let path = std::env::temp_dir().join(format!(
+            "checksig_bare_secp_preserved_row_{}.bin",
+            std::process::id()
+        ));
+        let mut file = std::fs::File::create(&path).unwrap();
+        std::io::Write::write_all(&mut file, RECORD_MAGIC).unwrap();
+        std::io::Write::write_all(&mut file, &1u64.to_le_bytes()).unwrap();
+        std::io::Write::write_all(&mut file, &preserved_over_capacity_row()).unwrap();
+        drop(file);
+
+        let records = load_records(&path).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].outcome, 2);
+        assert_eq!(records[0].pubkey_len, 66);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn record_to_bare_input_skips_over_capacity_outcome_two() {
+        // The exact over-capacity reason-1 record is outcome 2, so the
+        // production helper must return None before any capacity-indexed
+        // public-key slice. Removing the outcome-2 guard would make this
+        // test panic because pubkey_len (66) exceeds the fixed 65-byte array.
+        let rec = parse_record(&preserved_over_capacity_row(), 0).unwrap();
+        assert_eq!(rec.outcome, 2);
+        assert!(rec.pubkey_len > 65);
+        let input = record_to_bare_input(&rec).unwrap();
+        assert!(
+            input.is_none(),
+            "outcome-2 record must be skipped before copy"
+        );
+    }
+
+    #[test]
+    fn record_to_bare_input_accepts_ordinary_record() {
+        // Ordinary outcome-1 records are converted to a real FFI input.
+        let buf = valid_buf();
+        let rec = parse_record(&buf, 0).unwrap();
+        assert_eq!(rec.outcome, 1);
+        let input = record_to_bare_input(&rec).unwrap().unwrap();
+        assert_eq!(input.expected, 1);
+        assert_eq!(input.der_len, 72);
+        assert_eq!(input.pubkey_len, 65);
     }
 }

--- a/tools/checksig-census/bare-secp/src/main.rs
+++ b/tools/checksig-census/bare-secp/src/main.rs
@@ -27,7 +27,7 @@ const SUMMARY_SCHEMA: u32 = 1;
 /// Record size must match the native CensusRecord (224 bytes).
 const RECORD_SIZE: usize = 224;
 /// Counter names in the exact order defined by the census contract.
-const COUNTER_NAMES: [&str; 22] = [
+const COUNTER_NAMES: [&str; 24] = [
     "verify_script_calls",
     "ffi_verify_entries",
     "ffi_verify_true",
@@ -50,6 +50,8 @@ const COUNTER_NAMES: [&str; 22] = [
     "sighash_midstate_hit",
     "checkschnorr_entries",
     "schnorr_verify_calls",
+    "schnorr_verify_ok",
+    "schnorr_verify_fail",
 ];
 
 // ── Entry point ────────────────────────────────────────────────────────────
@@ -64,7 +66,7 @@ fn main() -> Result<()> {
     }
 
     // Convert records to btck_bare_input array.
-    // Only records with outcome != 2 (pre-secp reject) have valid sighash/der/pubkey.
+    // Only records with outcome != 2 (pre-verification reject) have a verification sighash.
     let mut inputs: Vec<libbitcoinkernel_sys::btck_bare_input> = Vec::with_capacity(records.len());
     let mut rejected: u64 = 0;
     for rec in &records {
@@ -124,9 +126,9 @@ fn main() -> Result<()> {
     }
 
     // Verify counters stayed zero.
-    let mut counters = [0u64; 22];
+    let mut counters = [0u64; 24];
     unsafe {
-        libbitcoinkernel_sys::btck_census_snapshot(counters.as_mut_ptr(), 22);
+        libbitcoinkernel_sys::btck_census_snapshot(counters.as_mut_ptr(), 24);
     }
     let counters_nonzero: u64 = counters.iter().map(|&v| v.min(1)).sum();
     if counters_nonzero != 0 {

--- a/tools/checksig-census/capture/src/main.rs
+++ b/tools/checksig-census/capture/src/main.rs
@@ -1,52 +1,120 @@
 //! CHECKSIG census capture harness.
 //!
 //! Reads a KSPIKE1 corpus and verifies every non-coinbase input exactly once
-//! through the production `KernelContext::verify_tx` path, using per-height
-//! flags derived identically to `compute_verify_flags` in
-//! `crates/node/src/apply.rs`. No width loop, no Rayon pools, no timers, and
+//! through the production `KernelContext::verify_tx` path, using the mainnet
+//! activation-height fallback that matches production on the active chain.
+//! No width loop, no Rayon pools, no timers, and
 //! no preliminary correctness pass — each input is verified once and only
 //! once.
 //!
 //! Adapted from `crates/consensus/examples/kernel_verify_spike.rs`, with the
 //! extraction phase, width loop, parallel pools, timing, and untimed pre-pass
-//! removed. The corpus format and production flag derivation are preserved
-//! exactly.
+//! removed. The corpus format and standalone activation-height fallback are
+//! preserved.
 //!
-//! CLI: `--corpus PATH [--output PATH]`. Emits a concise JSON summary to
-//! `--output` if given, otherwise stdout. A verification failure prints
-//! height, tx index, and input index to stderr and exits non-zero.
+//! CLI:
+//!   --corpus PATH                (required) KSPIKE1 corpus file
+//!   --output PATH                JSON summary file (default: stdout)
+//!   --start HEIGHT               first block height to include [0]
+//!   --stop HEIGHT                last block height to include [u32::MAX]
+//!   --counters PATH              native census counters JSON output
+//!   --journal PATH               native census journal binary output
+//!   --context-sidecar PATH       per-input context JSONL sidecar
+//!
+//! The native census sink paths are wired through the BRS_CENSUS_* environment
+//! variables when no explicit path is given; when a path is given it is both
+//! exported to the environment and recorded in the summary.  The context
+//! sidecar is always written; if `--context-sidecar` is omitted it is derived
+//! from `--output` (or `--corpus` if no output is given).
+//!
+//! A verification failure prints height, tx index, and input index to stderr
+//! and exits non-zero.
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use std::ffi::OsString;
-use std::io::{BufReader, Read as _};
+use std::io::{BufReader, BufWriter, Read as _, Write as _};
 use std::path::PathBuf;
 
 use anyhow::{Context as _, Result, bail};
 use bitcoin::consensus::Decodable as _;
+use bitcoin::hashes::{Hash as _, HashEngine as _, sha256};
+use bitcoin::hex::DisplayHex as _;
 use bitcoin::{Amount, OutPoint, ScriptBuf, TxOut};
 use bitcoin_rs_consensus::ConsensusError;
 use bitcoin_rs_consensus::UtxoView;
 use bitcoin_rs_consensus::kernel::KernelContext;
-use bitcoin_rs_primitives::{Network, Tx};
+use bitcoin_rs_primitives::{Hash256, Network, Tx};
 use bitcoin_rs_script::VerifyFlags;
 use serde_json::json;
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const CORPUS_MAGIC: &[u8; 8] = b"KSPIKE1\0";
-const SUMMARY_SCHEMA: u32 = 1;
+const SIDECAR_SCHEMA: &str = "census-context-input-v1";
+const SUMMARY_SCHEMA: &str = "census-capture-v2";
 
 /// Maximum acceptable length for a single `read_bytes` blob (4 MiB). Block
 /// bytes are at most ~4 MiB with segwit; scriptPubKeys are far smaller. This
 /// guards against a corrupted count field triggering an absurd allocation.
 const MAX_BLOB_LEN: usize = 4 * 1024 * 1024;
 
+const CENSUS_COUNTERS_ENV: &str = "BRS_CENSUS_COUNTERS";
+const CENSUS_JOURNAL_ENV: &str = "BRS_CENSUS_JOURNAL";
+
 // ── Entry point ────────────────────────────────────────────────────────────
 
 fn main() -> Result<()> {
     let args = Args::parse(std::env::args_os().skip(1))?;
 
+    // Resolve the sidecar path before anything else so we can fail early.
+    let sidecar_path = args
+        .context_sidecar
+        .clone()
+        .unwrap_or_else(|| resolve_default_sidecar(&args.corpus, args.output.as_ref()));
+    ensure_parent(&sidecar_path)?;
+
+    // The harness is still single-threaded here. Configure the native sinks
+    // before the kernel or any worker pool can read the process environment.
+    if let Some(path) = &args.counters {
+        ensure_parent(path)?;
+        // SAFETY: no other thread can access the environment before this call.
+        unsafe { std::env::set_var(CENSUS_COUNTERS_ENV, path.as_os_str()) };
+    }
+    if let Some(path) = &args.journal {
+        ensure_parent(path)?;
+        // SAFETY: no other thread can access the environment before this call.
+        unsafe { std::env::set_var(CENSUS_JOURNAL_ENV, path.as_os_str()) };
+    }
+
+    let (corpus_size, corpus_sha256) = sha256_file(&args.corpus)?;
     let corpus = load_corpus(&args.corpus)?;
+    let (corpus_min, corpus_max) = corpus_height_range(&corpus);
+
+    let start = args.start;
+    let stop = args.stop;
+    if stop < start {
+        bail!("inconsistent bounds: stop {stop} < start {start}");
+    }
+    if start > corpus_max || stop < corpus_min {
+        bail!(
+            "out-of-range blocks: requested {start}..={stop}, corpus spans {corpus_min}..={corpus_max}"
+        );
+    }
+
+    let filtered: Vec<&SampleBlock> = corpus
+        .iter()
+        .filter(|sample| sample.height >= start && sample.height <= stop)
+        .collect();
+    if filtered.is_empty() {
+        bail!("empty filtered range: no blocks in {start}..={stop}");
+    }
+    let height_min = filtered.iter().map(|sample| sample.height).min().unwrap();
+    let height_max = filtered.iter().map(|sample| sample.height).max().unwrap();
+
+    let sidecar_file = std::fs::File::create(&sidecar_path)
+        .with_context(|| format!("create sidecar {}", sidecar_path.display()))?;
+    let mut sidecar = BufWriter::new(sidecar_file);
+    let mut hasher = sha256::Hash::engine();
 
     let kernel = KernelContext::new(bitcoin::Network::Bitcoin)
         .map_err(|error| anyhow::anyhow!("create kernel context: {error}"))?;
@@ -55,14 +123,19 @@ fn main() -> Result<()> {
     let mut non_coinbase_inputs: u64 = 0;
     let mut verified_inputs: u64 = 0;
 
-    for sample in &corpus {
+    for sample in &filtered {
         blocks += 1;
 
         let block =
             bitcoin::Block::consensus_decode(&mut std::io::Cursor::new(sample.raw.as_slice()))
                 .with_context(|| format!("decode corpus block at height {}", sample.height))?;
-
-        let flags = production_verify_flags(Network::Mainnet, sample.height);
+        let hash = block.block_hash();
+        let block_hash = hash.to_string();
+        let flags = production_verify_flags(
+            Network::Mainnet,
+            sample.height,
+            Hash256::from_le_bytes(hash.as_byte_array()),
+        );
 
         let mut prevouts = sample.prevouts.iter();
 
@@ -71,6 +144,7 @@ fn main() -> Result<()> {
                 continue;
             }
 
+            let txid = tx.compute_txid().to_string();
             let mut map = hashbrown::HashMap::with_capacity(tx.input.len());
             for input in &tx.input {
                 let rec = prevouts.next().with_context(|| {
@@ -100,13 +174,59 @@ fn main() -> Result<()> {
                     )
                 })?;
 
-            verified_inputs += input_count;
+            for (input_index, input) in tx.input.iter().enumerate() {
+                let prevout = prevout_map.get(&input.previous_output).with_context(|| {
+                    format!(
+                        "missing prevout for sidecar at height {} tx_index {} input_index {}",
+                        sample.height, tx_index, input_index
+                    )
+                })?;
+                let witness_hex: Vec<String> = input
+                    .witness
+                    .iter()
+                    .map(|item| item.to_lower_hex_string())
+                    .collect();
+
+                let row = json!({
+                    "schema": SIDECAR_SCHEMA,
+                    "height": sample.height,
+                    "block_hash": block_hash,
+                    "tx_index": tx_index,
+                    "input_index": input_index,
+                    "txid": txid,
+                    "prevout_script_pubkey_hex": prevout.script_pubkey.as_bytes().to_lower_hex_string(),
+                    "script_sig_hex": input.script_sig.as_bytes().to_lower_hex_string(),
+                    "witness_hex": witness_hex,
+                });
+                let mut line = serde_json::to_string(&row).context("serialize sidecar row")?;
+                line.push('\n');
+
+                sidecar
+                    .write_all(line.as_bytes())
+                    .with_context(|| format!("write sidecar {}", sidecar_path.display()))?;
+                hasher.input(line.as_bytes());
+                verified_inputs += 1;
+            }
         }
 
         if prevouts.next().is_some() {
             bail!("corpus prevout overrun at height {}", sample.height);
         }
     }
+
+    if verified_inputs == 0 {
+        bail!("zero verified inputs in range {start}..={stop}");
+    }
+
+    sidecar
+        .flush()
+        .with_context(|| format!("flush sidecar {}", sidecar_path.display()))?;
+    sidecar
+        .get_ref()
+        .sync_all()
+        .with_context(|| format!("sync sidecar {}", sidecar_path.display()))?;
+    let sidecar_hash = sha256::Hash::from_engine(hasher).to_string();
+
     // SAFETY: This zero-argument FFI call flushes process-global census sinks.
     // Verification is complete, so no worker can still append records.
     let flush_status = unsafe { libbitcoinkernel_sys::btck_census_flush() };
@@ -116,19 +236,29 @@ fn main() -> Result<()> {
 
     let summary = json!({
         "schema": SUMMARY_SCHEMA,
+        "corpus": args.corpus.display().to_string(),
+        "corpus_size": corpus_size,
+        "corpus_sha256": corpus_sha256,
+        "range": {
+            "start": start,
+            "stop": stop,
+            "height_min": height_min,
+            "height_max": height_max,
+        },
         "blocks": blocks,
         "non_coinbase_inputs": non_coinbase_inputs,
         "verified_inputs": verified_inputs,
+        "sidecar": sidecar_path.display().to_string(),
+        "sidecar_sha256": sidecar_hash,
+        "counters": args.counters.as_ref().map(|p| p.display().to_string()),
+        "journal": args.journal.as_ref().map(|p| p.display().to_string()),
     });
 
     let rendered = serde_json::to_string_pretty(&summary).context("render summary JSON")?;
 
     match &args.output {
         Some(path) => {
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)
-                    .with_context(|| format!("create {}", parent.display()))?;
-            }
+            ensure_parent(path)?;
             std::fs::write(path, rendered + "\n")
                 .with_context(|| format!("write {}", path.display()))?;
         }
@@ -146,12 +276,22 @@ fn main() -> Result<()> {
 struct Args {
     corpus: PathBuf,
     output: Option<PathBuf>,
+    start: u32,
+    stop: u32,
+    counters: Option<PathBuf>,
+    journal: Option<PathBuf>,
+    context_sidecar: Option<PathBuf>,
 }
 
 impl Args {
     fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Self> {
         let mut corpus: Option<PathBuf> = None;
         let mut output: Option<PathBuf> = None;
+        let mut start: Option<u32> = None;
+        let mut stop: Option<u32> = None;
+        let mut counters: Option<PathBuf> = None;
+        let mut journal: Option<PathBuf> = None;
+        let mut context_sidecar: Option<PathBuf> = None;
         let mut args = args.into_iter();
         while let Some(arg) = args.next() {
             let arg = arg
@@ -160,14 +300,28 @@ impl Args {
             match arg.as_str() {
                 "--corpus" => corpus = Some(PathBuf::from(next_arg(&mut args, "--corpus")?)),
                 "--output" => output = Some(PathBuf::from(next_arg(&mut args, "--output")?)),
+                "--start" => start = Some(parse_u32(&next_arg(&mut args, "--start")?, "--start")?),
+                "--stop" => stop = Some(parse_u32(&next_arg(&mut args, "--stop")?, "--stop")?),
+                "--counters" => counters = Some(PathBuf::from(next_arg(&mut args, "--counters")?)),
+                "--journal" => journal = Some(PathBuf::from(next_arg(&mut args, "--journal")?)),
+                "--context-sidecar" => {
+                    context_sidecar = Some(PathBuf::from(next_arg(&mut args, "--context-sidecar")?))
+                }
                 other => bail!(
-                    "unknown argument: {other}\nusage: checksig-census-capture \
-                     --corpus <path> [--output <path>]"
+                    "unknown argument: {other}\nusage: checksig-census-capture --corpus <path> [--output <path>] [--start <u32>] [--stop <u32>] [--counters <path>] [--journal <path>] [--context-sidecar <path>]"
                 ),
             }
         }
         let corpus = corpus.context("--corpus is required")?;
-        Ok(Self { corpus, output })
+        Ok(Self {
+            corpus,
+            output,
+            start: start.unwrap_or(0),
+            stop: stop.unwrap_or(u32::MAX),
+            counters,
+            journal,
+            context_sidecar,
+        })
     }
 }
 
@@ -178,16 +332,65 @@ fn next_arg(args: &mut impl Iterator<Item = OsString>, name: &str) -> Result<Str
         .map_err(|value| anyhow::anyhow!("{name} value is not UTF-8: {}", value.display()))
 }
 
+fn parse_u32(value: &str, name: &str) -> Result<u32> {
+    value
+        .parse::<u32>()
+        .with_context(|| format!("{name} must be a non-negative 32-bit integer, got {value}"))
+}
+
+fn resolve_default_sidecar(corpus: &std::path::Path, output: Option<&PathBuf>) -> PathBuf {
+    if let Some(path) = output {
+        path.with_extension("context.jsonl")
+    } else {
+        corpus.with_extension("context.jsonl")
+    }
+}
+
+fn ensure_parent(path: &std::path::Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    Ok(())
+}
+
+fn sha256_file(path: &std::path::Path) -> Result<(u64, String)> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("open corpus for hashing {}", path.display()))?;
+    let size = file
+        .metadata()
+        .with_context(|| format!("stat corpus {}", path.display()))?
+        .len();
+    let mut reader = BufReader::new(file);
+    let mut hasher = sha256::Hash::engine();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = reader
+            .read(&mut buffer)
+            .with_context(|| format!("hash corpus {}", path.display()))?;
+        if count == 0 {
+            break;
+        }
+        hasher.input(&buffer[..count]);
+    }
+    Ok((size, sha256::Hash::from_engine(hasher).to_string()))
+}
+
+fn corpus_height_range(corpus: &[SampleBlock]) -> (u32, u32) {
+    (
+        corpus.iter().map(|sample| sample.height).min().unwrap_or(0),
+        corpus.iter().map(|sample| sample.height).max().unwrap_or(0),
+    )
+}
+
 // ── Production flag derivation ──────────────────────────────────────────────
 
-/// Mirrors `compute_verify_flags` in `crates/node/src/apply.rs`: P2SH is
-/// always-on for supported validation paths; DERSIG/CLTV/CSV/WITNESS/TAPROOT
-/// gate on activation height. Production resolves CSV/segwit through BIP9
-/// contextual state with these same height predicates as fallback; at the
-/// corpus heights (<= 150k, far below every activation) the two derivations
-/// are identical and every flag except P2SH is off.
-fn production_verify_flags(network: Network, height: u32) -> VerifyFlags {
-    let mut flags = VerifyFlags::P2SH;
+/// Mirrors the buried-deployment fallback in `compute_verify_flags` from
+/// `crates/node/src/apply.rs`, including Core's hash-pinned BIP16 exception.
+fn production_verify_flags(network: Network, height: u32, block_hash: Hash256) -> VerifyFlags {
+    let mut flags = VerifyFlags::NONE;
+    if !network.is_bip16_p2sh_exception(block_hash) {
+        flags = flags.union(VerifyFlags::P2SH);
+    }
     if network.is_bip66_active(height) {
         flags = flags.union(VerifyFlags::DERSIG);
     }
@@ -292,6 +495,12 @@ fn read_bytes(reader: &mut impl std::io::Read) -> Result<Vec<u8>> {
 /// Resolved prevouts for one transaction, served through the same `UtxoView`
 /// seam `verify_tx` uses in production.
 struct PrevoutMap(hashbrown::HashMap<OutPoint, TxOut>);
+
+impl PrevoutMap {
+    fn get(&self, outpoint: &OutPoint) -> Option<&TxOut> {
+        self.0.get(outpoint)
+    }
+}
 
 impl UtxoView for PrevoutMap {
     fn lookup(&self, outpoint: &OutPoint) -> Option<TxOut> {

--- a/tools/checksig-census/context.py
+++ b/tools/checksig-census/context.py
@@ -559,7 +559,9 @@ def parse_script(script: bytes) -> tuple[ScriptElement, ...]:
         opcode = script[offset]
         offset += 1
         pushed: bytes | None = None
-        if 1 <= opcode <= 75:
+        if opcode == 0:
+            pushed = b""
+        elif 1 <= opcode <= 75:
             if offset + opcode > len(script):
                 raise ContextError(
                     f"script push opcode {opcode} truncated at byte {offset}"
@@ -584,6 +586,19 @@ def parse_script(script: bytes) -> tuple[ScriptElement, ...]:
                 raise ContextError("script OP_PUSHDATA2 payload truncated")
             pushed = script[offset : offset + length]
             offset += length
+        elif opcode == 78:
+            if offset + 4 > len(script):
+                raise ContextError("script OP_PUSHDATA4 length bytes missing")
+            length = struct.unpack_from("<I", script, offset)[0]
+            offset += 4
+            if offset + length > len(script):
+                raise ContextError("script OP_PUSHDATA4 payload truncated")
+            pushed = script[offset : offset + length]
+            offset += length
+        elif opcode == 79:
+            pushed = b"\x81"
+        elif 81 <= opcode <= 96:
+            pushed = bytes([opcode - 80])
         elements.append(ScriptElement(opcode=opcode, pushed=pushed))
     return tuple(elements)
 

--- a/tools/checksig-census/context.py
+++ b/tools/checksig-census/context.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""Strict parsing and spend-container classification for census context evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+from collections.abc import Iterator
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import BinaryIO
+
+CONTEXT_MAGIC = b"BRSCTX1\x00"
+CONTEXT_HEADER = struct.Struct("<8sQ")
+CONTEXT_ROW_LENGTH = struct.Struct("<I")
+CONTEXT_FIXED = struct.Struct("<32sIIIII")
+CONTEXT_MIN_ROW_SIZE = CONTEXT_FIXED.size
+# Consensus-maximum serialized block payload. No single BRSCTX1 row may
+# legitimately exceed a block's worth of script/witness data.
+CONTEXT_MAX_ROW_BYTES = 1 << 24
+
+# Deprecated/diagnostic schema name retained for sampled tooling only.
+CONTEXT_INPUT_SCHEMA = "census-context-input-v1"
+_CONTEXT_FIELDS = {
+    "schema",
+    "height",
+    "block_hash",
+    "tx_index",
+    "input_index",
+    "txid",
+    "prevout_script_pubkey_hex",
+    "script_sig_hex",
+    "witness_hex",
+}
+
+
+# Incoming kernel script verify flag bits emitted by Core 31.99.
+# P2SH=1<<0, WITNESS=1<<11, TAPROOT=1<<17.
+VERIFY_P2SH = 0x1
+VERIFY_WITNESS = 1 << 11
+VERIFY_TAPROOT = 1 << 17
+
+
+class ContextError(ValueError):
+    """The context evidence is malformed, ambiguous, or incomplete."""
+
+
+class SpendContext(str, Enum):
+    BARE = "bare"
+    P2SH = "p2sh"
+    NATIVE_WITNESS_V0 = "native_witness_v0"
+    P2SH_WRAPPED_WITNESS_V0 = "p2sh_wrapped_witness_v0"
+    TAPROOT_KEY_PATH = "taproot_key_path"
+    TAPSCRIPT = "tapscript"
+
+
+@dataclass(frozen=True)
+class InputIdentity:
+    txid_le: bytes
+    input_index: int
+
+    def __post_init__(self) -> None:
+        if len(self.txid_le) != 32:
+            raise ContextError("CTX-RAW: execution txid must contain exactly 32 bytes")
+        if not 0 <= self.input_index <= 0xFFFF_FFFF:
+            raise ContextError("CTX-RAW: input index is outside u32 range")
+
+    @property
+    def execution_key(self) -> tuple[bytes, int]:
+        return (self.txid_le, self.input_index)
+
+    @property
+    def display_txid(self) -> str:
+        return self.txid_le[::-1].hex()
+
+
+@dataclass(frozen=True)
+class ContextInput:
+    identity: InputIdentity
+    verify_flags: int
+    prevout_script_pubkey: bytes
+    script_sig: bytes
+    witness: tuple[bytes, ...]
+
+
+@dataclass(frozen=True)
+class ClassifiedInput:
+    evidence: ContextInput
+    spend_context: SpendContext
+
+
+@dataclass(frozen=True)
+class ScriptElement:
+    opcode: int
+    pushed: bytes | None
+
+
+def _read_exact(
+    stream: BinaryIO, length: int, field: str, row_number: int | None = None
+) -> bytes:
+    data = stream.read(length)
+    if len(data) != length:
+        location = "header" if row_number is None else f"row {row_number}"
+        raise ContextError(
+            f"CTX-RAW: short {field} in {location}: expected {length} bytes, got {len(data)}"
+        )
+    return data
+
+
+def _consume_blob(
+    stream: BinaryIO, length: int, remaining: int, field: str, row_number: int
+) -> tuple[bytes, int]:
+    if length > remaining:
+        raise ContextError(
+            f"CTX-RAW: row {row_number} {field} length {length} exceeds "
+            f"the {remaining} bytes remaining in its row"
+        )
+    return _read_exact(stream, length, field, row_number), remaining - length
+
+
+def _parse_legacy_row(value: object, line_number: int) -> ContextInput:
+    """Parse one diagnostic census-context-input-v1 JSONL row."""
+    if not isinstance(value, dict):
+        raise ContextError(f"CTX-DIAG line {line_number}: JSON value must be an object")
+    if not all(isinstance(key, str) for key in value):
+        raise ContextError(f"CTX-DIAG line {line_number}: object keys must be strings")
+    row = {str(key): item for key, item in value.items()}
+    actual = set(row)
+    if actual != _CONTEXT_FIELDS:
+        missing = sorted(_CONTEXT_FIELDS - actual)
+        extra = sorted(actual - _CONTEXT_FIELDS)
+        raise ContextError(
+            f"CTX-DIAG line {line_number}: fields differ from {CONTEXT_INPUT_SCHEMA}; "
+            f"missing={missing}, extra={extra}"
+        )
+    if row["schema"] != CONTEXT_INPUT_SCHEMA:
+        raise ContextError(
+            f"CTX-DIAG line {line_number}: schema must be {CONTEXT_INPUT_SCHEMA!r}"
+        )
+
+    _require_hex(row["block_hash"], "block_hash", line_number, 32)
+    txid_bytes = _require_hex(row["txid"], "txid", line_number, 32)
+    witness_value = row["witness_hex"]
+    if not isinstance(witness_value, list):
+        raise ContextError(f"CTX-DIAG line {line_number}: witness_hex must be an array")
+    witness = tuple(
+        _require_hex(item, f"witness_hex[{index}]", line_number)
+        for index, item in enumerate(witness_value)
+    )
+
+    return ContextInput(
+        identity=InputIdentity(
+            txid_le=txid_bytes[::-1],
+            input_index=_require_uint(row["input_index"], "input_index", line_number),
+        ),
+        verify_flags=0,
+        prevout_script_pubkey=_require_hex(
+            row["prevout_script_pubkey_hex"], "prevout_script_pubkey_hex", line_number
+        ),
+        script_sig=_require_hex(row["script_sig_hex"], "script_sig_hex", line_number),
+        witness=witness,
+    )
+
+
+def _require_uint(value: object, field: str, line_number: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ContextError(
+            f"CTX-DIAG line {line_number}: {field} must be a non-negative integer"
+        )
+    return value
+
+
+def _require_hex(
+    value: object, field: str, line_number: int, size: int | None = None
+) -> bytes:
+    if not isinstance(value, str):
+        raise ContextError(f"CTX-DIAG line {line_number}: {field} must be a string")
+    if value != value.lower() or len(value) % 2 != 0:
+        raise ContextError(
+            f"CTX-DIAG line {line_number}: {field} must be even-length lowercase hex"
+        )
+    try:
+        decoded = bytes.fromhex(value)
+    except ValueError:
+        raise ContextError(
+            f"CTX-DIAG line {line_number}: {field} must be lowercase hex"
+        )
+    if size is not None and len(decoded) != size:
+        raise ContextError(
+            f"CTX-DIAG line {line_number}: {field} must encode exactly {size} bytes"
+        )
+    return decoded
+
+
+class _HashingReader:
+    """BinaryIO wrapper that hashes every byte read and counts total bytes."""
+
+    def __init__(self, stream: BinaryIO, hasher: hashlib._Hash) -> None:
+        self._stream = stream
+        self._hasher = hasher
+        self._bytes_read = 0
+
+    def read(self, length: int) -> bytes:
+        data = self._stream.read(length)
+        if data:
+            self._hasher.update(data)
+            self._bytes_read += len(data)
+        return data
+
+    def close(self) -> None:
+        self._stream.close()
+
+
+class ContextIterator(Iterator[ContextInput]):
+    """Single-open streaming BRSCTX1 parser that returns custody from the same stream.
+
+    The file is opened once, every byte read is fed into a SHA-256 hasher, and
+    the row count is tracked. After the iterator is exhausted, ``custody()``
+    returns ``{'bytes': total_bytes, 'sha256': hex_digest, 'count': row_count}``
+    from that exact parse stream.
+    """
+
+    def __init__(self, path: Path, dedup: bool = True) -> None:
+        self._path = path
+        self._dedup = dedup
+        self._hasher = hashlib.sha256()
+        self._stream: _HashingReader | None = None
+        self._count = 0
+        self._closed = False
+        self._gen = self._run()
+
+    def _open(self) -> _HashingReader:
+        if self._stream is None:
+            self._stream = _HashingReader(self._path.open("rb"), self._hasher)
+        return self._stream
+
+    def _run(self) -> Iterator[ContextInput]:
+        stream = self._open()
+        try:
+            file_size = self._path.stat().st_size
+            if file_size < CONTEXT_HEADER.size:
+                raise ContextError(
+                    f"CTX-RAW: short header: expected {CONTEXT_HEADER.size} bytes, got {file_size}"
+                )
+
+            magic, declared_count = CONTEXT_HEADER.unpack(
+                _read_exact(stream, CONTEXT_HEADER.size, "header")
+            )
+            if magic != CONTEXT_MAGIC:
+                raise ContextError(
+                    f"CTX-RAW: wrong magic {magic!r}, expected {CONTEXT_MAGIC!r}"
+                )
+            if declared_count > 0xFFFF_FFFF_FFFF_FFFF:
+                raise ContextError(
+                    "CTX-RAW: declared row count exceeds representable u64 range"
+                )
+
+            available = file_size - CONTEXT_HEADER.size
+            minimum_framed_row = CONTEXT_ROW_LENGTH.size + CONTEXT_MIN_ROW_SIZE
+            if declared_count > available // minimum_framed_row:
+                raise ContextError(
+                    f"CTX-RAW: declared row count {declared_count} cannot fit "
+                    f"in the {available} payload bytes"
+                )
+
+            identities: set[tuple[bytes, int]] | None = set() if self._dedup else None
+
+            for row_number in range(1, declared_count + 1):
+                row_length = CONTEXT_ROW_LENGTH.unpack(
+                    _read_exact(
+                        stream, CONTEXT_ROW_LENGTH.size, "row length", row_number
+                    )
+                )[0]
+                if row_length < CONTEXT_MIN_ROW_SIZE:
+                    raise ContextError(
+                        f"CTX-RAW: row {row_number} length {row_length} is shorter than "
+                        f"the {CONTEXT_MIN_ROW_SIZE}-byte fixed body"
+                    )
+                if row_length > CONTEXT_MAX_ROW_BYTES:
+                    raise ContextError(
+                        f"CTX-RAW: row {row_number} length {row_length} exceeds "
+                        f"the {CONTEXT_MAX_ROW_BYTES}-byte maximum"
+                    )
+                payload_remaining = file_size - stream._bytes_read
+                if row_length > payload_remaining:
+                    raise ContextError(
+                        f"CTX-RAW: row {row_number} length {row_length} extends "
+                        f"{payload_remaining} bytes past end of file"
+                    )
+                fixed = _read_exact(
+                    stream, CONTEXT_FIXED.size, "fixed fields", row_number
+                )
+                (
+                    txid_le,
+                    input_index,
+                    verify_flags,
+                    prevout_length,
+                    script_sig_length,
+                    witness_count,
+                ) = CONTEXT_FIXED.unpack(fixed)
+
+                if prevout_length > 0xFFFF_FFFF:
+                    raise ContextError(
+                        f"CTX-RAW: row {row_number} prevout length overflows u32"
+                    )
+                if script_sig_length > 0xFFFF_FFFF:
+                    raise ContextError(
+                        f"CTX-RAW: row {row_number} scriptSig length overflows u32"
+                    )
+                if witness_count > 0xFFFF_FFFF:
+                    raise ContextError(
+                        f"CTX-RAW: row {row_number} witness count overflows u32"
+                    )
+
+                remaining = row_length - CONTEXT_FIXED.size
+                if witness_count > remaining // 4:
+                    raise ContextError(
+                        f"CTX-RAW: row {row_number} witness count {witness_count} cannot fit "
+                        f"in the {remaining} bytes remaining in its row"
+                    )
+
+                prevout, remaining = _consume_blob(
+                    stream, prevout_length, remaining, "prevout script", row_number
+                )
+                script_sig, remaining = _consume_blob(
+                    stream, script_sig_length, remaining, "scriptSig", row_number
+                )
+
+                witness: list[bytes] = []
+                for item_index in range(witness_count):
+                    if remaining < 4:
+                        raise ContextError(
+                            f"CTX-RAW: row {row_number} is short before witness item {item_index}"
+                        )
+                    item_length = struct.unpack(
+                        "<I", _read_exact(stream, 4, "witness item length", row_number)
+                    )[0]
+                    remaining -= 4
+                    item, remaining = _consume_blob(
+                        stream,
+                        item_length,
+                        remaining,
+                        f"witness item {item_index}",
+                        row_number,
+                    )
+                    witness.append(item)
+
+                if remaining != 0:
+                    raise ContextError(
+                        f"CTX-RAW: row {row_number} length mismatch: {remaining} unconsumed bytes"
+                    )
+
+                identity = InputIdentity(txid_le=txid_le, input_index=input_index)
+                if identities is not None:
+                    if identity.execution_key in identities:
+                        raise ContextError(
+                            f"CTX-EXECUTION: duplicate context execution identity "
+                            f"{identity.display_txid}:{input_index}"
+                        )
+                    identities.add(identity.execution_key)
+                self._count += 1
+                yield ContextInput(
+                    identity=identity,
+                    verify_flags=verify_flags,
+                    prevout_script_pubkey=prevout,
+                    script_sig=script_sig,
+                    witness=tuple(witness),
+                )
+
+            trailing = stream.read(1)
+            if trailing:
+                raise ContextError(
+                    "CTX-RAW: trailing bytes after declared BRSCTX1 rows"
+                )
+        finally:
+            if not self._closed:
+                self.close()
+                self._closed = True
+
+    def __iter__(self) -> ContextIterator:
+        return self
+
+    def __next__(self) -> ContextInput:
+        return next(self._gen)
+
+    def close(self) -> None:
+        if self._stream is not None:
+            self._stream.close()
+            self._closed = True
+
+    def custody(self) -> dict[str, object]:
+        """Return custody metadata from the exact parse stream.
+
+        Must be called after the iterator is exhausted. The reported SHA-256
+        and byte count come from the same already-open byte stream used to
+        parse and validate rows.
+        """
+        return {
+            "bytes": self._stream._bytes_read if self._stream else 0,
+            "sha256": int(self._hasher.hexdigest(), 16),
+            "count": self._count,
+        }
+
+
+def iter_context_inputs(path: Path, dedup: bool = True) -> ContextIterator:
+    """Yield strict BRSCTX1 rows from a single open hashing stream."""
+    return ContextIterator(path, dedup=dedup)
+
+
+def read_context_inputs(path: Path) -> list[ContextInput]:
+    return list(iter_context_inputs(path))
+
+
+def iter_legacy_context_inputs(
+    path: Path, expected_input_count: int
+) -> Iterator[ContextInput]:
+    """Diagnostic-only JSONL iterator; no census certification path uses this."""
+    if (
+        isinstance(expected_input_count, bool)
+        or not isinstance(expected_input_count, int)
+        or expected_input_count < 0
+    ):
+        raise ContextError(
+            "CTX-DIAG: expected_input_count must be a non-negative integer"
+        )
+    seen = 0
+    identities: set[tuple[bytes, int]] = set()
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line.strip():
+            raise ContextError(
+                f"CTX-DIAG line {line_number}: blank lines are not permitted"
+            )
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ContextError(f"CTX-DIAG line {line_number}: invalid JSON: {error}")
+        row = _parse_legacy_row(value, line_number)
+        if row.identity.execution_key in identities:
+            raise ContextError(
+                f"CTX-DIAG line {line_number}: duplicate execution identity "
+                f"{row.identity.display_txid}:{row.identity.input_index}"
+            )
+        identities.add(row.identity.execution_key)
+        seen += 1
+        if seen > expected_input_count:
+            raise ContextError(
+                f"CTX-DIAG: context input count mismatch: expected {expected_input_count}, got more"
+            )
+        yield row
+    if seen != expected_input_count:
+        raise ContextError(
+            f"CTX-DIAG: context input count mismatch: expected {expected_input_count}, got {seen}"
+        )
+
+
+def parse_script(script: bytes) -> tuple[ScriptElement, ...]:
+    """Parse every script byte into data pushes or opcodes, rejecting truncation."""
+    elements: list[ScriptElement] = []
+    offset = 0
+    while offset < len(script):
+        opcode = script[offset]
+        offset += 1
+        pushed: bytes | None = None
+        if 1 <= opcode <= 75:
+            if offset + opcode > len(script):
+                raise ContextError(
+                    f"script push opcode {opcode} truncated at byte {offset}"
+                )
+            pushed = script[offset : offset + opcode]
+            offset += opcode
+        elif opcode == 76:
+            if offset + 1 > len(script):
+                raise ContextError("script OP_PUSHDATA1 length byte missing")
+            length = script[offset]
+            offset += 1
+            if offset + length > len(script):
+                raise ContextError("script OP_PUSHDATA1 payload truncated")
+            pushed = script[offset : offset + length]
+            offset += length
+        elif opcode == 77:
+            if offset + 2 > len(script):
+                raise ContextError("script OP_PUSHDATA2 length bytes missing")
+            length = struct.unpack_from("<H", script, offset)[0]
+            offset += 2
+            if offset + length > len(script):
+                raise ContextError("script OP_PUSHDATA2 payload truncated")
+            pushed = script[offset : offset + length]
+            offset += length
+        elements.append(ScriptElement(opcode=opcode, pushed=pushed))
+    return tuple(elements)
+
+
+def _push_only_stack(script_sig: bytes) -> tuple[bytes, ...]:
+    """Return the stack produced by a push-only script, or fail closed."""
+    stack: list[bytes] = []
+    for element in parse_script(script_sig):
+        if element.pushed is None:
+            raise ContextError("scriptSig is not push-only")
+        stack.append(element.pushed)
+    return tuple(stack)
+
+
+def _witness_v0_program(script: bytes) -> bool:
+    return len(script) in (22, 34) and script[0] == 0 and script[1] in (20, 32)
+
+
+def _is_p2sh(script: bytes) -> bool:
+    return len(script) == 23 and script[:2] == b"\xa9\x14" and script[-1:] == b"\x87"
+
+
+def _is_p2tr(script: bytes) -> bool:
+    return len(script) == 34 and script[:2] == b"\x51\x20"
+
+
+def _require_witness_v0(evidence: ContextInput) -> None:
+    if not evidence.witness:
+        raise ContextError("witness-v0 input has an empty witness stack")
+
+
+def _classify_bare(evidence: ContextInput) -> SpendContext:
+    return SpendContext.BARE
+
+
+def _classify_witness_v0(evidence: ContextInput) -> SpendContext:
+    if evidence.script_sig:
+        raise ContextError(
+            "native witness-v0 input has a non-empty scriptSig after successful validation"
+        )
+    _require_witness_v0(evidence)
+    return SpendContext.NATIVE_WITNESS_V0
+
+
+def _classify_p2sh(evidence: ContextInput) -> SpendContext:
+    stack = _push_only_stack(evidence.script_sig)
+    if stack:
+        redeem = stack[-1]
+        if _witness_v0_program(redeem) and (evidence.verify_flags & VERIFY_WITNESS):
+            return SpendContext.P2SH_WRAPPED_WITNESS_V0
+    return SpendContext.P2SH
+
+
+def _classify_taproot(evidence: ContextInput) -> SpendContext:
+    if evidence.script_sig:
+        raise ContextError("taproot input has a non-empty scriptSig")
+    witness = list(evidence.witness)
+    if witness and witness[-1] and witness[-1][0] == 0x50:
+        witness.pop()
+    if not witness:
+        raise ContextError("taproot input has no witness elements")
+    if len(witness) == 1:
+        if len(witness[0]) not in (64, 65):
+            raise ContextError("taproot key-path signature has wrong length")
+        return SpendContext.TAPROOT_KEY_PATH
+    control_block = witness[-1]
+    if (
+        len(control_block) < 33
+        or (len(control_block) - 1) % 32 != 0
+        or len(control_block) > 4129
+    ):
+        raise ContextError("tapscript control block has wrong length")
+    return SpendContext.TAPSCRIPT
+
+
+def classify_input(evidence: ContextInput) -> ClassifiedInput:
+    prevout = evidence.prevout_script_pubkey
+    if _is_p2tr(prevout):
+        if not (evidence.verify_flags & VERIFY_WITNESS) or not (
+            evidence.verify_flags & VERIFY_TAPROOT
+        ):
+            context = _classify_bare(evidence)
+        else:
+            context = _classify_taproot(evidence)
+    elif _is_p2sh(prevout):
+        if not (evidence.verify_flags & VERIFY_P2SH):
+            context = _classify_bare(evidence)
+        else:
+            context = _classify_p2sh(evidence)
+    elif _witness_v0_program(prevout):
+        if evidence.verify_flags & VERIFY_WITNESS:
+            context = _classify_witness_v0(evidence)
+        else:
+            context = _classify_bare(evidence)
+    else:
+        context = _classify_bare(evidence)
+    return ClassifiedInput(evidence=evidence, spend_context=context)
+
+
+def classify_context_inputs(rows: list[ContextInput]) -> list[ClassifiedInput]:
+    return [classify_input(row) for row in rows]

--- a/tools/checksig-census/context.py
+++ b/tools/checksig-census/context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import struct
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -115,9 +116,191 @@ def _consume_blob(
     if length > remaining:
         raise ContextError(
             f"CTX-RAW: row {row_number} {field} length {length} exceeds "
-            f"the {remaining} bytes remaining in its row"
+            f"{remaining} bytes remaining in row"
         )
     return _read_exact(stream, length, field, row_number), remaining - length
+
+
+def decode_context_row(
+    stream: BinaryIO,
+    row_number: int,
+    available: int,
+    *,
+    boundary: str = "end of file",
+) -> ContextInput:
+    """Decode one canonically framed BRSCTX1 row from ``stream``.
+
+    ``available`` is the exact number of bytes remaining in the caller's
+    trusted boundary. Strict full-file and live committed-prefix parsing both
+    use this function so framing and field legality cannot drift.
+    """
+    row_length = CONTEXT_ROW_LENGTH.unpack(
+        _read_exact(stream, CONTEXT_ROW_LENGTH.size, "row length", row_number)
+    )[0]
+    if row_length < CONTEXT_MIN_ROW_SIZE:
+        raise ContextError(
+            f"CTX-RAW: row {row_number} length {row_length} is shorter than "
+            f"the {CONTEXT_MIN_ROW_SIZE}-byte fixed body"
+        )
+    if row_length > CONTEXT_MAX_ROW_BYTES:
+        raise ContextError(
+            f"CTX-RAW: row {row_number} length {row_length} exceeds "
+            f"the {CONTEXT_MAX_ROW_BYTES}-byte maximum"
+        )
+    payload_available = available - CONTEXT_ROW_LENGTH.size
+    if row_length > payload_available:
+        raise ContextError(
+            f"CTX-RAW: row {row_number} length {row_length} extends "
+            f"{payload_available} bytes past {boundary}"
+        )
+
+    (
+        txid_le,
+        input_index,
+        verify_flags,
+        prevout_length,
+        script_sig_length,
+        witness_count,
+    ) = CONTEXT_FIXED.unpack(
+        _read_exact(stream, CONTEXT_FIXED.size, "fixed fields", row_number)
+    )
+
+    if prevout_length > 0xFFFF_FFFF:
+        raise ContextError(f"CTX-RAW: row {row_number} prevout length overflows u32")
+    if script_sig_length > 0xFFFF_FFFF:
+        raise ContextError(f"CTX-RAW: row {row_number} scriptSig length overflows u32")
+    if witness_count > 0xFFFF_FFFF:
+        raise ContextError(f"CTX-RAW: row {row_number} witness count overflows u32")
+
+    remaining = row_length - CONTEXT_FIXED.size
+    if witness_count > remaining // 4:
+        raise ContextError(
+            f"CTX-RAW: row {row_number} witness count {witness_count} cannot fit "
+            f"in the {remaining} bytes remaining in its row"
+        )
+
+    prevout, remaining = _consume_blob(
+        stream, prevout_length, remaining, "prevout script", row_number
+    )
+    script_sig, remaining = _consume_blob(
+        stream, script_sig_length, remaining, "scriptSig", row_number
+    )
+
+    witness: list[bytes] = []
+    for item_index in range(witness_count):
+        if remaining < 4:
+            raise ContextError(
+                f"CTX-RAW: row {row_number} is short before witness item {item_index}"
+            )
+        item_length = struct.unpack(
+            "<I", _read_exact(stream, 4, "witness item length", row_number)
+        )[0]
+        remaining -= 4
+        item, remaining = _consume_blob(
+            stream,
+            item_length,
+            remaining,
+            f"witness item {item_index}",
+            row_number,
+        )
+        witness.append(item)
+
+    if remaining != 0:
+        raise ContextError(
+            f"CTX-RAW: row {row_number} length mismatch: {remaining} unconsumed bytes"
+        )
+
+    return ContextInput(
+        identity=InputIdentity(txid_le=txid_le, input_index=input_index),
+        verify_flags=verify_flags,
+        prevout_script_pubkey=prevout,
+        script_sig=script_sig,
+        witness=tuple(witness),
+    )
+
+
+class _PreadBoundedReader:
+    """Sequential view over one immutable committed prefix using ``pread``."""
+
+    def __init__(self, fd: int, start: int, end: int) -> None:
+        self._fd = fd
+        self._cursor = start
+        self._end = end
+
+    @property
+    def cursor(self) -> int:
+        return self._cursor
+
+    @property
+    def remaining(self) -> int:
+        return self._end - self._cursor
+
+    def read(self, length: int) -> bytes:
+        length = min(length, self.remaining)
+        if length <= 0:
+            return b""
+        data = os.pread(self._fd, length, self._cursor)
+        self._cursor += len(data)
+        return data
+
+
+def read_bounded_context_rows(
+    fd: int,
+    *,
+    start_offset: int,
+    end_offset: int,
+    start_row: int,
+    committed_rows: int,
+) -> list[ContextInput]:
+    """Read only newly committed BRSCTX1 rows from an already-open fd.
+
+    The producer may still have the placeholder header count zero. A patched
+    terminal count is accepted only when it covers the requested committed
+    prefix. Bytes beyond ``end_offset`` are never observed.
+    """
+    if start_row < 0 or committed_rows < start_row:
+        raise ContextError(
+            f"CTX-RAW: invalid committed row range {start_row}..{committed_rows}"
+        )
+    if start_offset < CONTEXT_HEADER.size or end_offset < start_offset:
+        raise ContextError(
+            f"CTX-RAW: invalid committed byte range {start_offset}..{end_offset}"
+        )
+    file_size = os.fstat(fd).st_size
+    if end_offset > file_size:
+        raise ContextError(
+            f"CTX-RAW: committed endpoint {end_offset} exceeds current file size {file_size}"
+        )
+    header = os.pread(fd, CONTEXT_HEADER.size, 0)
+    if len(header) != CONTEXT_HEADER.size:
+        raise ContextError(
+            f"CTX-RAW: short header: expected {CONTEXT_HEADER.size} bytes, got {len(header)}"
+        )
+    magic, declared_count = CONTEXT_HEADER.unpack(header)
+    if magic != CONTEXT_MAGIC:
+        raise ContextError(
+            f"CTX-RAW: wrong magic {magic!r}, expected {CONTEXT_MAGIC!r}"
+        )
+    if declared_count != 0 and declared_count < committed_rows:
+        raise ContextError(
+            f"CTX-RAW: terminal row count {declared_count} is below committed prefix count {committed_rows}"
+        )
+
+    reader = _PreadBoundedReader(fd, start_offset, end_offset)
+    rows = [
+        decode_context_row(
+            reader,
+            row_number,
+            reader.remaining,
+            boundary="committed endpoint",
+        )
+        for row_number in range(start_row + 1, committed_rows + 1)
+    ]
+    if reader.cursor != end_offset:
+        raise ContextError(
+            f"CTX-RAW: {end_offset - reader.cursor} trailing byte(s) within committed prefix"
+        )
+    return rows
 
 
 def _parse_legacy_row(value: object, line_number: int) -> ContextInput:
@@ -268,106 +451,19 @@ class ContextIterator(Iterator[ContextInput]):
             identities: set[tuple[bytes, int]] | None = set() if self._dedup else None
 
             for row_number in range(1, declared_count + 1):
-                row_length = CONTEXT_ROW_LENGTH.unpack(
-                    _read_exact(
-                        stream, CONTEXT_ROW_LENGTH.size, "row length", row_number
-                    )
-                )[0]
-                if row_length < CONTEXT_MIN_ROW_SIZE:
-                    raise ContextError(
-                        f"CTX-RAW: row {row_number} length {row_length} is shorter than "
-                        f"the {CONTEXT_MIN_ROW_SIZE}-byte fixed body"
-                    )
-                if row_length > CONTEXT_MAX_ROW_BYTES:
-                    raise ContextError(
-                        f"CTX-RAW: row {row_number} length {row_length} exceeds "
-                        f"the {CONTEXT_MAX_ROW_BYTES}-byte maximum"
-                    )
-                payload_remaining = file_size - stream._bytes_read
-                if row_length > payload_remaining:
-                    raise ContextError(
-                        f"CTX-RAW: row {row_number} length {row_length} extends "
-                        f"{payload_remaining} bytes past end of file"
-                    )
-                fixed = _read_exact(
-                    stream, CONTEXT_FIXED.size, "fixed fields", row_number
+                evidence = decode_context_row(
+                    stream, row_number, file_size - stream._bytes_read
                 )
-                (
-                    txid_le,
-                    input_index,
-                    verify_flags,
-                    prevout_length,
-                    script_sig_length,
-                    witness_count,
-                ) = CONTEXT_FIXED.unpack(fixed)
-
-                if prevout_length > 0xFFFF_FFFF:
-                    raise ContextError(
-                        f"CTX-RAW: row {row_number} prevout length overflows u32"
-                    )
-                if script_sig_length > 0xFFFF_FFFF:
-                    raise ContextError(
-                        f"CTX-RAW: row {row_number} scriptSig length overflows u32"
-                    )
-                if witness_count > 0xFFFF_FFFF:
-                    raise ContextError(
-                        f"CTX-RAW: row {row_number} witness count overflows u32"
-                    )
-
-                remaining = row_length - CONTEXT_FIXED.size
-                if witness_count > remaining // 4:
-                    raise ContextError(
-                        f"CTX-RAW: row {row_number} witness count {witness_count} cannot fit "
-                        f"in the {remaining} bytes remaining in its row"
-                    )
-
-                prevout, remaining = _consume_blob(
-                    stream, prevout_length, remaining, "prevout script", row_number
-                )
-                script_sig, remaining = _consume_blob(
-                    stream, script_sig_length, remaining, "scriptSig", row_number
-                )
-
-                witness: list[bytes] = []
-                for item_index in range(witness_count):
-                    if remaining < 4:
-                        raise ContextError(
-                            f"CTX-RAW: row {row_number} is short before witness item {item_index}"
-                        )
-                    item_length = struct.unpack(
-                        "<I", _read_exact(stream, 4, "witness item length", row_number)
-                    )[0]
-                    remaining -= 4
-                    item, remaining = _consume_blob(
-                        stream,
-                        item_length,
-                        remaining,
-                        f"witness item {item_index}",
-                        row_number,
-                    )
-                    witness.append(item)
-
-                if remaining != 0:
-                    raise ContextError(
-                        f"CTX-RAW: row {row_number} length mismatch: {remaining} unconsumed bytes"
-                    )
-
-                identity = InputIdentity(txid_le=txid_le, input_index=input_index)
+                identity = evidence.identity
                 if identities is not None:
                     if identity.execution_key in identities:
                         raise ContextError(
                             f"CTX-EXECUTION: duplicate context execution identity "
-                            f"{identity.display_txid}:{input_index}"
+                            f"{identity.display_txid}:{identity.input_index}"
                         )
                     identities.add(identity.execution_key)
                 self._count += 1
-                yield ContextInput(
-                    identity=identity,
-                    verify_flags=verify_flags,
-                    prevout_script_pubkey=prevout,
-                    script_sig=script_sig,
-                    witness=tuple(witness),
-                )
+                yield evidence
 
             trailing = stream.read(1)
             if trailing:

--- a/tools/checksig-census/instrumentation.diff
+++ b/tools/checksig-census/instrumentation.diff
@@ -1,5 +1,5 @@
 diff --git a/bitcoin/src/kernel/bitcoinkernel.cpp b/bitcoin/src/kernel/bitcoinkernel.cpp
-index f21ea04..f8706c5 100644
+index f21ea04..1bb505d 100644
 --- a/bitcoin/src/kernel/bitcoinkernel.cpp
 +++ b/bitcoin/src/kernel/bitcoinkernel.cpp
 @@ -1,48 +1,51 @@
@@ -65,6 +65,9 @@ index f21ea04..f8706c5 100644
  
      if (status) *status = btck_ScriptVerifyStatus_OK;
  
+-    bool result = VerifyScript(tx.vin[input_index].scriptSig,
+-                               btck_ScriptPubkey::get(script_pubkey),
+-                               &tx.vin[input_index].scriptWitness,
 +    const auto& input = tx.vin[input_index];
 +    const auto& prevout_script = btck_ScriptPubkey::get(script_pubkey);
 +
@@ -84,18 +87,12 @@ index f21ea04..f8706c5 100644
 +        census_emit_context(*census_sinks, flags, prevout_script.data(), prevout_script.size(),
 +                            input.scriptSig.data(), input.scriptSig.size(), input.scriptWitness.stack);
 +    }
--    bool result = VerifyScript(tx.vin[input_index].scriptSig,
--                               btck_ScriptPubkey::get(script_pubkey),
--                               &tx.vin[input_index].scriptWitness,
--                               script_verify_flags::from_int(flags),
--                               TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
--                               nullptr);
 +    bool result = VerifyScript(input.scriptSig,
 +                               prevout_script,
 +                               &input.scriptWitness,
-+                               script_verify_flags::from_int(flags),
-+                               TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
-+                               nullptr);
+                                script_verify_flags::from_int(flags),
+                                TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
+                                nullptr);
 +
 +    // I2: census exit - emit journal, count true
 +    if (result) census_inc(C_FFI_VERIFY_TRUE);
@@ -112,7 +109,7 @@ index f21ea04..f8706c5 100644
  
  const btck_TransactionOutPoint* btck_transaction_input_get_out_point(const btck_TransactionInput* input)
  {
-@@ -1437,10 +1465,100 @@ int btck_block_header_to_bytes(const btck_BlockHeader* header, unsigned char out
+@@ -1437,10 +1465,117 @@ int btck_block_header_to_bytes(const btck_BlockHeader* header, unsigned char out
          return 0;
      } catch (...) {
          return -1;
@@ -145,6 +142,23 @@ index f21ea04..f8706c5 100644
 +int btck_census_flush(void)
 +{
 +    return census_flush();
++}
++
++int btck_census_checkpoint(btck_CensusCheckpoint* out, size_t out_size)
++{
++    if (out == nullptr || out_size != sizeof(btck_CensusCheckpoint)) return -1;
++    out->abi_version = BTCK_CENSUS_CHECKPOINT_ABI;
++    out->struct_size = sizeof(btck_CensusCheckpoint);
++    CensusCheckpointData data;
++    int rc = census_checkpoint(data);
++    if (rc != 0) return rc;
++    out->context_rows = data.context_rows;
++    out->context_end = data.context_end;
++    out->record_rows = data.record_rows;
++    out->record_end = data.record_end;
++    out->journal_rows = data.journal_rows;
++    out->journal_end = data.journal_end;
++    return 0;
 +}
 +
 +// btck_bare_verify_bench: mode 0 = CPubKey::Verify (parse pubkey + lax DER + normalize + verify)
@@ -215,10 +229,10 @@ index f21ea04..f8706c5 100644
 +}
 \ No newline at end of file
 diff --git a/bitcoin/src/kernel/bitcoinkernel.h b/bitcoin/src/kernel/bitcoinkernel.h
-index d302872..6aa4190 100644
+index d302872..b605c93 100644
 --- a/bitcoin/src/kernel/bitcoinkernel.h
 +++ b/bitcoin/src/kernel/bitcoinkernel.h
-@@ -1862,17 +1862,60 @@ BITCOINKERNEL_API uint32_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_header_ge
+@@ -1862,17 +1862,78 @@ BITCOINKERNEL_API uint32_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_header_ge
   * @return              0 on success.
   */
  BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_header_to_bytes(
@@ -244,6 +258,24 @@ index d302872..6aa4190 100644
 +
 +/** Flush census counters and binary streams to env-configured paths. Idempotent. Returns 0 on success. */
 +BITCOINKERNEL_API int btck_census_flush(void);
++
++#define BTCK_CENSUS_CHECKPOINT_ABI 1
++
++/** Non-terminal checkpoint of committed sink counts and byte endpoints. */
++typedef struct btck_CensusCheckpoint {
++    uint32_t abi_version;
++    uint32_t struct_size;
++    uint64_t context_rows;
++    uint64_t context_end;
++    uint64_t record_rows;
++    uint64_t record_end;
++    uint64_t journal_rows;
++    uint64_t journal_end;
++} btck_CensusCheckpoint;
++
++/** Flush sinks and return a coherent checkpoint without closing or patching counts. Returns 0 on success. */
++BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_census_checkpoint(
++    btck_CensusCheckpoint* out, size_t out_size) BITCOINKERNEL_ARG_NONNULL(1);
 +
 +/** Bare verify benchmark input: 176 bytes. */
 +typedef struct btck_bare_input {
@@ -279,12 +311,12 @@ index d302872..6aa4190 100644
  #endif // __cplusplus
  
  #endif // BITCOIN_KERNEL_BITCOINKERNEL_H
-diff --git a/bitcoin/src/kernel/census.h b/bitcoin/src/kernel/census.h
+diff --git 1/patched/bitcoin/src/kernel/census.h b/bitcoin/src/kernel/census.h
 new file mode 100644
-index 0000000..4f153ae
+index 0000000..d65d0a3
 --- /dev/null
 +++ b/bitcoin/src/kernel/census.h
-@@ -0,0 +1,478 @@
+@@ -0,0 +1,538 @@
 +#ifndef BITCOIN_KERNEL_CENSUS_H
 +#define BITCOIN_KERNEL_CENSUS_H
 +
@@ -537,6 +569,66 @@ index 0000000..4f153ae
 +    return sinks;
 +}
 +
++struct CensusCheckpointData {
++    uint64_t context_rows;
++    uint64_t context_end;
++    uint64_t record_rows;
++    uint64_t record_end;
++    uint64_t journal_rows;
++    uint64_t journal_end;
++};
++
++inline bool census_tell_binary(CensusBinarySink& binary, uint64_t& endpoint)
++{
++    if (!binary.file) return false;
++    const auto position = ::ftello(binary.file);
++    if (position < 0) return false;
++    const uintmax_t converted = static_cast<uintmax_t>(position);
++    if (converted > std::numeric_limits<uint64_t>::max()) return false;
++    endpoint = static_cast<uint64_t>(converted);
++    return endpoint >= 16;
++}
++
++// Non-terminal checkpoint. Holds the sink mutex, flushes all three enabled
++// streams, and returns a coherent (rows, endpoint) tuple. Fails if any sink
++// is closed, already flushed, or encountered an I/O error. Never patches the
++// 16-byte stream headers and never marks the sinks flushed.
++inline int census_checkpoint(CensusCheckpointData& out)
++{
++    CensusSinks* sp = census_resolve_sinks();
++    if (!sp) return 1;
++
++    std::lock_guard<std::mutex> lock(sp->mtx);
++    if (sp->flushed || sp->io_failed ||
++        !sp->contexts.enabled || !sp->contexts.file ||
++        !sp->records.enabled || !sp->records.file ||
++        !sp->journal.enabled || !sp->journal.file) {
++        return 1;
++    }
++
++    if (std::fflush(sp->contexts.file) != 0 ||
++        std::fflush(sp->records.file) != 0 ||
++        std::fflush(sp->journal.file) != 0) {
++        sp->io_failed = true;
++        return 1;
++    }
++
++    CensusCheckpointData data{
++        sp->contexts.count, 0,
++        sp->records.count, 0,
++        sp->journal.count, 0,
++    };
++    if (!census_tell_binary(sp->contexts, data.context_end) ||
++        !census_tell_binary(sp->records, data.record_end) ||
++        !census_tell_binary(sp->journal, data.journal_end)) {
++        sp->io_failed = true;
++        return 1;
++    }
++
++    out = data;
++    return 0;
++}
++
 +inline void census_patch_count_and_close(CensusSinks& sinks, CensusBinarySink& binary)
 +{
 +    if (!binary.file) return;
@@ -764,10 +856,13 @@ index 0000000..4f153ae
 +
 +#endif // BITCOIN_KERNEL_CENSUS_H
 diff --git a/bitcoin/src/script/interpreter.cpp b/bitcoin/src/script/interpreter.cpp
-index 443714c..a185230 100644
+index 443714c..ecf3fec 100644
 --- a/bitcoin/src/script/interpreter.cpp
 +++ b/bitcoin/src/script/interpreter.cpp
-@@ -4,6 +4,7 @@
+@@ -1,16 +1,17 @@
+ // Copyright (c) 2009-2010 Satoshi Nakamoto
+ // Copyright (c) 2009-present The Bitcoin Core developers
+ // Distributed under the MIT software license, see the accompanying
  // file COPYING or http://www.opensource.org/licenses/mit-license.php.
  
  #include <script/interpreter.h>
@@ -775,7 +870,21 @@ index 443714c..a185230 100644
  
  #include <crypto/ripemd160.h>
  #include <crypto/sha1.h>
-@@ -367,7 +368,10 @@
+ #include <crypto/sha256.h>
+ #include <pubkey.h>
+ #include <script/script.h>
+ #include <tinyformat.h>
+ #include <uint256.h>
+ 
+ typedef std::vector<unsigned char> valtype;
+@@ -360,21 +361,24 @@ static bool EvalChecksigTapscript(const valtype& sig, const valtype& pubkey, Scr
+         // Passing with an upgradable public key version is also counted.
+         assert(execdata.m_validation_weight_left_init);
+         execdata.m_validation_weight_left -= VALIDATION_WEIGHT_PER_SIGOP_PASSED;
+         if (execdata.m_validation_weight_left < 0) {
+             return set_error(serror, SCRIPT_ERR_TAPSCRIPT_VALIDATION_WEIGHT);
+         }
+     }
      if (pubkey.size() == 0) {
          return set_error(serror, SCRIPT_ERR_TAPSCRIPT_EMPTY_PUBKEY);
      } else if (pubkey.size() == 32) {
@@ -787,7 +896,21 @@ index 443714c..a185230 100644
              return false; // serror is set
          }
      } else {
-@@ -406,6 +410,7 @@
+         /*
+          *  New public key version softforks should be defined before this `else` block.
+          *  Generally, the new code should not do anything but failing the script execution. To avoid
+          *  consensus bugs, it should not modify any existing values (including `success`).
+          */
+         if ((flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE) != 0) {
+             return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_PUBKEYTYPE);
+@@ -399,20 +403,21 @@ static bool EvalChecksig(const valtype& sig, const valtype& pubkey, CScript::con
+         return EvalChecksigTapscript(sig, pubkey, execdata, flags, checker, sigversion, serror, success);
+     case SigVersion::TAPROOT:
+         // Key path spending in Taproot has no script, so this is unreachable.
+         break;
+     }
+     assert(false);
+ }
  
  bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, script_verify_flags flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror)
  {
@@ -795,7 +918,21 @@ index 443714c..a185230 100644
      static const CScriptNum bnZero(0);
      static const CScriptNum bnOne(1);
      // static const CScriptNum bnFalse(0);
-@@ -1059,6 +1064,10 @@
+     // static const CScriptNum bnTrue(1);
+     static const valtype vchFalse(0);
+     // static const valtype vchZero(0);
+     static const valtype vchTrue(1, 1);
+ 
+     // sigversion cannot be TAPROOT here, as it admits no script execution.
+     assert(sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0 || sigversion == SigVersion::TAPSCRIPT);
+@@ -1052,66 +1057,79 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript&
+ 
+                     // Hash starts after the code separator
+                     pbegincodehash = pc;
+                     execdata.m_codeseparator_pos = opcode_pos;
+                 }
+                 break;
+ 
                  case OP_CHECKSIG:
                  case OP_CHECKSIGVERIFY:
                  {
@@ -806,7 +943,9 @@ index 443714c..a185230 100644
                      // (sig pubkey -- bool)
                      if (stack.size() < 2)
                          return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-@@ -1068,6 +1077,7 @@
+ 
+                     valtype& vchSig    = stacktop(-2);
+                     valtype& vchPubKey = stacktop(-1);
  
                      bool fSuccess = true;
                      if (!EvalChecksig(vchSig, vchPubKey, pbegincodehash, pend, execdata, flags, checker, sigversion, serror, fSuccess)) return false;
@@ -814,7 +953,15 @@ index 443714c..a185230 100644
                      popstack(stack);
                      popstack(stack);
                      stack.push_back(fSuccess ? vchTrue : vchFalse);
-@@ -1083,6 +1093,9 @@
+                     if (opcode == OP_CHECKSIGVERIFY)
+                     {
+                         if (fSuccess)
+                             popstack(stack);
+                         else
+                             return set_error(serror, SCRIPT_ERR_CHECKSIGVERIFY);
+                     }
+                 }
+                 break;
  
                  case OP_CHECKSIGADD:
                  {
@@ -824,7 +971,12 @@ index 443714c..a185230 100644
                      // OP_CHECKSIGADD is only available in Tapscript
                      if (sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0) return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
  
-@@ -1095,6 +1108,7 @@
+                     // (sig num pubkey -- num)
+                     if (stack.size() < 3) return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+ 
+                     const valtype& sig = stacktop(-3);
+                     const CScriptNum num(stacktop(-2), fRequireMinimal);
+                     const valtype& pubkey = stacktop(-1);
  
                      bool success = true;
                      if (!EvalChecksig(sig, pubkey, pbegincodehash, pend, execdata, flags, checker, sigversion, serror, success)) return false;
@@ -832,7 +984,10 @@ index 443714c..a185230 100644
                      popstack(stack);
                      popstack(stack);
                      popstack(stack);
-@@ -1105,6 +1119,10 @@
+                     stack.push_back((num + (success ? 1 : 0)).getvch());
+                 }
+                 break;
+ 
                  case OP_CHECKMULTISIG:
                  case OP_CHECKMULTISIGVERIFY:
                  {
@@ -843,7 +998,21 @@ index 443714c..a185230 100644
                      if (sigversion == SigVersion::TAPSCRIPT) return set_error(serror, SCRIPT_ERR_TAPSCRIPT_CHECKMULTISIG);
  
                      // ([sig ...] num_of_signatures [pubkey ...] num_of_pubkeys -- bool)
-@@ -1179,6 +1197,8 @@
+ 
+                     int i = 1;
+                     if ((int)stack.size() < i)
+                         return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+ 
+                     int nKeysCount = CScriptNum(stacktop(-i), fRequireMinimal).getint();
+                     if (nKeysCount < 0 || nKeysCount > MAX_PUBKEYS_PER_MULTISIG)
+@@ -1172,20 +1190,22 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript&
+                         }
+                         ikey++;
+                         nKeysCount--;
+ 
+                         // If there are more signatures left than keys left,
+                         // then too many signatures have failed. Exit early,
+                         // without checking any further signatures.
                          if (nSigsCount > nKeysCount)
                              fSuccess = false;
                      }
@@ -852,7 +1021,21 @@ index 443714c..a185230 100644
  
                      // Clean up stack of actual arguments
                      while (i-- > 1) {
-@@ -1584,6 +1604,7 @@
+                         // If the operation failed, we require that all signatures must be empty vector
+                         if (!fSuccess && (flags & SCRIPT_VERIFY_NULLFAIL) && !ikey2 && stacktop(-1).size())
+                             return set_error(serror, SCRIPT_ERR_SIG_NULLFAIL);
+                         if (ikey2 > 0)
+                             ikey2--;
+                         popstack(stack);
+                     }
+@@ -1577,20 +1597,21 @@ int SigHashCache::CacheIndex(int32_t hash_type) const noexcept
+            2 * ((hash_type & 0x1f) == SIGHASH_SINGLE) +
+            1 * ((hash_type & 0x1f) == SIGHASH_NONE);
+ }
+ 
+ bool SigHashCache::Load(int32_t hash_type, const CScript& script_code, HashWriter& writer) const noexcept
+ {
+     auto& entry = m_cache_entries[CacheIndex(hash_type)];
      if (entry.has_value()) {
          if (script_code == entry->first) {
              writer = HashWriter(entry->second);
@@ -860,7 +1043,21 @@ index 443714c..a185230 100644
              return true;
          }
      }
-@@ -1685,29 +1706,75 @@
+     return false;
+ }
+ 
+ void SigHashCache::Store(int32_t hash_type, const CScript& script_code, const HashWriter& writer) noexcept
+ {
+     auto& entry = m_cache_entries[CacheIndex(hash_type)];
+     entry.emplace(script_code, writer);
+@@ -1678,73 +1699,142 @@ uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn
+ 
+ template <class T>
+ bool GenericTransactionSignatureChecker<T>::VerifyECDSASignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const uint256& sighash) const
+ {
+     return pubkey.Verify(sighash, vchSig);
+ }
+ 
  template <class T>
  bool GenericTransactionSignatureChecker<T>::VerifySchnorrSignature(std::span<const unsigned char> sig, const XOnlyPubKey& pubkey, const uint256& sighash) const
  {
@@ -911,14 +1108,13 @@ index 443714c..a185230 100644
  
      // Witness sighashes need the amount.
 -    if (sigversion == SigVersion::WITNESS_V0 && amount < 0) return HandleMissingData(m_mdb);
--
 +    if (sigversion == SigVersion::WITNESS_V0 && amount < 0) {
 +        // I9: reject missing data
 +        census_inc(C_CHECKECDSA_REJECT_MISSING_DATA);
 +        census_emit_record(tl_census.cur_op, sig_ver_byte, 2, (uint8_t)vchSig.size(), (uint8_t)vchPubKey.size(), (uint8_t)nHashType, 3, nullptr, vchSig.data(), vchPubKey.data());
 +        return HandleMissingData(m_mdb);
 +    }
-+
+ 
 +    // I10: sighash computed
 +    census_inc(C_SIGHASH_COMPUTED);
      uint256 sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion, this->txdata, &m_sighash_cache);
@@ -942,7 +1138,8 @@ index 443714c..a185230 100644
          return false;
  
      return true;
-@@ -1716,6 +1783,7 @@
+ }
+ 
  template <class T>
  bool GenericTransactionSignatureChecker<T>::CheckSchnorrSignature(std::span<const unsigned char> sig, std::span<const unsigned char> pubkey_in, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror) const
  {
@@ -950,7 +1147,7 @@ index 443714c..a185230 100644
      assert(sigversion == SigVersion::TAPROOT || sigversion == SigVersion::TAPSCRIPT);
      // Schnorr signatures have 32-byte public keys. The caller is responsible for enforcing this.
      assert(pubkey_in.size() == 32);
-@@ -1723,21 +1791,43 @@
+     // Note that in Tapscript evaluation, empty signatures are treated specially (invalid signature that does not
      // abort script execution). This is implemented in EvalChecksigTapscript, which won't invoke
      // CheckSchnorrSignature in that case. In other contexts, they are invalid like every other signature with
      // size different from 64 or 65.
@@ -970,13 +1167,12 @@ index 443714c..a185230 100644
      if (sig.size() == 65) {
          hashtype = SpanPopBack(sig);
 -        if (hashtype == SIGHASH_DEFAULT) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_HASHTYPE);
--    }
 +        if (hashtype == SIGHASH_DEFAULT) {
 +            census_emit_record(tl_census.cur_op, sig_ver_byte, 2, 64, 32, hashtype, 5,
 +                nullptr, sig.data(), pubkey_in.data());
 +            return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_HASHTYPE);
 +        }
-+    }
+     }
 +    if (!this->txdata) {
 +        census_emit_record(tl_census.cur_op, sig_ver_byte, 2, 64, 32, hashtype, 6,
 +            nullptr, sig.data(), pubkey_in.data());
@@ -999,7 +1195,21 @@ index 443714c..a185230 100644
      return true;
  }
  
-@@ -2001,6 +2091,7 @@
+ template <class T>
+ bool GenericTransactionSignatureChecker<T>::CheckLockTime(const CScriptNum& nLockTime) const
+ {
+     // There are two kinds of nLockTime: lock-by-blockheight
+     // and lock-by-blocktime, distinguished by whether
+     // nLockTime < LOCKTIME_THRESHOLD.
+     //
+@@ -1994,20 +2084,21 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion,
+             return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM);
+         }
+         // Other version/size/p2sh combinations return true for future softfork compatibility
+         return true;
+     }
+     // There is intentionally no return statement here, to be able to use "control reaches end of non-void function" warnings to detect gaps in the logic above.
+ }
  
  bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, script_verify_flags flags, const BaseSignatureChecker& checker, ScriptError* serror)
  {
@@ -1007,11 +1217,18 @@ index 443714c..a185230 100644
      static const CScriptWitness emptyWitness;
      if (witness == nullptr) {
          witness = &emptyWitness;
+     }
+     bool hadWitness = false;
+ 
+     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
+ 
+     if ((flags & SCRIPT_VERIFY_SIGPUSHONLY) != 0 && !scriptSig.IsPushOnly()) {
+         return set_error(serror, SCRIPT_ERR_SIG_PUSHONLY);
 diff --git a/src/lib.rs b/src/lib.rs
-index 96175be..eead168 100644
+index 96175be..2ae84bd 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
-@@ -191,20 +191,42 @@ pub struct btck_TransactionOutput {
+@@ -191,20 +191,54 @@ pub struct btck_TransactionOutput {
  }
  #[repr(C)]
  pub struct btck_TransactionSpentOutputs {
@@ -1044,6 +1261,18 @@ index 96175be..eead168 100644
 +    pub round_ns: [u64; 64],
 +}
 +
++
++#[repr(C)]
++pub struct btck_CensusCheckpoint {
++    pub abi_version: u32,
++    pub struct_size: u32,
++    pub context_rows: u64,
++    pub context_end: u64,
++    pub record_rows: u64,
++    pub record_end: u64,
++    pub journal_rows: u64,
++    pub journal_end: u64,
++}
  // Function-pointer type aliases - alphabetical order
  
  pub type btck_DestroyCallback = Option<unsafe extern "C" fn(user_data: *mut c_void)>;
@@ -1054,7 +1283,7 @@ index 96175be..eead168 100644
  
  pub type btck_NotifyBlockTip = Option<
      unsafe extern "C" fn(
-@@ -824,11 +846,26 @@ extern "C" {
+@@ -824,11 +858,28 @@ extern "C" {
  
      pub fn btck_block_header_get_nonce(header: *const btck_BlockHeader) -> u32;
  
@@ -1070,6 +1299,8 @@ index 96175be..eead168 100644
 +    pub fn btck_census_counter_count() -> usize;
 +    pub fn btck_census_snapshot(out_counters: *mut u64, counter_count: usize);
 +    pub fn btck_census_flush() -> c_int;
++    pub fn btck_census_checkpoint(out: *mut btck_CensusCheckpoint, out_size: usize) -> c_int;
++
 +    pub fn btck_bare_verify_bench(
 +        inputs: *const btck_bare_input,
 +        count: u64,

--- a/tools/checksig-census/instrumentation.diff
+++ b/tools/checksig-census/instrumentation.diff
@@ -1,7 +1,7 @@
-diff --git a/pristine/bitcoin/src/kernel/bitcoinkernel.cpp b/patched/bitcoin/src/kernel/bitcoinkernel.cpp
+diff --git a/bitcoin/src/kernel/bitcoinkernel.cpp b/bitcoin/src/kernel/bitcoinkernel.cpp
 index f21ea04..f8706c5 100644
---- a/pristine/bitcoin/src/kernel/bitcoinkernel.cpp
-+++ b/patched/bitcoin/src/kernel/bitcoinkernel.cpp
+--- a/bitcoin/src/kernel/bitcoinkernel.cpp
++++ b/bitcoin/src/kernel/bitcoinkernel.cpp
 @@ -1,48 +1,51 @@
  // Copyright (c) 2022-present The Bitcoin Core developers
  // Distributed under the MIT software license, see the accompanying
@@ -54,7 +54,7 @@ index f21ea04..f8706c5 100644
  #include <span>
  #include <stdexcept>
  #include <string>
-@@ -676,26 +679,44 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
+@@ -676,26 +679,51 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
  
      const PrecomputedTransactionData& txdata{precomputed_txdata ? btck_PrecomputedTransactionData::get(precomputed_txdata) : PrecomputedTransactionData(tx)};
  
@@ -65,11 +65,14 @@ index f21ea04..f8706c5 100644
  
      if (status) *status = btck_ScriptVerifyStatus_OK;
  
++    const auto& input = tx.vin[input_index];
++    const auto& prevout_script = btck_ScriptPubkey::get(script_pubkey);
++
 +    // I1: census entry - reset thread-local state, copy txid, set input_index.
 +    // Placed immediately before VerifyScript, after all flag and spent-output
 +    // preconditions. Invalid flags or missing taproot spent outputs return
 +    // above without incrementing ffi_verify_entries; they are not census rows.
-+    census_resolve_sinks();
++    CensusSinks* census_sinks = census_resolve_sinks();
 +    tl_census = CensusThreadState{};
 +    tl_census.active = true;
 +    const auto txid = tx.GetHash();
@@ -77,12 +80,22 @@ index f21ea04..f8706c5 100644
 +    tl_census.input_index = input_index;
 +    census_inc(C_FFI_VERIFY_ENTRIES);
 +
-     bool result = VerifyScript(tx.vin[input_index].scriptSig,
-                                btck_ScriptPubkey::get(script_pubkey),
-                                &tx.vin[input_index].scriptWitness,
-                                script_verify_flags::from_int(flags),
-                                TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
-                                nullptr);
++    if (census_sinks && census_sinks->contexts.enabled) {
++        census_emit_context(*census_sinks, flags, prevout_script.data(), prevout_script.size(),
++                            input.scriptSig.data(), input.scriptSig.size(), input.scriptWitness.stack);
++    }
+-    bool result = VerifyScript(tx.vin[input_index].scriptSig,
+-                               btck_ScriptPubkey::get(script_pubkey),
+-                               &tx.vin[input_index].scriptWitness,
+-                               script_verify_flags::from_int(flags),
+-                               TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
+-                               nullptr);
++    bool result = VerifyScript(input.scriptSig,
++                               prevout_script,
++                               &input.scriptWitness,
++                               script_verify_flags::from_int(flags),
++                               TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
++                               nullptr);
 +
 +    // I2: census exit - emit journal, count true
 +    if (result) census_inc(C_FFI_VERIFY_TRUE);
@@ -99,7 +112,7 @@ index f21ea04..f8706c5 100644
  
  const btck_TransactionOutPoint* btck_transaction_input_get_out_point(const btck_TransactionInput* input)
  {
-@@ -1437,10 +1458,100 @@ int btck_block_header_to_bytes(const btck_BlockHeader* header, unsigned char out
+@@ -1437,10 +1465,100 @@ int btck_block_header_to_bytes(const btck_BlockHeader* header, unsigned char out
          return 0;
      } catch (...) {
          return -1;
@@ -201,10 +214,10 @@ index f21ea04..f8706c5 100644
 +    return 0;
 +}
 \ No newline at end of file
-diff --git a/pristine/bitcoin/src/kernel/bitcoinkernel.h b/patched/bitcoin/src/kernel/bitcoinkernel.h
+diff --git a/bitcoin/src/kernel/bitcoinkernel.h b/bitcoin/src/kernel/bitcoinkernel.h
 index d302872..6aa4190 100644
---- a/pristine/bitcoin/src/kernel/bitcoinkernel.h
-+++ b/patched/bitcoin/src/kernel/bitcoinkernel.h
+--- a/bitcoin/src/kernel/bitcoinkernel.h
++++ b/bitcoin/src/kernel/bitcoinkernel.h
 @@ -1862,17 +1862,60 @@ BITCOINKERNEL_API uint32_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_header_ge
   * @return              0 on success.
   */
@@ -220,16 +233,16 @@ index d302872..6aa4190 100644
 +/// === Census API ===
 +///@{
 +
-+/** Reset all census counters to zero and clear journal/records. */
++/** Reset all census counters and reinitialize configured binary streams. */
 +BITCOINKERNEL_API void btck_census_reset(void);
 +
-+/** Get the fixed number of census counters (22). */
++/** Get the fixed number of census counters (24). */
 +BITCOINKERNEL_API size_t btck_census_counter_count(void);
 +
 +/** Snapshot all counters into the provided array. */
 +BITCOINKERNEL_API void btck_census_snapshot(uint64_t* out_counters, size_t counter_count);
 +
-+/** Flush census counters, journal, and records to env-configured paths. Idempotent. Returns 0 on success. */
++/** Flush census counters and binary streams to env-configured paths. Idempotent. Returns 0 on success. */
 +BITCOINKERNEL_API int btck_census_flush(void);
 +
 +/** Bare verify benchmark input: 176 bytes. */
@@ -266,12 +279,12 @@ index d302872..6aa4190 100644
  #endif // __cplusplus
  
  #endif // BITCOIN_KERNEL_BITCOINKERNEL_H
-diff --git a/patched/bitcoin/src/kernel/census.h b/patched/bitcoin/src/kernel/census.h
+diff --git a/bitcoin/src/kernel/census.h b/bitcoin/src/kernel/census.h
 new file mode 100644
 index 0000000..4f153ae
 --- /dev/null
-+++ b/patched/bitcoin/src/kernel/census.h
-@@ -0,0 +1,344 @@
++++ b/bitcoin/src/kernel/census.h
+@@ -0,0 +1,478 @@
 +#ifndef BITCOIN_KERNEL_CENSUS_H
 +#define BITCOIN_KERNEL_CENSUS_H
 +
@@ -281,15 +294,16 @@ index 0000000..4f153ae
 +// No other TU references these symbols, so no CMake change is needed.
 +
 +#include <atomic>
++#include <cstddef>
 +#include <cstdint>
 +#include <cstdio>
 +#include <cstdlib>
 +#include <cstring>
++#include <limits>
 +#include <mutex>
 +#include <string>
-+#include <vector>
 +
-+// --- 22 atomic counters in fixed order ---
++// --- 24 atomic counters in fixed order ---
 +enum CensusCounter : int {
 +    C_VERIFY_SCRIPT_CALLS = 0,
 +    C_FFI_VERIFY_ENTRIES,
@@ -313,10 +327,12 @@ index 0000000..4f153ae
 +    C_SIGHASH_MIDSTATE_HIT,
 +    C_CHECKSCHNORR_ENTRIES,
 +    C_SCHNORR_VERIFY_CALLS,
-+    C_CENSUS_COUNT // = 22
++    C_SCHNORR_VERIFY_OK,
++    C_SCHNORR_VERIFY_FAIL,
++    C_CENSUS_COUNT // = 24
 +};
 +
-+static constexpr size_t CENSUS_COUNTER_COUNT = 22;
++static constexpr size_t CENSUS_COUNTER_COUNT = 24;
 +
 +static constexpr const char* CENSUS_COUNTER_NAMES[CENSUS_COUNTER_COUNT] = {
 +    "verify_script_calls",
@@ -341,11 +357,14 @@ index 0000000..4f153ae
 +    "sighash_midstate_hit",
 +    "checkschnorr_entries",
 +    "schnorr_verify_calls",
++    "schnorr_verify_ok",
++    "schnorr_verify_fail",
 +};
 +
 +// --- Binary format constants ---
 +static constexpr char RECORD_MAGIC[8] = {'B','R','S','R','E','C','1','\0'};
 +static constexpr char JOURNAL_MAGIC[8] = {'B','R','S','J','R','N','1','\0'};
++static constexpr char CONTEXT_MAGIC[8] = {'B','R','S','C','T','X','1','\0'};
 +
 +// Record: 224 bytes packed
 +struct CensusRecord {
@@ -354,11 +373,11 @@ index 0000000..4f153ae
 +    uint32_t op_seq;          // 36
 +    uint8_t  op_kind;         // 40 (1=CHECKSIG,2=CHECKSIGVERIFY,3=CHECKMULTISIG,4=CHECKMULTISIGVERIFY,5=CHECKSIGADD)
 +    uint8_t  sig_version;     // 41 (0=BASE,1=WITNESS_V0,2=TAPSCRIPT,3=TAPROOT)
-+    uint8_t  outcome;         // 42 (0=false,1=true,2=pre-secp reject)
++    uint8_t  outcome;         // 42 (0=false,1=true,2=pre-verification reject)
 +    uint8_t  der_len;         // 43
 +    uint8_t  pubkey_len;      // 44
 +    uint8_t  sighash_type;    // 45
-+    uint8_t  reject_reason;   // 46 (0=none,1=bad pubkey,2=empty sig,3=missing data)
++    uint8_t  reject_reason;   // 46 (0=none; 1-3=ECDSA; 4-8=Schnorr; see README)
 +    uint8_t  _pad0;           // 47
 +    uint8_t  sighash[32];     // 48
 +    uint8_t  der_sig[72];     // 80  zero-padded
@@ -406,34 +425,89 @@ index 0000000..4f153ae
 +inline thread_local CensusThreadState tl_census;
 +
 +// --- Sink management ---
++struct CensusBinarySink {
++    FILE* file = nullptr;
++    std::string path;
++    uint64_t count = 0;
++    bool enabled = false;
++};
++
 +// CensusSinks is heap-allocated only when at least one of
-+// BRS_CENSUS_COUNTERS / JOURNAL / RECORDS is configured.  When all three
-+// are unset (the timing fast path) no sink object, mutex, vector, or string
-+// is ever constructed, and no atexit handler is registered.  BRS_CENSUS_LABEL
-+// alone does not enable sinks.
++// BRS_CENSUS_COUNTERS / JOURNAL / RECORDS / CONTEXTS is configured. When all
++// four are unset (the timing fast path), no sink object, mutex, or string is
++// constructed, no file is opened, and no atexit handler is registered.
++// BRS_CENSUS_LABEL alone does not enable sinks.
 +struct CensusSinks {
 +    std::mutex mtx;
-+    std::vector<CensusRecord> records;
-+    std::vector<CensusJournal> journal;
++    CensusBinarySink records;
++    CensusBinarySink journal;
++    CensusBinarySink contexts;
 +    std::string counters_path;
-+    std::string journal_path;
-+    std::string records_path;
 +    std::string label;
-+    bool has_records = false;
-+    bool has_journal = false;
-+    bool flushed = false;   // protected by mtx; set by flush, cleared by reset
-+    int flush_result = 0;    // protected by mtx; nonzero after any sink failure
++    bool io_failed = false;  // protected by mtx; sticky until quiescent reset
++    bool flushed = false;    // protected by mtx; set by flush, cleared by reset
++    int flush_result = 0;    // protected by mtx; cached idempotent flush result
 +};
++
++inline void census_write(CensusSinks& sinks, FILE* file, const void* data, size_t size)
++{
++    if (size != 0 && (!file || std::fwrite(data, 1, size, file) != size)) sinks.io_failed = true;
++}
++
++inline void census_write_u32(CensusSinks& sinks, FILE* file, uint32_t value)
++{
++    const uint8_t bytes[4] = {
++        static_cast<uint8_t>(value),
++        static_cast<uint8_t>(value >> 8),
++        static_cast<uint8_t>(value >> 16),
++        static_cast<uint8_t>(value >> 24),
++    };
++    census_write(sinks, file, bytes, sizeof(bytes));
++}
++
++inline void census_write_u64(CensusSinks& sinks, FILE* file, uint64_t value)
++{
++    const uint8_t bytes[8] = {
++        static_cast<uint8_t>(value),
++        static_cast<uint8_t>(value >> 8),
++        static_cast<uint8_t>(value >> 16),
++        static_cast<uint8_t>(value >> 24),
++        static_cast<uint8_t>(value >> 32),
++        static_cast<uint8_t>(value >> 40),
++        static_cast<uint8_t>(value >> 48),
++        static_cast<uint8_t>(value >> 56),
++    };
++    census_write(sinks, file, bytes, sizeof(bytes));
++}
++
++inline void census_open_binary(CensusSinks& sinks, CensusBinarySink& binary, const char magic[8])
++{
++    binary.count = 0;
++    binary.file = std::fopen(binary.path.c_str(), "wb+");
++    if (!binary.file) {
++        sinks.io_failed = true;
++        return;
++    }
++    census_write(sinks, binary.file, magic, 8);
++    census_write_u64(sinks, binary.file, 0);
++}
++
++inline void census_initialize_binary_files(CensusSinks& sinks)
++{
++    if (sinks.records.enabled) census_open_binary(sinks, sinks.records, RECORD_MAGIC);
++    if (sinks.journal.enabled) census_open_binary(sinks, sinks.journal, JOURNAL_MAGIC);
++    if (sinks.contexts.enabled) census_open_binary(sinks, sinks.contexts, CONTEXT_MAGIC);
++}
 +
 +// Forward declaration — referenced by the atexit lambda in census_resolve_sinks.
 +inline int census_flush();
 +
-+// Resolve env vars exactly once.  Returns a pointer to the heap-allocated
++// Resolve env vars exactly once. Returns a pointer to the heap-allocated
 +// CensusSinks, or nullptr when no output path is configured.
 +//
-+// The first call may invoke getenv and call_once.  It does NOT construct a
-+// mutex, vector, string-owning CensusSinks, allocate, register atexit, lock,
-+// or write unless at least one of COUNTERS/JOURNAL/RECORDS is set.
++// The first call may invoke getenv and call_once. It does not construct a
++// string-owning CensusSinks, allocate, register atexit, lock, or perform I/O
++// unless at least one of COUNTERS/JOURNAL/RECORDS/CONTEXTS is set.
 +inline CensusSinks* census_resolve_sinks() {
 +    static std::once_flag flag;
 +    static CensusSinks* sinks = nullptr;
@@ -441,16 +515,19 @@ index 0000000..4f153ae
 +        const char* counters = std::getenv("BRS_CENSUS_COUNTERS");
 +        const char* journal  = std::getenv("BRS_CENSUS_JOURNAL");
 +        const char* records  = std::getenv("BRS_CENSUS_RECORDS");
++        const char* contexts = std::getenv("BRS_CENSUS_CONTEXTS");
 +        const char* label    = std::getenv("BRS_CENSUS_LABEL");
 +
 +        // Label alone does not enable sinks.
-+        if (!counters && !journal && !records) return;
++        if (!counters && !journal && !records && !contexts) return;
 +
 +        CensusSinks* s = new CensusSinks();
 +        if (counters) s->counters_path = counters;
-+        if (journal)  { s->journal_path = journal;  s->has_journal = true; }
-+        if (records)  { s->records_path = records;  s->has_records = true; }
-+        if (label)    s->label = label;
++        if (journal)  { s->journal.path = journal; s->journal.enabled = true; }
++        if (records)  { s->records.path = records; s->records.enabled = true; }
++        if (contexts) { s->contexts.path = contexts; s->contexts.enabled = true; }
++        if (label) s->label = label;
++        census_initialize_binary_files(*s);
 +
 +        sinks = s;
 +        std::atexit([]() {
@@ -460,10 +537,23 @@ index 0000000..4f153ae
 +    return sinks;
 +}
 +
++inline void census_patch_count_and_close(CensusSinks& sinks, CensusBinarySink& binary)
++{
++    if (!binary.file) return;
++    if (std::fseek(binary.file, 8, SEEK_SET) != 0) {
++        sinks.io_failed = true;
++    } else {
++        census_write_u64(sinks, binary.file, binary.count);
++    }
++    if (std::fflush(binary.file) != 0) sinks.io_failed = true;
++    if (std::fclose(binary.file) != 0) sinks.io_failed = true;
++    binary.file = nullptr;
++}
++
 +// --- Flush: zero-argument, idempotent, race-free ---
-+// Writes counters JSON, journal binary, and records binary to the configured
-+// paths. Flush is a shutdown-only operation. Holding the sink mutex through
-+// I/O makes concurrent flush/reset/emit calls observe one final result.
++// Patches streamed binary counts, closes their files, and writes counters JSON.
++// Holding the one sink mutex through I/O gives all three binary sinks one
++// emission order and makes concurrent flush/reset/emit observe one result.
 +inline int census_flush() {
 +    CensusSinks* sp = census_resolve_sinks();
 +    if (!sp) return 0;
@@ -471,75 +561,53 @@ index 0000000..4f153ae
 +    std::lock_guard<std::mutex> lock(sp->mtx);
 +    if (sp->flushed) return sp->flush_result;
 +    sp->flushed = true;
-+    sp->flush_result = 1;
 +
-+    bool failed = false;
-+    auto close_file = [&failed](FILE* f) {
-+        const bool stream_error = std::ferror(f) != 0;
-+        const bool close_error = std::fclose(f) != 0;
-+        if (stream_error || close_error) failed = true;
-+    };
-+    auto write_items = [&failed](FILE* f, const void* data, size_t size, size_t count) {
-+        if (count != 0 && std::fwrite(data, size, count, f) != count) failed = true;
-+    };
++    census_patch_count_and_close(*sp, sp->records);
++    census_patch_count_and_close(*sp, sp->journal);
++    census_patch_count_and_close(*sp, sp->contexts);
 +
 +    if (!sp->counters_path.empty()) {
 +        FILE* f = std::fopen(sp->counters_path.c_str(), "wb");
 +        if (!f) {
-+            failed = true;
++            sp->io_failed = true;
 +        } else {
 +            if (std::fprintf(f, "{\"schema\":1,\"label\":\"%s\"", sp->label.c_str()) < 0) {
-+                failed = true;
++                sp->io_failed = true;
 +            }
 +            for (size_t i = 0; i < CENSUS_COUNTER_COUNT; i++) {
 +                if (std::fprintf(f, ",\"%s\":%llu",
 +                        CENSUS_COUNTER_NAMES[i],
 +                        (unsigned long long)census_counter((int)i).load(std::memory_order_relaxed)) < 0) {
-+                    failed = true;
++                    sp->io_failed = true;
 +                }
 +            }
-+            if (std::fprintf(f, ",\"record_count\":%llu,\"journal_count\":%llu}\n",
-+                    (unsigned long long)sp->records.size(),
-+                    (unsigned long long)sp->journal.size()) < 0) {
-+                failed = true;
++            if (std::fprintf(f, ",\"record_count\":%llu,\"journal_count\":%llu,\"context_count\":%llu}\n",
++                    (unsigned long long)sp->records.count,
++                    (unsigned long long)sp->journal.count,
++                    (unsigned long long)sp->contexts.count) < 0) {
++                sp->io_failed = true;
 +            }
-+            close_file(f);
++            if (std::fflush(f) != 0) sp->io_failed = true;
++            if (std::fclose(f) != 0) sp->io_failed = true;
 +        }
 +    }
 +
-+    if (sp->has_journal && !sp->journal_path.empty()) {
-+        FILE* f = std::fopen(sp->journal_path.c_str(), "wb");
-+        if (!f) {
-+            failed = true;
-+        } else {
-+            const uint64_t count = sp->journal.size();
-+            write_items(f, JOURNAL_MAGIC, 1, sizeof(JOURNAL_MAGIC));
-+            write_items(f, &count, sizeof(count), 1);
-+            write_items(f, sp->journal.data(), sizeof(CensusJournal), sp->journal.size());
-+            close_file(f);
-+        }
-+    }
-+
-+    if (sp->has_records && !sp->records_path.empty()) {
-+        FILE* f = std::fopen(sp->records_path.c_str(), "wb");
-+        if (!f) {
-+            failed = true;
-+        } else {
-+            const uint64_t count = sp->records.size();
-+            write_items(f, RECORD_MAGIC, 1, sizeof(RECORD_MAGIC));
-+            write_items(f, &count, sizeof(count), 1);
-+            write_items(f, sp->records.data(), sizeof(CensusRecord), sp->records.size());
-+            close_file(f);
-+        }
-+    }
-+
-+    sp->flush_result = failed ? 1 : 0;
++    sp->flush_result = sp->io_failed ? 1 : 0;
 +    return sp->flush_result;
 +}
 +
 +// --- Helper functions called from bitcoinkernel.cpp ---
 +
-+// Quiescent-only: reset all counters and clear sink vectors.
++inline bool census_close_for_reset(CensusBinarySink& binary)
++{
++    if (!binary.file) return false;
++    const bool failed = std::fclose(binary.file) != 0;
++    binary.file = nullptr;
++    binary.count = 0;
++    return failed;
++}
++
++// Quiescent-only: reset counters and truncate/reinitialize enabled streams.
 +inline void census_reset() {
 +    for (size_t i = 0; i < CENSUS_COUNTER_COUNT; i++) {
 +        census_counter((int)i).store(0, std::memory_order_relaxed);
@@ -547,13 +615,19 @@ index 0000000..4f153ae
 +    CensusSinks* sp = census_resolve_sinks();
 +    if (!sp) return;
 +    std::lock_guard<std::mutex> lock(sp->mtx);
-+    sp->records.clear();
-+    sp->journal.clear();
-+    sp->flushed = false;   // allow a subsequent flush after reset
++    const bool close_failed = census_close_for_reset(sp->records) |
++                              census_close_for_reset(sp->journal) |
++                              census_close_for_reset(sp->contexts);
++    sp->records.count = 0;
++    sp->journal.count = 0;
++    sp->contexts.count = 0;
++    sp->io_failed = close_failed;
++    sp->flushed = false;
 +    sp->flush_result = 0;
++    census_initialize_binary_files(*sp);
 +}
 +
-+// Returns the fixed counter count (22).  Counter values are obtained
++// Returns the fixed counter count (24). Counter values are obtained
 +// exclusively through census_snapshot.
 +inline size_t census_counter_count() {
 +    return CENSUS_COUNTER_COUNT;
@@ -575,7 +649,10 @@ index 0000000..4f153ae
 +                                const uint8_t* pubkey)   // pubkey_len bytes or null
 +{
 +    CensusSinks* sp = census_resolve_sinks();
-+    if (!sp || !sp->has_records) return;
++    if (!sp || !sp->records.enabled) return;
++
++    std::lock_guard<std::mutex> lock(sp->mtx);
++    if (sp->flushed || sp->io_failed) return;
 +
 +    CensusRecord rec{};
 +    std::memcpy(rec.spend_txid, tl_census.spend_txid, 32);
@@ -592,14 +669,16 @@ index 0000000..4f153ae
 +    if (der_sig && der_len > 0) std::memcpy(rec.der_sig, der_sig, der_len > 72 ? 72 : der_len);
 +    if (pubkey && pubkey_len > 0) std::memcpy(rec.pubkey, pubkey, pubkey_len > 65 ? 65 : pubkey_len);
 +
-+    std::lock_guard<std::mutex> lock(sp->mtx);
-+    if (sp->flushed) return;   // skip after flush — no post-snapshot record lost
-+    sp->records.push_back(rec);
++    census_write(*sp, sp->records.file, &rec, sizeof(rec));
++    if (!sp->io_failed) ++sp->records.count;
 +}
 +
 +inline void census_emit_journal(bool verdict) {
 +    CensusSinks* sp = census_resolve_sinks();
-+    if (!sp || !sp->has_journal) return;
++    if (!sp || !sp->journal.enabled) return;
++
++    std::lock_guard<std::mutex> lock(sp->mtx);
++    if (sp->flushed || sp->io_failed) return;
 +
 +    CensusJournal j{};
 +    std::memcpy(j.spend_txid, tl_census.spend_txid, 32);
@@ -610,20 +689,85 @@ index 0000000..4f153ae
 +    j.ecdsa_verify_ok = tl_census.ecdsa_ok;
 +    j.verdict = verdict ? 1 : 0;
 +
-+    std::lock_guard<std::mutex> lock(sp->mtx);
-+    if (sp->flushed) return;   // skip after flush — no post-snapshot record lost
-+    sp->journal.push_back(j);
++    census_write(*sp, sp->journal.file, &j, sizeof(j));
++    if (!sp->io_failed) ++sp->journal.count;
++}
++
++inline bool census_size_u32(size_t size, uint32_t& out)
++{
++    if (size > std::numeric_limits<uint32_t>::max()) return false;
++    out = static_cast<uint32_t>(size);
++    return true;
++}
++
++inline bool census_add_u32(uint32_t& total, uint32_t value)
++{
++    if (value > std::numeric_limits<uint32_t>::max() - total) return false;
++    total += value;
++    return true;
++}
++
++// BRSCTX1 rows are validated first, then streamed field-by-field without a row buffer.
++template <typename WitnessStack>
++inline void census_emit_context(CensusSinks& sinks, uint32_t flags,
++                                const uint8_t* prevout_script, size_t prevout_script_size,
++                                const uint8_t* script_sig, size_t script_sig_size,
++                                const WitnessStack& witness)
++{
++    std::lock_guard<std::mutex> lock(sinks.mtx);
++    if (sinks.flushed || sinks.io_failed) return;
++
++    uint32_t prevout_script_len;
++    uint32_t script_sig_len;
++    uint32_t witness_count;
++    if (!census_size_u32(prevout_script_size, prevout_script_len) ||
++        !census_size_u32(script_sig_size, script_sig_len) ||
++        !census_size_u32(witness.size(), witness_count)) {
++        sinks.io_failed = true;
++        return;
++    }
++
++    uint32_t row_len = 32 + 5 * static_cast<uint32_t>(sizeof(uint32_t));
++    if (!census_add_u32(row_len, prevout_script_len) ||
++        !census_add_u32(row_len, script_sig_len)) {
++        sinks.io_failed = true;
++        return;
++    }
++    for (const auto& item : witness) {
++        uint32_t item_len;
++        if (!census_size_u32(item.size(), item_len) ||
++            !census_add_u32(row_len, sizeof(uint32_t)) ||
++            !census_add_u32(row_len, item_len)) {
++            sinks.io_failed = true;
++            return;
++        }
++    }
++
++    FILE* const file = sinks.contexts.file;
++    census_write_u32(sinks, file, row_len);
++    census_write(sinks, file, tl_census.spend_txid, sizeof(tl_census.spend_txid));
++    census_write_u32(sinks, file, tl_census.input_index);
++    census_write_u32(sinks, file, flags);
++    census_write_u32(sinks, file, prevout_script_len);
++    census_write_u32(sinks, file, script_sig_len);
++    census_write_u32(sinks, file, witness_count);
++    census_write(sinks, file, prevout_script, prevout_script_len);
++    census_write(sinks, file, script_sig, script_sig_len);
++    for (const auto& item : witness) {
++        uint32_t item_len;
++        if (!census_size_u32(item.size(), item_len)) { sinks.io_failed = true; return; }
++        census_write_u32(sinks, file, item_len);
++        census_write(sinks, file, item.data(), item_len);
++    }
++    if (!sinks.io_failed) ++sinks.contexts.count;
 +}
 +
 +#endif // BITCOIN_KERNEL_CENSUS_H
-diff --git a/pristine/bitcoin/src/script/interpreter.cpp b/patched/bitcoin/src/script/interpreter.cpp
+diff --git a/bitcoin/src/script/interpreter.cpp b/bitcoin/src/script/interpreter.cpp
 index 443714c..a185230 100644
---- a/pristine/bitcoin/src/script/interpreter.cpp
-+++ b/patched/bitcoin/src/script/interpreter.cpp
-@@ -1,16 +1,17 @@
- // Copyright (c) 2009-2010 Satoshi Nakamoto
- // Copyright (c) 2009-present The Bitcoin Core developers
- // Distributed under the MIT software license, see the accompanying
+--- a/bitcoin/src/script/interpreter.cpp
++++ b/bitcoin/src/script/interpreter.cpp
+@@ -4,6 +4,7 @@
  // file COPYING or http://www.opensource.org/licenses/mit-license.php.
  
  #include <script/interpreter.h>
@@ -631,21 +775,19 @@ index 443714c..a185230 100644
  
  #include <crypto/ripemd160.h>
  #include <crypto/sha1.h>
- #include <crypto/sha256.h>
- #include <pubkey.h>
- #include <script/script.h>
- #include <tinyformat.h>
- #include <uint256.h>
- 
- typedef std::vector<unsigned char> valtype;
-@@ -399,20 +400,21 @@ static bool EvalChecksig(const valtype& sig, const valtype& pubkey, CScript::con
-         return EvalChecksigTapscript(sig, pubkey, execdata, flags, checker, sigversion, serror, success);
-     case SigVersion::TAPROOT:
-         // Key path spending in Taproot has no script, so this is unreachable.
-         break;
-     }
-     assert(false);
- }
+@@ -367,7 +368,10 @@
+     if (pubkey.size() == 0) {
+         return set_error(serror, SCRIPT_ERR_TAPSCRIPT_EMPTY_PUBKEY);
+     } else if (pubkey.size() == 32) {
+-        if (success && !checker.CheckSchnorrSignature(sig, pubkey, sigversion, execdata, serror)) {
++        if (!success) {
++            census_emit_record(tl_census.cur_op, 2, 2, 0, 32, 0, 8,
++                nullptr, nullptr, pubkey.data());
++        } else if (!checker.CheckSchnorrSignature(sig, pubkey, sigversion, execdata, serror)) {
+             return false; // serror is set
+         }
+     } else {
+@@ -406,6 +410,7 @@
  
  bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, script_verify_flags flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror)
  {
@@ -653,21 +795,7 @@ index 443714c..a185230 100644
      static const CScriptNum bnZero(0);
      static const CScriptNum bnOne(1);
      // static const CScriptNum bnFalse(0);
-     // static const CScriptNum bnTrue(1);
-     static const valtype vchFalse(0);
-     // static const valtype vchZero(0);
-     static const valtype vchTrue(1, 1);
- 
-     // sigversion cannot be TAPROOT here, as it admits no script execution.
-     assert(sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0 || sigversion == SigVersion::TAPSCRIPT);
-@@ -1052,66 +1054,79 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript&
- 
-                     // Hash starts after the code separator
-                     pbegincodehash = pc;
-                     execdata.m_codeseparator_pos = opcode_pos;
-                 }
-                 break;
- 
+@@ -1059,6 +1064,10 @@
                  case OP_CHECKSIG:
                  case OP_CHECKSIGVERIFY:
                  {
@@ -678,9 +806,7 @@ index 443714c..a185230 100644
                      // (sig pubkey -- bool)
                      if (stack.size() < 2)
                          return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
- 
-                     valtype& vchSig    = stacktop(-2);
-                     valtype& vchPubKey = stacktop(-1);
+@@ -1068,6 +1077,7 @@
  
                      bool fSuccess = true;
                      if (!EvalChecksig(vchSig, vchPubKey, pbegincodehash, pend, execdata, flags, checker, sigversion, serror, fSuccess)) return false;
@@ -688,15 +814,7 @@ index 443714c..a185230 100644
                      popstack(stack);
                      popstack(stack);
                      stack.push_back(fSuccess ? vchTrue : vchFalse);
-                     if (opcode == OP_CHECKSIGVERIFY)
-                     {
-                         if (fSuccess)
-                             popstack(stack);
-                         else
-                             return set_error(serror, SCRIPT_ERR_CHECKSIGVERIFY);
-                     }
-                 }
-                 break;
+@@ -1083,6 +1093,9 @@
  
                  case OP_CHECKSIGADD:
                  {
@@ -706,12 +824,7 @@ index 443714c..a185230 100644
                      // OP_CHECKSIGADD is only available in Tapscript
                      if (sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0) return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
  
-                     // (sig num pubkey -- num)
-                     if (stack.size() < 3) return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
- 
-                     const valtype& sig = stacktop(-3);
-                     const CScriptNum num(stacktop(-2), fRequireMinimal);
-                     const valtype& pubkey = stacktop(-1);
+@@ -1095,6 +1108,7 @@
  
                      bool success = true;
                      if (!EvalChecksig(sig, pubkey, pbegincodehash, pend, execdata, flags, checker, sigversion, serror, success)) return false;
@@ -719,10 +832,7 @@ index 443714c..a185230 100644
                      popstack(stack);
                      popstack(stack);
                      popstack(stack);
-                     stack.push_back((num + (success ? 1 : 0)).getvch());
-                 }
-                 break;
- 
+@@ -1105,6 +1119,10 @@
                  case OP_CHECKMULTISIG:
                  case OP_CHECKMULTISIGVERIFY:
                  {
@@ -733,21 +843,7 @@ index 443714c..a185230 100644
                      if (sigversion == SigVersion::TAPSCRIPT) return set_error(serror, SCRIPT_ERR_TAPSCRIPT_CHECKMULTISIG);
  
                      // ([sig ...] num_of_signatures [pubkey ...] num_of_pubkeys -- bool)
- 
-                     int i = 1;
-                     if ((int)stack.size() < i)
-                         return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
- 
-                     int nKeysCount = CScriptNum(stacktop(-i), fRequireMinimal).getint();
-                     if (nKeysCount < 0 || nKeysCount > MAX_PUBKEYS_PER_MULTISIG)
-@@ -1172,20 +1187,22 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript&
-                         }
-                         ikey++;
-                         nKeysCount--;
- 
-                         // If there are more signatures left than keys left,
-                         // then too many signatures have failed. Exit early,
-                         // without checking any further signatures.
+@@ -1179,6 +1197,8 @@
                          if (nSigsCount > nKeysCount)
                              fSuccess = false;
                      }
@@ -756,21 +852,7 @@ index 443714c..a185230 100644
  
                      // Clean up stack of actual arguments
                      while (i-- > 1) {
-                         // If the operation failed, we require that all signatures must be empty vector
-                         if (!fSuccess && (flags & SCRIPT_VERIFY_NULLFAIL) && !ikey2 && stacktop(-1).size())
-                             return set_error(serror, SCRIPT_ERR_SIG_NULLFAIL);
-                         if (ikey2 > 0)
-                             ikey2--;
-                         popstack(stack);
-                     }
-@@ -1577,20 +1594,21 @@ int SigHashCache::CacheIndex(int32_t hash_type) const noexcept
-            2 * ((hash_type & 0x1f) == SIGHASH_SINGLE) +
-            1 * ((hash_type & 0x1f) == SIGHASH_NONE);
- }
- 
- bool SigHashCache::Load(int32_t hash_type, const CScript& script_code, HashWriter& writer) const noexcept
- {
-     auto& entry = m_cache_entries[CacheIndex(hash_type)];
+@@ -1584,6 +1604,7 @@
      if (entry.has_value()) {
          if (script_code == entry->first) {
              writer = HashWriter(entry->second);
@@ -778,26 +860,15 @@ index 443714c..a185230 100644
              return true;
          }
      }
-     return false;
- }
- 
- void SigHashCache::Store(int32_t hash_type, const CScript& script_code, const HashWriter& writer) noexcept
- {
-     auto& entry = m_cache_entries[CacheIndex(hash_type)];
-     entry.emplace(script_code, writer);
-@@ -1678,51 +1696,96 @@ uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn
- 
- template <class T>
- bool GenericTransactionSignatureChecker<T>::VerifyECDSASignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const uint256& sighash) const
- {
-     return pubkey.Verify(sighash, vchSig);
- }
- 
+@@ -1685,29 +1706,75 @@
  template <class T>
  bool GenericTransactionSignatureChecker<T>::VerifySchnorrSignature(std::span<const unsigned char> sig, const XOnlyPubKey& pubkey, const uint256& sighash) const
  {
+-    return pubkey.VerifySchnorr(sighash, sig);
 +    census_inc(C_SCHNORR_VERIFY_CALLS);
-     return pubkey.VerifySchnorr(sighash, sig);
++    const bool ok = pubkey.VerifySchnorr(sighash, sig);
++    census_inc(ok ? C_SCHNORR_VERIFY_OK : C_SCHNORR_VERIFY_FAIL);
++    return ok;
  }
  
  template <class T>
@@ -840,13 +911,14 @@ index 443714c..a185230 100644
  
      // Witness sighashes need the amount.
 -    if (sigversion == SigVersion::WITNESS_V0 && amount < 0) return HandleMissingData(m_mdb);
+-
 +    if (sigversion == SigVersion::WITNESS_V0 && amount < 0) {
 +        // I9: reject missing data
 +        census_inc(C_CHECKECDSA_REJECT_MISSING_DATA);
 +        census_emit_record(tl_census.cur_op, sig_ver_byte, 2, (uint8_t)vchSig.size(), (uint8_t)vchPubKey.size(), (uint8_t)nHashType, 3, nullptr, vchSig.data(), vchPubKey.data());
 +        return HandleMissingData(m_mdb);
 +    }
- 
++
 +    // I10: sighash computed
 +    census_inc(C_SIGHASH_COMPUTED);
      uint256 sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion, this->txdata, &m_sighash_cache);
@@ -870,8 +942,7 @@ index 443714c..a185230 100644
          return false;
  
      return true;
- }
- 
+@@ -1716,6 +1783,7 @@
  template <class T>
  bool GenericTransactionSignatureChecker<T>::CheckSchnorrSignature(std::span<const unsigned char> sig, std::span<const unsigned char> pubkey_in, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror) const
  {
@@ -879,21 +950,56 @@ index 443714c..a185230 100644
      assert(sigversion == SigVersion::TAPROOT || sigversion == SigVersion::TAPSCRIPT);
      // Schnorr signatures have 32-byte public keys. The caller is responsible for enforcing this.
      assert(pubkey_in.size() == 32);
-     // Note that in Tapscript evaluation, empty signatures are treated specially (invalid signature that does not
+@@ -1723,21 +1791,43 @@
      // abort script execution). This is implemented in EvalChecksigTapscript, which won't invoke
      // CheckSchnorrSignature in that case. In other contexts, they are invalid like every other signature with
      // size different from 64 or 65.
-     if (sig.size() != 64 && sig.size() != 65) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_SIZE);
+-    if (sig.size() != 64 && sig.size() != 65) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_SIZE);
++
++    const uint8_t sig_ver_byte = sigversion == SigVersion::TAPSCRIPT ? 2 : 3;
++    const uint8_t captured_sig_len = sig.size() > 72 ? 72 : static_cast<uint8_t>(sig.size());
++    if (sig.size() != 64 && sig.size() != 65) {
++        census_emit_record(tl_census.cur_op, sig_ver_byte, 2, captured_sig_len, 32, 0, 4,
++            nullptr, sig.data(), pubkey_in.data());
++        return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_SIZE);
++    }
  
      XOnlyPubKey pubkey{pubkey_in};
-@@ -1994,20 +2057,21 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion,
-             return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM);
-         }
-         // Other version/size/p2sh combinations return true for future softfork compatibility
-         return true;
+ 
+     uint8_t hashtype = SIGHASH_DEFAULT;
+     if (sig.size() == 65) {
+         hashtype = SpanPopBack(sig);
+-        if (hashtype == SIGHASH_DEFAULT) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_HASHTYPE);
+-    }
++        if (hashtype == SIGHASH_DEFAULT) {
++            census_emit_record(tl_census.cur_op, sig_ver_byte, 2, 64, 32, hashtype, 5,
++                nullptr, sig.data(), pubkey_in.data());
++            return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_HASHTYPE);
++        }
++    }
++    if (!this->txdata) {
++        census_emit_record(tl_census.cur_op, sig_ver_byte, 2, 64, 32, hashtype, 6,
++            nullptr, sig.data(), pubkey_in.data());
++        return HandleMissingData(m_mdb);
++    }
++
+     uint256 sighash;
+-    if (!this->txdata) return HandleMissingData(m_mdb);
+     if (!SignatureHashSchnorr(sighash, execdata, *txTo, nIn, hashtype, sigversion, *this->txdata, m_mdb)) {
++        census_emit_record(tl_census.cur_op, sig_ver_byte, 2, 64, 32, hashtype, 7,
++            nullptr, sig.data(), pubkey_in.data());
+         return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_HASHTYPE);
      }
-     // There is intentionally no return statement here, to be able to use "control reaches end of non-void function" warnings to detect gaps in the logic above.
+-    if (!VerifySchnorrSignature(sig, pubkey, sighash)) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG);
++
++    const bool schnorr_ok = VerifySchnorrSignature(sig, pubkey, sighash);
++    census_emit_record(tl_census.cur_op, sig_ver_byte, schnorr_ok ? 1 : 0, 64, 32, hashtype, 0,
++        sighash.begin(), sig.data(), pubkey_in.data());
++    if (!schnorr_ok) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG);
+     return true;
  }
+ 
+@@ -2001,6 +2091,7 @@
  
  bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, script_verify_flags flags, const BaseSignatureChecker& checker, ScriptError* serror)
  {
@@ -901,17 +1007,10 @@ index 443714c..a185230 100644
      static const CScriptWitness emptyWitness;
      if (witness == nullptr) {
          witness = &emptyWitness;
-     }
-     bool hadWitness = false;
- 
-     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
- 
-     if ((flags & SCRIPT_VERIFY_SIGPUSHONLY) != 0 && !scriptSig.IsPushOnly()) {
-         return set_error(serror, SCRIPT_ERR_SIG_PUSHONLY);
-diff --git a/pristine/src/lib.rs b/patched/src/lib.rs
+diff --git a/src/lib.rs b/src/lib.rs
 index 96175be..eead168 100644
---- a/pristine/src/lib.rs
-+++ b/patched/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
 @@ -191,20 +191,42 @@ pub struct btck_TransactionOutput {
  }
  #[repr(C)]

--- a/tools/checksig-census/test_validation_contracts.py
+++ b/tools/checksig-census/test_validation_contracts.py
@@ -77,6 +77,7 @@ from context import (
     classify_input,
     iter_context_inputs,
     iter_legacy_context_inputs,
+    parse_script,
     read_bounded_context_rows,
 )
 
@@ -1667,6 +1668,29 @@ def test_brsctx1_accepts_valid_file() -> None:
 # ── Tests: classify_input spend-context classification ───────────────────────
 
 
+def test_classify_input_block_177609_op_0_p2sh() -> None:
+    """The exact block-177609 OP_0 multisig spend classifies as P2SH."""
+    evidence = _ctx_input(
+        bytes.fromhex(
+            "1cc1ecdf5c05765df3d1f59fba24cd01c45464c329b0f0a25aa9883adfcf7f29"
+        )[::-1],
+        0,
+        verify_flags=VERIFY_P2SH,
+        prevout=bytes.fromhex("a9145c02c49641699863f909bf4bf3be8398d2e383f187"),
+        script_sig=bytes.fromhex(
+            "00483045022100beb926da7428fa009ac770576342ebd1960939e73584a5d0"
+            "f3229b58c41e906f022017c0d143077906afccf30caf21f5ece0bb30e3f7"
+            "08fd4a17f9d9ef9fe7cdc983014751210307ac6296168948c3f64ce22f51"
+            "f6e5424f936c846f1d01223b3d9864f4d955662103ac6ad514715bec8d5d"
+            "e1873b9bc873bb71773b51338b4d115f9938b6a029b7d152ae"
+        ),
+    )
+
+    classified = classify_input(evidence)
+
+    assert classified.spend_context == SpendContext.P2SH
+
+
 def test_classify_input_bare_p2pkh() -> None:
     """Bare P2PKH with no flags classifies as BARE."""
     txid_le = b"\x10" * 32
@@ -1836,6 +1860,101 @@ def test_classify_input_taproot_bad_control_block() -> None:
         lambda: classify_input(evidence),
         "P2TR script-path bad control block",
     )
+
+
+def test_classify_input_p2sh_op_reserved_scriptsig() -> None:
+    """P2SH with OP_RESERVED in scriptSig must raise ContextError."""
+    txid_le = b"\x1c" * 32
+    redeem = _multisig_redeem_script()
+    bad_script_sig = _push(redeem) + bytes([0x50])  # extra OP_RESERVED byte
+    evidence = _ctx_input(
+        txid_le,
+        0,
+        verify_flags=VERIFY_P2SH,
+        prevout=_p2sh_prevout(),
+        script_sig=bad_script_sig,
+    )
+    _raises(
+        ContextError, lambda: classify_input(evidence), "OP_RESERVED P2SH scriptSig"
+    )
+
+
+# ── Tests: parse_script Core stack semantics ─────────────────────────────────
+
+
+def test_parse_script_op_0_pushes_empty() -> None:
+    """OP_0 must push an empty byte vector, matching Core."""
+    elements = parse_script(bytes([0x00]))
+    assert len(elements) == 1
+    assert elements[0].opcode == 0x00
+    assert elements[0].pushed == b""
+
+
+def test_parse_script_op_1negate_pushes_negative_one() -> None:
+    """OP_1NEGATE must push the single-byte ScriptNum 0x81."""
+    elements = parse_script(bytes([0x4F]))
+    assert len(elements) == 1
+    assert elements[0].opcode == 0x4F
+    assert elements[0].pushed == b"\x81"
+
+
+def test_parse_script_small_integers_pushes_core_scriptnum() -> None:
+    """OP_1..OP_16 must push the single bytes 0x01..0x10."""
+    script = bytes(range(0x51, 0x61))
+    elements = parse_script(script)
+    assert len(elements) == 16
+    for i, element in enumerate(elements):
+        assert element.opcode == 0x51 + i
+        assert element.pushed == bytes([i + 1])
+
+
+def test_parse_script_pushdata4_success() -> None:
+    """OP_PUSHDATA4 must read a 4-byte little-endian length and payload."""
+    payload = b"payload"
+    length_le = struct.pack("<I", len(payload))
+    script = bytes([0x4E]) + length_le + payload + bytes([0x00])
+    elements = parse_script(script)
+    assert len(elements) == 2
+    assert elements[0].opcode == 0x4E
+    assert elements[0].pushed == payload
+    assert elements[1].opcode == 0x00
+    assert elements[1].pushed == b""
+
+
+def test_parse_script_pushdata4_truncated_length() -> None:
+    """OP_PUSHDATA4 with fewer than 4 length bytes must fail closed."""
+    _raises_with(
+        ContextError,
+        lambda: parse_script(bytes([0x4E, 0x01])),
+        "OP_PUSHDATA4 truncated length",
+        "OP_PUSHDATA4 length bytes missing",
+    )
+
+
+def test_parse_script_pushdata4_truncated_payload() -> None:
+    """OP_PUSHDATA4 with a declared payload beyond remaining bytes must fail closed."""
+    _raises_with(
+        ContextError,
+        lambda: parse_script(bytes([0x4E, 0x05, 0x00, 0x00, 0x00])),
+        "OP_PUSHDATA4 truncated payload",
+        "OP_PUSHDATA4 payload truncated",
+    )
+
+
+def test_parse_script_op_reserved_pushes_none() -> None:
+    """OP_RESERVED is not a data push and must leave pushed as None."""
+    elements = parse_script(bytes([0x50]))
+    assert len(elements) == 1
+    assert elements[0].opcode == 0x50
+    assert elements[0].pushed is None
+
+
+def test_parse_script_op_drop_pushes_none() -> None:
+    """OP_DROP is not a data push and must leave pushed as None."""
+    elements = parse_script(bytes([0x75]))
+    assert len(elements) == 1
+    assert elements[0].opcode == 0x75
+    assert elements[0].pushed is None
 
 
 # ── Tests: classify-corpus txid reversal mutation ────────────────────────────
@@ -6992,6 +7111,7 @@ def main() -> int:
         test_brsctx1_rejects_declared_count_mismatch,
         test_brsctx1_rejects_trailing_bytes,
         test_brsctx1_accepts_valid_file,
+        test_classify_input_block_177609_op_0_p2sh,
         test_classify_input_bare_p2pkh,
         test_classify_input_p2sh_without_flag,
         test_classify_input_p2sh_with_flag,
@@ -7008,6 +7128,15 @@ def main() -> int:
         test_classify_input_native_v0_with_scriptsig,
         test_classify_input_taproot_bad_key_path_sig,
         test_classify_input_taproot_bad_control_block,
+        test_classify_input_p2sh_op_reserved_scriptsig,
+        test_parse_script_op_0_pushes_empty,
+        test_parse_script_op_1negate_pushes_negative_one,
+        test_parse_script_small_integers_pushes_core_scriptnum,
+        test_parse_script_pushdata4_success,
+        test_parse_script_pushdata4_truncated_length,
+        test_parse_script_pushdata4_truncated_payload,
+        test_parse_script_op_reserved_pushes_none,
+        test_parse_script_op_drop_pushes_none,
         test_classify_corpus_txid_reversal_mutation,
         test_classify_corpus_all_spend_contexts,
         test_classify_corpus_c150_passes,

--- a/tools/checksig-census/test_validation_contracts.py
+++ b/tools/checksig-census/test_validation_contracts.py
@@ -7,21 +7,32 @@ Tests the observable behavior of:
 - sorted-records output prepends BRSREC1 header + u64 count (Finding 1)
 - extract_spike_width1 rejects non-integer or non-1 threads (Finding 5)
 - cmd_verdict cross-checks native_mode0 vs inv_8 (Finding 4)
+- BRSCTX1 strict binary parser adversarial cases (CTX-RAW / CTX-EXECUTION)
+- classify-corpus v2 disk-backed contract (c150 / cmodern)
+- custody / replay / manifest / archive adversarial validation
 
 Stdlib-only, Python 3.12+. Run: python3 test_validation_contracts.py
 """
 
 from __future__ import annotations
 
+import argparse
+import hashlib
 import json
+import os
+import struct
 import sys
 import tempfile
 from pathlib import Path
 
-# Make analyze importable
+# Make sibling modules importable when run directly
 sys.path.insert(0, str(Path(__file__).parent))
+
 from analyze import (
+    CONTEXT_COUNTER_DEFINITIONS,
+    CONTEXT_COUNTER_NAMES,
     COUNTER_NAMES,
+    EXPECTED_FFI_VERIFY_ENTRIES_FULL,
     EXPECTED_FFI_VERIFY_ENTRIES_KSPIKE1,
     HEADER_STRUCT,
     JOURNAL_MAGIC,
@@ -30,61 +41,143 @@ from analyze import (
     RECORD_STRUCT,
     AnalyzerError,
     Counters,
+    JournalEntry,
+    Record,
+    _c150_passed,
+    _count_context_records_disk,
+    cmd_classify_corpus,
     extract_bare_mode0,
     extract_spike_width1,
+    iter_journal_with_custody,
+    iter_records_with_custody,
+    parse_counters,
+    parse_journal,
     parse_records,
     sort_records_raw,
 )
+from context import (
+    VERIFY_P2SH,
+    VERIFY_TAPROOT,
+    VERIFY_WITNESS,
+    ContextError,
+    ContextInput,
+    InputIdentity,
+    SpendContext,
+    classify_input,
+    iter_context_inputs,
+    iter_legacy_context_inputs,
+)
+
+# ── Shared assertion helpers ─────────────────────────────────────────────────
+
+
+def _raises(exc_type: type[BaseException], fn, label: str) -> None:
+    """Call *fn* and assert it raises *exc_type*; re-raise with *label* on miss."""
+    try:
+        fn()
+    except exc_type:
+        return
+    raise AssertionError(f"expected {exc_type.__name__} for {label}")
+
+
+def _raises_with(
+    exc_type: type[BaseException], fn, label: str, *substrings: str
+) -> None:
+    """Assert *fn* raises *exc_type* whose message contains every *substrings*."""
+    try:
+        fn()
+    except exc_type as exc:
+        msg = str(exc)
+        for sub in substrings:
+            if sub not in msg:
+                raise AssertionError(
+                    f"expected {exc_type.__name__} for {label} containing {sub!r}, got {msg!r}"
+                )
+        return
+    raise AssertionError(f"expected {exc_type.__name__} for {label}")
+
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
 def _valid_counters_dict(**overrides: object) -> dict[str, object]:
-    """Return a counters dict with all 22 fields set to valid values."""
+    """Return a counters dict with all 24 COUNTER_NAMES fields plus the three
+    reconciliation count fields set to valid values."""
     d: dict[str, object] = {name: 0 for name in COUNTER_NAMES}
     d["schema"] = 1
     d["label"] = "test"
     d["record_count"] = 0
     d["journal_count"] = 0
+    d["context_count"] = 0
     d.update(overrides)
     return d
 
 
-def _make_record_bytes(txid: bytes, input_index: int) -> bytes:
-    """Build a minimal valid 224-byte record."""
+def _make_record_bytes(
+    txid_le: bytes,
+    input_index: int,
+    *,
+    op_kind: int = 1,
+    sig_version: int = 0,
+    op_seq: int = 0,
+    outcome: int = 1,
+    reject_reason: int = 0,
+    der_len: int = 72,
+    pubkey_len: int = 65,
+    sighash: bytes | None = None,
+) -> bytes:
+    """Build a canonical 224-byte record (txid is little-endian/raw).
+
+    Defaults represent a successful ECDSA CHECKSIG verify:
+    op_kind=1 (CHECKSIG), sig_version=0 (BASE), outcome=1 (success),
+    reject_reason=0, der_len=72, pubkey_len=65.
+    """
+    if sighash is None:
+        sighash = b"\x00" * 32
+    # Realistic-looking DER signature (0x30 = SEQUENCE) and uncompressed
+    # pubkey (0x04 prefix).  The validator only checks padding beyond the
+    # declared lengths, so truncate then zero-pad to the full field size.
+    der_sig = bytes([0x30, 0x45, 0x02, 0x20]) + bytes(68)
+    pubkey = bytes([0x04]) + bytes(64)
+    der_sig = der_sig[:der_len] + bytes(72 - der_len)
+    pubkey = pubkey[:pubkey_len] + bytes(65 - pubkey_len)
     fields = (
-        txid,  # 32s spend_txid
+        txid_le,  # 32s spend_txid
         input_index,  # I input_index
-        0,  # I op_seq
-        0,  # B op_kind
-        0,  # B sig_version
-        1,  # B outcome (true)
-        0,  # B der_len
-        0,  # B pubkey_len
+        op_seq,  # I op_seq
+        op_kind,  # B op_kind
+        sig_version,  # B sig_version
+        outcome,  # B outcome
+        der_len,  # B der_len
+        pubkey_len,  # B pubkey_len
         0,  # B sighash_type
-        0,  # B reject_reason
+        reject_reason,  # B reject_reason
         0,  # B _pad0
-        b"\x00" * 32,  # 32s sighash
-        b"\x00" * 72,  # 72s der_sig
-        b"\x00" * 65,  # 65s pubkey
+        sighash,  # 32s sighash
+        der_sig,  # 72s der_sig
+        pubkey,  # 65s pubkey
         b"\x00" * 7,  # 7s _pad1
     )
     return RECORD_STRUCT.pack(*fields)
 
 
 def _make_journal_bytes(
-    txid: bytes,
+    txid_le: bytes,
     input_index: int,
     *,
-    checksig_ops: int = 0,
+    checksig_ops: int = 1,
     checkmultisig_ops: int = 0,
-    ecdsa_verify_calls: int = 0,
-    ecdsa_verify_ok: int = 0,
-    verdict: int = 0,
+    ecdsa_verify_calls: int = 1,
+    ecdsa_verify_ok: int = 1,
+    verdict: int = 1,
 ) -> bytes:
-    """Build a minimal valid 56-byte journal entry."""
+    """Build a canonical 56-byte journal entry (txid is little-endian/raw).
+
+    Defaults represent a successful ECDSA CHECKSIG: verdict=1,
+    checksig_ops=1, ecdsa_verify_calls=1, ecdsa_verify_ok=1.
+    """
     fields = (
-        txid,  # 32s spend_txid
+        txid_le,  # 32s spend_txid
         input_index,  # I input_index
         checksig_ops,  # I checksig_ops
         checkmultisig_ops,  # I checkmultisig_ops
@@ -108,62 +201,652 @@ def _write_journal_file(path: Path, entries: list[bytes]) -> None:
     path.write_bytes(data)
 
 
+# ── BRSCTX1 binary builder ───────────────────────────────────────────────────
+
+# Must match context.py CONTEXT_FIXED = struct.Struct("<32sIIIII") (52 bytes).
+_BRSCTX1_MAGIC = b"BRSCTX1\x00"
+_BRSCTX1_HEADER = struct.Struct("<8sQ")
+_BRSCTX1_ROW_LEN = struct.Struct("<I")
+_BRSCTX1_FIXED = struct.Struct(
+    "<32sIIIII"
+)  # txid_le, input_index, verify_flags, prevout_len, script_sig_len, witness_count
+
+
+def _make_brsctx1_file(path: Path, rows: list[ContextInput]) -> None:
+    """Write a BRSCTX1 binary file with the exact streaming layout.
+
+    Per row: u32 row_len, 32s txid_le, I input_index, I verify_flags,
+    I prevout_script_len, I script_sig_len, I witness_count,
+    prevout bytes, scriptSig bytes, then for each witness item:
+    u32 item_len + item bytes.
+    row_len is the number of bytes after the row_len field.
+    """
+    body = bytearray()
+    for evidence in rows:
+        prevout = evidence.prevout_script_pubkey
+        script_sig = evidence.script_sig
+        witness = evidence.witness
+
+        fixed = _BRSCTX1_FIXED.pack(
+            evidence.identity.txid_le,
+            evidence.identity.input_index,
+            evidence.verify_flags,
+            len(prevout),
+            len(script_sig),
+            len(witness),
+        )
+        witness_blob = bytearray()
+        for item in witness:
+            witness_blob += struct.pack("<I", len(item))
+            witness_blob += item
+
+        row_payload = fixed + prevout + script_sig + bytes(witness_blob)
+        body += _BRSCTX1_ROW_LEN.pack(len(row_payload))
+        body += row_payload
+
+    header = _BRSCTX1_HEADER.pack(_BRSCTX1_MAGIC, len(rows))
+    path.write_bytes(bytes(header + body))
+
+
+def _ctx_input(
+    txid_le: bytes,
+    input_index: int,
+    *,
+    verify_flags: int = 0,
+    prevout: bytes = b"",
+    script_sig: bytes = b"",
+    witness: tuple[bytes, ...] = (),
+) -> ContextInput:
+    """Build a ContextInput directly from raw little-endian txid."""
+    return ContextInput(
+        identity=InputIdentity(txid_le=txid_le, input_index=input_index),
+        verify_flags=verify_flags,
+        prevout_script_pubkey=prevout,
+        script_sig=script_sig,
+        witness=witness,
+    )
+
+
+# ── Prevout / scriptSig / witness builders ───────────────────────────────────
+
+
+def _p2pkh_prevout() -> bytes:
+    return bytes.fromhex("76a914") + bytes(20) + bytes.fromhex("88ac")
+
+
+def _p2sh_prevout() -> bytes:
+    return bytes.fromhex("a914") + bytes(20) + bytes.fromhex("87")
+
+
+def _p2wpkh_prevout() -> bytes:
+    return bytes.fromhex("0014") + bytes(20)
+
+
+def _p2wsh_prevout() -> bytes:
+    return bytes.fromhex("0020") + bytes(32)
+
+
+def _p2tr_prevout() -> bytes:
+    return bytes.fromhex("5120") + bytes(32)
+
+
+def _multisig_redeem_script() -> bytes:
+    """1-of-2 multisig redeem script for P2SH/P2WSH fixtures."""
+    return bytes([1]) + bytes([33]) + bytes(33) + bytes([2, 0xAE])
+
+
+def _push(data: bytes) -> bytes:
+    """Encode a data push for scriptSig (handles len <= 75 directly)."""
+    if len(data) <= 75:
+        return bytes([len(data)]) + data
+    return bytes([76]) + bytes([len(data)]) + data
+
+
+# ── Spend-context fixture builders (each returns ContextInput) ───────────────
+
+
+def _bare_p2pkh(txid_le: bytes, idx: int = 0) -> ContextInput:
+    """Bare P2PKH spend: no flags, no witness, empty scriptSig."""
+    return _ctx_input(txid_le, idx, prevout=_p2pkh_prevout())
+
+
+def _p2sh_push_only(txid_le: bytes, idx: int = 0, *, flags: int = 0) -> ContextInput:
+    """P2SH prevout with push-only scriptSig (no witness).
+
+    Without P2SH flag -> BARE; with P2SH flag -> P2SH.
+    """
+    redeem = _multisig_redeem_script()
+    script_sig = _push(redeem)
+    return _ctx_input(
+        txid_le,
+        idx,
+        verify_flags=flags,
+        prevout=_p2sh_prevout(),
+        script_sig=script_sig,
+    )
+
+
+def _p2sh_wrapped_w0(txid_le: bytes, idx: int = 0, *, flags: int = 0) -> ContextInput:
+    """P2SH prevout with one-push witness-v0 redeem in scriptSig.
+
+    With P2SH only -> P2SH; with P2SH+WITNESS -> P2SH_WRAPPED_WITNESS_V0.
+    """
+    redeem = _p2wsh_prevout()  # witness-v0 program as the redeem
+    script_sig = _push(redeem)
+    witness = (b"\x00", _multisig_redeem_script())
+    return _ctx_input(
+        txid_le,
+        idx,
+        verify_flags=flags,
+        prevout=_p2sh_prevout(),
+        script_sig=script_sig,
+        witness=witness,
+    )
+
+
+def _native_w0(txid_le: bytes, idx: int = 0, *, flags: int = 0) -> ContextInput:
+    """Native witness-v0 prevout (P2WSH).
+
+    Without WITNESS -> BARE; with WITNESS -> NATIVE_WITNESS_V0.
+    """
+    return _ctx_input(
+        txid_le,
+        idx,
+        verify_flags=flags,
+        prevout=_p2wsh_prevout(),
+        witness=(b"\x00", _multisig_redeem_script()),
+    )
+
+
+def _taproot_key_path(txid_le: bytes, idx: int = 0, *, flags: int = 0) -> ContextInput:
+    """P2TR prevout with 64-byte key-path signature.
+
+    No WITNESS -> BARE; WITNESS only -> BARE; WITNESS+TAPROOT -> TAPROOT_KEY_PATH.
+    """
+    return _ctx_input(
+        txid_le,
+        idx,
+        verify_flags=flags,
+        prevout=_p2tr_prevout(),
+        witness=(bytes(64),),
+    )
+
+
+def _taproot_script_path(
+    txid_le: bytes, idx: int = 0, *, flags: int = 0
+) -> ContextInput:
+    """P2TR prevout with stack arg + tapscript + control block.
+
+    No WITNESS -> BARE; WITNESS only -> BARE; WITNESS+TAPROOT -> TAPSCRIPT.
+    """
+    control = bytes([0xC0]) + bytes(32)
+    return _ctx_input(
+        txid_le,
+        idx,
+        verify_flags=flags,
+        prevout=_p2tr_prevout(),
+        witness=(bytes(64), bytes([0xAC]), control),
+    )
+
+
+# ── Counters / replay / manifest / archive helpers ───────────────────────────
+
+
+def _make_valid_counters(
+    record_count: int,
+    journal_count: int,
+    ffi_verify_entries: int,
+    **extra: object,
+) -> dict[str, object]:
+    """Return a counters dict for a canonical all-CHECKSIG ECDSA corpus.
+
+    Every context row has one successful ECDSA CHECKSIG, so the full
+    equality chain equals *ffi_verify_entries* and all complementary
+    counters are zero.
+    """
+    d = _valid_counters_dict()
+    d["record_count"] = record_count
+    d["journal_count"] = journal_count
+    d["context_count"] = ffi_verify_entries
+    d["ffi_verify_entries"] = ffi_verify_entries
+    d["verify_script_calls"] = ffi_verify_entries
+    d["ffi_verify_true"] = ffi_verify_entries
+    d["eval_script_entries"] = ffi_verify_entries
+    d["op_checksig"] = ffi_verify_entries
+    d["checkecdsa_entries"] = ffi_verify_entries
+    d["ecdsa_from_checksig"] = ffi_verify_entries
+    d["ecdsa_verify_calls"] = ffi_verify_entries
+    d["ecdsa_verify_ok"] = ffi_verify_entries
+    d["sighash_computed"] = ffi_verify_entries
+    d.update(extra)
+    return d
+
+
+# ── Minimal regtest genesis block for archive/manifest fixtures ──────────────
+
+_REGTEST_MAGIC = bytes.fromhex("fabfb5da")
+_REGTEST_GENESIS_HEADER = (
+    b"\x00" * 4  # version
+    + b"\x00" * 32  # prev_blockhash (all zero for genesis)
+    + b"\x00" * 32  # merkle_root
+    + struct.pack("<I", 0x5CE9B2A1)  # timestamp (regtest genesis)
+    + b"\x20" * 4  # difficulty bits (regtest: 0x207fffff)
+    + struct.pack("<I", 0)  # nonce
+)
+_REGTEST_GENESIS_HASH_RAW = hashlib.sha256(
+    hashlib.sha256(_REGTEST_GENESIS_HEADER).digest()
+).digest()
+_REGTEST_GENESIS_HASH_DISPLAY = _REGTEST_GENESIS_HASH_RAW[::-1].hex()
+
+# Minimal regtest genesis block: 80-byte header + tx count (0x01 varint) +
+# 4-byte version + 1-byte input count (0x01) + 32-byte prevout (null) +
+# 4-byte input_index + 1-byte scriptSig length + 4-byte sequence +
+# 1-byte output count + 8-byte value + 1-byte scriptPubKey len + 2-byte OP_TRUE +
+# 4-byte locktime.
+_REGTEST_GENESIS_BLOCK = (
+    _REGTEST_GENESIS_HEADER
+    + bytes([0x01])  # tx count (1)
+    + struct.pack("<I", 1)  # tx version
+    + bytes([0x01])  # input count (1)
+    + b"\x00" * 32  # prev txid (null)
+    + struct.pack("<I", 0xFFFFFFFF)  # input index (null)
+    + bytes([0x01])  # scriptSig length (1)
+    + bytes([0x00])  # scriptSig
+    + struct.pack("<I", 0)  # sequence
+    + bytes([0x01])  # output count (1)
+    + struct.pack("<Q", 50 * 10**8)  # value (50 BTC)
+    + bytes([0x01])  # scriptPubKey length
+    + bytes([0x51])  # OP_TRUE
+    + struct.pack("<I", 0)  # locktime
+)
+
+# ── Mainnet canonical constants for custody validation ───────────────────────
+
+_MAINNET_MAGIC = bytes.fromhex("f9beb4d9")
+_MAINNET_GENESIS_HASH = (
+    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+)
+_MAINNET_GENESIS_HEADER = (
+    struct.pack("<I", 1)  # version = 1
+    + b"\x00" * 32  # prev_blockhash (all zero for genesis)
+    + bytes.fromhex(
+        "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
+    )  # merkle_root (internal LE byte order)
+    + struct.pack("<I", 0x495FAB29)  # timestamp = 1231006505
+    + struct.pack("<I", 0x1D00FFFF)  # bits
+    + struct.pack("<I", 0x7C2BAC1D)  # nonce = 2083236893
+)
+_MAINNET_GENESIS_HASH_RAW = hashlib.sha256(
+    hashlib.sha256(_MAINNET_GENESIS_HEADER).digest()
+).digest()
+assert _MAINNET_GENESIS_HASH_RAW[::-1].hex() == _MAINNET_GENESIS_HASH
+
+# Minimal mainnet genesis block: real 80-byte header + minimal coinbase tx body.
+# The archive validator only checks the 80-byte header for block hashing.
+_MAINNET_GENESIS_BLOCK = (
+    _MAINNET_GENESIS_HEADER
+    + bytes([0x01])  # tx count (1)
+    + struct.pack("<I", 1)  # tx version
+    + bytes([0x01])  # input count (1)
+    + b"\x00" * 32  # prev txid (null)
+    + struct.pack("<I", 0xFFFFFFFF)  # input index (null)
+    + bytes([0x01])  # scriptSig length (1)
+    + bytes([0x00])  # scriptSig
+    + struct.pack("<I", 0)  # sequence
+    + bytes([0x01])  # output count (1)
+    + struct.pack("<Q", 50 * 10**8)  # value (50 BTC)
+    + bytes([0x01])  # scriptPubKey length
+    + bytes([0x51])  # OP_TRUE
+    + struct.pack("<I", 0)  # locktime
+)
+
+# C150 pinned stop values (mainnet block 150000).
+_C150_STOP_HEIGHT = 150000
+_C150_STOP_HASH = "0000000000000a3290f20e75860d505ce0e948a1d1d846bec7e39015d242884b"
+
+
+def _make_archive(
+    path: Path, blocks: list[bytes], magic: bytes = _MAINNET_MAGIC
+) -> bytes:
+    """Write a Core-framed archive and return the raw bytes.
+
+    Each frame: 4-byte magic + u32 LE payload_length + payload.
+    """
+    data = bytearray()
+    for block in blocks:
+        data += magic
+        data += struct.pack("<I", len(block))
+        data += block
+    path.write_bytes(bytes(data))
+    return bytes(data)
+
+
+def _block_hash_raw(block: bytes) -> bytes:
+    """Double-SHA256 of the 80-byte block header (internal LE byte order)."""
+    return hashlib.sha256(hashlib.sha256(block[:80]).digest()).digest()
+
+
+def _block_hash_display(block: bytes) -> str:
+    """Display-order hex of the block hash."""
+    return _block_hash_raw(block)[::-1].hex()
+
+
+def _make_manifest(
+    path: Path,
+    *,
+    network: str = "mainnet",
+    network_magic: str = _MAINNET_MAGIC.hex(),
+    genesis_hash: str = _MAINNET_GENESIS_HASH,
+    start_height: int = 0,
+    stop_height: int = 0,
+    blocks: list[bytes] | None = None,
+    archive_size: int | None = None,
+    archive_sha256: str | None = None,
+) -> bytes:
+    """Write a bitcoin-rs-corpus-manifest v1 JSON and return the raw bytes.
+
+    Entry fields: height, hash (display hex), offset, payload_length.
+    """
+    if blocks is None:
+        blocks = [_MAINNET_GENESIS_BLOCK]
+
+    entries: list[dict[str, object]] = []
+    offset = 0
+    for height, block in enumerate(blocks):
+        entries.append(
+            {
+                "height": height,
+                "hash": _block_hash_display(block),
+                "offset": offset,
+                "payload_length": len(block),
+            }
+        )
+        offset += 8 + len(block)
+
+    if archive_size is None:
+        archive_size = offset
+    if archive_sha256 is None:
+        # Caller must set this to the actual archive sha; default to a placeholder
+        # that the test will override.
+        archive_sha256 = "0" * 64
+
+    manifest = {
+        "schema": "bitcoin-rs-corpus-manifest",
+        "version": 1,
+        "network": network,
+        "network_magic": network_magic,
+        "genesis_hash": genesis_hash,
+        "range": {"start_height": start_height, "stop_height": stop_height},
+        "archive": {"size": archive_size, "sha256": archive_sha256},
+        "entries": entries,
+    }
+    raw = (json.dumps(manifest, indent=2) + "\n").encode()
+    path.write_bytes(raw)
+    return raw
+
+
+def _make_replay_v2(
+    path: Path,
+    *,
+    window: int = 150000,
+    assume_valid_height: int = 0,
+    window_verify_success_total: int = 1,
+    network: str = "mainnet",
+    network_magic: str = _MAINNET_MAGIC.hex(),
+    genesis_hash: str = _MAINNET_GENESIS_HASH,
+    start_height: int = 0,
+    start_hash: str | None = None,
+    stop_height: int = 0,
+    stop_hash: str | None = None,
+    block_count: int | None = None,
+    corpus_manifest_bytes: int = 0,
+    corpus_manifest_sha256: str = "0" * 64,
+    archive_bytes: int = 0,
+    archive_sha256: str = "0" * 64,
+    block_bytes: int = 0,
+    block_source: str = "file",
+    blockfilterindex: bool = False,
+    blocks_per_second: float = 0.0,
+    checkpoint_generation: int = 1,
+    data_dir: str = "/tmp",
+    decode_seconds: float = 0.0,
+    elapsed_seconds: float = 0.0,
+    fetch_seconds: float = 0.0,
+    git_head: str = "0" * 40,
+    measurement_target: str = "mainnet-prefix-replay",
+    rss_high_water_bytes: int = 0,
+    stage_seconds: list[dict[str, object]] | None = None,
+    storage_backend: str = "fjall",
+    tx_count: int = 0,
+    txindex: bool = False,
+) -> bytes:
+    """Write a mainnet-prefix-replay-v2 JSON and return the raw bytes.
+
+    Defaults to mainnet canonical values: network="mainnet",
+    network_magic="f9beb4d9", genesis_hash=mainnet genesis,
+    start_height=0, start_hash=genesis_hash, stop_height=0,
+    stop_hash=genesis block display hash, block_count=stop_height+1.
+    """
+    if start_hash is None:
+        start_hash = genesis_hash
+    if stop_hash is None:
+        stop_hash = _block_hash_display(_MAINNET_GENESIS_BLOCK)
+    if block_count is None:
+        block_count = stop_height + 1
+    if stage_seconds is None:
+        stage_seconds = []
+    replay = {
+        "schema": "mainnet-prefix-replay-v2",
+        "network": network,
+        "network_magic": network_magic,
+        "genesis_hash": genesis_hash,
+        "start_height": start_height,
+        "start_hash": start_hash,
+        "stop_height": stop_height,
+        "stop_hash": stop_hash,
+        "block_count": block_count,
+        "window": window,
+        "assume_valid_height": assume_valid_height,
+        "window_verify_success_total": window_verify_success_total,
+        "corpus_manifest": {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "path": "manifest.json",
+            "bytes": corpus_manifest_bytes,
+            "sha256": corpus_manifest_sha256,
+        },
+        "archive": {
+            "path": "archive.bin",
+            "bytes": archive_bytes,
+            "sha256": archive_sha256,
+        },
+        "block_bytes": block_bytes,
+        "block_source": block_source,
+        "blockfilterindex": blockfilterindex,
+        "blocks_per_second": blocks_per_second,
+        "checkpoint_generation": checkpoint_generation,
+        "data_dir": data_dir,
+        "decode_seconds": decode_seconds,
+        "elapsed_seconds": elapsed_seconds,
+        "fetch_seconds": fetch_seconds,
+        "git_head": git_head,
+        "measurement_target": measurement_target,
+        "rss_high_water_bytes": rss_high_water_bytes,
+        "stage_seconds": stage_seconds,
+        "storage_backend": storage_backend,
+        "tx_count": tx_count,
+        "txindex": txindex,
+    }
+    raw = (json.dumps(replay, indent=2) + "\n").encode()
+    path.write_bytes(raw)
+    return raw
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_classify_args(
+    tmp: Path,
+    context_rows: list[ContextInput],
+    records: list[bytes],
+    journal_entries: list[bytes],
+    contract: str,
+    input_count: int | None = None,
+    counters_overrides: dict[str, object] | None = None,
+    counters_dict: dict[str, object] | None = None,
+    replay_overrides: dict[str, object] | None = None,
+    manifest_overrides: dict[str, object] | None = None,
+    archive_blocks: list[bytes] | None = None,
+) -> argparse.Namespace:
+    """Create all supporting files and return an argparse.Namespace for
+    cmd_classify_corpus.
+
+    Files created:
+      tmp/counters.json, tmp/contexts.bin, tmp/records.bin, tmp/journal.bin,
+      tmp/replay.json, tmp/manifest.json, tmp/archive.bin
+
+    If *counters_dict* is provided it replaces the built-in counters entirely;
+    otherwise counters are built from _make_valid_counters and optionally
+    patched with *counters_overrides*.
+    """
+
+    # ── Contexts (BRSCTX1) ──
+    _make_brsctx1_file(tmp / "contexts.bin", context_rows)
+
+    # ── Records (BRSREC1) ──
+    _write_records_file(tmp / "records.bin", records)
+
+    # ── Journal (BRSJRN1) ──
+    _write_journal_file(tmp / "journal.bin", journal_entries)
+
+    # ── Counters ──
+    if counters_dict is not None:
+        counters = counters_dict
+    else:
+        record_count = len(records)
+        journal_count = len(journal_entries)
+        ffi_verify_entries = len(context_rows)
+        counters = _make_valid_counters(record_count, journal_count, ffi_verify_entries)
+        if counters_overrides:
+            counters.update(counters_overrides)
+    (tmp / "counters.json").write_text(json.dumps(counters))
+    # ── Archive ──
+    if archive_blocks is None:
+        archive_blocks = [_MAINNET_GENESIS_BLOCK]
+    archive_raw = _make_archive(tmp / "archive.bin", archive_blocks)
+    arch_size = len(archive_raw)
+    arch_sha = _sha256_bytes(archive_raw)
+
+    # ── Manifest ──
+    manifest_raw = _make_manifest(
+        tmp / "manifest.json",
+        stop_height=len(archive_blocks) - 1,
+        blocks=archive_blocks,
+        archive_size=arch_size,
+        archive_sha256=arch_sha,
+    )
+    cm_size = len(manifest_raw)
+    cm_sha = _sha256_bytes(manifest_raw)
+
+    # ── Replay v2 ──
+    replay_kwargs: dict[str, object] = {
+        "stop_height": len(archive_blocks) - 1,
+        "stop_hash": _block_hash_display(archive_blocks[-1]),
+        "corpus_manifest_bytes": cm_size,
+        "corpus_manifest_sha256": cm_sha,
+        "archive_bytes": arch_size,
+        "archive_sha256": arch_sha,
+    }
+    if replay_overrides:
+        replay_kwargs.update(replay_overrides)
+    _make_replay_v2(tmp / "replay.json", **replay_kwargs)  # type: ignore[arg-type]
+
+    # ── Manifest overrides (applied after replay is written so we can
+    # independently mutate the manifest file) ──
+    if manifest_overrides:
+        manifest_obj = json.loads((tmp / "manifest.json").read_text())
+        manifest_obj.update(manifest_overrides)
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+
+    ns = argparse.Namespace(
+        counters=str(tmp / "counters.json"),
+        contexts=str(tmp / "contexts.bin"),
+        records=str(tmp / "records.bin"),
+        journal=str(tmp / "journal.bin"),
+        replay=str(tmp / "replay.json"),
+        corpus_manifest=str(tmp / "manifest.json"),
+        archive=str(tmp / "archive.bin"),
+        output=str(tmp / "report.json"),
+        contract=contract,
+        input_count=input_count,
+    )
+    return ns
+
+
+# ── Legacy JSONL helpers (for diagnostic iter_legacy_context_inputs tests) ───
+
+
+def _make_legacy_row(
+    display_txid: str,
+    input_index: int,
+    prevout: bytes,
+    script_sig: bytes = b"",
+    witness: tuple[bytes, ...] = (),
+    height: int = 100,
+    tx_index: int = 0,
+) -> dict[str, object]:
+    return {
+        "schema": "census-context-input-v1",
+        "height": height,
+        "block_hash": bytes(32).hex(),
+        "tx_index": tx_index,
+        "input_index": input_index,
+        "txid": display_txid,
+        "prevout_script_pubkey_hex": prevout.hex(),
+        "script_sig_hex": script_sig.hex(),
+        "witness_hex": [w.hex() for w in witness],
+    }
+
+
+def _write_legacy_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    with path.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
 # ── Tests: Counters validation (Finding 3) ───────────────────────────────────
 
 
 def test_counters_rejects_missing_field() -> None:
     """A counters dict missing a required COUNTER_NAMES field must raise."""
     d = _valid_counters_dict()
-    del d["ffi_verify_entries"]
-    try:
-        Counters(d)
-    except AnalyzerError as e:
-        assert "ffi_verify_entries" in str(e)
-        return
-    raise AssertionError("expected AnalyzerError for missing field")
+    del d["op_checksig"]
+    _raises(AnalyzerError, lambda: Counters(d), "missing field")
 
 
 def test_counters_rejects_non_int_value() -> None:
     """A counters dict with a string value must raise."""
-    d = _valid_counters_dict()
-    d["op_checksig"] = "not_an_int"
-    try:
-        Counters(d)
-    except AnalyzerError as e:
-        assert "op_checksig" in str(e)
-        return
-    raise AssertionError("expected AnalyzerError for non-int value")
+    d = _valid_counters_dict(op_checksig="42")  # type: ignore[dict-item]
+    _raises(AnalyzerError, lambda: Counters(d), "non-int value")
 
 
 def test_counters_rejects_bool_value() -> None:
     """Python bools are ints but must be rejected for counter fields."""
-    d = _valid_counters_dict()
-    d["ecdsa_verify_ok"] = True
-    try:
-        Counters(d)
-    except AnalyzerError as e:
-        assert "ecdsa_verify_ok" in str(e)
-        return
-    raise AssertionError("expected AnalyzerError for bool value")
+    d = _valid_counters_dict(op_checksig=True)
+    _raises(AnalyzerError, lambda: Counters(d), "bool value")
 
 
 def test_counters_rejects_negative_value() -> None:
     """A counters dict with a negative value must raise."""
-    d = _valid_counters_dict()
-    d["sighash_computed"] = -1
-    try:
-        Counters(d)
-    except AnalyzerError as e:
-        assert "sighash_computed" in str(e)
-        return
-    raise AssertionError("expected AnalyzerError for negative value")
+    d = _valid_counters_dict(op_checksig=-1)
+    _raises(AnalyzerError, lambda: Counters(d), "negative value")
 
 
 def test_counters_accepts_valid_dict() -> None:
     """A well-formed counters dict must parse without error."""
-    d = _valid_counters_dict(ffi_verify_entries=42, op_checksig=42)
-    c = Counters(d)
-    assert c.ffi_verify_entries == 42
+    c = Counters(_valid_counters_dict(op_checksig=42))
     assert c.op_checksig == 42
 
 
@@ -202,18 +885,6 @@ def test_validate_capture_rejects_wrong_ffi_verify_entries() -> None:
         _write_journal_file(tmp / "journal.bin", jnl)
         _write_journal_file(tmp / "repeat_journal.bin", jnl)
 
-        # Self-consistent counters with ffi_verify_entries=1 (not 159259).
-        # INV-1: verify_script_calls == ffi_verify_entries            → 1==1 ✓
-        # INV-2: ffi_verify_true == ffi_verify_entries                → 1==1 ✓
-        # INV-3: checkecdsa_entries == from_checksig + from_checkmultisig → 1==1+0 ✓
-        # INV-4: checkecdsa_entries == ecdsa_verify_calls + rejects   → 1==1+0 ✓
-        # INV-5: ecdsa_verify_calls == ok+fail and == sighash_computed → 1==1+0 and 1==1 ✓
-        # INV-6: ecdsa_from_checksig <= op_checksig + op_checksigverify → 1<=1+0 ✓
-        # INV-7: op_checksigadd==0, checkschnorr==0, schnorr_verify==0 → all 0 ✓
-        # INV-9: 1 record (outcome=1) == ecdsa_verify_calls; 1 total == checkecdsa_entries ✓
-        # INV-10: journal sums match counters                         → 1==1, 1==1, 0==0, 1==1 ✓
-        # INV-11: no duplicate keys                                   → 1 record ✓
-        # INV-13: both runs identical                                 → same data ✓
         c = _valid_counters_dict(
             ffi_verify_entries=1,
             verify_script_calls=1,
@@ -249,15 +920,12 @@ def test_validate_capture_rejects_wrong_ffi_verify_entries() -> None:
         assert rc == 1, "expected return code 1 for wrong ffi_verify_entries"
         report = json.loads(out.read_text())
         assert report["all_passed"] is False
-        # Every invariant must pass — the only failure is the EXP-KSPIKE1 gate.
         inv_failed = [r["id"] for r in report["invariants"] if not r["passed"]]
         assert inv_failed == [], f"invariants should all pass, but {inv_failed} failed"
-        # The stderr message lists the exact failed IDs.
         stderr_msg = stderr_buf.getvalue().strip()
         assert "EXP-KSPIKE1" in stderr_msg, (
             f"stderr should mention EXP-KSPIKE1, got: {stderr_msg!r}"
         )
-        # No INV- should appear in the failed list.
         for inv_id in (
             "INV-1",
             "INV-2",
@@ -276,8 +944,57 @@ def test_validate_capture_rejects_wrong_ffi_verify_entries() -> None:
             )
 
 
+def test_validate_capture_binds_corpus_identity() -> None:
+    """validate-capture emits census-capture-v2 and binds corpus_size and corpus_sha256."""
+    import argparse
+
+    import analyze
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        recs = [_make_record_bytes(b"\x01" * 32, 0)]
+        _write_records_file(tmp / "records.bin", recs)
+        _write_records_file(tmp / "repeat.bin", recs)
+        _write_journal_file(tmp / "journal.bin", [])
+        _write_journal_file(tmp / "repeat_journal.bin", [])
+
+        c = _valid_counters_dict(
+            ffi_verify_entries=EXPECTED_FFI_VERIFY_ENTRIES_KSPIKE1,
+            record_count=1,
+            journal_count=0,
+        )
+        (tmp / "counters.json").write_text(json.dumps(c))
+        (tmp / "repeat_counters.json").write_text(json.dumps(c))
+
+        row = _make_legacy_row(bytes(32).hex(), 0, _p2pkh_prevout())
+        _write_legacy_jsonl(tmp / "ctx.jsonl", [row])
+
+        args = argparse.Namespace(
+            subcommand="validate-capture",
+            counters=tmp / "counters.json",
+            records=tmp / "records.bin",
+            journal=tmp / "journal.bin",
+            repeat_counters=tmp / "repeat_counters.json",
+            repeat_records=tmp / "repeat.bin",
+            repeat_journal=tmp / "repeat_journal.bin",
+            output=tmp / "report.json",
+            sorted_records_output=None,
+            context_inputs=str(tmp / "ctx.jsonl"),
+        )
+        analyze.cmd_validate_capture(args)
+        report = json.loads((tmp / "report.json").read_text())
+        assert report["schema"] == "census-capture-v2"
+        assert "corpus_size" in report
+        assert "corpus_sha256" in report
+        real_size, real_sha256 = analyze._sha256_file(tmp / "ctx.jsonl")
+        assert report["corpus_size"] == real_size
+        assert report["corpus_sha256"] == real_sha256
+
+
 def test_validate_capture_sorted_output_has_header() -> None:
     """The sorted-records output file must start with BRSREC1 magic + u64 count."""
+    import argparse
+
     import analyze
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -303,8 +1020,6 @@ def test_validate_capture_sorted_output_has_header() -> None:
         out = tmp / "report.json"
         sorted_out = tmp / "sorted.bin"
 
-        import argparse
-
         args = argparse.Namespace(
             subcommand="validate-capture",
             counters=tmp / "counters.json",
@@ -316,14 +1031,12 @@ def test_validate_capture_sorted_output_has_header() -> None:
             output=out,
             sorted_records_output=sorted_out,
         )
-        # Will fail because counters don't match records, but sorted output is still written
         analyze.cmd_validate_capture(args)
 
         data = sorted_out.read_bytes()
         magic, count = HEADER_STRUCT.unpack_from(data, 0)
         assert magic == RECORD_MAGIC, f"bad magic {magic!r}"
         assert count == 2, f"expected count 2, got {count}"
-        # Verify the payload is sorted
         payload = data[HEADER_STRUCT.size :]
         sorted_recs = sort_records_raw(recs)
         assert payload == sorted_recs, (
@@ -337,17 +1050,13 @@ def test_records_reject_invalid_encoded_fields() -> None:
         path = Path(tmpdir) / "records.bin"
         for offset, bad, field in (
             (42, 3, "outcome"),
-            (43, 73, "der_len"),
+            (43, 0, "der_len"),
             (44, 66, "pubkey_len"),
         ):
             record = bytearray(_make_record_bytes(b"\x01" * 32, 0))
             record[offset] = bad
             _write_records_file(path, [bytes(record)])
-            try:
-                parse_records(path)
-            except AnalyzerError:
-                continue
-            raise AssertionError(f"expected AnalyzerError for {field}={bad}")
+            _raises(AnalyzerError, lambda p=path: parse_records(p), f"{field}={bad}")
 
 
 # ── Tests: extract_spike_width1 validation (Finding 5) ───────────────────────
@@ -355,29 +1064,29 @@ def test_records_reject_invalid_encoded_fields() -> None:
 
 def test_spike_rejects_non_integer_threads() -> None:
     """Top-level us_per_input with non-integer threads must raise."""
-    try:
-        extract_spike_width1({"us_per_input": 50.0, "threads": "1"})
-    except AnalyzerError:
-        return
-    raise AssertionError("expected AnalyzerError for string threads")
+    _raises(
+        AnalyzerError,
+        lambda: extract_spike_width1({"us_per_input": 50.0, "threads": "1"}),
+        "string threads",
+    )
 
 
 def test_spike_rejects_bool_threads() -> None:
     """Top-level us_per_input with bool threads must raise."""
-    try:
-        extract_spike_width1({"us_per_input": 50.0, "threads": True})
-    except AnalyzerError:
-        return
-    raise AssertionError("expected AnalyzerError for bool threads")
+    _raises(
+        AnalyzerError,
+        lambda: extract_spike_width1({"us_per_input": 50.0, "threads": True}),
+        "bool threads",
+    )
 
 
 def test_spike_rejects_threads_not_1() -> None:
     """Top-level us_per_input with threads != 1 must raise."""
-    try:
-        extract_spike_width1({"us_per_input": 50.0, "threads": 2})
-    except AnalyzerError:
-        return
-    raise AssertionError("expected AnalyzerError for threads == 2")
+    _raises(
+        AnalyzerError,
+        lambda: extract_spike_width1({"us_per_input": 50.0, "threads": 2}),
+        "threads == 2",
+    )
 
 
 def test_spike_accepts_threads_1() -> None:
@@ -388,99 +1097,113 @@ def test_spike_accepts_threads_1() -> None:
 
 def test_spike_accepts_runs_list_with_threads_1() -> None:
     """A runs list containing a run with threads == 1 must succeed."""
-    val = extract_spike_width1(
-        {
-            "runs": [
-                {"threads": 4, "us_per_input": 25.0},
-                {"threads": 1, "us_per_input": 50.0},
-            ]
-        }
-    )
+    val = extract_spike_width1({"runs": [{"us_per_input": 50.0, "threads": 1}]})
     assert val == 50.0
 
 
 def test_spike_rejects_runs_list_without_threads_1() -> None:
     """A runs list with no threads == 1 run must raise."""
-    try:
-        extract_spike_width1({"runs": [{"threads": 4, "us_per_input": 25.0}]})
-    except AnalyzerError:
-        return
-    raise AssertionError("expected AnalyzerError for no threads==1 run")
+    _raises(
+        AnalyzerError,
+        lambda: extract_spike_width1({"runs": [{"us_per_input": 50.0, "threads": 2}]}),
+        "no threads==1 run",
+    )
 
 
 def test_spike_rejects_runs_list_bool_threads() -> None:
     """A runs list with boolean threads must not be accepted as threads == 1."""
-    try:
-        extract_spike_width1({"runs": [{"threads": True, "us_per_input": 50.0}]})
-    except AnalyzerError:
-        return
-    raise AssertionError("expected AnalyzerError for bool threads in runs list")
+    _raises(
+        AnalyzerError,
+        lambda: extract_spike_width1(
+            {"runs": [{"us_per_input": 50.0, "threads": True}]}
+        ),
+        "bool threads in runs list",
+    )
 
 
 def test_spike_rejects_nonfinite_us_per_input() -> None:
     """Spike us_per_input must be a finite positive number in both forms."""
-    bad_values = [float("nan"), float("inf"), 0.0, -1.0]
-    for bad in bad_values:
-        try:
-            extract_spike_width1({"us_per_input": bad, "threads": 1})
-        except AnalyzerError:
-            continue
-        raise AssertionError(
-            f"expected AnalyzerError for top-level us_per_input={bad!r}"
+    for bad in (float("nan"), float("inf"), float("-inf"), -1.0, 0.0):
+        _raises(
+            AnalyzerError,
+            lambda v=bad: extract_spike_width1({"us_per_input": v, "threads": 1}),
+            f"top-level us_per_input={bad!r}",
         )
-    for bad in bad_values:
-        try:
-            extract_spike_width1({"runs": [{"threads": 1, "us_per_input": bad}]})
-        except AnalyzerError:
-            continue
-        raise AssertionError(f"expected AnalyzerError for list us_per_input={bad!r}")
+        _raises(
+            AnalyzerError,
+            lambda v=bad: extract_spike_width1(
+                {"runs": [{"us_per_input": v, "threads": 1}]}
+            ),
+            f"list us_per_input={bad!r}",
+        )
 
 
 def test_bare_rejects_nonfinite_reported_values() -> None:
     """Reported bare median/min/max must be finite positive numbers."""
+    base = {
+        "inputs_per_round": 1,
+        "rounds": 1,
+        "attempts_total": 1,
+        "round_ns": [50000],
+        "mismatches": 0,
+        "first_mismatch": None,
+        "ok_count": 1,
+    }
     for field in ("median_ns_per_attempt", "min_ns_per_attempt", "max_ns_per_attempt"):
-        for bad in (float("nan"), float("inf"), -1.0):
-            bare = _make_bare_run_json()
-            bare["native_mode0"][field] = bad
-            try:
-                extract_bare_mode0(bare)
-            except AnalyzerError:
-                continue
-            raise AssertionError(f"expected AnalyzerError for {field}={bad!r}")
+        for bad in (float("nan"), float("inf"), float("-inf"), -1.0, 0.0):
+            d = dict(base, **{field: bad})
+            _raises(
+                AnalyzerError,
+                lambda d=d: extract_bare_mode0(d),
+                f"{field}={bad!r}",
+            )
 
 
 def test_bare_rejects_invalid_round_ns_types() -> None:
     """round_ns must contain integers and must not accept booleans."""
-    for bad, reported in ((100.5, 100.5), ("100", 100.0), (True, 1.0)):
-        bare = _make_bare_run_json()
-        bare["native_mode0"]["round_ns"] = [bad]
-        for field in (
-            "median_ns_per_attempt",
-            "min_ns_per_attempt",
-            "max_ns_per_attempt",
-        ):
-            bare["native_mode0"][field] = reported
-        try:
-            extract_bare_mode0(bare)
-        except AnalyzerError:
-            continue
-        raise AssertionError(f"expected AnalyzerError for round_ns={bad!r}")
+    base = {
+        "inputs_per_round": 1,
+        "rounds": 1,
+        "attempts_total": 1,
+        "median_ns_per_attempt": 50000.0,
+        "min_ns_per_attempt": 50000.0,
+        "max_ns_per_attempt": 50000.0,
+        "mismatches": 0,
+        "first_mismatch": None,
+        "ok_count": 1,
+    }
+    for bad in ([True], [1.5], ["1"]):
+        d = dict(base, round_ns=bad)
+        _raises(AnalyzerError, lambda d=d: extract_bare_mode0(d), f"round_ns={bad!r}")
 
 
 def test_bare_rejects_nonpositive_round_ns() -> None:
     """round_ns must contain positive values."""
-    for bad in (-50, 0):
-        bare = _make_bare_run_json()
-        bare["native_mode0"]["round_ns"] = [bad]
-        try:
-            extract_bare_mode0(bare)
-        except AnalyzerError:
-            continue
-        raise AssertionError(f"expected AnalyzerError for round_ns={bad!r}")
+    base = {
+        "inputs_per_round": 1,
+        "rounds": 1,
+        "attempts_total": 1,
+        "median_ns_per_attempt": 50000.0,
+        "min_ns_per_attempt": 50000.0,
+        "max_ns_per_attempt": 50000.0,
+        "mismatches": 0,
+        "first_mismatch": None,
+        "ok_count": 1,
+    }
+    for bad in ([0], [-1]):
+        d = dict(base, round_ns=bad)
+        _raises(AnalyzerError, lambda d=d: extract_bare_mode0(d), f"round_ns={bad!r}")
 
 
 def test_bare_rejects_non_integer_summary_fields() -> None:
-    """Native timing summaries must not coerce booleans or floats to integers."""
+    """Native timing summary must not coerce booleans or floats to integers."""
+    base = {
+        "round_ns": [50000],
+        "median_ns_per_attempt": 50000.0,
+        "min_ns_per_attempt": 50000.0,
+        "max_ns_per_attempt": 50000.0,
+        "first_mismatch": None,
+    }
     for field in (
         "inputs_per_round",
         "rounds",
@@ -489,13 +1212,13 @@ def test_bare_rejects_non_integer_summary_fields() -> None:
         "ok_count",
     ):
         for bad in (True, 1.5):
-            bare = _make_bare_run_json()
-            bare["native_mode0"][field] = bad
-            try:
-                extract_bare_mode0(bare)
-            except AnalyzerError:
-                continue
-            raise AssertionError(f"expected AnalyzerError for {field}={bad!r}")
+            d = dict(base, **{field: bad})
+            _raises(
+                AnalyzerError, lambda d=d: extract_bare_mode0(d), f"{field}={bad!r}"
+            )
+
+
+# ── Tests: cmd_verdict numeric and cross-check ───────────────────────────────
 
 
 def test_verdict_rejects_invalid_numeric_fields() -> None:
@@ -550,12 +1273,10 @@ def test_verdict_rejects_invalid_numeric_fields() -> None:
                 output=out,
                 integrity=integrity_path,
             )
-            try:
-                analyze.cmd_verdict(args)
-            except AnalyzerError:
-                continue
-            raise AssertionError(
-                f"expected AnalyzerError for wall={current_wall!r}, script={current_script!r}"
+            _raises(
+                AnalyzerError,
+                lambda a=args: analyze.cmd_verdict(a),
+                f"wall={current_wall!r}, script={current_script!r}",
             )
 
         for field in ("mismatches", "ok_count", "expected_true_count"):
@@ -573,16 +1294,11 @@ def test_verdict_rejects_invalid_numeric_fields() -> None:
                     output=out,
                     integrity=integrity_path,
                 )
-                try:
-                    analyze.cmd_verdict(args)
-                except AnalyzerError:
-                    continue
-                raise AssertionError(
-                    f"expected AnalyzerError for inv_8 {field}={bad!r}"
+                _raises(
+                    AnalyzerError,
+                    lambda a=args: analyze.cmd_verdict(a),
+                    f"inv_8 {field}={bad!r}",
                 )
-
-
-# ── Tests: cmd_verdict native_mode0 cross-check (Finding 4) ──────────────────
 
 
 def _make_bare_run_json(
@@ -593,11 +1309,7 @@ def _make_bare_run_json(
     inv8_ok_count: int = 1,
     inv8_expected_true_count: int = 1,
 ) -> dict[str, object]:
-    """Build a minimal bare-secp run JSON that passes all verdict checks.
-
-    The native_mode0 mismatches/ok_count can be set independently from
-    inv_8 to create a contradiction (Finding 4).
-    """
+    """Build a minimal bare-secp run JSON that passes all verdict checks."""
     ns = 50000
     return {
         "native_mode0": {
@@ -641,12 +1353,7 @@ def _make_integrity_json() -> dict[str, object]:
 
 
 def test_verdict_native_mode0_contradiction_fails() -> None:
-    """Contradictory native_mode0 vs inv_8 must make verdict INVALID.
-
-    An agreeing artifact passes (verdict is OPEN or CLOSED, return code 0),
-    while a contradictory artifact (mode0.mismatches != inv_8.mismatches)
-    must yield INVALID with return code 2.
-    """
+    """Contradictory native_mode0 vs inv_8 must make verdict INVALID."""
     import argparse
 
     import analyze
@@ -654,7 +1361,6 @@ def test_verdict_native_mode0_contradiction_fails() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
 
-        # Capture counters: ffi_verify_entries=1, ecdsa_verify_calls=1 → a=1.0
         cap = _valid_counters_dict(
             ffi_verify_entries=1,
             ecdsa_verify_calls=1,
@@ -677,14 +1383,8 @@ def test_verdict_native_mode0_contradiction_fails() -> None:
         out_ok = tmp / "verdict_ok.json"
         out_bad = tmp / "verdict_bad.json"
 
-        # --- Agreeing artifact: mode0 matches inv_8 ---
-        agreeing = _make_bare_run_json(
-            mode0_mismatches=0,
-            mode0_ok_count=1,
-            inv8_mismatches=0,
-            inv8_ok_count=1,
-            inv8_expected_true_count=1,
-        )
+        # --- Agreeing artifact ---
+        agreeing = _make_bare_run_json()
         agreeing_paths = []
         for i in range(3):
             p = tmp / f"agree{i}.json"
@@ -704,19 +1404,11 @@ def test_verdict_native_mode0_contradiction_fails() -> None:
         rc_ok = analyze.cmd_verdict(args_ok)
         assert rc_ok == 0, f"agreeing artifact should not be INVALID, got rc={rc_ok}"
         report_ok = json.loads(out_ok.read_text())
-        assert report_ok["verdict"] != "INVALID", (
-            f"agreeing artifact verdict should not be INVALID, got {report_ok['verdict']!r}"
-        )
+        assert report_ok["verdict"] != "INVALID"
         assert report_ok["inv_8"]["passed"] is True
 
-        # --- Contradictory artifact: mode0.mismatches != inv_8.mismatches ---
-        contradictory = _make_bare_run_json(
-            mode0_mismatches=1,
-            mode0_ok_count=1,
-            inv8_mismatches=0,
-            inv8_ok_count=1,
-            inv8_expected_true_count=1,
-        )
+        # --- Contradictory artifact ---
+        contradictory = _make_bare_run_json(mode0_mismatches=1)
         contra_paths = []
         for i in range(3):
             p = tmp / f"contra{i}.json"
@@ -738,12 +1430,3969 @@ def test_verdict_native_mode0_contradiction_fails() -> None:
             f"contradictory artifact should be INVALID (rc=2), got rc={rc_bad}"
         )
         report_bad = json.loads(out_bad.read_text())
-        assert report_bad["verdict"] == "INVALID", (
-            f"contradictory artifact should be INVALID, got {report_bad['verdict']!r}"
+        assert report_bad["verdict"] == "INVALID"
+        assert report_bad["inv_8"]["passed"] is False
+
+
+# ── Tests: legacy JSONL diagnostic parser ────────────────────────────────────
+
+
+def test_legacy_jsonl_rejects_malformed_fields() -> None:
+    """Diagnostic JSONL must have exact fields, lowercase hex, and sane integers."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        # Use a txid with at least one a-f digit so .upper() changes the string.
+        base = _make_legacy_row(
+            bytes.fromhex("0a" + "00" * 30).hex(), 0, _p2pkh_prevout()
         )
-        assert report_bad["inv_8"]["passed"] is False, (
-            "INV-8 must fail when native_mode0 contradicts inv_8"
+
+        for label, broken in (
+            ("missing height", {k: v for k, v in base.items() if k != "height"}),
+            ("extra field", {**base, "extra": 1}),
+            ("uppercase txid", {**base, "txid": base["txid"].upper()}),
+            ("odd hex", {**base, "txid": base["txid"][:-1]}),
+            ("negative height", {**base, "height": -1}),
+            ("bool input_index", {**base, "input_index": True}),
+        ):
+            _write_legacy_jsonl(tmp / "ctx.jsonl", [broken])
+            _raises(
+                ContextError,
+                lambda p=tmp / "ctx.jsonl": list(iter_legacy_context_inputs(p, 1)),
+                label,
+            )
+
+
+def test_legacy_jsonl_rejects_duplicate_and_count_mismatch() -> None:
+    """Duplicate identities and wrong input-count are diagnostic contract failures."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid = bytes(32).hex()
+        rows = [
+            _make_legacy_row(txid, 0, _p2pkh_prevout(), tx_index=0),
+            _make_legacy_row(txid, 0, _p2pkh_prevout(), tx_index=1),
+        ]
+        _write_legacy_jsonl(tmp / "ctx.jsonl", rows)
+        _raises(
+            ContextError,
+            lambda: list(iter_legacy_context_inputs(tmp / "ctx.jsonl", 2)),
+            "duplicate execution identity",
         )
+
+        _write_legacy_jsonl(tmp / "ctx.jsonl", [])
+        _raises(
+            ContextError,
+            lambda: list(iter_legacy_context_inputs(tmp / "ctx.jsonl", 1)),
+            "count mismatch",
+        )
+
+        assert list(iter_legacy_context_inputs(tmp / "ctx.jsonl", 0)) == []
+
+
+# ── Tests: BRSCTX1 strict binary parser adversarial cases ────────────────────
+
+
+def test_brsctx1_rejects_wrong_magic() -> None:
+    """A file with wrong magic must raise CTX-RAW."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "bad.bin"
+        # 8-byte wrong magic + u64 count=0
+        path.write_bytes(b"BADMAGIC" + struct.pack("<Q", 0))
+        _raises_with(
+            ContextError,
+            lambda: list(iter_context_inputs(path)),
+            "wrong magic",
+            "CTX-RAW",
+        )
+
+
+def test_brsctx1_rejects_short_header() -> None:
+    """A file shorter than the 16-byte header must raise CTX-RAW."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "short.bin"
+        path.write_bytes(b"BRSCTX1\x00" + b"\x00" * 3)  # 11 bytes < 16
+        _raises_with(
+            ContextError,
+            lambda: list(iter_context_inputs(path)),
+            "short header",
+            "CTX-RAW",
+        )
+
+
+def test_brsctx1_rejects_short_row_field() -> None:
+    """A row whose declared length is shorter than the fixed body must raise CTX-RAW."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "short_row.bin"
+        # Header: magic + count=1
+        data = _BRSCTX1_MAGIC + struct.pack("<Q", 1)
+        # Row length = 10 (< 52-byte CONTEXT_MIN_ROW_SIZE)
+        data += struct.pack("<I", 10)
+        data += b"\x00" * 10
+        path.write_bytes(data)
+        _raises_with(
+            ContextError,
+            lambda: list(iter_context_inputs(path)),
+            "short row",
+            "CTX-RAW",
+        )
+
+
+def test_brsctx1_rejects_row_length_mismatch() -> None:
+    """row_len declares more bytes than are actually present."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "mismatch.bin"
+        txid_le = bytes(32)
+        fixed = _BRSCTX1_FIXED.pack(txid_le, 0, 0, 0, 0, 0)
+        # Declare row_length = _BRSCTX1_FIXED.size + 5 extra bytes, but only write fixed
+        row_length = _BRSCTX1_FIXED.size + 5
+        data = _BRSCTX1_MAGIC + struct.pack("<Q", 1)
+        data += struct.pack("<I", row_length)
+        data += fixed
+        # Don't write the 5 extra bytes — the read will be short
+        path.write_bytes(data)
+        _raises_with(
+            ContextError,
+            lambda: list(iter_context_inputs(path)),
+            "short read",
+            "CTX-RAW",
+        )
+
+
+def test_brsctx1_rejects_impossible_witness_count() -> None:
+    """A witness_count that cannot fit in the declared row length must fail before allocation."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "badwitness.bin"
+        txid_le = bytes(32)
+        # witness_count=100 but row_length only has a few bytes remaining
+        fixed = _BRSCTX1_FIXED.pack(txid_le, 0, 0, 0, 0, 100)
+        row_length = (
+            _BRSCTX1_FIXED.size + 4
+        )  # only 4 bytes remaining, can't fit 100 witness items
+        data = _BRSCTX1_MAGIC + struct.pack("<Q", 1)
+        data += struct.pack("<I", row_length)
+        data += fixed
+        data += b"\x00" * 4
+        path.write_bytes(data)
+        _raises_with(
+            ContextError,
+            lambda: list(iter_context_inputs(path)),
+            "witness count cannot fit",
+            "CTX-RAW",
+        )
+
+
+def test_brsctx1_rejects_duplicate_execution_identity() -> None:
+    """Two rows with the same (txid_le, input_index) must raise CTX-EXECUTION."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "dup.bin"
+        txid_le = b"\x01" * 32
+        row = _ctx_input(txid_le, 0, prevout=_p2pkh_prevout())
+        _make_brsctx1_file(path, [row, row])
+        _raises_with(
+            ContextError,
+            lambda: list(iter_context_inputs(path)),
+            "duplicate execution identity",
+            "CTX-EXECUTION",
+        )
+
+
+def test_brsctx1_rejects_declared_count_mismatch() -> None:
+    """A declared count that cannot fit in the payload must raise CTX-RAW."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "bad_count.bin"
+        # Declare count=1000000 but only provide a tiny payload
+        data = _BRSCTX1_MAGIC + struct.pack("<Q", 1_000_000)
+        data += b"\x00" * 100
+        path.write_bytes(data)
+        _raises_with(
+            ContextError,
+            lambda: list(iter_context_inputs(path)),
+            "declared count mismatch",
+            "CTX-RAW",
+        )
+
+
+def test_brsctx1_rejects_trailing_bytes() -> None:
+    """Extra bytes after the declared rows must raise CTX-RAW."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "trailing.bin"
+        txid_le = b"\x02" * 32
+        row = _ctx_input(txid_le, 0, prevout=_p2pkh_prevout())
+        _make_brsctx1_file(path, [row])
+        # Append a trailing byte
+        path.write_bytes(path.read_bytes() + b"\x00")
+        _raises_with(
+            ContextError,
+            lambda: list(iter_context_inputs(path)),
+            "trailing bytes",
+            "CTX-RAW",
+        )
+
+
+def test_brsctx1_accepts_valid_file() -> None:
+    """A well-formed BRSCTX1 file with one row must parse successfully."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "ok.bin"
+        txid_le = b"\x03" * 32
+        row = _ctx_input(txid_le, 0, prevout=_p2pkh_prevout())
+        _make_brsctx1_file(path, [row])
+        inputs = list(iter_context_inputs(path))
+        assert len(inputs) == 1
+        assert inputs[0].identity.txid_le == txid_le
+        assert inputs[0].identity.input_index == 0
+
+
+# ── Tests: classify_input spend-context classification ───────────────────────
+
+
+def test_classify_input_bare_p2pkh() -> None:
+    """Bare P2PKH with no flags classifies as BARE."""
+    txid_le = b"\x10" * 32
+    classified = classify_input(_bare_p2pkh(txid_le))
+    assert classified.spend_context == SpendContext.BARE
+
+
+def test_classify_input_p2sh_without_flag() -> None:
+    """P2SH prevout without P2SH flag classifies as BARE."""
+    txid_le = b"\x11" * 32
+    classified = classify_input(_p2sh_push_only(txid_le, flags=0))
+    assert classified.spend_context == SpendContext.BARE
+
+
+def test_classify_input_p2sh_with_flag() -> None:
+    """P2SH prevout with P2SH flag classifies as P2SH."""
+    txid_le = b"\x12" * 32
+    classified = classify_input(_p2sh_push_only(txid_le, flags=VERIFY_P2SH))
+    assert classified.spend_context == SpendContext.P2SH
+
+
+def test_classify_input_p2sh_wrapped_w0_p2sh_only() -> None:
+    """P2SH-wrapped witness-v0 with P2SH only classifies as P2SH."""
+    txid_le = b"\x13" * 32
+    classified = classify_input(_p2sh_wrapped_w0(txid_le, flags=VERIFY_P2SH))
+    assert classified.spend_context == SpendContext.P2SH
+
+
+def test_classify_input_p2sh_wrapped_w0_p2sh_witness() -> None:
+    """P2SH-wrapped witness-v0 with P2SH+WITNESS classifies as P2SH_WRAPPED_WITNESS_V0."""
+    txid_le = b"\x14" * 32
+    classified = classify_input(
+        _p2sh_wrapped_w0(txid_le, flags=VERIFY_P2SH | VERIFY_WITNESS)
+    )
+    assert classified.spend_context == SpendContext.P2SH_WRAPPED_WITNESS_V0
+
+
+def test_classify_input_native_w0_without_witness() -> None:
+    """Native witness-v0 prevout without WITNESS flag classifies as BARE."""
+    txid_le = b"\x15" * 32
+    classified = classify_input(_native_w0(txid_le, flags=0))
+    assert classified.spend_context == SpendContext.BARE
+
+
+def test_classify_input_native_w0_with_witness() -> None:
+    """Native witness-v0 prevout with WITNESS flag classifies as NATIVE_WITNESS_V0."""
+    txid_le = b"\x16" * 32
+    classified = classify_input(_native_w0(txid_le, flags=VERIFY_WITNESS))
+    assert classified.spend_context == SpendContext.NATIVE_WITNESS_V0
+
+
+def test_classify_input_taproot_no_witness() -> None:
+    """P2TR prevout without WITNESS flag classifies as BARE."""
+    txid_le = b"\x17" * 32
+    classified = classify_input(_taproot_key_path(txid_le, flags=0))
+    assert classified.spend_context == SpendContext.BARE
+
+
+def test_classify_input_taproot_witness_only() -> None:
+    """P2TR prevout with WITNESS only (no TAPROOT) classifies as BARE."""
+    txid_le = b"\x18" * 32
+    classified = classify_input(_taproot_key_path(txid_le, flags=VERIFY_WITNESS))
+    assert classified.spend_context == SpendContext.BARE
+
+
+def test_classify_input_taproot_key_path() -> None:
+    """P2TR prevout with WITNESS+TAPROOT and 64-byte sig classifies as TAPROOT_KEY_PATH."""
+    txid_le = b"\x19" * 32
+    classified = classify_input(
+        _taproot_key_path(txid_le, flags=VERIFY_WITNESS | VERIFY_TAPROOT)
+    )
+    assert classified.spend_context == SpendContext.TAPROOT_KEY_PATH
+
+
+def test_classify_input_taproot_script_path() -> None:
+    """P2TR prevout with WITNESS+TAPROOT and stack+tapscript+control classifies as TAPSCRIPT."""
+    txid_le = b"\x1a" * 32
+    classified = classify_input(
+        _taproot_script_path(txid_le, flags=VERIFY_WITNESS | VERIFY_TAPROOT)
+    )
+    assert classified.spend_context == SpendContext.TAPSCRIPT
+
+
+def test_classify_input_taproot_annex_stripping() -> None:
+    """A final annex (0x50) is stripped before P2TR path classification."""
+    txid_le = b"\x1b" * 32
+    annex = bytes([0x50]) + bytes(10)
+
+    # Key path with annex: two elements, strip -> one -> key path.
+    evidence = _ctx_input(
+        txid_le,
+        0,
+        verify_flags=VERIFY_WITNESS | VERIFY_TAPROOT,
+        prevout=_p2tr_prevout(),
+        witness=(bytes(64), annex),
+    )
+    assert classify_input(evidence).spend_context == SpendContext.TAPROOT_KEY_PATH
+
+    # Script path with annex: four elements, strip -> three -> script path.
+    control = bytes([0xC0]) + bytes(32)
+    evidence = _ctx_input(
+        txid_le,
+        1,
+        verify_flags=VERIFY_WITNESS | VERIFY_TAPROOT,
+        prevout=_p2tr_prevout(),
+        witness=(bytes(64), bytes([0xAC]), control, annex),
+    )
+    assert classify_input(evidence).spend_context == SpendContext.TAPSCRIPT
+
+
+def test_classify_input_p2sh_non_push_scriptsig() -> None:
+    """P2SH with non-push scriptSig must raise ContextError."""
+    txid_le = b"\x1c" * 32
+    redeem = _multisig_redeem_script()
+    bad_script_sig = _push(redeem) + bytes([0x75])  # extra non-push byte
+    evidence = _ctx_input(
+        txid_le,
+        0,
+        verify_flags=VERIFY_P2SH,
+        prevout=_p2sh_prevout(),
+        script_sig=bad_script_sig,
+    )
+    _raises(ContextError, lambda: classify_input(evidence), "non-push P2SH scriptSig")
+
+
+def test_classify_input_native_v0_with_scriptsig() -> None:
+    """Native v0 with non-empty scriptSig must raise ContextError."""
+    txid_le = b"\x1d" * 32
+    evidence = _ctx_input(
+        txid_le,
+        0,
+        verify_flags=VERIFY_WITNESS,
+        prevout=_p2wsh_prevout(),
+        script_sig=bytes([1]),
+        witness=(b"\x00", _multisig_redeem_script()),
+    )
+    _raises(ContextError, lambda: classify_input(evidence), "native v0 with scriptSig")
+
+
+def test_classify_input_taproot_bad_key_path_sig() -> None:
+    """P2TR key-path with wrong signature length must raise ContextError."""
+    txid_le = b"\x1e" * 32
+    evidence = _ctx_input(
+        txid_le,
+        0,
+        verify_flags=VERIFY_WITNESS | VERIFY_TAPROOT,
+        prevout=_p2tr_prevout(),
+        witness=(bytes(20),),  # 20 bytes is not 64/65
+    )
+    _raises(
+        ContextError, lambda: classify_input(evidence), "P2TR key-path bad sig length"
+    )
+
+
+def test_classify_input_taproot_bad_control_block() -> None:
+    """P2TR script-path with malformed control block must raise ContextError."""
+    txid_le = b"\x1f" * 32
+    evidence = _ctx_input(
+        txid_le,
+        0,
+        verify_flags=VERIFY_WITNESS | VERIFY_TAPROOT,
+        prevout=_p2tr_prevout(),
+        witness=(bytes(1), bytes(32)),  # second element is 32 bytes (< 33)
+    )
+    _raises(
+        ContextError,
+        lambda: classify_input(evidence),
+        "P2TR script-path bad control block",
+    )
+
+
+# ── Tests: classify-corpus txid reversal mutation ────────────────────────────
+
+
+def test_classify_corpus_txid_reversal_mutation() -> None:
+    """BRSCTX1 and BRSREC1/BRSJRN1 must use the same raw LE txid bytes.
+
+    Baseline: all fixtures use the same raw LE txid; the join logic passes
+    and the command reaches the c150 pin (which raises CTX-CUSTODY for a
+    1-block corpus).
+    Mutation: flip only the BRSCTX1 txid bytes; journal and records keep the
+    original LE bytes; cmd_classify_corpus must raise AnalyzerError with
+    CTX-OPERATIONS from the key-equality check.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = bytes(range(1, 33))
+
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = _make_journal_bytes(txid_le, 0)
+
+        # ── Baseline: all use the same LE txid ──
+        # The join logic passes; the c150 pin raises CTX-CUSTODY for a 1-block
+        # corpus (stop_height=0 != 150000).  This proves the join succeeded.
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            [journal],
+            "c150",
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "baseline c150 pin",
+            "CTX-CUSTODY",
+        )
+
+        # ── Mutation: flip BRSCTX1 txid only ──
+        flipped_txid = txid_le[::-1]  # reverse to display order
+        mutated_row = _bare_p2pkh(flipped_txid)
+        args = _make_classify_args(
+            tmp,
+            [mutated_row],
+            [record],
+            [journal],
+            "c150",
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "flipped BRSCTX1 txid",
+            "CTX-OPERATIONS",
+        )
+
+
+def test_classify_corpus_all_spend_contexts() -> None:
+    """All required spend containers and multisig/Schnorr records are counted.
+
+    Builds all 6 spend contexts producing all 11 nonzero context counters,
+    then runs with contract="cmodern" and asserts it fails (cmodern is
+    fail-closed).  The context_counts are checked to be all positive before
+    the pass/fail assertion, proving the failure is from the contract gate,
+    not from missing data.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txids = [bytes([i + 1]) * 32 for i in range(6)]
+
+        contexts = [
+            _bare_p2pkh(txids[0]),  # bare
+            _p2sh_push_only(txids[1], flags=VERIFY_P2SH),  # p2sh
+            _native_w0(txids[2], flags=VERIFY_WITNESS),  # native v0
+            _p2sh_wrapped_w0(
+                txids[3], flags=VERIFY_P2SH | VERIFY_WITNESS
+            ),  # wrapped v0
+            _taproot_key_path(
+                txids[4], flags=VERIFY_WITNESS | VERIFY_TAPROOT
+            ),  # taproot key path
+            _taproot_script_path(
+                txids[5], flags=VERIFY_WITNESS | VERIFY_TAPROOT
+            ),  # tapscript
+        ]
+
+        records = [
+            _make_record_bytes(txids[0], 0, op_kind=3, sig_version=0),  # bare multisig
+            _make_record_bytes(txids[1], 0, op_kind=3, sig_version=0),  # p2sh multisig
+            _make_record_bytes(
+                txids[2], 0, op_kind=3, sig_version=1
+            ),  # native v0 multisig
+            _make_record_bytes(
+                txids[3], 0, op_kind=3, sig_version=1
+            ),  # wrapped v0 multisig
+            _make_record_bytes(
+                txids[5], 0, op_kind=1, sig_version=2
+            ),  # tapscript schnorr
+            _make_record_bytes(
+                txids[5], 0, op_kind=5, sig_version=2, op_seq=1
+            ),  # checksigadd
+        ]
+
+        # Journal entries must match the actual records per key:
+        # txids[0..3]: ECDSA multisig → ecdsa_verify_calls=1, ecdsa_verify_ok=1, checkmultisig_ops=1
+        # txids[4]: no record (taproot key path has no BRSREC1 record) → all zero
+        # txids[5]: Schnorr (not ECDSA) → ecdsa_verify_calls=0, ecdsa_verify_ok=0
+        journal = [
+            _make_journal_bytes(
+                txids[0],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+            _make_journal_bytes(
+                txids[1],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+            _make_journal_bytes(
+                txids[2],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+            _make_journal_bytes(
+                txids[3],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+            _make_journal_bytes(
+                txids[4],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=0,
+                ecdsa_verify_calls=0,
+                ecdsa_verify_ok=0,
+            ),
+            _make_journal_bytes(
+                txids[5],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=0,
+                ecdsa_verify_calls=0,
+                ecdsa_verify_ok=0,
+            ),
+        ]
+
+        # Counters must match the actual record/journal sums:
+        # 4 ECDSA multisig records + 2 Schnorr records = 6 total
+        # op_checksig=0, op_checkmultisig=4, op_checksigadd=1
+        # checkecdsa_entries=4, ecdsa_verify_calls=4, ecdsa_verify_ok=4
+        # checkschnorr_entries=2, schnorr_verify_calls=2, schnorr_verify_ok=2
+        counters = _make_valid_counters(
+            record_count=6,
+            journal_count=6,
+            ffi_verify_entries=6,
+            op_checksig=0,
+            op_checkmultisig=4,
+            op_checksigadd=1,
+            checkecdsa_entries=4,
+            ecdsa_from_checksig=0,
+            ecdsa_from_checkmultisig=4,
+            ecdsa_verify_calls=4,
+            ecdsa_verify_ok=4,
+            ecdsa_verify_fail=0,
+            sighash_computed=4,
+            checkschnorr_entries=2,
+            schnorr_verify_calls=2,
+            schnorr_verify_ok=2,
+            schnorr_verify_fail=0,
+        )
+
+        args = _make_classify_args(
+            tmp, contexts, records, journal, "cmodern", counters_dict=counters
+        )
+        # cmodern is fail-closed: it must return 1 or raise AnalyzerError
+        _cmodern_failed = False
+        try:
+            rc = cmd_classify_corpus(args)
+            assert rc == 1, (
+                "cmodern must not certify even with all 11 counters positive"
+            )
+        except AnalyzerError:
+            _cmodern_failed = True  # not-frozen error is an acceptable failure path
+
+        # If a report was written, verify all 11 context_counts are positive,
+        # then assert all_passed is False — proving the failure is the contract
+        # gate, not missing data.
+        report_path = tmp / "report.json"
+        if report_path.exists():
+            counts = json.loads(report_path.read_text())["context_counts"]
+            for name in CONTEXT_COUNTER_NAMES:
+                assert counts[name] > 0, (
+                    f"{name} should be positive in all-spend fixture"
+                )
+            report = json.loads(report_path.read_text())
+            assert report["all_passed"] is False
+
+
+def test_classify_corpus_c150_passes() -> None:
+    """c150 is pinned to stop_height=150000 and a specific stop_hash.
+
+    A 1-block fixture cannot satisfy the pin, so c150 must raise
+    AnalyzerError with CTX-CUSTODY.  The counter shape (bare_multisig_checks>0,
+    all others ==0) is verified via the report if one is written.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x40" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0, op_kind=3, sig_version=0)
+        journal = [
+            _make_journal_bytes(
+                txid_le,
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=0,
+                ecdsa_verify_ok=0,
+            )
+        ]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={
+                "stop_height": _C150_STOP_HEIGHT,
+                "stop_hash": _C150_STOP_HASH,
+            },
+            counters_overrides={
+                "op_checksig": 0,
+                "op_checkmultisig": 1,
+                "checkecdsa_entries": 0,
+                "ecdsa_from_checksig": 0,
+                "ecdsa_verify_calls": 0,
+                "ecdsa_verify_ok": 0,
+                "sighash_computed": 0,
+            },
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "CTX-CUSTODY",
+        )
+
+
+def test_classify_corpus_cmodern_fails() -> None:
+    """cmodern always fails (rc=1 or AnalyzerError) because the contract is
+    not frozen — even when all 11 context counters are nonzero it cannot
+    certify.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x41" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(tmp, [ctx_row], [record], journal, "cmodern")
+        # cmodern is fail-closed: it must return 1 or raise AnalyzerError
+        _cmodern_failed = False
+        try:
+            rc = cmd_classify_corpus(args)
+            assert rc == 1, "cmodern must not certify (rc=1)"
+        except AnalyzerError:
+            _cmodern_failed = True  # not-frozen error is an acceptable failure path
+        # If a report was written, all_passed must be False
+        report_path = tmp / "report.json"
+        if report_path.exists():
+            report = json.loads(report_path.read_text())
+            assert report["all_passed"] is False
+
+
+def test_classify_corpus_zero_inputs() -> None:
+    """An empty BRSCTX1 file with zero records/journal raises CTX-EXECUTION
+    because cmd_classify_corpus rejects zero-input evidence.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        args = _make_classify_args(tmp, [], [], [], "c150")
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "zero inputs",
+            "CTX-EXECUTION",
+        )
+
+
+def test_classify_corpus_definitions_match_counter_names() -> None:
+    """Every named context counter has a definition and no extra grid is introduced."""
+    assert set(CONTEXT_COUNTER_NAMES) == set(CONTEXT_COUNTER_DEFINITIONS)
+    assert len(CONTEXT_COUNTER_NAMES) == 11
+
+
+# ── Tests: classify-corpus missing / duplicate / swap records ────────────────
+
+
+def test_classify_corpus_missing_record_identity() -> None:
+    """A BRSREC1 record whose key is not in context/journal raises CTX-OPERATIONS."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        ctx_txid = b"\x60" * 32
+        other_txid = b"\x99" * 32
+        ctx_row = _bare_p2pkh(ctx_txid)
+        record = _make_record_bytes(other_txid, 0)
+        journal = [_make_journal_bytes(ctx_txid, 0)]
+        args = _make_classify_args(tmp, [ctx_row], [record], journal, "c150")
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "missing record identity",
+            "CTX-OPERATIONS",
+        )
+
+
+def test_classify_corpus_duplicate_record_key() -> None:
+    """Duplicate BRSREC1 (same txid/input_index/op_seq) raises CTX-OPERATIONS."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x61" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        records = [
+            _make_record_bytes(txid_le, 0, op_seq=0),
+            _make_record_bytes(txid_le, 0, op_seq=0),
+        ]
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(tmp, [ctx_row], records, journal, "c150")
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "duplicate record key",
+            "CTX-OPERATIONS",
+        )
+
+
+def test_classify_corpus_duplicate_journal_key() -> None:
+    """Duplicate BRSJRN1 (same txid/input_index) raises CTX-EXECUTION."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x62" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [
+            _make_journal_bytes(txid_le, 0),
+            _make_journal_bytes(txid_le, 0),
+        ]
+        args = _make_classify_args(tmp, [ctx_row], [record], journal, "c150")
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "duplicate journal key",
+            "CTX-EXECUTION",
+        )
+
+
+def test_classify_corpus_native_wrapped_swap() -> None:
+    """A P2SH-wrapped witness-v0 input joined to a BASE sig_version record fails."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x63" * 32
+        ctx_row = _p2sh_wrapped_w0(txid_le, flags=VERIFY_P2SH | VERIFY_WITNESS)
+        record = _make_record_bytes(txid_le, 0, op_kind=3, sig_version=0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(tmp, [ctx_row], [record], journal, "c150")
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "native/wrapped swap",
+            "CTX-OPERATIONS",
+        )
+
+
+# ── Tests: custody / replay / manifest adversarial ───────────────────────────
+
+
+def test_classify_corpus_rejects_jsonl_context_file() -> None:
+    """cmd_classify_corpus rejects a sampled JSONL context file (wrong magic)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x70" * 32
+        # Write a JSONL file instead of BRSCTX1 binary
+        row = _make_legacy_row(txid_le[::-1].hex(), 0, _p2pkh_prevout())
+        _write_legacy_jsonl(tmp / "contexts.bin", [row])
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+
+        # Build the rest of the fixtures normally
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_raw = _make_manifest(
+            tmp / "manifest.json",
+            stop_height=0,
+            blocks=[_MAINNET_GENESIS_BLOCK],
+            archive_size=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises(AnalyzerError, lambda: cmd_classify_corpus(args), "JSONL context file")
+
+
+def test_classify_corpus_rejects_mismatched_context_size() -> None:
+    """A mismatched custody size for the context file raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x71" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+
+        # Build fixtures normally, then corrupt the replay's corpus_manifest
+        # bytes field to create a custody size mismatch for the manifest.
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"corpus_manifest_bytes": 99999},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "manifest size mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_classify_corpus_rejects_mismatched_context_sha256() -> None:
+    """A mismatched custody sha256 for the manifest raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x72" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"corpus_manifest_sha256": "f" * 64},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "manifest sha256 mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_classify_corpus_context_journal_key_inequality() -> None:
+    """Context/journal key inequality (mutate one journal key) raises CTX-OPERATIONS."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        ctx_txid = b"\x80" * 32
+        jrn_txid = b"\x81" * 32  # different txid in journal
+        ctx_row = _bare_p2pkh(ctx_txid)
+        record = _make_record_bytes(ctx_txid, 0)
+        journal = [_make_journal_bytes(jrn_txid, 0)]
+        args = _make_classify_args(tmp, [ctx_row], [record], journal, "c150")
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "context/journal key inequality",
+            "CTX-OPERATIONS",
+        )
+
+
+def test_classify_corpus_count_mismatch_ffi_verify_entries() -> None:
+    """Context count != counters.ffi_verify_entries raises CTX-EXECUTION."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x82" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # ffi_verify_entries=2 but only 1 context row
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            counters_overrides={
+                "ffi_verify_entries": 2,
+                "verify_script_calls": 2,
+                "ffi_verify_true": 2,
+            },
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "context count != ffi_verify_entries",
+            "CTX-EXECUTION",
+        )
+
+
+def test_classify_corpus_record_count_mismatch() -> None:
+    """BRSREC1 record count != counters.record_count raises CTX-OPERATIONS."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x83" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # record_count=2 but only 1 record
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            counters_overrides={"record_count": 2},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "record count mismatch",
+            "CTX-OPERATIONS",
+        )
+
+
+# ── Tests: replay v2 window validation ───────────────────────────────────────
+
+
+def test_replay_rejects_nonzero_assume_valid_height() -> None:
+    """Replay assume_valid_height != 0 raises CTX-WINDOW."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x90" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"assume_valid_height": 100},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "assume_valid_height != 0",
+            "CTX-WINDOW",
+        )
+
+
+def test_replay_rejects_window_le_one() -> None:
+    """Replay window <= 1 raises CTX-WINDOW."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x91" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"window": 1},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "window <= 1",
+            "CTX-WINDOW",
+        )
+
+
+def test_replay_rejects_zero_window_verify_success_total() -> None:
+    """Replay window_verify_success_total == 0 raises CTX-WINDOW."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x92" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"window_verify_success_total": 0},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "window_verify_success_total == 0",
+            "CTX-WINDOW",
+        )
+
+
+# ── Tests: manifest / archive custody validation ─────────────────────────────
+
+
+def test_manifest_network_mismatch_raises() -> None:
+    """Manifest network mismatch raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa0" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            manifest_overrides={"network": "testnet"},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "manifest network mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_genesis_mismatch_raises() -> None:
+    """Manifest genesis_hash mismatch raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa1" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            manifest_overrides={"genesis_hash": "1" * 64},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "manifest genesis mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_range_mismatch_raises() -> None:
+    """Manifest stop_height mismatch raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa2" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            manifest_overrides={"range": {"start_height": 0, "stop_height": 99}},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "manifest range mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_archive_size_mismatch_raises() -> None:
+    """Manifest archive size mismatch raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa3" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            manifest_overrides={"archive": {"size": 99999, "sha256": "0" * 64}},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "archive size mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_archive_sha256_mismatch_raises() -> None:
+    """Manifest archive sha256 mismatch raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa4" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Get the real archive size, then set a wrong sha256
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_raw = _make_manifest(
+            tmp / "manifest.json",
+            stop_height=0,
+            blocks=[_MAINNET_GENESIS_BLOCK],
+            archive_size=len(archive_raw),
+            archive_sha256="e" * 64,  # wrong sha256
+        )
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256="e" * 64,
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "archive sha256 mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+# ── Tests: manifest entry validation ─────────────────────────────────────────
+
+
+def test_manifest_start_height_nonzero_raises() -> None:
+    """Manifest range.start_height != 0 raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb0" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Override manifest with start_height=1 (also need matching replay)
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 1, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 0,
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            start_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "start_height != 0",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_empty_entries_raises() -> None:
+    """Missing or empty manifest entries raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb1" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "empty entries",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_gapped_heights_raises() -> None:
+    """Noncontiguous manifest entry heights raise CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb2" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Build a 2-block archive
+        block1 = _MAINNET_GENESIS_BLOCK
+        # Create a second block with prev_blockhash = genesis hash (raw LE)
+        header2 = (
+            b"\x00" * 4  # version
+            + _MAINNET_GENESIS_HASH_RAW  # prev_blockhash (raw LE)
+            + b"\x00" * 32  # merkle_root
+            + struct.pack("<I", 0x5CE9B2A2)  # timestamp
+            + b"\x20" * 4  # bits
+            + struct.pack("<I", 1)  # nonce
+        )
+        block2 = (
+            header2
+            + bytes([0x01])
+            + struct.pack("<I", 1)
+            + bytes([0x00])
+            + b"\x00" * 36
+            + bytes([0x00])
+            + struct.pack("<I", 0)
+        )
+        blocks = [block1, block2]
+        archive_raw = _make_archive(tmp / "archive.bin", blocks)
+        # Manifest with gapped height (0, 2 instead of 0, 1)
+        entries = [
+            {
+                "height": 0,
+                "hash": _block_hash_display(block1),
+                "offset": 0,
+                "payload_length": len(block1),
+            },
+            {
+                "height": 2,
+                "hash": _block_hash_display(block2),
+                "offset": 8 + len(block1),
+                "payload_length": len(block2),
+            },
+        ]
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 1},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": entries,
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=1,
+            stop_hash=_block_hash_display(block2),
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "gapped heights",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_inconsistent_offset_raises() -> None:
+    """Inconsistent manifest entry offsets raise CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb3" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        # Wrong offset (100 instead of 0)
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 100,
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "inconsistent offset",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_frame_magic_mismatch_raises() -> None:
+    """Archive frame magic mismatch raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb4" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Write archive with wrong magic
+        wrong_magic = bytes.fromhex("deadbeef")
+        archive_raw = _make_archive(
+            tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK], magic=wrong_magic
+        )
+        manifest_raw = _make_manifest(
+            tmp / "manifest.json",
+            stop_height=0,
+            blocks=[_MAINNET_GENESIS_BLOCK],
+            archive_size=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+            network_magic=wrong_magic.hex(),
+        )
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            network_magic=wrong_magic.hex(),
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        # The manifest network_magic won't match the replay's, so this raises
+        # CTX-CUSTODY for magic mismatch (either manifest-vs-replay or frame-vs-manifest)
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "frame magic mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_frame_payload_length_mismatch_raises() -> None:
+    """Archive frame u32 payload_length mismatch raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb5" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        # Manifest declares wrong payload_length
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 0,
+                    "payload_length": 999,
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "payload_length mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_header_hash_mismatch_raises() -> None:
+    """Decoded block header hash mismatch raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb6" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        # Manifest declares wrong hash for the entry
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": "0" * 64,
+                    "offset": 0,
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "header hash mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_genesis_prev_blockhash_nonzero_raises() -> None:
+    """First entry prev_blockhash not all-zero raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb7" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Build a block with non-zero prev_blockhash
+        bad_header = (
+            b"\x00" * 4
+            + b"\xff" * 32  # non-zero prev_blockhash
+            + b"\x00" * 32
+            + struct.pack("<I", 0x5CE9B2A1)
+            + b"\x20" * 4
+            + struct.pack("<I", 0)
+        )
+        bad_block = bad_header + _MAINNET_GENESIS_BLOCK[80:]
+        bad_hash = _block_hash_display(bad_block)
+        archive_raw = _make_archive(tmp / "archive.bin", [bad_block])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": bad_hash,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": bad_hash,
+                    "offset": 0,
+                    "payload_length": len(bad_block),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            stop_hash=bad_hash,
+            genesis_hash=bad_hash,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "genesis prev_blockhash nonzero",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_chain_break_raises() -> None:
+    """Block prev_blockhash chain break raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb8" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Block 1: valid genesis
+        block1 = _MAINNET_GENESIS_BLOCK
+        # Block 2: prev_blockhash is wrong (not the hash of block1)
+        header2 = (
+            b"\x00" * 4
+            + b"\xee" * 32  # wrong prev_blockhash
+            + b"\x00" * 32
+            + struct.pack("<I", 0x5CE9B2A2)
+            + b"\x20" * 4
+            + struct.pack("<I", 1)
+        )
+        block2 = header2 + _MAINNET_GENESIS_BLOCK[80:]
+        blocks = [block1, block2]
+        archive_raw = _make_archive(tmp / "archive.bin", blocks)
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 1},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _block_hash_display(block1),
+                    "offset": 0,
+                    "payload_length": len(block1),
+                },
+                {
+                    "height": 1,
+                    "hash": _block_hash_display(block2),
+                    "offset": 8 + len(block1),
+                    "payload_length": len(block2),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=1,
+            stop_hash=_block_hash_display(block2),
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "chain break",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_trailing_bytes_raises() -> None:
+    """Extra bytes after the final archive frame raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xb9" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Build archive then append trailing byte
+        _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        (tmp / "archive.bin").write_bytes((tmp / "archive.bin").read_bytes() + b"\x00")
+        archive_raw = (tmp / "archive.bin").read_bytes()
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {
+                "size": len(archive_raw) - 1,
+                "sha256": _sha256_bytes(archive_raw[:-1]),
+            },
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 0,
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw) - 1,
+            archive_sha256=_sha256_bytes(archive_raw[:-1]),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "trailing bytes",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_entry_count_mismatch_raises() -> None:
+    """Manifest entries count != stop_height+1 raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xba" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 5},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 0,
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=5,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        args = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "entry count mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_happy_path() -> None:
+    """A valid manifest/archive with a single mainnet genesis block passes
+    custody validation.  c150 is pinned to stop_height=150000 so the contract
+    fails (rc=1), but the custody/replay/manifest checks all pass and a valid
+    report is written.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xc0" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+        )
+        rc = cmd_classify_corpus(args)
+        # cmodern is not frozen, so it fails (rc=1), but custody passes.
+        assert rc == 1
+        report = json.loads((tmp / "report.json").read_text())
+        assert report["schema"] == "classify-corpus-v2"
+        assert "custody" in report
+        assert "replay" in report
+        assert "corpus_manifest" in report
+
+
+# ── Tests: C150 pin — stop_height/stop_hash spoofing ─────────────────────────
+
+
+def test_classify_corpus_c150_rejects_wrong_stop_height() -> None:
+    """c150 rejects stop_height=149999 instead of 150000 with CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xd0" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"stop_height": 149999, "stop_hash": _C150_STOP_HASH},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "c150 wrong stop_height",
+            "CTX-CUSTODY",
+        )
+
+
+def test_classify_corpus_c150_rejects_wrong_stop_hash() -> None:
+    """c150 rejects a wrong mainnet stop_hash with CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xd1" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        wrong_hash = "0" * 64
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={
+                "stop_height": _C150_STOP_HEIGHT,
+                "stop_hash": wrong_hash,
+            },
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "c150 wrong stop_hash",
+            "CTX-CUSTODY",
+        )
+
+
+def test_classify_corpus_c150_rejects_mismatched_stop_hash() -> None:
+    """c150 with stop_height=150000 but a stop_hash that doesn't match the
+    pinned hash raises CTX-CUSTODY.  This proves c150 is pinned and cannot
+    be spoofed even with the correct height.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xd2" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={
+                "stop_height": _C150_STOP_HEIGHT,
+                "stop_hash": "1" * 64,  # wrong hash
+            },
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "c150 mismatched stop_hash",
+            "CTX-CUSTODY",
+        )
+
+
+# ── Tests: cmodern regression — cannot certify even with all positive ────────
+
+
+def test_classify_corpus_cmodern_cannot_certify_all_positive() -> None:
+    """cmodern fails even when all 11 context counters are nonzero and custody
+    is valid.  The contract is not frozen, so it can never certify.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txids = [bytes([i + 1]) * 32 for i in range(6)]
+
+        contexts = [
+            _bare_p2pkh(txids[0]),  # bare
+            _p2sh_push_only(txids[1], flags=VERIFY_P2SH),  # p2sh
+            _native_w0(txids[2], flags=VERIFY_WITNESS),  # native v0
+            _p2sh_wrapped_w0(
+                txids[3], flags=VERIFY_P2SH | VERIFY_WITNESS
+            ),  # wrapped v0
+            _taproot_key_path(
+                txids[4], flags=VERIFY_WITNESS | VERIFY_TAPROOT
+            ),  # taproot key path
+            _taproot_script_path(
+                txids[5], flags=VERIFY_WITNESS | VERIFY_TAPROOT
+            ),  # tapscript
+        ]
+
+        records = [
+            _make_record_bytes(txids[0], 0, op_kind=3, sig_version=0),  # bare multisig
+            _make_record_bytes(txids[1], 0, op_kind=3, sig_version=0),  # p2sh multisig
+            _make_record_bytes(
+                txids[2], 0, op_kind=3, sig_version=1
+            ),  # native v0 multisig
+            _make_record_bytes(
+                txids[3], 0, op_kind=3, sig_version=1
+            ),  # wrapped v0 multisig
+            _make_record_bytes(
+                txids[5], 0, op_kind=1, sig_version=2
+            ),  # tapscript schnorr
+            _make_record_bytes(
+                txids[5], 0, op_kind=5, sig_version=2, op_seq=1
+            ),  # checksigadd
+        ]
+
+        journal = [
+            _make_journal_bytes(
+                txids[0],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+            _make_journal_bytes(
+                txids[1],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+            _make_journal_bytes(
+                txids[2],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+            _make_journal_bytes(
+                txids[3],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+            _make_journal_bytes(
+                txids[4],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=0,
+                ecdsa_verify_calls=0,
+                ecdsa_verify_ok=0,
+            ),
+            _make_journal_bytes(
+                txids[5],
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=0,
+                ecdsa_verify_calls=0,
+                ecdsa_verify_ok=0,
+            ),
+        ]
+
+        counters = _make_valid_counters(
+            record_count=6,
+            journal_count=6,
+            ffi_verify_entries=6,
+            op_checksig=0,
+            op_checkmultisig=4,
+            op_checksigadd=1,
+            checkecdsa_entries=4,
+            ecdsa_from_checksig=0,
+            ecdsa_from_checkmultisig=4,
+            ecdsa_verify_calls=4,
+            ecdsa_verify_ok=4,
+            ecdsa_verify_fail=0,
+            sighash_computed=4,
+            checkschnorr_entries=2,
+            schnorr_verify_calls=2,
+            schnorr_verify_ok=2,
+            schnorr_verify_fail=0,
+        )
+
+        args = _make_classify_args(
+            tmp, contexts, records, journal, "cmodern", counters_dict=counters
+        )
+        _cmodern_failed = False
+        try:
+            rc = cmd_classify_corpus(args)
+            assert rc == 1, "cmodern must not certify even with all 11 positive"
+        except AnalyzerError:
+            _cmodern_failed = True  # not-frozen error is an acceptable failure path
+
+        report_path = tmp / "report.json"
+        if report_path.exists():
+            report = json.loads(report_path.read_text())
+            counts = report["context_counts"]
+            for name in CONTEXT_COUNTER_NAMES:
+                assert counts[name] > 0, f"{name} should be positive"
+            assert report["all_passed"] is False
+
+
+# ── Tests: replay/manifest field invariant mutations ─────────────────────────
+
+
+def test_replay_rejects_wrong_network() -> None:
+    """Replay network != 'mainnet' raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe0" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"network": "testnet"},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "wrong network",
+            "CTX-CUSTODY",
+        )
+
+
+def test_replay_rejects_wrong_network_magic() -> None:
+    """Replay network_magic != 'f9beb4d9' raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe1" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"network_magic": "fabfb5da"},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "wrong network_magic",
+            "CTX-CUSTODY",
+        )
+
+
+def test_replay_rejects_wrong_genesis_hash() -> None:
+    """Replay genesis_hash != mainnet canonical raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe2" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"genesis_hash": "1" * 64},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "wrong genesis_hash",
+            "CTX-CUSTODY",
+        )
+
+
+def test_replay_rejects_start_height_nonzero() -> None:
+    """Replay start_height != 0 raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe3" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"start_height": 1},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "start_height nonzero",
+            "CTX-CUSTODY",
+        )
+
+
+def test_replay_rejects_start_hash_not_genesis() -> None:
+    """Replay start_hash != genesis_hash raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe4" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"start_hash": "1" * 64},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "start_hash != genesis",
+            "CTX-CUSTODY",
+        )
+
+
+def test_replay_rejects_block_count_mismatch() -> None:
+    """Replay block_count != stop_height+1 raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe5" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"block_count": 999},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "block_count mismatch",
+            "CTX-CUSTODY",
+        )
+
+
+def test_replay_rejects_missing_stop_hash() -> None:
+    """Replay missing stop_hash field raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe6" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Build normally, then remove stop_hash from the replay JSON
+        args = _make_classify_args(tmp, [ctx_row], [record], journal, "c150")
+        replay_obj = json.loads((tmp / "replay.json").read_text())
+        del replay_obj["stop_hash"]
+        (tmp / "replay.json").write_text(json.dumps(replay_obj))
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "missing stop_hash",
+            "CTX-CUSTODY",
+        )
+
+
+def test_replay_rejects_unknown_field() -> None:
+    """Replay with an unknown top-level field raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe7" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Build normally, then inject an unknown field into the replay JSON
+        args = _make_classify_args(tmp, [ctx_row], [record], journal, "c150")
+        replay_obj = json.loads((tmp / "replay.json").read_text())
+        replay_obj["unknown_field"] = "malicious"
+        (tmp / "replay.json").write_text(json.dumps(replay_obj))
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "replay unknown field",
+            "CTX-CUSTODY",
+        )
+
+
+def test_replay_rejects_nonhex_git_head() -> None:
+    """A git_head with a non-hex character (but 40 chars) raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xea" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"git_head": "z" * 40},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "nonhex git_head",
+            "CTX-CUSTODY",
+            "lowercase hex",
+        )
+
+
+def test_replay_rejects_uppercase_git_head() -> None:
+    """An uppercase-hex git_head (40 chars) raises CTX-CUSTODY: lowercase only."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xeb" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"git_head": "A" * 40},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "uppercase git_head",
+            "CTX-CUSTODY",
+            "lowercase hex",
+        )
+
+
+def test_replay_rejects_bool_stage_count() -> None:
+    """A stage_seconds entry whose count is a bool raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xec" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={
+                "stage_seconds": [
+                    {
+                        "count": True,
+                        "stage": "node.apply_block.total_seconds",
+                        "sum_seconds": 1.0,
+                    }
+                ]
+            },
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "bool stage count",
+            "CTX-CUSTODY",
+            "non-bool integer",
+        )
+
+
+def test_replay_rejects_extra_stage_key() -> None:
+    """A stage_seconds entry with an extra key raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xed" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={
+                "stage_seconds": [
+                    {
+                        "count": 1,
+                        "stage": "node.apply_block.total_seconds",
+                        "sum_seconds": 1.0,
+                        "unexpected": 0,
+                    }
+                ]
+            },
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "extra stage key",
+            "CTX-CUSTODY",
+            "unknown key",
+        )
+
+
+def test_manifest_rejects_unknown_field() -> None:
+    """Manifest with an unknown top-level field raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe8" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            manifest_overrides={"unknown_field": "malicious"},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "manifest unknown field",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_rejects_out_of_u32_range_height() -> None:
+    """Manifest entry height > u32 max raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xe9" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 2**32,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 0,
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        ns = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(ns),
+            "height > u32",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_rejects_out_of_u64_range_offset() -> None:
+    """Manifest entry offset > u64 max raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xea" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 2**64,
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        ns = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(ns),
+            "offset > u64",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_rejects_duplicate_entry_height() -> None:
+    """Manifest with duplicate entry heights raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xeb" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 1},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 0,
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 8 + len(_MAINNET_GENESIS_BLOCK),
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=1,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        ns = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(ns),
+            "duplicate entry height",
+            "CTX-CUSTODY",
+        )
+
+
+def test_manifest_rejects_duplicate_entry_hash() -> None:
+    """Manifest with duplicate entry hashes raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xec" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Build a 2-block archive with distinct blocks
+        block1 = _MAINNET_GENESIS_BLOCK
+        header2 = (
+            b"\x00" * 4
+            + _MAINNET_GENESIS_HASH_RAW
+            + b"\x00" * 32
+            + struct.pack("<I", 0x495FAB30)
+            + struct.pack("<I", 0x1D00FFFF)
+            + struct.pack("<I", 1)
+        )
+        block2 = header2 + block1[80:]
+        blocks = [block1, block2]
+        archive_raw = _make_archive(tmp / "archive.bin", blocks)
+        # Both entries have the same hash (block1's hash)
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 1},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _block_hash_display(block1),
+                    "offset": 0,
+                    "payload_length": len(block1),
+                },
+                {
+                    "height": 1,
+                    "hash": _block_hash_display(block1),
+                    "offset": 8 + len(block1),
+                    "payload_length": len(block2),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=1,
+            stop_hash=_block_hash_display(block2),
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        ns = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(ns),
+            "duplicate entry hash",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_rejects_payload_length_above_max() -> None:
+    """Manifest entry payload_length > 4_000_000 raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xed" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 0,
+                    "payload_length": 4_000_001,
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        ns = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(ns),
+            "payload_length > 4M",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_rejects_payload_length_below_80() -> None:
+    """Manifest entry payload_length < 80 raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xee" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 0,
+                    "payload_length": 79,
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        ns = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(ns),
+            "payload_length < 80",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_rejects_frame_tail_not_stop_hash() -> None:
+    """Archive last frame hash != replay stop_hash raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xef" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Build a valid 1-block fixture, then set a wrong stop_hash in replay
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            replay_overrides={"stop_hash": "e" * 64},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "frame tail != stop_hash",
+            "CTX-CUSTODY",
+        )
+
+
+def test_archive_rejects_missing_archive_bytes() -> None:
+    """Archive file shorter than declared raises CTX-CUSTODY."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xf0" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        archive_raw = _make_archive(tmp / "archive.bin", [_MAINNET_GENESIS_BLOCK])
+        # Truncate the archive by 1 byte
+        (tmp / "archive.bin").write_bytes(archive_raw[:-1])
+        manifest_obj = {
+            "schema": "bitcoin-rs-corpus-manifest",
+            "version": 1,
+            "network": "mainnet",
+            "network_magic": _MAINNET_MAGIC.hex(),
+            "genesis_hash": _MAINNET_GENESIS_HASH,
+            "range": {"start_height": 0, "stop_height": 0},
+            "archive": {"size": len(archive_raw), "sha256": _sha256_bytes(archive_raw)},
+            "entries": [
+                {
+                    "height": 0,
+                    "hash": _MAINNET_GENESIS_HASH,
+                    "offset": 0,
+                    "payload_length": len(_MAINNET_GENESIS_BLOCK),
+                },
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_obj, indent=2) + "\n").encode()
+        (tmp / "manifest.json").write_bytes(manifest_raw)
+        _make_replay_v2(
+            tmp / "replay.json",
+            stop_height=0,
+            corpus_manifest_bytes=len(manifest_raw),
+            corpus_manifest_sha256=_sha256_bytes(manifest_raw),
+            archive_bytes=len(archive_raw),
+            archive_sha256=_sha256_bytes(archive_raw),
+        )
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        import argparse
+
+        ns = argparse.Namespace(
+            counters=str(tmp / "counters.json"),
+            contexts=str(tmp / "contexts.bin"),
+            records=str(tmp / "records.bin"),
+            journal=str(tmp / "journal.bin"),
+            replay=str(tmp / "replay.json"),
+            corpus_manifest=str(tmp / "manifest.json"),
+            archive=str(tmp / "archive.bin"),
+            output=str(tmp / "report.json"),
+            contract="c150",
+            input_count=None,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(ns),
+            "missing archive bytes",
+            "CTX-CUSTODY",
+        )
+
+
+# ── Tests: C150 exact predicate (standalone _c150_passed) ───────────────────
+
+
+def _c150_canonical_counts() -> dict[str, int]:
+    """All 11 context counters zero — the C150 streaming shape."""
+    return {name: 0 for name in CONTEXT_COUNTER_NAMES}
+
+
+def _c150_canonical_counters_dict(
+    target: int = EXPECTED_FFI_VERIFY_ENTRIES_FULL,
+) -> dict[str, object]:
+    """A counters dict matching the canonical C150 shape.
+
+    The six ordinary equality-chain counters equal *target* (2_868_199) and
+    all complementary counters are zero. ``eval_script_entries`` is set to
+    ``2 * target`` (5_736_398) because every ordinary P2PKH VerifyScript runs
+    two EvalScript passes (scriptSig + scriptPubKey); it must never equal the
+    one-times ordinary total."""
+    d = _valid_counters_dict(
+        ffi_verify_entries=target,
+        verify_script_calls=target,
+        ffi_verify_true=target,
+        eval_script_entries=2 * target,
+        op_checksig=target,
+        checkecdsa_entries=target,
+        ecdsa_from_checksig=target,
+        ecdsa_verify_calls=target,
+        ecdsa_verify_ok=target,
+        sighash_computed=target,
+        sighash_midstate_hit=target,
+        record_count=target,
+        journal_count=target,
+        context_count=target,
+    )
+    return d
+
+
+def test_c150_exact_canonical_total_passes() -> None:
+    """All equality counters = 2_868_199, all context counters zero,
+    complementary counters zero → _c150_passed returns True."""
+    counts = _c150_canonical_counts()
+    counters = Counters(_c150_canonical_counters_dict())
+    assert _c150_passed(counts, counters) is True
+
+
+def test_c150_truncated_positive_total_fails() -> None:
+    """One equality counter (ecdsa_verify_ok) = 2_868_198 → fails."""
+    counts = _c150_canonical_counts()
+    d = _c150_canonical_counters_dict()
+    d["ecdsa_verify_ok"] = EXPECTED_FFI_VERIFY_ENTRIES_FULL - 1
+    counters = Counters(d)
+    assert _c150_passed(counts, counters) is False
+
+
+def test_c150_zero_total_fails() -> None:
+    """All counters zero → fails (equality chain != 2_868_199)."""
+    counts = _c150_canonical_counts()
+    counters = Counters(_valid_counters_dict())
+    assert _c150_passed(counts, counters) is False
+
+
+def test_c150_mutate_each_equality_member_fails() -> None:
+    """For each equality-chain member, set it to 2_868_198 and expect fail."""
+    members = [
+        "ffi_verify_entries",
+        "op_checksig",
+        "ecdsa_from_checksig",
+        "checkecdsa_entries",
+        "ecdsa_verify_calls",
+        "ecdsa_verify_ok",
+    ]
+    counts = _c150_canonical_counts()
+    for member in members:
+        d = _c150_canonical_counters_dict()
+        d[member] = EXPECTED_FFI_VERIFY_ENTRIES_FULL - 1
+        counters = Counters(d)
+        assert _c150_passed(counts, counters) is False, (
+            f"_c150_passed should fail when {member} is truncated"
+        )
+
+
+def test_c150_nonzero_context_counter_fails() -> None:
+    """A nonzero context counter (bare_multisig_checks or
+    native_witness_v0_spends) causes _c150_passed to return False."""
+    for ctx_name in ("bare_multisig_checks", "native_witness_v0_spends"):
+        counts = _c150_canonical_counts()
+        counts[ctx_name] = 1
+        counters = Counters(_c150_canonical_counters_dict())
+        assert _c150_passed(counts, counters) is False, (
+            f"_c150_passed should fail when {ctx_name} is nonzero"
+        )
+
+
+def test_c150_eval_script_entries_not_double_fails() -> None:
+    """eval_script_entries must equal exactly 2*expected (5_736_398).
+
+    Setting it to the one-times ordinary total (the value the report wrongly
+    claimed) must make _c150_passed return False, and every other off-by-one
+    variant must fail too."""
+    counts = _c150_canonical_counts()
+    for bad in (
+        EXPECTED_FFI_VERIFY_ENTRIES_FULL,  # one-times ordinary total
+        2 * EXPECTED_FFI_VERIFY_ENTRIES_FULL - 1,  # one short of double
+        2 * EXPECTED_FFI_VERIFY_ENTRIES_FULL + 1,  # one over double
+    ):
+        d = _c150_canonical_counters_dict()
+        d["eval_script_entries"] = bad
+        counters = Counters(d)
+        assert _c150_passed(counts, counters) is False, (
+            f"_c150_passed should fail when eval_script_entries is {bad}"
+        )
+
+
+# ── Tests: Counters strictness for context_count/record_count/journal_count ──
+
+
+def test_counters_rejects_missing_context_count() -> None:
+    """A counters dict missing context_count must raise."""
+    d = _valid_counters_dict()
+    del d["context_count"]
+    _raises(AnalyzerError, lambda: Counters(d), "missing context_count")
+
+
+def test_counters_rejects_missing_record_count() -> None:
+    """A counters dict missing record_count must raise."""
+    d = _valid_counters_dict()
+    del d["record_count"]
+    _raises(AnalyzerError, lambda: Counters(d), "missing record_count")
+
+
+def test_counters_rejects_missing_journal_count() -> None:
+    """A counters dict missing journal_count must raise."""
+    d = _valid_counters_dict()
+    del d["journal_count"]
+    _raises(AnalyzerError, lambda: Counters(d), "missing journal_count")
+
+
+def test_counters_rejects_bool_context_count() -> None:
+    """A bool context_count must raise."""
+    d = _valid_counters_dict(context_count=True)
+    _raises(AnalyzerError, lambda: Counters(d), "bool context_count")
+
+
+def test_counters_rejects_string_record_count() -> None:
+    """A string record_count must raise."""
+    d = _valid_counters_dict(record_count="1")  # type: ignore[dict-item]
+    _raises(AnalyzerError, lambda: Counters(d), "string record_count")
+
+
+def test_counters_rejects_negative_journal_count() -> None:
+    """A negative journal_count must raise."""
+    d = _valid_counters_dict(journal_count=-1)
+    _raises(AnalyzerError, lambda: Counters(d), "negative journal_count")
+
+
+# ── Tests: JournalEntry validation (corrupt journal) ─────────────────────────
+
+
+def test_journal_rejects_verdict_outside_01() -> None:
+    """A journal entry with verdict=2 must raise."""
+    raw = bytearray(_make_journal_bytes(b"\x01" * 32, 0))
+    # JOURNAL_STRUCT = "<32sIIIIIB3s" → verdict is the 6th field (byte at offset 56-4-3=... )
+    # Layout: 32(txid) + 4(input_index) + 4(checksig_ops) + 4(checkmultisig_ops)
+    #         + 4(ecdsa_verify_calls) + 4(ecdsa_verify_ok) + 1(verdict) + 3(pad) = 56
+    # verdict byte is at offset 32+4+4+4+4+4 = 52
+    raw[52] = 2
+    _raises(AnalyzerError, lambda: JournalEntry(bytes(raw)), "verdict=2")
+
+
+def test_journal_rejects_nonzero_padding() -> None:
+    """A journal entry with nonzero 3-byte padding must raise."""
+    raw = bytearray(_make_journal_bytes(b"\x02" * 32, 0))
+    # padding is the last 3 bytes (offset 53..55)
+    raw[53] = 0xFF
+    _raises(AnalyzerError, lambda: JournalEntry(bytes(raw)), "nonzero padding")
+
+
+def test_journal_rejects_ok_gt_calls() -> None:
+    """ecdsa_verify_ok > ecdsa_verify_calls must raise."""
+    raw = _make_journal_bytes(
+        b"\x03" * 32,
+        0,
+        ecdsa_verify_calls=1,
+        ecdsa_verify_ok=2,
+    )
+    _raises(AnalyzerError, lambda: JournalEntry(raw), "ok > calls")
+
+
+def test_journal_rejects_bad_magic() -> None:
+    """A journal file with wrong magic must raise."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        entry = _make_journal_bytes(b"\x04" * 32, 0)
+        data = HEADER_STRUCT.pack(b"WRONGMAG", 1) + entry
+        (tmp / "journal.bin").write_bytes(data)
+        _raises(
+            AnalyzerError,
+            lambda: parse_journal(tmp / "journal.bin"),
+            "bad journal magic",
+        )
+
+
+def test_journal_rejects_short_file() -> None:
+    """A journal file shorter than the header must raise."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        (tmp / "journal.bin").write_bytes(b"\x00" * 10)
+        _raises(
+            AnalyzerError,
+            lambda: parse_journal(tmp / "journal.bin"),
+            "short journal file",
+        )
+
+
+# ── Tests: check_counter_arithmetic and journal-sum invariants ───────────────
+
+
+def test_classify_corpus_journal_sum_op_checksig_mismatch() -> None:
+    """A counters dict where op_checksig != sum(journal checksig_ops) due to
+    a mutated op_checksigverify raises CTX-OPERATIONS."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xc1" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # op_checksigverify=1 makes sum(journal checksig_ops)=1 != op_checksig+1=2
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "c150",
+            counters_overrides={"op_checksigverify": 1},
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "journal sum checksig mismatch",
+            "CTX-OPERATIONS",
+        )
+
+
+def test_classify_corpus_inv1_verify_script_calls_mismatch() -> None:
+    """verify_script_calls != ffi_verify_entries fails INV-1.  Using cmodern
+    (no c150 pin) so the report is written and we can check inv_all_passed."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xc2" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+            counters_overrides={"verify_script_calls": 999},
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+        report = json.loads((tmp / "report.json").read_text())
+        inv1 = next(r for r in report["counter_arithmetic"] if r["id"] == "INV-1")
+        assert inv1["passed"] is False
+
+
+def test_classify_corpus_inv2_ffi_verify_true_mismatch() -> None:
+    """ffi_verify_true != ffi_verify_entries fails INV-2.  Using cmodern
+    (no c150 pin) so the report is written and we can check inv_all_passed."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xc3" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+            counters_overrides={"ffi_verify_true": 999},
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+        report = json.loads((tmp / "report.json").read_text())
+        inv2 = next(r for r in report["counter_arithmetic"] if r["id"] == "INV-2")
+        assert inv2["passed"] is False
+
+
+def test_classify_corpus_cmodern_bad_eval_counter_fails_closed() -> None:
+    """C150 separately pins eval_script_entries to twice the canonical
+    ordinary total; this cmodern fixture supplies a bad eval counter and
+    proves the fail-closed classifier still writes a failure report/returns
+    1, not the C150 predicate."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xc4" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+            counters_overrides={"eval_script_entries": 999},
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+
+
+def test_classify_corpus_sighash_computed_mismatch() -> None:
+    """sighash_computed != ecdsa_verify_calls fails INV-5.  Using cmodern
+    (no c150 pin) so the report is written and we can check INV-5."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xc5" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+            counters_overrides={"sighash_computed": 999},
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+        report = json.loads((tmp / "report.json").read_text())
+        inv5 = next(r for r in report["counter_arithmetic"] if r["id"] == "INV-5")
+        assert inv5["passed"] is False
+
+
+def test_classify_corpus_sighash_midstate_hit_mismatch() -> None:
+    """sighash_midstate_hit is not checked by _c150_passed, INV-1..INV-7, or
+    the aggregate reconciliation.  Using cmodern, the report is written and
+    all_passed is False (cmodern is never frozen)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xc6" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+            counters_overrides={"sighash_midstate_hit": 999},
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+
+
+# ── Tests: Corrupt record canonicality ───────────────────────────────────────
+
+
+def test_record_rejects_outcome0_with_reject_reason() -> None:
+    """outcome=0 (verify fail) with reject_reason != 0 must raise."""
+    raw = _make_record_bytes(b"\x01" * 32, 0, outcome=0, reject_reason=1)
+    _raises(AnalyzerError, lambda: Record(raw), "outcome=0 with reject_reason")
+
+
+def test_record_rejects_outcome1_with_reject_reason() -> None:
+    """outcome=1 (verify success) with reject_reason != 0 must raise."""
+    raw = _make_record_bytes(b"\x02" * 32, 0, outcome=1, reject_reason=1)
+    _raises(AnalyzerError, lambda: Record(raw), "outcome=1 with reject_reason")
+
+
+def test_record_rejects_outcome2_with_zero_reject_reason() -> None:
+    """outcome=2 (pre-verification reject) with reject_reason=0 must raise."""
+    raw = _make_record_bytes(b"\x03" * 32, 0, outcome=2, reject_reason=0)
+    _raises(AnalyzerError, lambda: Record(raw), "outcome=2 reject_reason=0")
+
+
+def test_record_rejects_outcome2_with_nonzero_sighash() -> None:
+    """outcome=2 with a non-zero sighash must raise."""
+    raw = _make_record_bytes(
+        b"\x04" * 32,
+        0,
+        outcome=2,
+        reject_reason=1,
+        sighash=b"\xff" * 32,
+    )
+    _raises(AnalyzerError, lambda: Record(raw), "outcome=2 nonzero sighash")
+
+
+def test_record_rejects_op_kind_above_5() -> None:
+    """op_kind=6 must raise."""
+    raw = _make_record_bytes(b"\x05" * 32, 0, op_kind=6)
+    _raises(AnalyzerError, lambda: Record(raw), "op_kind=6")
+
+
+def test_record_rejects_sig_version_above_3() -> None:
+    """sig_version=4 must raise."""
+    raw = _make_record_bytes(b"\x06" * 32, 0, sig_version=4)
+    _raises(AnalyzerError, lambda: Record(raw), "sig_version=4")
+
+
+def test_record_rejects_outcome_above_2() -> None:
+    """outcome=3 must raise."""
+    raw = _make_record_bytes(b"\x07" * 32, 0, outcome=3)
+    _raises(AnalyzerError, lambda: Record(raw), "outcome=3")
+
+
+def test_record_rejects_reject_reason_above_8() -> None:
+    """reject_reason=9 must raise."""
+    raw = _make_record_bytes(b"\x08" * 32, 0, outcome=2, reject_reason=9)
+    _raises(AnalyzerError, lambda: Record(raw), "reject_reason=9")
+
+
+def test_record_rejects_ecdsa_reject_on_schnorr_record() -> None:
+    """reject_reason=1 (ECDSA reject) on a Schnorr record must raise."""
+    # Schnorr: sig_version=2, op_kind=1
+    raw = _make_record_bytes(
+        b"\x09" * 32,
+        0,
+        op_kind=1,
+        sig_version=2,
+        outcome=2,
+        reject_reason=1,
+    )
+    _raises(AnalyzerError, lambda: Record(raw), "ECDSA reject on Schnorr record")
+
+
+def test_record_rejects_schnorr_reject_on_ecdsa_record() -> None:
+    """reject_reason=4 (Schnorr reject) on an ECDSA record must raise."""
+    # ECDSA: sig_version=0, op_kind=1
+    raw = _make_record_bytes(
+        b"\x0a" * 32,
+        0,
+        op_kind=1,
+        sig_version=0,
+        outcome=2,
+        reject_reason=4,
+    )
+    _raises(AnalyzerError, lambda: Record(raw), "Schnorr reject on ECDSA record")
+
+
+def test_record_accepts_ecdsa_reject_on_ecdsa_record() -> None:
+    """reject_reason=1 on an ECDSA record (sig_version=0, op_kind=1) is valid."""
+    raw = _make_record_bytes(
+        b"\x0b" * 32,
+        0,
+        op_kind=1,
+        sig_version=0,
+        outcome=2,
+        reject_reason=1,
+    )
+    rec = Record(raw)
+    assert rec.outcome == 2
+    assert rec.reject_reason == 1
+
+
+def test_record_accepts_schnorr_reject_on_schnorr_record() -> None:
+    """reject_reason=4 on a Schnorr record (sig_version=2, op_kind=1) is valid."""
+    raw = _make_record_bytes(
+        b"\x0c" * 32,
+        0,
+        op_kind=1,
+        sig_version=2,
+        outcome=2,
+        reject_reason=4,
+    )
+    rec = Record(raw)
+    assert rec.outcome == 2
+    assert rec.reject_reason == 4
+
+
+def test_record_accepts_reason8_tapscript_skip() -> None:
+    """reject_reason=8 on a Tapscript skip (sig_version=2, op_kind=1,
+    der_len=0) is valid."""
+    raw = _make_record_bytes(
+        b"\x0d" * 32,
+        0,
+        op_kind=1,
+        sig_version=2,
+        outcome=2,
+        reject_reason=8,
+        der_len=0,
+    )
+    rec = Record(raw)
+    assert rec.reject_reason == 8
+
+
+# ── Tests: Aggregate reconciliation (ECDSA/Schnorr reject families) ──────────
+
+
+def test_classify_corpus_ecdsa_reject_record_counts_entry() -> None:
+    """An ECDSA in-function reject (outcome=2, reject_reason=2) is counted
+    by the aggregate as a checkecdsa entry and the named reject counter
+    checkecdsa_reject_empty_sig, but does not emit an ecdsa_verify_call
+    or ecdsa_verify_fail (pre-verification guards return before the verifier).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa1" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        # ECDSA CHECKSIG with reject_reason=2 (empty-sig reject)
+        record = _make_record_bytes(
+            txid_le,
+            0,
+            op_kind=1,
+            sig_version=0,
+            outcome=2,
+            reject_reason=2,
+        )
+        journal = [
+            _make_journal_bytes(
+                txid_le,
+                0,
+                checksig_ops=1,
+                checkmultisig_ops=0,
+                ecdsa_verify_calls=0,
+                ecdsa_verify_ok=0,
+            )
+        ]
+        counters = _make_valid_counters(
+            1,
+            1,
+            1,
+            op_checksig=1,
+            checkecdsa_entries=1,
+            ecdsa_from_checksig=1,
+            ecdsa_verify_calls=0,
+            ecdsa_verify_ok=0,
+            ecdsa_verify_fail=0,
+            sighash_computed=0,
+            checkecdsa_reject_empty_sig=1,
+        )
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+            counters_dict=counters,
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+
+
+def test_classify_corpus_schnorr_reject_record_counts_entry() -> None:
+    """A Schnorr in-function reject (outcome=2, reject_reason=4) is counted
+    by the aggregate as a checkschnorr entry, but does not emit a
+    schnorr_verify_call or schnorr_verify_fail.  reject_reason=4
+    is not in the named reject counters (only 0..2 are checked).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa2" * 32
+        ctx_row = _taproot_script_path(txid_le, flags=VERIFY_WITNESS | VERIFY_TAPROOT)
+        record = _make_record_bytes(
+            txid_le,
+            0,
+            op_kind=1,
+            sig_version=2,
+            outcome=2,
+            reject_reason=4,
+        )
+        journal = [
+            _make_journal_bytes(
+                txid_le,
+                0,
+                checksig_ops=1,
+                checkmultisig_ops=0,
+                ecdsa_verify_calls=0,
+                ecdsa_verify_ok=0,
+            )
+        ]
+        counters = _make_valid_counters(
+            1,
+            1,
+            1,
+            op_checksig=1,
+            checkecdsa_entries=0,
+            ecdsa_from_checksig=0,
+            ecdsa_verify_calls=0,
+            ecdsa_verify_ok=0,
+            ecdsa_verify_fail=0,
+            sighash_computed=0,
+            checkschnorr_entries=1,
+            schnorr_verify_calls=0,
+            schnorr_verify_ok=0,
+            schnorr_verify_fail=0,
+            op_checksigadd=0,
+        )
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+            counters_dict=counters,
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+
+
+def test_classify_corpus_reason8_tapscript_skip() -> None:
+    """reject_reason=8 (Tapscript skip) is emitted in EvalChecksigTapscript
+    before CheckSchnorrSignature is called, so it is counted as an
+    op_checksig but is neither a checkschnorr entry nor a schnorr
+    verify call/fail.  reject_reason=8 is not in the named reject counters.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa3" * 32
+        ctx_row = _taproot_script_path(txid_le, flags=VERIFY_WITNESS | VERIFY_TAPROOT)
+        record = _make_record_bytes(
+            txid_le,
+            0,
+            op_kind=1,
+            sig_version=2,
+            outcome=2,
+            reject_reason=8,
+            der_len=0,
+        )
+        journal = [
+            _make_journal_bytes(
+                txid_le,
+                0,
+                checksig_ops=1,
+                checkmultisig_ops=0,
+                ecdsa_verify_calls=0,
+                ecdsa_verify_ok=0,
+            )
+        ]
+        counters = _make_valid_counters(
+            1,
+            1,
+            1,
+            op_checksig=1,
+            checkecdsa_entries=0,
+            ecdsa_from_checksig=0,
+            ecdsa_verify_calls=0,
+            ecdsa_verify_ok=0,
+            ecdsa_verify_fail=0,
+            sighash_computed=0,
+            checkschnorr_entries=0,
+            schnorr_verify_calls=0,
+            schnorr_verify_ok=0,
+            schnorr_verify_fail=0,
+            op_checksigadd=0,
+        )
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+            counters_dict=counters,
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+
+
+def test_classify_corpus_ecdsa_fail_record() -> None:
+    """An ECDSA verify fail (outcome=0) is counted by the aggregate as
+    ecdsa_verify_calls and ecdsa_verify_fail, but not ecdsa_verify_ok.
+    INV-5 holds because calls(1) == ok(0) + fail(1).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa4" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0, op_kind=1, sig_version=0, outcome=0)
+        journal = [
+            _make_journal_bytes(
+                txid_le,
+                0,
+                checksig_ops=1,
+                checkmultisig_ops=0,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=0,
+            )
+        ]
+        counters = _make_valid_counters(
+            1,
+            1,
+            1,
+            op_checksig=1,
+            checkecdsa_entries=1,
+            ecdsa_from_checksig=1,
+            ecdsa_verify_calls=1,
+            ecdsa_verify_ok=0,
+            ecdsa_verify_fail=1,
+            sighash_computed=1,
+        )
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+            counters_dict=counters,
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+
+
+def test_classify_corpus_ecdsa_success_record() -> None:
+    """An ECDSA verify success (outcome=1) counts as ecdsa_verify_call and
+    ecdsa_verify_ok but not ecdsa_verify_fail.  Using cmodern so the report
+    is written and we can verify the aggregate counts."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xa5" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0, op_kind=1, sig_version=0, outcome=1)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1
+
+
+# ── Tests: Multi-key SQLite op_seq/ECDSA ─────────────────────────────────────
+
+
+def test_count_context_records_multi_key_contiguous() -> None:
+    """Two keys, each with two records (op_seq 0 and 1), verify
+    _count_context_records_disk returns counts/custody."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid1 = b"\xb1" * 32
+        txid2 = b"\xb2" * 32
+        ctx_rows = [_bare_p2pkh(txid1), _bare_p2pkh(txid2)]
+        records = [
+            _make_record_bytes(txid1, 0, op_seq=0),
+            _make_record_bytes(txid1, 0, op_seq=1),
+            _make_record_bytes(txid2, 0, op_seq=0),
+            _make_record_bytes(txid2, 0, op_seq=1),
+        ]
+        journal = [
+            _make_journal_bytes(
+                txid1, 0, checksig_ops=2, ecdsa_verify_calls=2, ecdsa_verify_ok=2
+            ),
+            _make_journal_bytes(
+                txid2, 0, checksig_ops=2, ecdsa_verify_calls=2, ecdsa_verify_ok=2
+            ),
+        ]
+        _make_brsctx1_file(tmp / "contexts.bin", ctx_rows)
+        _write_records_file(tmp / "records.bin", records)
+        _write_journal_file(tmp / "journal.bin", journal)
+        counters = _valid_counters_dict(
+            ffi_verify_entries=2,
+            verify_script_calls=2,
+            ffi_verify_true=2,
+            op_checksig=4,
+            checkecdsa_entries=4,
+            ecdsa_from_checksig=4,
+            ecdsa_verify_calls=4,
+            ecdsa_verify_ok=4,
+            sighash_computed=4,
+            record_count=4,
+            journal_count=2,
+            context_count=2,
+        )
+        (tmp / "counters.json").write_text(json.dumps(counters))
+        counters_obj = Counters(counters)
+        counts, _ctx_count, custody = _count_context_records_disk(
+            Path(tmp / "contexts.bin"),
+            Path(tmp / "records.bin"),
+            Path(tmp / "journal.bin"),
+            counters_obj,
+        )
+        assert counts["bare_multisig_checks"] == 0  # CHECKSIG, not CHECKMULTISIG
+        assert "contexts" in custody
+        assert "records" in custody
+        assert "journal" in custody
+
+
+def test_count_context_records_multi_key_gap_raises() -> None:
+    """One key with op_seq 0 and 2 (gap at 1) raises CTX-OPERATIONS."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid1 = b"\xb3" * 32
+        ctx_rows = [_bare_p2pkh(txid1)]
+        records = [
+            _make_record_bytes(txid1, 0, op_seq=0),
+            _make_record_bytes(txid1, 0, op_seq=2),
+        ]
+        journal = [
+            _make_journal_bytes(txid1, 0, ecdsa_verify_calls=2, ecdsa_verify_ok=2)
+        ]
+        _make_brsctx1_file(tmp / "contexts.bin", ctx_rows)
+        _write_records_file(tmp / "records.bin", records)
+        _write_journal_file(tmp / "journal.bin", journal)
+        counters = _make_valid_counters(2, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+        counters_obj = Counters(counters)
+        _raises_with(
+            AnalyzerError,
+            lambda: _count_context_records_disk(
+                Path(tmp / "contexts.bin"),
+                Path(tmp / "records.bin"),
+                Path(tmp / "journal.bin"),
+                counters_obj,
+            ),
+            "op_seq gap",
+            "CTX-OPERATIONS",
+        )
+
+
+# ── Tests: TOCTOU / custody seam ─────────────────────────────────────────────
+
+
+def test_classify_corpus_custody_archive_matches_manifest() -> None:
+    """cmd_classify_corpus report custody['archive'] bytes/sha256 equal the
+    manifest's archive fields, not a separate prehash."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xd3" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        # Use cmodern to avoid the c150 stop_height/stop_hash pin —
+        # cmodern always fails (not frozen) but still writes the report.
+        args = _make_classify_args(
+            tmp,
+            [ctx_row],
+            [record],
+            journal,
+            "cmodern",
+        )
+        rc = cmd_classify_corpus(args)
+        assert rc == 1  # cmodern never certifies
+        report = json.loads((tmp / "report.json").read_text())
+        custody = report["custody"]
+        archive = custody["archive"]
+        manifest = report["corpus_manifest"]
+        assert archive["bytes"] == manifest["archive"]["size"]
+        assert archive["sha256"] == manifest["archive"]["sha256"]
+        # Verify the archive sha256 matches the actual file on disk
+        actual_arch = (tmp / "archive.bin").read_bytes()
+        assert archive["bytes"] == len(actual_arch)
+        assert archive["sha256"] == _sha256_bytes(actual_arch)
+
+
+def test_classify_corpus_custody_records_from_single_open() -> None:
+    """iter_records_with_custody returns custody matching the file on disk."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xd4" * 32
+        record = _make_record_bytes(txid_le, 0)
+        _write_records_file(tmp / "records.bin", [record])
+        file_bytes = (tmp / "records.bin").read_bytes()
+        gen, custody = iter_records_with_custody(tmp / "records.bin")
+        list(gen)  # consume the iterator
+        assert custody["bytes"] == len(file_bytes)
+        assert format(custody["sha256"], "064x") == _sha256_bytes(file_bytes)
+
+
+def test_classify_corpus_custody_journal_from_single_open() -> None:
+    """iter_journal_with_custody returns custody matching the file on disk."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xd5" * 32
+        entry = _make_journal_bytes(txid_le, 0)
+        _write_journal_file(tmp / "journal.bin", [entry])
+        file_bytes = (tmp / "journal.bin").read_bytes()
+        gen, custody = iter_journal_with_custody(tmp / "journal.bin")
+        list(gen)  # consume the iterator
+        assert custody["bytes"] == len(file_bytes)
+        assert format(custody["sha256"], "064x") == _sha256_bytes(file_bytes)
+
+
+def test_parse_counters_returns_custody() -> None:
+    """parse_counters returns (Counters, custody) from the single read."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+        file_bytes = (tmp / "counters.json").read_bytes()
+        parsed, custody = parse_counters(tmp / "counters.json")
+        assert parsed.op_checksig == 1
+        assert custody["bytes"] == len(file_bytes)
+        assert format(custody["sha256"], "064x") == _sha256_bytes(file_bytes)
+
+
+def test_classify_corpus_custody_contexts_from_same_open() -> None:
+    """iter_context_inputs keeps the original fd open; os.replace after the
+    first row does not change the bytes/sha256 it hashes from the stream.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        path = tmp / "contexts.bin"
+
+        # File A: two BRSCTX1 rows.
+        txid_a1 = b"\xd3" * 32
+        txid_a2 = b"\xd4" * 32
+        rows_a = [_bare_p2pkh(txid_a1), _bare_p2pkh(txid_a2)]
+        _make_brsctx1_file(path, rows_a)
+        a_bytes = path.read_bytes()
+
+        it = iter_context_inputs(path)
+        first = next(it)  # opens fd, hashes header and first row
+        assert first.identity.txid_le == txid_a1
+
+        # File B: one row, swapped onto the same pathname via inode replacement.
+        txid_b = b"\xd5" * 32
+        rows_b = [_bare_p2pkh(txid_b)]
+        other = tmp / "other.bin"
+        _make_brsctx1_file(other, rows_b)
+        os.replace(other, path)
+
+        # Continue from the original fd; should still read row 2 of A.
+        second = next(it)
+        assert second.identity.txid_le == txid_a2
+        try:
+            next(it)
+        except StopIteration:
+            pass
+        else:
+            raise AssertionError("expected exactly two rows from file A")
+
+        custody = it.custody()
+        assert custody["bytes"] == len(a_bytes)
+        assert format(custody["sha256"], "064x") == _sha256_bytes(a_bytes)
+
+        # Confirm the path now points to B (sanity: replacement did happen).
+        assert path.read_bytes() != a_bytes
 
 
 # ── Runner ───────────────────────────────────────────────────────────────────
@@ -772,7 +5421,144 @@ def main() -> int:
         test_bare_rejects_nonpositive_round_ns,
         test_bare_rejects_non_integer_summary_fields,
         test_verdict_rejects_invalid_numeric_fields,
+        test_validate_capture_binds_corpus_identity,
         test_verdict_native_mode0_contradiction_fails,
+        test_legacy_jsonl_rejects_malformed_fields,
+        test_legacy_jsonl_rejects_duplicate_and_count_mismatch,
+        test_brsctx1_rejects_wrong_magic,
+        test_brsctx1_rejects_short_header,
+        test_brsctx1_rejects_short_row_field,
+        test_brsctx1_rejects_row_length_mismatch,
+        test_brsctx1_rejects_impossible_witness_count,
+        test_brsctx1_rejects_duplicate_execution_identity,
+        test_brsctx1_rejects_declared_count_mismatch,
+        test_brsctx1_rejects_trailing_bytes,
+        test_brsctx1_accepts_valid_file,
+        test_classify_input_bare_p2pkh,
+        test_classify_input_p2sh_without_flag,
+        test_classify_input_p2sh_with_flag,
+        test_classify_input_p2sh_wrapped_w0_p2sh_only,
+        test_classify_input_p2sh_wrapped_w0_p2sh_witness,
+        test_classify_input_native_w0_without_witness,
+        test_classify_input_native_w0_with_witness,
+        test_classify_input_taproot_no_witness,
+        test_classify_input_taproot_witness_only,
+        test_classify_input_taproot_key_path,
+        test_classify_input_taproot_script_path,
+        test_classify_input_taproot_annex_stripping,
+        test_classify_input_p2sh_non_push_scriptsig,
+        test_classify_input_native_v0_with_scriptsig,
+        test_classify_input_taproot_bad_key_path_sig,
+        test_classify_input_taproot_bad_control_block,
+        test_classify_corpus_txid_reversal_mutation,
+        test_classify_corpus_all_spend_contexts,
+        test_classify_corpus_c150_passes,
+        test_classify_corpus_cmodern_fails,
+        test_classify_corpus_zero_inputs,
+        test_classify_corpus_definitions_match_counter_names,
+        test_classify_corpus_missing_record_identity,
+        test_classify_corpus_duplicate_record_key,
+        test_classify_corpus_duplicate_journal_key,
+        test_classify_corpus_native_wrapped_swap,
+        test_classify_corpus_rejects_jsonl_context_file,
+        test_classify_corpus_rejects_mismatched_context_size,
+        test_classify_corpus_rejects_mismatched_context_sha256,
+        test_classify_corpus_context_journal_key_inequality,
+        test_classify_corpus_count_mismatch_ffi_verify_entries,
+        test_classify_corpus_record_count_mismatch,
+        test_replay_rejects_nonzero_assume_valid_height,
+        test_replay_rejects_window_le_one,
+        test_replay_rejects_zero_window_verify_success_total,
+        test_manifest_network_mismatch_raises,
+        test_manifest_genesis_mismatch_raises,
+        test_manifest_range_mismatch_raises,
+        test_manifest_archive_size_mismatch_raises,
+        test_manifest_archive_sha256_mismatch_raises,
+        test_manifest_start_height_nonzero_raises,
+        test_manifest_empty_entries_raises,
+        test_manifest_gapped_heights_raises,
+        test_manifest_inconsistent_offset_raises,
+        test_archive_frame_magic_mismatch_raises,
+        test_archive_frame_payload_length_mismatch_raises,
+        test_archive_header_hash_mismatch_raises,
+        test_archive_genesis_prev_blockhash_nonzero_raises,
+        test_archive_chain_break_raises,
+        test_archive_trailing_bytes_raises,
+        test_manifest_entry_count_mismatch_raises,
+        test_manifest_happy_path,
+        test_classify_corpus_c150_rejects_wrong_stop_height,
+        test_classify_corpus_c150_rejects_wrong_stop_hash,
+        test_classify_corpus_c150_rejects_mismatched_stop_hash,
+        test_classify_corpus_cmodern_cannot_certify_all_positive,
+        test_replay_rejects_wrong_network,
+        test_replay_rejects_wrong_network_magic,
+        test_replay_rejects_wrong_genesis_hash,
+        test_replay_rejects_start_height_nonzero,
+        test_replay_rejects_start_hash_not_genesis,
+        test_replay_rejects_block_count_mismatch,
+        test_replay_rejects_missing_stop_hash,
+        test_replay_rejects_unknown_field,
+        test_replay_rejects_nonhex_git_head,
+        test_replay_rejects_uppercase_git_head,
+        test_replay_rejects_bool_stage_count,
+        test_replay_rejects_extra_stage_key,
+        test_manifest_rejects_unknown_field,
+        test_manifest_rejects_out_of_u32_range_height,
+        test_manifest_rejects_out_of_u64_range_offset,
+        test_manifest_rejects_duplicate_entry_height,
+        test_manifest_rejects_duplicate_entry_hash,
+        test_archive_rejects_payload_length_above_max,
+        test_archive_rejects_payload_length_below_80,
+        test_archive_rejects_frame_tail_not_stop_hash,
+        test_archive_rejects_missing_archive_bytes,
+        test_c150_exact_canonical_total_passes,
+        test_c150_truncated_positive_total_fails,
+        test_c150_zero_total_fails,
+        test_c150_mutate_each_equality_member_fails,
+        test_c150_nonzero_context_counter_fails,
+        test_c150_eval_script_entries_not_double_fails,
+        test_counters_rejects_missing_context_count,
+        test_counters_rejects_missing_record_count,
+        test_counters_rejects_missing_journal_count,
+        test_counters_rejects_bool_context_count,
+        test_counters_rejects_string_record_count,
+        test_counters_rejects_negative_journal_count,
+        test_journal_rejects_verdict_outside_01,
+        test_journal_rejects_nonzero_padding,
+        test_journal_rejects_ok_gt_calls,
+        test_journal_rejects_bad_magic,
+        test_journal_rejects_short_file,
+        test_classify_corpus_journal_sum_op_checksig_mismatch,
+        test_classify_corpus_inv1_verify_script_calls_mismatch,
+        test_classify_corpus_inv2_ffi_verify_true_mismatch,
+        test_classify_corpus_cmodern_bad_eval_counter_fails_closed,
+        test_classify_corpus_sighash_computed_mismatch,
+        test_classify_corpus_sighash_midstate_hit_mismatch,
+        test_record_rejects_outcome0_with_reject_reason,
+        test_record_rejects_outcome1_with_reject_reason,
+        test_record_rejects_outcome2_with_zero_reject_reason,
+        test_record_rejects_outcome2_with_nonzero_sighash,
+        test_record_rejects_op_kind_above_5,
+        test_record_rejects_sig_version_above_3,
+        test_record_rejects_outcome_above_2,
+        test_record_rejects_reject_reason_above_8,
+        test_record_rejects_ecdsa_reject_on_schnorr_record,
+        test_record_rejects_schnorr_reject_on_ecdsa_record,
+        test_record_accepts_ecdsa_reject_on_ecdsa_record,
+        test_record_accepts_schnorr_reject_on_schnorr_record,
+        test_record_accepts_reason8_tapscript_skip,
+        test_classify_corpus_ecdsa_reject_record_counts_entry,
+        test_classify_corpus_schnorr_reject_record_counts_entry,
+        test_classify_corpus_reason8_tapscript_skip,
+        test_classify_corpus_ecdsa_fail_record,
+        test_classify_corpus_ecdsa_success_record,
+        test_count_context_records_multi_key_contiguous,
+        test_count_context_records_multi_key_gap_raises,
+        test_classify_corpus_custody_archive_matches_manifest,
+        test_classify_corpus_custody_records_from_single_open,
+        test_classify_corpus_custody_journal_from_single_open,
+        test_parse_counters_returns_custody,
+        test_classify_corpus_custody_contexts_from_same_open,
     ]
     passed = 0
     failed = 0
@@ -781,7 +5567,6 @@ def main() -> int:
             test()
             print(f"  PASS  {test.__name__}")
             passed += 1
-        # Run every guard so one failure does not hide the remaining broken contracts.
         except Exception as e:  # noqa: BLE001
             print(f"  FAIL  {test.__name__}: {e}")
             failed += 1

--- a/tools/checksig-census/test_validation_contracts.py
+++ b/tools/checksig-census/test_validation_contracts.py
@@ -214,6 +214,25 @@ def _write_journal_file(path: Path, entries: list[bytes]) -> None:
     path.write_bytes(data)
 
 
+_PRESERVED_OVER_CAPACITY_ROW = bytes.fromhex(
+    "cf42bd87b9982595bf2d354c5f758c144d663301cefc3b31ad3132f87f4918d1"
+    "00000000000000000300020042000100" + "00" * 176
+)
+assert len(_PRESERVED_OVER_CAPACITY_ROW) == RECORD_STRUCT.size
+assert hashlib.sha256(_PRESERVED_OVER_CAPACITY_ROW).hexdigest() == (
+    "316f268a31cea2efdd5f8d37c2cd87d0d5597d19756490331978894c42e8c78c"
+)
+
+
+def _assert_over_capacity_length_error(raw: bytes, label: str) -> None:
+    _raises_with(
+        AnalyzerError,
+        lambda: Record(raw),
+        label,
+        "pubkey_len 66 exceeds 65",
+    )
+
+
 # ── BRSCTX1 binary builder ───────────────────────────────────────────────────
 
 # Must match context.py CONTEXT_FIXED = struct.Struct("<32sIIIII") (52 bytes).
@@ -1072,6 +1091,84 @@ def test_records_reject_invalid_encoded_fields() -> None:
             record[offset] = bad
             _write_records_file(path, [bytes(record)])
             _raises(AnalyzerError, lambda p=path: parse_records(p), f"{field}={bad}")
+
+
+def test_records_accept_preserved_over_capacity_ecdsa_reject() -> None:
+    """The public reader accepts the exact native reason-1 preserved row."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "records.bin"
+        _write_records_file(path, [_PRESERVED_OVER_CAPACITY_ROW])
+        records = parse_records(path)
+    assert len(records) == 1
+    record = records[0]
+    assert record.spend_txid[::-1].hex() == (
+        "d118497ff83231ad313bfcce0133664d148c755f4c352dbf952598b987bd42cf"
+    )
+    assert (record.input_index, record.op_kind, record.sig_version) == (0, 3, 0)
+    assert (record.outcome, record.der_len, record.pubkey_len) == (2, 0, 66)
+    assert (record.sighash_type, record.reject_reason) == (0, 1)
+
+
+def test_records_reject_every_over_capacity_shape_near_miss() -> None:
+    """Every valid-domain gating-field near miss retains the length error."""
+    mutations = (
+        (40, 0, "op_kind=0"),
+        (40, 5, "op_kind=5"),
+        (41, 2, "sig_version=2"),
+        (41, 3, "sig_version=3"),
+        (42, 0, "outcome=0"),
+        (42, 1, "outcome=1"),
+        (43, 1, "der_len=1"),
+        (43, 73, "der_len=73"),
+        (45, 1, "sighash_type=1"),
+        (46, 0, "reject_reason=0"),
+        *((46, reason, f"reject_reason={reason}") for reason in range(2, 9)),
+    )
+    for offset, value, label in mutations:
+        raw = bytearray(_PRESERVED_OVER_CAPACITY_ROW)
+        raw[offset] = value
+        _assert_over_capacity_length_error(bytes(raw), label)
+
+    for offset in range(48, 217):
+        raw = bytearray(_PRESERVED_OVER_CAPACITY_ROW)
+        raw[offset] = 1
+        _assert_over_capacity_length_error(
+            bytes(raw), f"nonzero payload/pad byte {offset}"
+        )
+
+
+def test_records_reject_ordinary_over_capacity_pubkey() -> None:
+    """An ordinary verification record with pubkey_len=66 stays invalid."""
+    raw = bytearray(_make_record_bytes(b"\x01" * 32, 0))
+    raw[44] = 66
+    _assert_over_capacity_length_error(bytes(raw), "ordinary pubkey_len=66")
+
+
+def test_preserved_over_capacity_padding_checks_remain_unchanged() -> None:
+    """The exact accepted row has all-zero padding, and ordinary records still fail with the existing padding errors."""
+    record = Record(_PRESERVED_OVER_CAPACITY_ROW)
+    assert record is not None  # exact row accepted
+
+    for offset, message in (
+        (47, "record _pad0 is not all-zero"),
+        (217, "record _pad1 is not all-zero"),
+    ):
+        # Ordinary records (pubkey_len=65) retain the unchanged padding checks.
+        raw = bytearray(_make_record_bytes(b"\x01" * 32, 0, outcome=1, reject_reason=0))
+        raw[offset] = 1
+        _raises_with(
+            AnalyzerError,
+            lambda r=bytes(raw): Record(r),
+            f"ordinary padding byte {offset}",
+            message,
+        )
+
+        # Over-capacity near misses fall through to the existing length error.
+        raw = bytearray(_PRESERVED_OVER_CAPACITY_ROW)
+        raw[offset] = 1
+        _assert_over_capacity_length_error(
+            bytes(raw), f"over-capacity padding byte {offset}"
+        )
 
 
 # ── Tests: extract_spike_width1 validation (Finding 5) ───────────────────────
@@ -7085,6 +7182,10 @@ def main() -> int:
         test_validate_capture_rejects_wrong_ffi_verify_entries,
         test_validate_capture_sorted_output_has_header,
         test_records_reject_invalid_encoded_fields,
+        test_records_accept_preserved_over_capacity_ecdsa_reject,
+        test_records_reject_every_over_capacity_shape_near_miss,
+        test_records_reject_ordinary_over_capacity_pubkey,
+        test_preserved_over_capacity_padding_checks_remain_unchanged,
         test_spike_rejects_non_integer_threads,
         test_spike_rejects_bool_threads,
         test_spike_rejects_threads_not_1,

--- a/tools/checksig-census/test_validation_contracts.py
+++ b/tools/checksig-census/test_validation_contracts.py
@@ -20,6 +20,7 @@ import argparse
 import hashlib
 import json
 import os
+import stat
 import struct
 import sys
 import tempfile
@@ -34,17 +35,26 @@ from analyze import (
     COUNTER_NAMES,
     EXPECTED_FFI_VERIFY_ENTRIES_FULL,
     EXPECTED_FFI_VERIFY_ENTRIES_KSPIKE1,
+    HEADER_SIZE,
     HEADER_STRUCT,
     JOURNAL_MAGIC,
+    JOURNAL_SIZE,
     JOURNAL_STRUCT,
+    MAINNET_GENESIS_HASH,
     RECORD_MAGIC,
+    RECORD_SIZE,
     RECORD_STRUCT,
     AnalyzerError,
     Counters,
+    DiagnosticCheckpoint,
     JournalEntry,
     Record,
     _c150_passed,
     _count_context_records_disk,
+    _diagnostic_counter_totals,
+    _read_diagnostic_streams,
+    _run_diagnostic_scan,
+    _validate_replay_diagnostic,
     cmd_classify_corpus,
     extract_bare_mode0,
     extract_spike_width1,
@@ -56,6 +66,7 @@ from analyze import (
     sort_records_raw,
 )
 from context import (
+    CONTEXT_MIN_ROW_SIZE,
     VERIFY_P2SH,
     VERIFY_TAPROOT,
     VERIFY_WITNESS,
@@ -66,6 +77,7 @@ from context import (
     classify_input,
     iter_context_inputs,
     iter_legacy_context_inputs,
+    read_bounded_context_rows,
 )
 
 # ── Shared assertion helpers ─────────────────────────────────────────────────
@@ -5726,6 +5738,1221 @@ def test_count_context_records_disk_restores_env_on_failure() -> None:
                 os.environ.pop("TMPDIR", None)
 
 
+# ── Tests: Task 7A2 diagnostic scanner/controller ─────────────────────────────
+
+
+_FAKE_CENSUS_CHILD = """#!/usr/bin/env python3
+import json
+import os
+import struct
+import sys
+import time
+from pathlib import Path
+
+PREFACE = b"BRSHGT1\\x00" + struct.pack("<II", 1, 84)
+
+def write_frame(payload, split):
+    if os.environ.get("FAKE_CENSUS_FRAGMENTED") != "1":
+        sys.stdout.buffer.write(payload)
+        sys.stdout.buffer.flush()
+        return
+    os.write(sys.stdout.fileno(), payload[:split])
+    time.sleep(0.05)
+    os.write(sys.stdout.fileno(), payload[split:])
+
+def main():
+    meta_path = Path(os.environ["FAKE_CENSUS_META"])
+    stage_dir = Path(os.environ["FAKE_CENSUS_STAGE"])
+    replay_path = Path(sys.argv[sys.argv.index("--output") + 1])
+    for name in ("BRS_CENSUS_CONTEXTS", "BRS_CENSUS_RECORDS", "BRS_CENSUS_JOURNAL"):
+        src = stage_dir / f"{name}.bin"
+        dst = Path(os.environ[name])
+        dst.write_bytes(src.read_bytes())
+    counters_path = Path(os.environ["BRS_CENSUS_COUNTERS"])
+    counters_path.write_bytes((stage_dir / "counters.json").read_bytes())
+    meta = json.loads(meta_path.read_text())
+    replay = meta["replay"]
+    replay_path.write_text(json.dumps(replay, indent=2) + "\\n")
+    write_frame(PREFACE, 3)
+    for row in meta["rows"]:
+        payload = (
+            struct.pack("<I", row["height"]) +
+            bytes.fromhex(row["block_hash_le"]) +
+            struct.pack("<Q", row["context_rows"]) +
+            struct.pack("<Q", row["context_end"]) +
+            struct.pack("<Q", row["record_rows"]) +
+            struct.pack("<Q", row["record_end"]) +
+            struct.pack("<Q", row["journal_rows"]) +
+            struct.pack("<Q", row["journal_end"])
+        )
+        write_frame(payload, 7)
+        control = sys.stdin.buffer.read(1)
+        if not control or control == b"\\x01":
+            break
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+def _make_fake_binary(tmp: Path) -> Path:
+    child = tmp / "fake_child.py"
+    child.write_text(_FAKE_CENSUS_CHILD)
+    child.chmod(0o755)
+    return child
+
+
+def _diagnostic_counters_dict(
+    context_count: int, record_count: int, journal_count: int
+) -> dict[str, object]:
+    return _valid_counters_dict(
+        record_count=record_count,
+        journal_count=journal_count,
+        context_count=context_count,
+    )
+
+
+def _write_diagnostic_stage(tmp: Path) -> Path:
+    stage = tmp / "stage"
+    stage.mkdir()
+    txids = [bytes([i]) * 32 for i in range(10)]
+    contexts = [
+        _p2sh_push_only(txids[0], flags=VERIFY_P2SH),
+        _native_w0(txids[1], flags=VERIFY_WITNESS),
+        _p2sh_wrapped_w0(txids[2], flags=VERIFY_P2SH | VERIFY_WITNESS),
+        _bare_p2pkh(txids[3]),
+        _p2sh_push_only(txids[4], flags=VERIFY_P2SH),
+        _native_w0(txids[5], flags=VERIFY_WITNESS),
+        _p2sh_wrapped_w0(txids[6], flags=VERIFY_P2SH | VERIFY_WITNESS),
+        _taproot_key_path(txids[7], flags=VERIFY_WITNESS | VERIFY_TAPROOT),
+        _taproot_script_path(txids[8], flags=VERIFY_WITNESS | VERIFY_TAPROOT),
+        _taproot_script_path(txids[9], flags=VERIFY_WITNESS | VERIFY_TAPROOT),
+    ]
+    records = [
+        _make_record_bytes(
+            txids[0], 0, op_kind=1, sig_version=0, outcome=1
+        ),  # p2sh checksig
+        _make_record_bytes(
+            txids[1], 0, op_kind=1, sig_version=1, outcome=1
+        ),  # native checksig
+        _make_record_bytes(
+            txids[2], 0, op_kind=1, sig_version=1, outcome=1
+        ),  # wrapped checksig
+        _make_record_bytes(
+            txids[3], 0, op_kind=3, sig_version=0, outcome=1
+        ),  # bare multisig
+        _make_record_bytes(
+            txids[4], 0, op_kind=3, sig_version=0, outcome=1
+        ),  # p2sh multisig
+        _make_record_bytes(
+            txids[5], 0, op_kind=3, sig_version=1, outcome=1
+        ),  # native multisig
+        _make_record_bytes(
+            txids[6], 0, op_kind=3, sig_version=1, outcome=1
+        ),  # wrapped multisig
+        _make_record_bytes(
+            txids[7], 0, op_kind=0, sig_version=3, outcome=1
+        ),  # taproot key
+        _make_record_bytes(
+            txids[8], 0, op_kind=1, sig_version=2, outcome=1
+        ),  # tapscript schnorr
+        _make_record_bytes(
+            txids[9], 0, op_kind=5, sig_version=2, outcome=1
+        ),  # tapscript checksigadd
+    ]
+    journals = [
+        _make_journal_bytes(
+            txids[0],
+            0,
+            checksig_ops=1,
+            checkmultisig_ops=0,
+            ecdsa_verify_calls=1,
+            ecdsa_verify_ok=1,
+        ),
+        _make_journal_bytes(
+            txids[1],
+            0,
+            checksig_ops=1,
+            checkmultisig_ops=0,
+            ecdsa_verify_calls=1,
+            ecdsa_verify_ok=1,
+        ),
+        _make_journal_bytes(
+            txids[2],
+            0,
+            checksig_ops=1,
+            checkmultisig_ops=0,
+            ecdsa_verify_calls=1,
+            ecdsa_verify_ok=1,
+        ),
+        _make_journal_bytes(
+            txids[3],
+            0,
+            checksig_ops=0,
+            checkmultisig_ops=1,
+            ecdsa_verify_calls=1,
+            ecdsa_verify_ok=1,
+        ),
+        _make_journal_bytes(
+            txids[4],
+            0,
+            checksig_ops=0,
+            checkmultisig_ops=1,
+            ecdsa_verify_calls=1,
+            ecdsa_verify_ok=1,
+        ),
+        _make_journal_bytes(
+            txids[5],
+            0,
+            checksig_ops=0,
+            checkmultisig_ops=1,
+            ecdsa_verify_calls=1,
+            ecdsa_verify_ok=1,
+        ),
+        _make_journal_bytes(
+            txids[6],
+            0,
+            checksig_ops=0,
+            checkmultisig_ops=1,
+            ecdsa_verify_calls=1,
+            ecdsa_verify_ok=1,
+        ),
+        _make_journal_bytes(
+            txids[7],
+            0,
+            checksig_ops=0,
+            checkmultisig_ops=0,
+            ecdsa_verify_calls=0,
+            ecdsa_verify_ok=0,
+        ),
+        _make_journal_bytes(
+            txids[8],
+            0,
+            checksig_ops=1,
+            checkmultisig_ops=0,
+            ecdsa_verify_calls=0,
+            ecdsa_verify_ok=0,
+        ),
+        _make_journal_bytes(
+            txids[9],
+            0,
+            checksig_ops=0,
+            checkmultisig_ops=0,
+            ecdsa_verify_calls=0,
+            ecdsa_verify_ok=0,
+        ),
+    ]
+    _make_brsctx1_file(stage / "BRS_CENSUS_CONTEXTS.bin", contexts)
+    _write_records_file(stage / "BRS_CENSUS_RECORDS.bin", records)
+    _write_journal_file(stage / "BRS_CENSUS_JOURNAL.bin", journals)
+    (stage / "counters.json").write_text(
+        json.dumps(_diagnostic_counters_dict(10, 10, 10))
+    )
+    return stage
+
+
+def _compute_context_ends(path: Path) -> list[int]:
+    data = path.read_bytes()
+    assert data[:8] == _BRSCTX1_MAGIC
+    count = struct.unpack("<Q", data[8:16])[0]
+    ends = [16]
+    cursor = 16
+    for _ in range(count):
+        row_len = struct.unpack("<I", data[cursor : cursor + 4])[0]
+        cursor += 4 + row_len
+        ends.append(cursor)
+    return ends
+
+
+def _build_meta(
+    tmp: Path,
+    stage: Path,
+    ceiling: int,
+    work_dir: Path,
+    *,
+    replay_overrides: dict[str, object] | None = None,
+) -> Path:
+    ctx_ends = _compute_context_ends(stage / "BRS_CENSUS_CONTEXTS.bin")
+    assert len(ctx_ends) == 11  # 10 rows + final sentinel
+    rows = []
+    for h in range(10):
+        if h == 0:
+            block_hash = bytes.fromhex(MAINNET_GENESIS_HASH)[::-1]
+        else:
+            block_hash = bytes([h] * 32)
+        rows.append(
+            {
+                "height": h,
+                "block_hash_le": block_hash.hex(),
+                "context_rows": h + 1,
+                "context_end": ctx_ends[h + 1],
+                "record_rows": h + 1,
+                "record_end": HEADER_SIZE + (h + 1) * RECORD_SIZE,
+                "journal_rows": h + 1,
+                "journal_end": HEADER_SIZE + (h + 1) * JOURNAL_SIZE,
+            }
+        )
+    final = rows[-1]
+    replay = {
+        "schema": "mainnet-prefix-replay-diagnostic-v1",
+        "non_certifying": True,
+        "block_source": "rest",
+        "start_height": 0,
+        "assume_valid_height": 0,
+        "window": 1,
+        "requested_stop_height_ceiling": ceiling,
+        "actual_stop_height": final["height"],
+        "actual_stop_hash": bytes.fromhex(final["block_hash_le"])[::-1].hex(),
+        "stop_reason": "controller-request",
+        "storage_backend": "fjall",
+        "txindex": False,
+        "blockfilterindex": False,
+        "data_dir": str(work_dir / "state"),
+        "elapsed_seconds": 0.0,
+    }
+    if replay_overrides:
+        replay.update(replay_overrides)
+    meta = {"rows": rows, "replay": replay}
+    meta_path = tmp / "meta.json"
+    meta_path.write_text(json.dumps(meta, indent=2) + "\n")
+    return meta_path
+
+
+def test_find_cmodern_height_fake_child_success() -> None:
+    """Fake child distributes all 11 types and the candidate H equals max first heights."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        stage = _write_diagnostic_stage(tmp)
+        work_dir = tmp / "work"
+        work_dir.mkdir()
+        output = tmp / "candidate.json"
+        meta_path = _build_meta(tmp, stage, 100, work_dir)
+        child = _make_fake_binary(tmp)
+        os.environ["FAKE_CENSUS_META"] = str(meta_path)
+        os.environ["FAKE_CENSUS_STAGE"] = str(stage)
+        try:
+            _run_diagnostic_scan(child, "127.0.0.1:18443", 100, work_dir, output)
+        finally:
+            os.environ.pop("FAKE_CENSUS_META", None)
+            os.environ.pop("FAKE_CENSUS_STAGE", None)
+        candidate = json.loads(output.read_text())
+        assert candidate["schema"] == "cmodern-candidate-diagnostic-v1"
+        assert candidate["non_certifying"] is True
+        assert candidate["certifying_replay_required"] is True
+        assert candidate["earliest_defensible_height_h"] == 9
+        first = candidate["first_occurrence_heights"]
+        assert set(first.keys()) == set(CONTEXT_COUNTER_NAMES)
+        assert all(first[n] is not None for n in CONTEXT_COUNTER_NAMES)
+        expected_h = max(first.values())
+        assert candidate["earliest_defensible_height_h"] == expected_h
+        assert candidate["final_stream_counts"]["context_rows"] == 10
+
+
+def test_find_cmodern_height_assembles_fragmented_child_frames() -> None:
+    """Legal fragmented preface and 7 + 77 byte checkpoint writes are assembled."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        stage = _write_diagnostic_stage(tmp)
+        work_dir = tmp / "work"
+        work_dir.mkdir()
+        output = tmp / "candidate.json"
+        meta_path = _build_meta(tmp, stage, 100, work_dir)
+        child = _make_fake_binary(tmp)
+        os.environ["FAKE_CENSUS_META"] = str(meta_path)
+        os.environ["FAKE_CENSUS_STAGE"] = str(stage)
+        os.environ["FAKE_CENSUS_FRAGMENTED"] = "1"
+        try:
+            _run_diagnostic_scan(child, "127.0.0.1:18443", 100, work_dir, output)
+        finally:
+            os.environ.pop("FAKE_CENSUS_META", None)
+            os.environ.pop("FAKE_CENSUS_STAGE", None)
+            os.environ.pop("FAKE_CENSUS_FRAGMENTED", None)
+        candidate = json.loads(output.read_text())
+        assert candidate["earliest_defensible_height_h"] == 9
+        assert candidate["final_stream_counts"]["context_rows"] == 10
+
+
+def test_find_cmodern_height_reaps_failed_child() -> None:
+    """A parser-failure child must be reaped and no candidate published."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        stage = _write_diagnostic_stage(tmp)
+        work_dir = tmp / "work"
+        work_dir.mkdir()
+        output = tmp / "candidate.json"
+        meta_path = _build_meta(tmp, stage, 100, work_dir)
+        bad = tmp / "bad_child.py"
+        bad.write_text(
+            "#!/usr/bin/env python3\nimport sys\nsys.stdout.buffer.write(b'NOTMAGIC!!')\nsys.stdout.buffer.flush()\nsys.exit(1)\n"
+        )
+        bad.chmod(0o755)
+        os.environ["FAKE_CENSUS_META"] = str(meta_path)
+        os.environ["FAKE_CENSUS_STAGE"] = str(stage)
+        try:
+            _raises_with(
+                AnalyzerError,
+                lambda: _run_diagnostic_scan(
+                    bad, "127.0.0.1:18443", 100, work_dir, output
+                ),
+                "bad child",
+                "DIAG-PROTO",
+            )
+        finally:
+            os.environ.pop("FAKE_CENSUS_META", None)
+            os.environ.pop("FAKE_CENSUS_STAGE", None)
+        assert not output.exists(), "candidate must not be published on child failure"
+
+
+def test_find_cmodern_height_destination_race() -> None:
+    """A concurrent file at the destination must prevent replacement and leave it intact."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        stage = _write_diagnostic_stage(tmp)
+        work_dir = tmp / "work"
+        work_dir.mkdir()
+        output = tmp / "candidate.json"
+        output.write_text("racer\n")
+        meta_path = _build_meta(tmp, stage, 100, work_dir)
+        child = _make_fake_binary(tmp)
+        os.environ["FAKE_CENSUS_META"] = str(meta_path)
+        os.environ["FAKE_CENSUS_STAGE"] = str(stage)
+        try:
+            _raises_with(
+                AnalyzerError,
+                lambda: _run_diagnostic_scan(
+                    child, "127.0.0.1:18443", 100, work_dir, output
+                ),
+                "destination race",
+                "DIAG-OUTPUT",
+            )
+        finally:
+            os.environ.pop("FAKE_CENSUS_META", None)
+            os.environ.pop("FAKE_CENSUS_STAGE", None)
+        assert output.read_text() == "racer\n", "racer must survive the collision"
+        assert not any(tmp.glob(".*candidate.json.tmp*")), "temp must be cleaned up"
+
+
+def test_validate_replay_diagnostic_accepts_a1_artifact_without_rest_url() -> None:
+    """An A1-shaped child replay without the invented rest_url field passes validation."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        replay_path = tmp / "replay.json"
+        block_hash_le = bytes.fromhex(
+            "000000000000000000000000000000000000000000000000000000000000000a"
+        )
+        replay: dict[str, object] = {
+            "schema": "mainnet-prefix-replay-diagnostic-v1",
+            "non_certifying": True,
+            "block_source": "rest",
+            "start_height": 0,
+            "requested_stop_height_ceiling": 11,
+            "actual_stop_height": 10,
+            "actual_stop_hash": block_hash_le[::-1].hex(),
+            "window": 1,
+            "assume_valid_height": 0,
+            "stop_reason": "controller-request",
+            "storage_backend": "fjall",
+            "txindex": False,
+            "blockfilterindex": False,
+            "data_dir": str(tmp / "state"),
+            "elapsed_seconds": 1.5,
+        }
+        replay_path.write_text(json.dumps(replay, indent=2) + "\n")
+        final = DiagnosticCheckpoint(
+            height=10,
+            block_hash_le=block_hash_le,
+            context_rows=0,
+            context_end=0,
+            record_rows=0,
+            record_end=0,
+            journal_rows=0,
+            journal_end=0,
+        )
+        _validate_replay_diagnostic(
+            replay_path, final, 11, "fjall", False, False, str(tmp / "state")
+        )
+
+
+def test_validate_replay_diagnostic_rejects_invented_rest_url() -> None:
+    """The parent owns rest_url; it must not appear as an invented child field."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        replay_path = tmp / "replay.json"
+        block_hash_le = bytes.fromhex(
+            "000000000000000000000000000000000000000000000000000000000000000a"
+        )
+        replay: dict[str, object] = {
+            "schema": "mainnet-prefix-replay-diagnostic-v1",
+            "non_certifying": True,
+            "block_source": "rest",
+            "rest_url": "127.0.0.1:18443",
+            "start_height": 0,
+            "requested_stop_height_ceiling": 11,
+            "actual_stop_height": 10,
+            "actual_stop_hash": block_hash_le[::-1].hex(),
+            "window": 1,
+            "assume_valid_height": 0,
+            "stop_reason": "controller-request",
+            "storage_backend": "fjall",
+            "txindex": False,
+            "blockfilterindex": False,
+            "data_dir": str(tmp / "state"),
+            "elapsed_seconds": 1.5,
+        }
+        replay_path.write_text(json.dumps(replay, indent=2) + "\n")
+        final = DiagnosticCheckpoint(
+            height=10,
+            block_hash_le=block_hash_le,
+            context_rows=0,
+            context_end=0,
+            record_rows=0,
+            record_end=0,
+            journal_rows=0,
+            journal_end=0,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: _validate_replay_diagnostic(
+                replay_path, final, 11, "fjall", False, False, str(tmp / "state")
+            ),
+            "invented rest_url",
+            "rest_url",
+        )
+
+
+def test_find_cmodern_height_settings_mismatch_storage_backend() -> None:
+    """A child reporting a different storage_backend must not be finalized."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        stage = _write_diagnostic_stage(tmp)
+        work_dir = tmp / "work"
+        work_dir.mkdir()
+        output = tmp / "candidate.json"
+        meta_path = _build_meta(
+            tmp,
+            stage,
+            100,
+            work_dir,
+            replay_overrides={"storage_backend": "rocksdb"},
+        )
+        child = _make_fake_binary(tmp)
+        os.environ["FAKE_CENSUS_META"] = str(meta_path)
+        os.environ["FAKE_CENSUS_STAGE"] = str(stage)
+        try:
+            _raises_with(
+                AnalyzerError,
+                lambda: _run_diagnostic_scan(
+                    child, "127.0.0.1:18443", 100, work_dir, output
+                ),
+                "mismatched storage_backend",
+                "storage_backend",
+            )
+            assert not output.exists(), "candidate must not be published"
+        finally:
+            os.environ.pop("FAKE_CENSUS_META", None)
+            os.environ.pop("FAKE_CENSUS_STAGE", None)
+
+
+def test_find_cmodern_height_settings_mismatch_txindex() -> None:
+    """A child reporting txindex=True when parent passed False must fail."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        stage = _write_diagnostic_stage(tmp)
+        work_dir = tmp / "work"
+        work_dir.mkdir()
+        output = tmp / "candidate.json"
+        meta_path = _build_meta(
+            tmp,
+            stage,
+            100,
+            work_dir,
+            replay_overrides={"txindex": True},
+        )
+        child = _make_fake_binary(tmp)
+        os.environ["FAKE_CENSUS_META"] = str(meta_path)
+        os.environ["FAKE_CENSUS_STAGE"] = str(stage)
+        try:
+            _raises_with(
+                AnalyzerError,
+                lambda: _run_diagnostic_scan(
+                    child, "127.0.0.1:18443", 100, work_dir, output
+                ),
+                "mismatched txindex",
+                "txindex",
+            )
+            assert not output.exists(), "candidate must not be published"
+        finally:
+            os.environ.pop("FAKE_CENSUS_META", None)
+            os.environ.pop("FAKE_CENSUS_STAGE", None)
+
+
+def test_find_cmodern_height_settings_mismatch_blockfilterindex() -> None:
+    """A child reporting blockfilterindex=True when parent passed False must fail."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        stage = _write_diagnostic_stage(tmp)
+        work_dir = tmp / "work"
+        work_dir.mkdir()
+        output = tmp / "candidate.json"
+        meta_path = _build_meta(
+            tmp,
+            stage,
+            100,
+            work_dir,
+            replay_overrides={"blockfilterindex": True},
+        )
+        child = _make_fake_binary(tmp)
+        os.environ["FAKE_CENSUS_META"] = str(meta_path)
+        os.environ["FAKE_CENSUS_STAGE"] = str(stage)
+        try:
+            _raises_with(
+                AnalyzerError,
+                lambda: _run_diagnostic_scan(
+                    child, "127.0.0.1:18443", 100, work_dir, output
+                ),
+                "mismatched blockfilterindex",
+                "blockfilterindex",
+            )
+            assert not output.exists(), "candidate must not be published"
+        finally:
+            os.environ.pop("FAKE_CENSUS_META", None)
+            os.environ.pop("FAKE_CENSUS_STAGE", None)
+
+
+def test_find_cmodern_height_settings_mismatch_data_dir() -> None:
+    """A child reporting a different data_dir must fail before publication."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        stage = _write_diagnostic_stage(tmp)
+        work_dir = tmp / "work"
+        work_dir.mkdir()
+        output = tmp / "candidate.json"
+        meta_path = _build_meta(
+            tmp,
+            stage,
+            100,
+            work_dir,
+            replay_overrides={"data_dir": str(tmp / "other_state")},
+        )
+        child = _make_fake_binary(tmp)
+        os.environ["FAKE_CENSUS_META"] = str(meta_path)
+        os.environ["FAKE_CENSUS_STAGE"] = str(stage)
+        try:
+            _raises_with(
+                AnalyzerError,
+                lambda: _run_diagnostic_scan(
+                    child, "127.0.0.1:18443", 100, work_dir, output
+                ),
+                "mismatched data_dir",
+                "data_dir",
+            )
+            assert not output.exists(), "candidate must not be published"
+        finally:
+            os.environ.pop("FAKE_CENSUS_META", None)
+            os.environ.pop("FAKE_CENSUS_STAGE", None)
+
+
+def test_read_bounded_context_rows_zero_rows() -> None:
+    """An empty committed prefix with start_row=0 and rows=0 must parse."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        _make_brsctx1_file(tmp / "ctx.bin", [])
+        fd = os.open(tmp / "ctx.bin", os.O_RDONLY)
+        try:
+            rows = read_bounded_context_rows(
+                fd,
+                start_offset=HEADER_SIZE,
+                end_offset=HEADER_SIZE,
+                start_row=0,
+                committed_rows=0,
+            )
+            assert rows == []
+        finally:
+            os.close(fd)
+
+
+def test_read_bounded_context_rows_exact_endpoint() -> None:
+    """One committed row whose end equals the file size parses."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        ctx = _bare_p2pkh(b"\xa1" * 32)
+        _make_brsctx1_file(tmp / "ctx.bin", [ctx])
+        fd = os.open(tmp / "ctx.bin", os.O_RDONLY)
+        try:
+            rows = read_bounded_context_rows(
+                fd,
+                start_offset=HEADER_SIZE,
+                end_offset=os.fstat(fd).st_size,
+                start_row=0,
+                committed_rows=1,
+            )
+            assert len(rows) == 1
+            assert rows[0].identity.input_index == 0
+        finally:
+            os.close(fd)
+
+
+def test_read_bounded_context_rows_trailing_uncommitted() -> None:
+    """A file longer than the committed endpoint must not observe past it."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        ctxs = [_bare_p2pkh(b"\xa1" * 32), _bare_p2pkh(b"\xa2" * 32)]
+        _make_brsctx1_file(tmp / "ctx.bin", ctxs)
+        fd = os.open(tmp / "ctx.bin", os.O_RDONLY)
+        try:
+            first_row_end = _compute_context_ends(tmp / "ctx.bin")[1]
+            rows = read_bounded_context_rows(
+                fd,
+                start_offset=HEADER_SIZE,
+                end_offset=first_row_end,
+                start_row=0,
+                committed_rows=1,
+            )
+            assert len(rows) == 1
+        finally:
+            os.close(fd)
+
+
+def test_read_bounded_context_rows_truncated_row() -> None:
+    """A row that crosses the committed endpoint fails."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        ctx = _bare_p2pkh(b"\xa1" * 32)
+        _make_brsctx1_file(tmp / "ctx.bin", [ctx])
+        fd = os.open(tmp / "ctx.bin", os.O_RDONLY)
+        try:
+            _raises(
+                ContextError,
+                lambda: read_bounded_context_rows(
+                    fd,
+                    start_offset=HEADER_SIZE,
+                    end_offset=HEADER_SIZE + CONTEXT_MIN_ROW_SIZE - 1,
+                    start_row=0,
+                    committed_rows=1,
+                ),
+                "truncated committed row",
+            )
+        finally:
+            os.close(fd)
+
+
+def test_c150_helper_parity() -> None:
+    """_diagnostic_counter_totals matches the C150 strict counter shape."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid = b"\xc0" * 32
+        ctx_row = _bare_p2pkh(txid)
+        record = _make_record_bytes(txid, 0, op_kind=1, sig_version=0, outcome=1)
+        journal = [
+            _make_journal_bytes(
+                txid,
+                0,
+                checksig_ops=1,
+                checkmultisig_ops=0,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            )
+        ]
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+        paths = {
+            "contexts": tmp / "contexts.bin",
+            "records": tmp / "records.bin",
+            "journal": tmp / "journal.bin",
+        }
+        row = DiagnosticCheckpoint(
+            height=1,
+            block_hash_le=bytes([1] * 32),
+            context_rows=1,
+            context_end=(paths["contexts"].stat().st_size),
+            record_rows=1,
+            record_end=(paths["records"].stat().st_size),
+            journal_rows=1,
+            journal_end=(paths["journal"].stat().st_size),
+        )
+        classified, r, _j, ctx_map, _record_counts = _read_diagnostic_streams(
+            row, None, paths
+        )
+        totals = _diagnostic_counter_totals(classified, r, ctx_map)
+        assert totals["bare_multisig_checks"] == 0
+        assert totals["p2sh_redeem_spends"] == 0
+        assert totals["taproot_key_path_spends"] == 0
+        assert totals["tapscript_spends"] == 0
+        assert totals["native_witness_v0_spends"] == 0
+        assert totals["p2sh_wrapped_witness_v0_spends"] == 0
+
+
+def test_diagnostic_multisig_opcode_allows_multiple_ecdsa_records() -> None:
+    """One CHECKMULTISIG opcode may emit multiple ordered ECDSA records."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xc1" * 32
+        _make_brsctx1_file(
+            tmp / "contexts.bin",
+            [_p2sh_push_only(txid_le, flags=VERIFY_P2SH)],
+        )
+        _write_records_file(
+            tmp / "records.bin",
+            [
+                _make_record_bytes(txid_le, 0, op_kind=3, op_seq=0, outcome=1),
+                _make_record_bytes(txid_le, 0, op_kind=3, op_seq=1, outcome=0),
+            ],
+        )
+        _write_journal_file(
+            tmp / "journal.bin",
+            [
+                _make_journal_bytes(
+                    txid_le,
+                    0,
+                    checksig_ops=0,
+                    checkmultisig_ops=1,
+                    ecdsa_verify_calls=2,
+                    ecdsa_verify_ok=1,
+                )
+            ],
+        )
+        paths = {
+            "contexts": tmp / "contexts.bin",
+            "records": tmp / "records.bin",
+            "journal": tmp / "journal.bin",
+        }
+        row = DiagnosticCheckpoint(
+            height=164676,
+            block_hash_le=b"\x01" * 32,
+            context_rows=1,
+            context_end=paths["contexts"].stat().st_size,
+            record_rows=2,
+            record_end=paths["records"].stat().st_size,
+            journal_rows=1,
+            journal_end=paths["journal"].stat().st_size,
+        )
+
+        _classified, records, journal, _context_map, record_counts = (
+            _read_diagnostic_streams(row, None, paths)
+        )
+
+        assert len(records) == 2
+        assert journal[0].checkmultisig_ops == 1
+        assert journal[0].ecdsa_verify_calls == 2
+        assert journal[0].ecdsa_verify_ok == 1
+        assert record_counts["p2sh_multisig_checks"] == 2
+
+
+def test_diagnostic_multisig_short_circuit_zero_ecdsa_records() -> None:
+    """One CHECKMULTISIG opcode may short-circuit before any ECDSA verification."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xc2" * 32
+        _make_brsctx1_file(
+            tmp / "contexts.bin",
+            [_p2sh_push_only(txid_le, flags=VERIFY_P2SH)],
+        )
+        _write_records_file(tmp / "records.bin", [])
+        _write_journal_file(
+            tmp / "journal.bin",
+            [
+                _make_journal_bytes(
+                    txid_le,
+                    0,
+                    checksig_ops=0,
+                    checkmultisig_ops=1,
+                    ecdsa_verify_calls=0,
+                    ecdsa_verify_ok=0,
+                )
+            ],
+        )
+        paths = {
+            "contexts": tmp / "contexts.bin",
+            "records": tmp / "records.bin",
+            "journal": tmp / "journal.bin",
+        }
+        row = DiagnosticCheckpoint(
+            height=2,
+            block_hash_le=b"\x02" * 32,
+            context_rows=1,
+            context_end=paths["contexts"].stat().st_size,
+            record_rows=0,
+            record_end=paths["records"].stat().st_size,
+            journal_rows=1,
+            journal_end=paths["journal"].stat().st_size,
+        )
+
+        _classified, records, journal, _context_map, record_counts = (
+            _read_diagnostic_streams(row, None, paths)
+        )
+
+        assert len(records) == 0
+        assert journal[0].checkmultisig_ops == 1
+        assert journal[0].ecdsa_verify_calls == 0
+        assert journal[0].ecdsa_verify_ok == 0
+        assert record_counts["p2sh_multisig_checks"] == 0
+
+
+def test_diagnostic_helper_synthetic_all_types() -> None:
+    """A synthetic fixture with all spend contexts/record rules counts all 11 types."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        distinct = [bytes([0xD0 + i] * 32) for i in range(6)]
+        contexts = [
+            _bare_p2pkh(distinct[0]),
+            _p2sh_push_only(distinct[1], flags=VERIFY_P2SH),
+            _native_w0(distinct[2], flags=VERIFY_WITNESS),
+            _p2sh_wrapped_w0(distinct[3], flags=VERIFY_P2SH | VERIFY_WITNESS),
+            _taproot_key_path(distinct[4], flags=VERIFY_WITNESS | VERIFY_TAPROOT),
+            _taproot_script_path(distinct[5], flags=VERIFY_WITNESS | VERIFY_TAPROOT),
+        ]
+        records = [
+            _make_record_bytes(distinct[0], 0, op_kind=1, sig_version=0),
+            _make_record_bytes(distinct[1], 0, op_kind=1, sig_version=0),
+            _make_record_bytes(distinct[2], 0, op_kind=1, sig_version=1),
+            _make_record_bytes(distinct[3], 0, op_kind=1, sig_version=1),
+            _make_record_bytes(distinct[4], 0, op_kind=0, sig_version=3),
+            _make_record_bytes(distinct[5], 0, op_kind=1, sig_version=2),
+            _make_record_bytes(distinct[5], 0, op_kind=5, sig_version=2, op_seq=1),
+        ]
+        journal = [
+            _make_journal_bytes(
+                distinct[0], 0, checksig_ops=1, ecdsa_verify_calls=1, ecdsa_verify_ok=1
+            ),
+            _make_journal_bytes(
+                distinct[1], 0, checksig_ops=1, ecdsa_verify_calls=1, ecdsa_verify_ok=1
+            ),
+            _make_journal_bytes(
+                distinct[2], 0, checksig_ops=1, ecdsa_verify_calls=1, ecdsa_verify_ok=1
+            ),
+            _make_journal_bytes(
+                distinct[3], 0, checksig_ops=1, ecdsa_verify_calls=1, ecdsa_verify_ok=1
+            ),
+            _make_journal_bytes(
+                distinct[4], 0, checksig_ops=0, ecdsa_verify_calls=0, ecdsa_verify_ok=0
+            ),
+            _make_journal_bytes(
+                distinct[5], 0, checksig_ops=1, ecdsa_verify_calls=0, ecdsa_verify_ok=0
+            ),
+        ]
+        _make_brsctx1_file(tmp / "contexts.bin", contexts)
+        _write_records_file(tmp / "records.bin", records)
+        _write_journal_file(tmp / "journal.bin", journal)
+        paths = {
+            "contexts": tmp / "contexts.bin",
+            "records": tmp / "records.bin",
+            "journal": tmp / "journal.bin",
+        }
+        row = DiagnosticCheckpoint(
+            height=1,
+            block_hash_le=bytes([1] * 32),
+            context_rows=6,
+            context_end=(paths["contexts"].stat().st_size),
+            record_rows=7,
+            record_end=(paths["records"].stat().st_size),
+            journal_rows=6,
+            journal_end=(paths["journal"].stat().st_size),
+        )
+        classified, r, _j, ctx_map, _record_counts = _read_diagnostic_streams(
+            row, None, paths
+        )
+        totals = _diagnostic_counter_totals(classified, r, ctx_map)
+        assert totals["p2sh_redeem_spends"] == 1
+        assert totals["native_witness_v0_spends"] == 1
+        assert totals["p2sh_wrapped_witness_v0_spends"] == 1
+        assert totals["bare_multisig_checks"] == 0
+        assert totals["p2sh_multisig_checks"] == 0
+        assert totals["native_witness_v0_multisig_checks"] == 0
+        assert totals["p2sh_wrapped_witness_v0_multisig_checks"] == 0
+        assert totals["taproot_key_path_spends"] == 1
+        assert totals["tapscript_spends"] == 1
+        assert totals["tapscript_schnorr_checks"] == 2
+        assert totals["tapscript_checksigadd_checks"] == 1
+
+
+def test_diagnostic_op_seq_stream_order_rejects_one_before_zero() -> None:
+    """Encounter-order stream 1,0 for one identity must raise CTX-OPERATIONS.
+
+    A sorted-set implementation would accept this as {0,1}; strict row-number
+    semantics reject the first emitted row because its expected op_seq is 0.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xd1" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        records = [
+            _make_record_bytes(
+                txid_le, 0, op_kind=1, sig_version=0, op_seq=1, outcome=1
+            ),
+            _make_record_bytes(
+                txid_le, 0, op_kind=1, sig_version=0, op_seq=0, outcome=1
+            ),
+        ]
+        journal = [
+            _make_journal_bytes(
+                txid_le, 0, checksig_ops=2, ecdsa_verify_calls=2, ecdsa_verify_ok=2
+            )
+        ]
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx_row])
+        _write_records_file(tmp / "records.bin", records)
+        _write_journal_file(tmp / "journal.bin", journal)
+        paths = {
+            "contexts": tmp / "contexts.bin",
+            "records": tmp / "records.bin",
+            "journal": tmp / "journal.bin",
+        }
+        row = DiagnosticCheckpoint(
+            height=1,
+            block_hash_le=bytes([1] * 32),
+            context_rows=1,
+            context_end=(paths["contexts"].stat().st_size),
+            record_rows=2,
+            record_end=(paths["records"].stat().st_size),
+            journal_rows=1,
+            journal_end=(paths["journal"].stat().st_size),
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: _read_diagnostic_streams(row, None, paths),
+            "misordered op_seq 1 before 0",
+            "CTX-OPERATIONS",
+        )
+
+
+def _diagnostic_stage(
+    tmp: Path,
+    contexts: list[ContextInput],
+    records: list[bytes],
+    journal: list[bytes],
+) -> tuple[DiagnosticCheckpoint, dict[str, Path]]:
+    """Write a BRSCTX1/BRSREC1/BRSJRN1 triple and a matching checkpoint."""
+    _make_brsctx1_file(tmp / "contexts.bin", contexts)
+    _write_records_file(tmp / "records.bin", records)
+    _write_journal_file(tmp / "journal.bin", journal)
+    paths = {
+        "contexts": tmp / "contexts.bin",
+        "records": tmp / "records.bin",
+        "journal": tmp / "journal.bin",
+    }
+    return (
+        DiagnosticCheckpoint(
+            height=1,
+            block_hash_le=bytes([1] * 32),
+            context_rows=len(contexts),
+            context_end=paths["contexts"].stat().st_size,
+            record_rows=len(records),
+            record_end=paths["records"].stat().st_size,
+            journal_rows=len(journal),
+            journal_end=paths["journal"].stat().st_size,
+        ),
+        paths,
+    )
+
+
+def test_diagnostic_first_record_op_seq_with_illegal_reports_sequence() -> None:
+    """An out-of-order op_seq on the first record beats the same record's legality error."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xd2" * 32
+        ctx = _bare_p2pkh(txid_le)
+        records = [
+            _make_record_bytes(
+                txid_le, 0, op_kind=3, sig_version=2, op_seq=1, outcome=1
+            ),
+        ]
+        journal = [_make_journal_bytes(txid_le, 0)]
+        row, paths = _diagnostic_stage(tmp, [ctx], records, journal)
+        _raises_with(
+            AnalyzerError,
+            lambda: _read_diagnostic_streams(row, None, paths),
+            "first-record op_seq=1 plus illegal op",
+            "CTX-OPERATIONS",
+            "op_seq contiguity violation",
+            "expected 0, got 1",
+        )
+
+
+def test_diagnostic_earlier_sequence_beats_later_illegal() -> None:
+    """A sequence error on an earlier record wins over a later illegal record."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_a = b"\xd3" * 32
+        txid_b = b"\xd4" * 32
+        contexts = [_bare_p2pkh(txid_a), _bare_p2pkh(txid_b)]
+        records = [
+            _make_record_bytes(
+                txid_a, 0, op_kind=1, sig_version=0, op_seq=1, outcome=1
+            ),
+            _make_record_bytes(
+                txid_b, 0, op_kind=3, sig_version=2, op_seq=0, outcome=1
+            ),
+        ]
+        journal = [_make_journal_bytes(txid_a, 0), _make_journal_bytes(txid_b, 0)]
+        row, paths = _diagnostic_stage(tmp, contexts, records, journal)
+        _raises_with(
+            AnalyzerError,
+            lambda: _read_diagnostic_streams(row, None, paths),
+            "earlier sequence beats later illegal",
+            "CTX-OPERATIONS",
+            "op_seq contiguity violation",
+            "expected 0, got 1",
+        )
+
+
+def test_diagnostic_earlier_illegal_beats_later_sequence() -> None:
+    """An illegal record on an earlier record wins over a later sequence error."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_a = b"\xd5" * 32
+        txid_b = b"\xd6" * 32
+        contexts = [_bare_p2pkh(txid_a), _bare_p2pkh(txid_b)]
+        records = [
+            _make_record_bytes(
+                txid_a, 0, op_kind=3, sig_version=2, op_seq=0, outcome=1
+            ),
+            _make_record_bytes(
+                txid_b, 0, op_kind=1, sig_version=0, op_seq=1, outcome=1
+            ),
+        ]
+        journal = [_make_journal_bytes(txid_a, 0), _make_journal_bytes(txid_b, 0)]
+        row, paths = _diagnostic_stage(tmp, contexts, records, journal)
+        _raises_with(
+            AnalyzerError,
+            lambda: _read_diagnostic_streams(row, None, paths),
+            "earlier illegal beats later sequence",
+            "CTX-OPERATIONS",
+            "multisig record must have sig_version BASE or WITNESS_V0",
+            "TAPSCRIPT",
+        )
+
+
+def test_diagnostic_duplicate_key_retains_precedence() -> None:
+    """A duplicate record key is reported before that record's sequence or legality failure."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\xd7" * 32
+        ctx = _bare_p2pkh(txid_le)
+        records = [
+            _make_record_bytes(
+                txid_le, 0, op_kind=1, sig_version=0, op_seq=0, outcome=1
+            ),
+            _make_record_bytes(
+                txid_le, 0, op_kind=3, sig_version=2, op_seq=0, outcome=1
+            ),
+        ]
+        journal = [_make_journal_bytes(txid_le, 0)]
+        row, paths = _diagnostic_stage(tmp, [ctx], records, journal)
+        _raises_with(
+            AnalyzerError,
+            lambda: _read_diagnostic_streams(row, None, paths),
+            "duplicate key retains precedence",
+            "CTX-OPERATIONS",
+            "duplicate record key in BRSREC1",
+            f"txid={txid_le[::-1].hex()}",
+            "op_seq=0",
+        )
+
+
+def test_atomic_publish_rollback_fsyncs_after_unlink() -> None:
+    """First post-link directory fsync fails; rollback unlinks target then fsyncs.
+
+    The injected failure fires once, then rollback uses the real fsync on the
+    reopened parent directory. We assert unlink precedes the rollback fsync and
+    that neither target nor temp survive.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        target = tmp / "out.json"
+        from analyze import _atomic_publish_no_replace
+
+        original_fsync = os.fsync
+        original_unlink = os.unlink
+
+        ops: list[str] = []
+        dir_fsync_count = 0
+
+        def instrumented_unlink(p, *, dir_fd=None):
+            ops.append(f"unlink:{p}")
+            if dir_fd is not None:
+                return original_unlink(p, dir_fd=dir_fd)
+            return original_unlink(p)
+
+        fsync_calls: list[tuple[bool, bool]] = []
+
+        def counting_fsync(fd):
+            nonlocal dir_fsync_count
+            is_dir = stat.S_ISDIR(os.fstat(fd).st_mode)
+            after_unlink = len(ops) > 0
+            fsync_calls.append((is_dir, after_unlink))
+            if is_dir:
+                dir_fsync_count += 1
+                if dir_fsync_count == 1 and not after_unlink:
+                    raise OSError(5, "simulated post-link directory fsync error")
+            return original_fsync(fd)
+
+        try:
+            os.fsync = counting_fsync
+            os.unlink = instrumented_unlink
+            _raises(
+                OSError,
+                lambda: _atomic_publish_no_replace(target, b"candidate"),
+                "post-link fsync failure",
+            )
+        finally:
+            os.fsync = original_fsync
+            os.unlink = original_unlink
+        assert not target.exists()
+        assert not any(tmp.glob(".*out.json.tmp*"))
+        assert any("unlink" in op for op in ops), (
+            "target must be unlinked during rollback"
+        )
+        # fsync called after at least one unlink (rollback directory fsync).
+        assert any(after for (_, after) in fsync_calls if after), (
+            "rollback fsync must follow unlink"
+        )
+
+
+def test_atomic_publish_no_replace_collision() -> None:
+    """os.link must fail atomically when the destination already exists."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        target = tmp / "out.json"
+        target.write_text("racer\n")
+        from analyze import _atomic_publish_no_replace
+
+        _raises_with(
+            AnalyzerError,
+            lambda: _atomic_publish_no_replace(target, b"candidate"),
+            "output race",
+            "DIAG-OUTPUT",
+        )
+        assert target.read_text() == "racer\n"
+
+
+def test_atomic_publish_cleans_temp_on_post_link_fsync_failure() -> None:
+    """If directory fsync after the link fails, the output and temp are removed."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        target = tmp / "out.json"
+        from analyze import _atomic_publish_no_replace
+
+        original_fsync = os.fsync
+
+        def broken_fsync(fd):
+            if fd >= 0:
+                raise OSError(5, "simulated I/O error")
+            original_fsync(fd)
+
+        try:
+            os.fsync = broken_fsync
+            _raises(
+                OSError,
+                lambda: _atomic_publish_no_replace(target, b"candidate"),
+                "post-link fsync failure",
+            )
+        finally:
+            os.fsync = original_fsync
+        assert not target.exists()
+        assert not any(tmp.glob(".*out.json.tmp*")), "temp must be removed on failure"
+
+
 # ── Runner ───────────────────────────────────────────────────────────────────
 
 
@@ -5901,6 +7128,32 @@ def main() -> int:
         test_classify_corpus_scratch_dir_rejects_unwritable,
         test_count_context_records_disk_scratch_dir_smoke,
         test_count_context_records_disk_restores_env_on_failure,
+        test_find_cmodern_height_fake_child_success,
+        test_find_cmodern_height_assembles_fragmented_child_frames,
+        test_find_cmodern_height_reaps_failed_child,
+        test_find_cmodern_height_destination_race,
+        test_validate_replay_diagnostic_accepts_a1_artifact_without_rest_url,
+        test_validate_replay_diagnostic_rejects_invented_rest_url,
+        test_read_bounded_context_rows_zero_rows,
+        test_read_bounded_context_rows_exact_endpoint,
+        test_read_bounded_context_rows_trailing_uncommitted,
+        test_read_bounded_context_rows_truncated_row,
+        test_c150_helper_parity,
+        test_diagnostic_multisig_opcode_allows_multiple_ecdsa_records,
+        test_diagnostic_multisig_short_circuit_zero_ecdsa_records,
+        test_diagnostic_helper_synthetic_all_types,
+        test_diagnostic_op_seq_stream_order_rejects_one_before_zero,
+        test_diagnostic_first_record_op_seq_with_illegal_reports_sequence,
+        test_diagnostic_earlier_sequence_beats_later_illegal,
+        test_diagnostic_earlier_illegal_beats_later_sequence,
+        test_diagnostic_duplicate_key_retains_precedence,
+        test_atomic_publish_rollback_fsyncs_after_unlink,
+        test_atomic_publish_no_replace_collision,
+        test_atomic_publish_cleans_temp_on_post_link_fsync_failure,
+        test_find_cmodern_height_settings_mismatch_storage_backend,
+        test_find_cmodern_height_settings_mismatch_txindex,
+        test_find_cmodern_height_settings_mismatch_blockfilterindex,
+        test_find_cmodern_height_settings_mismatch_data_dir,
     ]
     passed = 0
     failed = 0

--- a/tools/checksig-census/test_validation_contracts.py
+++ b/tools/checksig-census/test_validation_contracts.py
@@ -698,6 +698,7 @@ def _make_classify_args(
     replay_overrides: dict[str, object] | None = None,
     manifest_overrides: dict[str, object] | None = None,
     archive_blocks: list[bytes] | None = None,
+    scratch_dir: Path | None = None,
 ) -> argparse.Namespace:
     """Create all supporting files and return an argparse.Namespace for
     cmd_classify_corpus.
@@ -781,6 +782,7 @@ def _make_classify_args(
         output=str(tmp / "report.json"),
         contract=contract,
         input_count=input_count,
+        scratch_dir=str(scratch_dir) if scratch_dir else None,
     )
     return ns
 
@@ -5395,6 +5397,335 @@ def test_classify_corpus_custody_contexts_from_same_open() -> None:
         assert path.read_bytes() != a_bytes
 
 
+# ── Tests: Task 7B focused regressions ───────────────────────────────────────
+
+
+def test_classify_corpus_duplicate_context_key() -> None:
+    """Duplicate BRSCTX1 (same txid/input_index) raises CTX-EXECUTION."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x65" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        dup = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(tmp, [ctx_row, dup], [record], journal, "c150")
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "duplicate context key",
+            "CTX-EXECUTION",
+        )
+
+
+def test_classify_corpus_mixed_duplicate_before_malformed() -> None:
+    """A duplicate record in the same bounded chunk wins over a later malformed row."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x66" * 32
+        ctx_row = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0, op_seq=0)
+        duplicate = _make_record_bytes(txid_le, 0, op_seq=0)
+        malformed = _make_record_bytes(txid_le, 0, op_kind=6)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        args = _make_classify_args(
+            tmp, [ctx_row], [record, duplicate, malformed], journal, "c150"
+        )
+        try:
+            cmd_classify_corpus(args)
+        except AnalyzerError as exc:
+            msg = str(exc)
+            assert "CTX-OPERATIONS" in msg, msg
+            assert "duplicate record key" in msg, msg
+            assert "op_kind" not in msg, f"malformed row was parsed first: {msg}"
+        else:
+            raise AssertionError("expected AnalyzerError for duplicate record")
+
+
+def test_record_validation_earlier_illegal_precedes_later_orphan() -> None:
+    """Stream order wins when a later record is orphaned."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x70" * 32
+        orphan_txid = b"\x71" * 32
+        args = _make_classify_args(
+            tmp,
+            [_bare_p2pkh(txid_le)],
+            [
+                _make_record_bytes(txid_le, 0, op_kind=3, sig_version=2),
+                _make_record_bytes(orphan_txid, 0),
+            ],
+            [_make_journal_bytes(txid_le, 0)],
+            "c150",
+        )
+        try:
+            cmd_classify_corpus(args)
+        except AnalyzerError as exc:
+            assert str(exc) == (
+                "CTX-OPERATIONS: multisig record must have sig_version BASE or WITNESS_V0, "
+                "got TAPSCRIPT for "
+                f"txid={txid_le[::-1].hex()}, input_index=0"
+            )
+        else:
+            raise AssertionError("expected earlier illegal-record error")
+
+
+def test_record_validation_earlier_illegal_precedes_later_sequence_gap() -> None:
+    """Stream order wins when a later record has an op_seq gap."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x72" * 32
+        args = _make_classify_args(
+            tmp,
+            [_bare_p2pkh(txid_le)],
+            [
+                _make_record_bytes(txid_le, 0, op_seq=0, op_kind=3, sig_version=2),
+                _make_record_bytes(txid_le, 0, op_seq=2),
+            ],
+            [_make_journal_bytes(txid_le, 0)],
+            "c150",
+        )
+        try:
+            cmd_classify_corpus(args)
+        except AnalyzerError as exc:
+            assert str(exc) == (
+                "CTX-OPERATIONS: multisig record must have sig_version BASE or WITNESS_V0, "
+                "got TAPSCRIPT for "
+                f"txid={txid_le[::-1].hex()}, input_index=0"
+            )
+        else:
+            raise AssertionError("expected earlier illegal-record error")
+
+
+def test_record_validation_semantic_error_precedes_record_count_mismatch() -> None:
+    """Semantic validation precedes the aggregate record-count check."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x73" * 32
+        args = _make_classify_args(
+            tmp,
+            [_bare_p2pkh(txid_le)],
+            [_make_record_bytes(txid_le, 0, op_kind=3, sig_version=2)],
+            [_make_journal_bytes(txid_le, 0)],
+            "c150",
+            counters_overrides={"record_count": 2},
+        )
+        try:
+            cmd_classify_corpus(args)
+        except AnalyzerError as exc:
+            assert str(exc) == (
+                "CTX-OPERATIONS: multisig record must have sig_version BASE or WITNESS_V0, "
+                "got TAPSCRIPT for "
+                f"txid={txid_le[::-1].hex()}, input_index=0"
+            )
+        else:
+            raise AssertionError("expected semantic record error")
+
+
+def test_record_validation_same_record_orphan_precedence() -> None:
+    """Orphan wins over sequence and legality failures on one record."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        context_txid = b"\x74" * 32
+        orphan_txid = b"\x75" * 32
+        args = _make_classify_args(
+            tmp,
+            [_bare_p2pkh(context_txid)],
+            [_make_record_bytes(orphan_txid, 0, op_seq=1, op_kind=3, sig_version=2)],
+            [_make_journal_bytes(context_txid, 0)],
+            "c150",
+        )
+        try:
+            cmd_classify_corpus(args)
+        except AnalyzerError as exc:
+            assert str(exc) == (
+                "CTX-OPERATIONS: BRSREC1 record has no matching context identity: "
+                f"txid={orphan_txid[::-1].hex()}, input_index=0"
+            )
+        else:
+            raise AssertionError("expected orphan record error")
+
+
+def test_count_context_records_spend_context_tally_sensitivity() -> None:
+    """CHECKMULTISIG records with the same op/sig map to different context
+    counters depending on the input's spend_context, proving the tally is
+    sensitive to context classification."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_bare = b"\xb4" * 32
+        txid_p2sh = b"\xb5" * 32
+        contexts = [
+            _bare_p2pkh(txid_bare),
+            _p2sh_push_only(txid_p2sh, flags=VERIFY_P2SH),
+        ]
+        records = [
+            _make_record_bytes(txid_bare, 0, op_kind=3, sig_version=0),
+            _make_record_bytes(txid_p2sh, 0, op_kind=3, sig_version=0),
+        ]
+        journal = [
+            _make_journal_bytes(
+                txid_bare,
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+            _make_journal_bytes(
+                txid_p2sh,
+                0,
+                checksig_ops=0,
+                checkmultisig_ops=1,
+                ecdsa_verify_calls=1,
+                ecdsa_verify_ok=1,
+            ),
+        ]
+        _make_brsctx1_file(tmp / "contexts.bin", contexts)
+        _write_records_file(tmp / "records.bin", records)
+        _write_journal_file(tmp / "journal.bin", journal)
+
+        counters = _make_valid_counters(
+            2,
+            2,
+            2,
+            op_checksig=0,
+            op_checkmultisig=2,
+            checkecdsa_entries=2,
+            ecdsa_from_checksig=0,
+            ecdsa_from_checkmultisig=2,
+            ecdsa_verify_calls=2,
+            ecdsa_verify_ok=2,
+            sighash_computed=2,
+        )
+        (tmp / "counters.json").write_text(json.dumps(counters))
+        counts, ctx_count, _ = _count_context_records_disk(
+            tmp / "contexts.bin",
+            tmp / "records.bin",
+            tmp / "journal.bin",
+            Counters(counters),
+        )
+        assert ctx_count == 2
+        assert counts["bare_multisig_checks"] == 1
+        assert counts["p2sh_multisig_checks"] == 1
+
+
+def test_classify_corpus_scratch_dir_rejects_non_directory() -> None:
+    """A scratch-dir argument that is not a directory is rejected clearly."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txid_le = b"\x67" * 32
+        scratch = tmp / "not-a-dir"
+        scratch.write_text("file")
+        args = _make_classify_args(
+            tmp,
+            [_bare_p2pkh(txid_le)],
+            [_make_record_bytes(txid_le, 0)],
+            [_make_journal_bytes(txid_le, 0)],
+            "c150",
+            scratch_dir=scratch,
+        )
+        _raises_with(
+            AnalyzerError,
+            lambda: cmd_classify_corpus(args),
+            "scratch-dir rejects file",
+            "CTX-EXECUTION",
+            "scratch-dir is not a writable directory",
+        )
+
+
+def test_classify_corpus_scratch_dir_rejects_unwritable() -> None:
+    """An existing but unwritable scratch-dir is rejected clearly."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        scratch = tmp / "no-write"
+        scratch.mkdir(mode=0o555)
+        txid_le = b"\x68" * 32
+        args = _make_classify_args(
+            tmp,
+            [_bare_p2pkh(txid_le)],
+            [_make_record_bytes(txid_le, 0)],
+            [_make_journal_bytes(txid_le, 0)],
+            "c150",
+            scratch_dir=scratch,
+        )
+        try:
+            _raises_with(
+                AnalyzerError,
+                lambda: cmd_classify_corpus(args),
+                "scratch-dir rejects unwritable",
+                "CTX-EXECUTION",
+                "scratch-dir is not a writable directory",
+            )
+        finally:
+            scratch.chmod(0o755)
+
+
+def test_count_context_records_disk_scratch_dir_smoke() -> None:
+    """A valid scratch_dir is accepted and set-based counts remain correct."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        scratch = tmp / "scratch"
+        scratch.mkdir()
+        txid_le = b"\x69" * 32
+        ctx = _bare_p2pkh(txid_le)
+        record = _make_record_bytes(txid_le, 0)
+        journal = [_make_journal_bytes(txid_le, 0)]
+        _make_brsctx1_file(tmp / "contexts.bin", [ctx])
+        _write_records_file(tmp / "records.bin", [record])
+        _write_journal_file(tmp / "journal.bin", journal)
+
+        counters = _make_valid_counters(1, 1, 1)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+        counts, ctx_count, _ = _count_context_records_disk(
+            tmp / "contexts.bin",
+            tmp / "records.bin",
+            tmp / "journal.bin",
+            Counters(counters),
+            scratch_dir=scratch,
+        )
+        assert ctx_count == 1
+        assert counts["bare_multisig_checks"] == 0
+
+
+def test_count_context_records_disk_restores_env_on_failure() -> None:
+    """A BRSCTX1 parse failure after SQLite setup still restores environment."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        scratch = tmp / "scratch"
+        scratch.mkdir()
+        (tmp / "contexts.bin").write_bytes(b"BADC0D1C" + struct.pack("<Q", 0))
+
+        counters = _make_valid_counters(0, 0, 0)
+        (tmp / "counters.json").write_text(json.dumps(counters))
+
+        original_sqlite = os.environ.get("SQLITE_TMPDIR")
+        original_tmp = os.environ.get("TMPDIR")
+        try:
+            os.environ["SQLITE_TMPDIR"] = "/tmp/original-sqlite"
+            os.environ["TMPDIR"] = "/tmp/original-tmp"
+            try:
+                _count_context_records_disk(
+                    tmp / "contexts.bin",
+                    tmp / "records.bin",
+                    tmp / "journal.bin",
+                    Counters(counters),
+                    scratch_dir=scratch,
+                )
+            except AnalyzerError:
+                pass
+            assert os.environ.get("SQLITE_TMPDIR") == "/tmp/original-sqlite"
+            assert os.environ.get("TMPDIR") == "/tmp/original-tmp"
+        finally:
+            if original_sqlite is not None:
+                os.environ["SQLITE_TMPDIR"] = original_sqlite
+            else:
+                os.environ.pop("SQLITE_TMPDIR", None)
+            if original_tmp is not None:
+                os.environ["TMPDIR"] = original_tmp
+            else:
+                os.environ.pop("TMPDIR", None)
+
+
 # ── Runner ───────────────────────────────────────────────────────────────────
 
 
@@ -5559,6 +5890,17 @@ def main() -> int:
         test_classify_corpus_custody_journal_from_single_open,
         test_parse_counters_returns_custody,
         test_classify_corpus_custody_contexts_from_same_open,
+        test_classify_corpus_duplicate_context_key,
+        test_classify_corpus_mixed_duplicate_before_malformed,
+        test_record_validation_earlier_illegal_precedes_later_orphan,
+        test_record_validation_earlier_illegal_precedes_later_sequence_gap,
+        test_record_validation_semantic_error_precedes_record_count_mismatch,
+        test_record_validation_same_record_orphan_precedence,
+        test_count_context_records_spend_context_tally_sensitivity,
+        test_classify_corpus_scratch_dir_rejects_non_directory,
+        test_classify_corpus_scratch_dir_rejects_unwritable,
+        test_count_context_records_disk_scratch_dir_smoke,
+        test_count_context_records_disk_restores_env_on_failure,
     ]
     passed = 0
     failed = 0


### PR DESCRIPTION
## Summary

- preserve the exact reason-1 ECDSA rejection row when signature or public-key bytes exceed the fixed record capacity
- validate the exceptional BRSREC1 shape without admitting near misses
- skip that preserved row in bare verification while retaining census accounting

## Verification

- Ruff check and format check
- 210 analyzer contract tests
- bare-secp release clippy and 12 release tests
- independent C+F+G reconstruction passed the same gates

Part of #42

## Stacked-merge note

This atomic PR currently targets `atomic/checksig-census-push-only` after #66. GitHub does not activate closing keywords on a non-default base. After #66 merges, retarget this PR to `main`; `Closes #69` will then become effective.

Closes #69