### PR TITLE
fix(node): clear the clippy expect_used lint failing CI on main

### DIFF
--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -6344,14 +6344,15 @@ mod consensus_rule_tests {
             utxo.commit_block(&remove, &Hash256::from_le_bytes(&[0x83; 32]))?;
 
             let transition = handles.begin_chain_transition()?;
-            let error = apply_block_admitted(
+            let Err(error) = apply_block_admitted(
                 &handles,
                 &block,
                 Some(raw),
                 Some(ProvenApply::Proven(proof)),
                 &transition,
-            )
-            .expect_err("a mismatched proof must re-read the now-missing live prevout");
+            ) else {
+                panic!("a mismatched proof must re-read the now-missing live prevout");
+            };
             assert!(
                 matches!(
                     error,
@@ -6539,26 +6540,24 @@ mod consensus_rule_tests {
             "an empty verification dispatch must not count as script verification",
         );
         let mut entries = prove_window(&handles, &[&block], core::slice::from_ref(&raw));
-        let skipped = entries
-            .pop()
-            .expect("the trusted assume-valid window returned one entry above");
+        let Some(skipped) = entries.pop() else {
+            panic!("the trusted assume-valid window returned one entry above");
+        };
         handles.assume_valid_gate = Arc::new(AssumeValidGate::with_anchor(Some((
             1,
             Hash256::from_le_bytes(&[0xff; 32]),
         ))));
         assert!(!handles.assume_valid_gate.trusted());
         let transition = handles.begin_chain_transition()?;
-        let error = apply_block_admitted(&handles, &block, Some(raw), Some(skipped), &transition)
-            .expect_err("an untrusted gate at commit must run and reject the bad script");
+        let outcome = apply_block_admitted(&handles, &block, Some(raw), Some(skipped), &transition);
         assert!(
             matches!(
-                error,
-                ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Script {
-                    input_index: 0,
-                    ..
-                })
+                outcome,
+                Err(ApplyError::Consensus(
+                    bitcoin_rs_consensus::ConsensusError::Script { input_index: 0, .. }
+                ))
             ),
-            "trust-gate flip must re-enter ordinary script validation, got {error:?}"
+            "trust-gate flip must re-enter ordinary script validation, got {outcome:?}"
         );
 
         // Full verification must be completely unaffected.


### PR DESCRIPTION
`cargo clippy -p bitcoin-rs-node --all-targets -- -D warnings` has been failing on `main` since `bfe5044`, on three `expect()`/`expect_err()` calls in `apply.rs` test code. **Every open PR inherits the red check** — that lane is the one the CI comment describes as "catches test-target lints invisible to the line above", so it is doing its job; nothing had cleared it.

Rewritten in the crate's existing idiom, `let ... else { panic!(...) }`.

One of the three sites sits in a test already at the 100-line `too_many_lines` ceiling, so a `let-else` there trades one lint for another. That site instead folds the unwrap into the assertion that immediately followed it — `matches!(outcome, Err(...))` against the `Result` directly. One assertion instead of unwrap-then-match, and three lines shorter than before.

## Verification

WSL2, `CARGO_TARGET_DIR=/home/pipe/target-dev`, `-j4`.

- `cargo clippy -p bitcoin-rs-node --all-targets -- -D warnings` — clean, reproducing the exact CI invocation.
- `cargo fmt --check` — clean.
- `cargo test -p bitcoin-rs-node --no-default-features --features fjall --no-fail-fast` — green. Both rewritten tests pass, and each assertion still fails on exactly what it failed on before.

Behaviour is unchanged; this is a lint fix in test code only.