### PR TITLE
fix: keep shell scripts LF so a Windows checkout can run them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Shell scripts must keep LF endings whatever the checkout platform.
+#
+# Git converts LF to CRLF on checkout wherever `core.autocrlf=true`, which is
+# the Windows default. The blobs here are LF, so this costs nothing on Linux --
+# but on a Windows checkout every one of these scripts fails on its second line
+# with `set: pipefail: invalid option name`, because the shell reads the
+# trailing carriage return as part of the option name.
+#
+# Two integration suites run these scripts and so fail with it:
+# `bin/bitcoin-rs/tests/g2_bitcoind_muhash_script.rs` and
+# `bin/bitcoin-rs/tests/g14_guarded_run.rs`. CI runs on Linux and never sees
+# any of it, so the failure looks like a broken checkout rather than a missing
+# attribute -- and the message points nowhere near the cause.
+*.sh text eol=lf


### PR DESCRIPTION
The repository has no `.gitattributes`, so on any checkout with `core.autocrlf=true` — the Windows default — all nine scripts under `scripts/` arrive with CRLF endings and fail on their second line:

```
$ bash scripts/collect-g2-bitcoind-muhash-samples.sh --print-heights 20001
scripts/collect-g2-bitcoind-muhash-samples.sh: line 2: set: pipefail: invalid option name
```

The shell reads the trailing carriage return as part of the option name.

## What it breaks

Two integration suites run those scripts:

| suite | before | after |
|---|---|---|
| `bin/bitcoin-rs/tests/g2_bitcoind_muhash_script.rs` | 0 / 3 | **3 / 3** |
| `bin/bitcoin-rs/tests/g14_guarded_run.rs` | 3 / 11 | **10 / 11** |

CI runs on Linux and never sees any of it, so on Windows this reads as a broken checkout rather than a missing attribute — and `set: pipefail: invalid option name` points nowhere near the cause. I spent a while assuming these were environmental before checking the bytes.

## What this changes

One line, `*.sh text eol=lf`. **The blobs are already LF**, so no file content changes and it is a no-op on Linux; it only stops the checkout from rewriting them. Verified: `git status` after re-checking-out all nine scripts shows only `.gitattributes` added.

## What it does not fix

`setsid_descendant_rss_breach_kills_tree_and_deletes_fixture` still fails here — the guard exits 0 where the test wants 75, i.e. it does not observe the detached descendant's RSS in this environment. That is a different problem and I am not claiming it fixed; it is the 1 of 11 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
