### PR TITLE
fix(wallet): declare the script backend psbt_roundtrip needs

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -80,7 +80,7 @@ mdbx = [
     "bitcoin-rs-index/mdbx",
     "bitcoin-rs-storage/mdbx",
 ]
-kernel = ["bitcoin-rs-consensus/kernel"]
+kernel = ["bitcoin-rs-consensus/kernel", "bitcoin-rs-wallet/kernel"]
 checksig-census = [
     "kernel",
     "bitcoin-rs-consensus/checksig-census",

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -37,6 +37,10 @@ tempfile = "3"
 
 [features]
 default = []
+# The real script backend, for the one test that verifies a finished
+# transaction against consensus. Off by default, as `bitcoin-rs-consensus`'s
+# own workspace declaration is, so a portable build stays portable.
+kernel = ["bitcoin-rs-consensus/kernel"]
 rocksdb = ["bitcoin-rs-storage/rocksdb"]
 fjall = ["bitcoin-rs-storage/fjall"]
 redb = ["bitcoin-rs-storage/redb"]

--- a/crates/wallet/tests/psbt_roundtrip.rs
+++ b/crates/wallet/tests/psbt_roundtrip.rs
@@ -1,4 +1,35 @@
 //! PSBT build, external signing, finalization, and consensus roundtrips.
+//!
+//! **Gated on the `kernel` feature, because it needs the real script backend.**
+//! The last step hands the finished transaction to
+//! `bitcoin_rs_consensus::verify_transaction`, which without the kernel routes
+//! to `verify_non_taproot_portable` -- a stub that accepts only bare `OP_TRUE`
+//! and refuses everything else.
+//!
+//! Before the gate this crate declared no such dependency and the test passed
+//! anyway, because `cargo test --workspace` unifies features across members and
+//! `bin/bitcoin-rs` turns the kernel on. So it was green through a dependency it
+//! did not name, of a crate it did not mention -- and `cargo test -p
+//! bitcoin-rs-wallet` failed with "portable script backend cannot verify this
+//! non-taproot spend", a message about script backends, in a PSBT test, with
+//! nothing connecting the two.
+//!
+//! Two things follow, and both matter:
+//!
+//! - `crates/node`'s `kernel` feature now forwards to this crate's, so anything
+//!   turning the kernel on turns it on here too. `cargo test --workspace` still
+//!   runs this.
+//! - A gated-out file is an empty binary, and an empty binary reports success --
+//!   which is the failure mode the gate exists to remove. `psbt_roundtrip_gate`
+//!   compiles in its place and says what is not being checked.
+//!
+//! Run it alone with:
+//!
+//! ```text
+//! cargo test -p bitcoin-rs-wallet --features kernel --test psbt_roundtrip
+//! ```
+#![cfg(feature = "kernel")]
+
 use std::collections::BTreeMap;
 
 use bitcoin::hashes::Hash as _;

--- a/crates/wallet/tests/psbt_roundtrip_gate.rs
+++ b/crates/wallet/tests/psbt_roundtrip_gate.rs
@@ -1,0 +1,61 @@
+//! What runs in place of `psbt_roundtrip` when the kernel backend is absent.
+//!
+//! A gated-out test file compiles to an empty binary, and an empty binary
+//! reports success. That is the failure mode the gate on `psbt_roundtrip` was
+//! added to remove, so replacing one silence with another would be no
+//! improvement: this keeps a named test in the output, so a run that skips the
+//! consensus roundtrip looks like a run that skips it.
+//!
+//! It also checks that the reason is the one claimed. If the portable backend
+//! ever starts verifying real spends, `psbt_roundtrip` is being skipped for a
+//! reason that no longer holds, and somebody should find that out here rather
+//! than by wondering why coverage went quiet.
+#![cfg(not(feature = "kernel"))]
+
+use bitcoin::hashes::Hash as _;
+use bitcoin::{Amount, OutPoint, PubkeyHash, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid};
+use bitcoin_rs_script::{Interpreter, VerifyFlags};
+
+/// The portable script backend is why the consensus roundtrip is not running.
+///
+/// Asked of the backend directly rather than through
+/// `bitcoin_rs_consensus::verify_transaction`, because the backend is the whole
+/// of the reason and going through the consensus layer would add height and
+/// locktime rules that have nothing to do with it.
+#[test]
+fn the_consensus_roundtrip_needs_the_kernel_backend() {
+    let prevout = TxOut {
+        value: Amount::from_sat(1_000),
+        script_pubkey: ScriptBuf::new_p2pkh(&PubkeyHash::from_byte_array([7_u8; 20])),
+    };
+    let spending = Transaction {
+        version: bitcoin::transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::new(Txid::from_byte_array([3_u8; 32]), 0),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: bitcoin::Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(900),
+            script_pubkey: ScriptBuf::new_p2pkh(&PubkeyHash::from_byte_array([9_u8; 20])),
+        }],
+    };
+
+    let outcome = Interpreter::default().execute(
+        prevout.script_pubkey.as_bytes(),
+        &[],
+        &[],
+        VerifyFlags::P2SH,
+        &prevout,
+        &spending,
+        0,
+    );
+    assert!(
+        outcome.is_err(),
+        "the portable backend verified a real spend, so `psbt_roundtrip` is \
+         being skipped for a reason that no longer holds -- run it with \
+         `--features kernel` and consider removing the gate"
+    );
+}


### PR DESCRIPTION
Closes #147.

`psbt_roundtrip.rs` verifies its finished transaction with `bitcoin_rs_consensus::verify_transaction`, which without the kernel routes to `verify_non_taproot_portable` — a stub accepting only bare `OP_TRUE`. The wallet crate declared no such dependency: `bitcoin-rs-consensus` is a dev-dependency taken with `default-features = false`, so `kernel` is off for a per-crate build.

It passed anyway, because `cargo test --workspace` unifies features across members and `bin/bitcoin-rs` turns the kernel on. **Green through a dependency it did not name, of a crate it did not mention** — while `cargo test -p bitcoin-rs-wallet` failed with `portable script backend cannot verify this non-taproot spend`: a message about script backends, in a PSBT test, with nothing connecting the two.

The wallet now has a `kernel` feature forwarding to `bitcoin-rs-consensus/kernel`, and the test is gated on it.

## Two things gating alone would have got wrong

**CI would have stopped running it.** Feature unification lifts a *dependency's* features, not the wallet's own — so `cargo test --workspace` would have skipped the gated file and reported the same unbroken green while checking strictly less. That is the original bug wearing a different hat. `crates/node`'s `kernel` feature now forwards to the wallet's, so anything turning the kernel on turns it on here too.

**A gated-out file is an empty binary, and an empty binary reports success** — which is the failure mode this is meant to remove. `psbt_roundtrip_gate.rs` compiles in its place when the feature is off, so the skip appears in the output as a named test rather than as nothing. It also asserts the portable backend really does refuse a real spend: if that ever stops being true, `psbt_roundtrip` is being skipped for a reason that no longer holds, and somebody finds out here instead of wondering why coverage went quiet.

## Verified in all three configurations

| invocation | roundtrip | gate |
|---|---|---|
| `-p bitcoin-rs-wallet --no-default-features` | skipped | **runs** |
| `-p bitcoin-rs-wallet --features kernel` | **runs** | skipped |
| `cargo test --workspace` (what CI runs) | **runs** | skipped |

Each was executed, not reasoned about — the middle row is the one that would have silently regressed.

## Note on CI

This branch is cut from `main` at `2cf953f`, where the `fmt` and `kernel-parity` jobs are already failing for reasons unrelated to it (`30e8430`). #161 fixes those; expect those two jobs red here until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
