### PR TITLE
fix(ci): publish guarded-test PID atomically

### DIFF
--- a/bin/bitcoin-rs/tests/g14_guarded_run.rs
+++ b/bin/bitcoin-rs/tests/g14_guarded_run.rs
@@ -97,7 +97,10 @@ fn sighup_stops_unit_kills_descendant_and_writes_failure_verdict()
 import pathlib
 import sys
 import time
-pathlib.Path(sys.argv[1]).write_text(str(os.getpid()), encoding="ascii")
+pid_path = pathlib.Path(sys.argv[1])
+pending_pid_path = pid_path.with_suffix(".tmp")
+pending_pid_path.write_text(str(os.getpid()), encoding="ascii")
+pending_pid_path.replace(pid_path)
 pathlib.Path(sys.argv[2]).mkdir()
 time.sleep(30)
 "#,


### PR DESCRIPTION
The guarded systemd SIGHUP integration test could observe an empty descendant PID file and fail before sending the signal. Its Python fixture now writes the PID to a sibling temporary file and atomically renames it into place, so path existence implies complete content.

Validation: `cargo test -p bitcoin-rs --test g14_guarded_run sighup_stops_unit_kills_descendant_and_writes_failure_verdict -- --exact` passed.
