### PR TITLE
docs: satisfy strict clippy documentation lint

### DIFF
--- a/crates/chain/README.md
+++ b/crates/chain/README.md
@@ -19,7 +19,7 @@ parent, height, and header hash with a `NodeStatus` (header-valid, active, or
 off-best-chain), and every failure surfaces as a structured `ChainError` variant.
 
 ## Features
-- `rocksdb`: enables the RocksDB backend in `bitcoin-rs-storage`
+- `rocksdb`: enables the `RocksDB` backend in `bitcoin-rs-storage`
 - `fjall`: enables the fjall backend in `bitcoin-rs-storage`
 - `redb`: enables the redb backend in `bitcoin-rs-storage`
 

--- a/crates/coinstats/README.md
+++ b/crates/coinstats/README.md
@@ -4,14 +4,14 @@ Owns running UTXO-set statistics: the `MuHash3072` accumulator, incremental per-
 `CoinStats`, their persistence, and the rewind that owed derived state requires when a
 block disconnects.
 
-`MuHash3072` is Bitcoin Core's 3072-bit MuHash as a running numerator/denominator
+`MuHash3072` is Bitcoin Core's 3072-bit `MuHash` as a running numerator/denominator
 (`insert`, `remove`, `combine`, `finalize_hash` yielding the Core-compatible `uint256`).
 `CoinStats` folds the live set — `insert_utxo` and `remove_utxo` feed the accumulator and
 the scalar tallies — and serializes to a stable byte layout (`to_bytes`/`from_bytes`).
 `CoinStatsListener` keeps stats behind a lock, applies the block-level delta in
 `finish_block`, and exposes `rewind_block` as the explicit inverse for disconnects.
 `CoinStatsAccumulator` serves checkpoint traversals: `with_parallel_muhash` buffers exact
-coin preimages and combines ordered insert-only partial MuHash values, while
+coin preimages and combines ordered insert-only partial `MuHash` values, while
 `without_muhash` skips hashing entirely. `scan_coin_stats` recomputes stats on demand
 from a `UtxoSetView` (Core's on-demand model, no rolling listener required), and
 `store_coin_stats`/`load_coin_stats` persist rows keyed by little-endian height.
@@ -19,7 +19,7 @@ from a `UtxoSetView` (Core's on-demand model, no rolling listener required), and
 ## Features
 - `bench-mimalloc`: bench-only A/B allocator toggle; gates the `#[global_allocator]`
   registration in `benches/coinstats_hotpath.rs` only, off by default
-- `rocksdb`: enables the RocksDB backend in `bitcoin-rs-storage`
+- `rocksdb`: enables the `RocksDB` backend in `bitcoin-rs-storage`
 - `fjall`: enables the fjall backend in `bitcoin-rs-storage`
 - `redb`: enables the redb backend in `bitcoin-rs-storage`
 - `mdbx`: enables the MDBX backend in `bitcoin-rs-storage`

--- a/crates/electrum/README.md
+++ b/crates/electrum/README.md
@@ -17,7 +17,7 @@ connection, bounded by `ServerConfig::max_sessions`, with optional TLS — and
 `run_with_shutdown` stops it on an atomic flag.
 
 ## Features
-- `rocksdb`: enables the RocksDB backend in `bitcoin-rs-storage`
+- `rocksdb`: enables the `RocksDB` backend in `bitcoin-rs-storage`
 - `fjall`: enables the fjall backend in `bitcoin-rs-storage`
 - `redb`: enables the redb backend in `bitcoin-rs-storage`
 - `mdbx`: enables the MDBX backend in `bitcoin-rs-storage`

--- a/crates/filters/README.md
+++ b/crates/filters/README.md
@@ -3,7 +3,7 @@
 Owns BIP157/BIP158 compact block filters: the Golomb-coded-set codec, filter-header
 chaining, and the persistent filter index over the workspace key-value store.
 
-The `gcs` module implements the BIP158 codec: `key_from_block_hash` derives the SipHash
+The `gcs` module implements the BIP158 codec: `key_from_block_hash` derives the `SipHash`
 key from the first 16 block-hash bytes, `hash_elements` maps raw items into the set's
 range, `encode`/`decode` handle the Golomb-coded byte stream, and `matches` tests a
 filter against query targets (`GcsError` for malformed streams).
@@ -16,7 +16,7 @@ filter and its chained header atomically and returns the new header, `filter`,
 storage-agnostic ingest interface (`wants_filters`, `put_filter`).
 
 ## Features
-- `rocksdb`: enables the RocksDB backend in `bitcoin-rs-storage`
+- `rocksdb`: enables the `RocksDB` backend in `bitcoin-rs-storage`
 - `fjall`: enables the fjall backend in `bitcoin-rs-storage`
 - `redb`: enables the redb backend in `bitcoin-rs-storage`
 - `mdbx`: enables the MDBX backend in `bitcoin-rs-storage`

--- a/crates/index/README.md
+++ b/crates/index/README.md
@@ -1,7 +1,7 @@
 # bitcoin-rs-index
 
 Owns the confirmed-transaction index: electrs-shaped rows over the workspace key-value
-store, the versioned TxIndex watermark that pins rows to an exact active-chain prefix,
+store, the versioned `TxIndex` watermark that pins rows to an exact active-chain prefix,
 and Electrum scripthash status hashing.
 
 `Indexer<S: KvStore>` walks a serialized block once (`ingest_block`) and writes txid,
@@ -19,7 +19,7 @@ values carry transaction positions. Around the rows sit the stable types (`Scrip
 unconfirmed rows, and `compute_status_hash` over ordered `HistoryEntry`s.
 
 ## Features
-- `rocksdb`: enables the RocksDB backend in `bitcoin-rs-storage`
+- `rocksdb`: enables the `RocksDB` backend in `bitcoin-rs-storage`
 - `fjall`: enables the fjall backend in `bitcoin-rs-storage`
 - `redb`: enables the redb backend in `bitcoin-rs-storage`
 - `mdbx`: enables the MDBX backend in `bitcoin-rs-storage`


### PR DESCRIPTION
## Summary

- mark technical names as code in crate READMEs
- clear the `clippy::doc_markdown` failures blocking the node `-D warnings` lane

## Verification

- `cargo clippy -p bitcoin-rs-node --all-targets -- -D warnings`