### PR TITLE
fix(consensus): restore the kernel-parity lane on main

### DIFF
--- a/crates/consensus/src/verify_block.rs
+++ b/crates/consensus/src/verify_block.rs
@@ -470,7 +470,12 @@ mod tests {
         block
     }
     fn check_block_rules(block: &Block, context: BlockRuleContext) -> Result<(), ConsensusError> {
-        let txids: Vec<Txid> = block.0.txdata.iter().map(|tx| tx.compute_txid()).collect();
+        let txids: Vec<Txid> = block
+            .0
+            .txdata
+            .iter()
+            .map(bitcoin::Transaction::compute_txid)
+            .collect();
         let has_witness = block_has_witness(&block.0);
         verify_block_rules_precomputed(&block.0, context, &txids, has_witness)
     }

--- a/crates/consensus/src/verify_tx.rs
+++ b/crates/consensus/src/verify_tx.rs
@@ -793,7 +793,7 @@ mod tests {
 
     use super::{
         ScriptStageTimings, is_final_tx_with_locktime_cutoff, verify_coinbase_script_sig_size,
-        verify_transaction, verify_transaction_non_script,
+        verify_transaction,
     };
 
     /// Wraps `txs` in a block and parses it the way production does, so tests


### PR DESCRIPTION
`kernel-parity` has been red on `main` since 30e8430 ("refactor(consensus): collapse transaction verification entrypoints"). Two mechanical leftovers of that refactor:

- **`verify_tx.rs:796`** still imports `verify_transaction_non_script` into the test module. The one remaining call site reaches it through `super::`, so the import is unused.
- **`verify_block.rs:473`** maps `|tx| tx.compute_txid()` where the method itself will do, which `redundant_closure_for_method_calls` refuses under `-D warnings`.

Both fail the lane's `cargo clippy -p bitcoin-rs-consensus --all-targets -- -D warnings` step. Because the errors are in a `lib test` target, the crate does not compile and **the lane never reaches its tests** — so the parity vectors have not run on `main` for as long as this has been broken.

## What changed since this PR was opened

It originally also carried an `fmt` fix. It no longer does. 19da503 ("style(consensus): satisfy Rust 1.95 formatting") landed the same reformatting on `main` independently, and rebasing onto 00938d8 absorbed it. The diff is now **2 files, 7 lines** — exactly the part `main` still needs, and nothing that duplicates work already done.

The title changed to match. Carrying a description that claims an `fmt` fix this branch no longer makes would be the smaller kind of lie, but still one.

## Verified

Run on this branch rebased onto `main` at 00938d8, using the lane's own steps rather than a paraphrase of them:

```
cargo fmt --all -- --check                                        ok
cargo clippy -p bitcoin-rs --all-targets -- -D warnings           ok
cargo clippy -p bitcoin-rs-consensus --all-targets -- -D warnings ok
cargo test -p bitcoin-rs-consensus --no-fail-fast -- --include-ignored  ok
```

The same two clippy errors reproduce on `origin/main` unpatched, so the lane's redness is confirmed present before and absent after, not assumed.

## No test

Deliberate. The constraint is already executable — it *is* the lane. A test asserting that source text satisfies a lint would be a second, weaker copy of a check CI already runs, and #122 asks for exactly the opposite: permanent tests should carry information that survives a different implementation, which this would not.

## Why separately

Nothing behavioural. A red lane costs every open PR its CI signal, and there are sixteen others. Landing this first is what makes their results mean anything.

Note also that the current `main` CI run has had `clippy`, `kernel-parity` and `bench-smoke` sitting in `in_progress` for nine hours — so `main`'s signal is currently both red *and* stalled. This PR addresses the red half only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
