### PR TITLE
Expose Core network controls

### DIFF
--- a/crates/p2p/src/connection.rs
+++ b/crates/p2p/src/connection.rs
@@ -2,7 +2,8 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use std::time::Duration;
 
 use crossbeam_channel::{SendError, Sender};
 
@@ -20,6 +21,163 @@ impl ConnectionId {
             Ok(id) => Self(id),
             Err(_) => std::process::abort(),
         }
+    }
+
+    /// Returns the process-unique numeric id backing this identity.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Live traffic and ping telemetry for one peer connection.
+///
+/// Shared between the connection's reader/writer threads and external
+/// observers (network control queries), so every counter is atomic and every
+/// timestamp is supplied by the caller for deterministic tests. Timestamps are
+/// Unix microseconds; ping durations are microseconds.
+#[derive(Debug)]
+pub struct PeerStats {
+    bytes_recv: AtomicU64,
+    bytes_sent: AtomicU64,
+    msgs_recv: AtomicU64,
+    msgs_sent: AtomicU64,
+    time_offset_secs: AtomicI64,
+    next_ping_nonce: AtomicU64,
+    ping_out_nonce: AtomicU64,
+    ping_sent_us: AtomicU64,
+    last_ping_us: AtomicU64,
+    min_ping_us: AtomicU64,
+}
+
+impl Default for PeerStats {
+    fn default() -> Self {
+        Self {
+            bytes_recv: AtomicU64::new(0),
+            bytes_sent: AtomicU64::new(0),
+            msgs_recv: AtomicU64::new(0),
+            msgs_sent: AtomicU64::new(0),
+            time_offset_secs: AtomicI64::new(TIME_OFFSET_UNSET),
+            next_ping_nonce: AtomicU64::new(0),
+            ping_out_nonce: AtomicU64::new(0),
+            ping_sent_us: AtomicU64::new(0),
+            last_ping_us: AtomicU64::new(0),
+            min_ping_us: AtomicU64::new(0),
+        }
+    }
+}
+
+/// Sentinel for "no time offset recorded yet" (`0` is a valid offset).
+const TIME_OFFSET_UNSET: i64 = i64::MIN;
+
+impl PeerStats {
+    /// Accounts `bytes` of received wire traffic.
+    pub fn record_recv(&self, bytes: u64) {
+        self.bytes_recv.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Accounts `bytes` of sent wire traffic.
+    pub fn record_sent(&self, bytes: u64) {
+        self.bytes_sent.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Counts one received message.
+    pub fn record_msg_recv(&self) {
+        self.msgs_recv.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Counts one sent message.
+    pub fn record_msg_sent(&self) {
+        self.msgs_sent.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Total wire bytes received on this connection.
+    #[must_use]
+    pub fn bytes_recv(&self) -> u64 {
+        self.bytes_recv.load(Ordering::Relaxed)
+    }
+
+    /// Total wire bytes sent on this connection.
+    #[must_use]
+    pub fn bytes_sent(&self) -> u64 {
+        self.bytes_sent.load(Ordering::Relaxed)
+    }
+
+    /// Number of messages received on this connection.
+    #[must_use]
+    pub fn msgs_recv(&self) -> u64 {
+        self.msgs_recv.load(Ordering::Relaxed)
+    }
+
+    /// Number of messages sent on this connection.
+    #[must_use]
+    pub fn msgs_sent(&self) -> u64 {
+        self.msgs_sent.load(Ordering::Relaxed)
+    }
+
+    /// Records the remote clock offset in seconds observed from its `version`.
+    pub fn set_time_offset(&self, offset_secs: i64) {
+        self.time_offset_secs.store(offset_secs, Ordering::Relaxed);
+    }
+
+    /// Remote clock offset in seconds, when a `version` message was observed.
+    #[must_use]
+    pub fn time_offset(&self) -> Option<i64> {
+        let offset = self.time_offset_secs.load(Ordering::Relaxed);
+        (offset != TIME_OFFSET_UNSET).then_some(offset)
+    }
+
+    /// Registers an outgoing ping at `now_us` and returns its nonce.
+    ///
+    /// Mirrors Bitcoin Core: a new ping supersedes any outstanding one, so a
+    /// later pong carrying a stale nonce is discarded by [`Self::complete_ping`].
+    pub fn begin_ping(&self, now_us: u64) -> u64 {
+        let nonce = self.next_ping_nonce.fetch_add(1, Ordering::Relaxed) + 1;
+        self.ping_out_nonce.store(nonce, Ordering::Relaxed);
+        self.ping_sent_us.store(now_us, Ordering::Relaxed);
+        nonce
+    }
+
+    /// Completes the outstanding ping when `nonce` matches, returning its
+    /// round-trip duration; a stale or unknown nonce completes nothing.
+    pub fn complete_ping(&self, nonce: u64, now_us: u64) -> Option<u64> {
+        if self
+            .ping_out_nonce
+            .compare_exchange(nonce, 0, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return None;
+        }
+        let elapsed = now_us.saturating_sub(self.ping_sent_us.load(Ordering::Relaxed));
+        self.last_ping_us.store(elapsed, Ordering::Relaxed);
+        let prior = self.min_ping_us.load(Ordering::Relaxed);
+        if prior == 0 || elapsed < prior {
+            self.min_ping_us.store(elapsed, Ordering::Relaxed);
+        }
+        Some(elapsed)
+    }
+
+    /// Duration of the most recently completed ping round trip.
+    #[must_use]
+    pub fn ping_time(&self) -> Option<Duration> {
+        let micros = self.last_ping_us.load(Ordering::Relaxed);
+        (micros != 0).then(|| Duration::from_micros(micros))
+    }
+
+    /// Shortest observed ping round trip on this connection.
+    #[must_use]
+    pub fn min_ping(&self) -> Option<Duration> {
+        let micros = self.min_ping_us.load(Ordering::Relaxed);
+        (micros != 0).then(|| Duration::from_micros(micros))
+    }
+
+    /// Time an outstanding ping has been unanswered at `now_us`.
+    #[must_use]
+    pub fn ping_wait(&self, now_us: u64) -> Option<Duration> {
+        let nonce = self.ping_out_nonce.load(Ordering::Relaxed);
+        (nonce != 0).then(|| {
+            Duration::from_micros(now_us.saturating_sub(self.ping_sent_us.load(Ordering::Relaxed)))
+        })
     }
 }
 
@@ -40,17 +198,55 @@ pub struct PeerLease {
     id: ConnectionId,
     outbound: Sender<crate::Message>,
     cancel: Arc<AtomicBool>,
+    stats: Arc<PeerStats>,
+    inbound: bool,
 }
 
 impl PeerLease {
-    /// Creates a lease with a fresh process-unique identity.
+    /// Creates an outbound-direction lease with a fresh process-unique identity.
     #[must_use]
     pub fn new(outbound: Sender<crate::Message>) -> Self {
+        Self::with_direction(outbound, false)
+    }
+
+    /// Creates an inbound-direction lease with a fresh process-unique identity.
+    #[must_use]
+    pub fn new_inbound(outbound: Sender<crate::Message>) -> Self {
+        Self::with_direction(outbound, true)
+    }
+
+    fn with_direction(outbound: Sender<crate::Message>, inbound: bool) -> Self {
         Self {
             id: ConnectionId::allocate(),
             outbound,
             cancel: Arc::new(AtomicBool::new(false)),
+            stats: Arc::new(PeerStats::default()),
+            inbound,
         }
+    }
+
+    /// Stable process-unique node id for this connection (Core `nodeid`).
+    #[must_use]
+    pub const fn node_id(&self) -> u64 {
+        self.id.get()
+    }
+
+    /// Whether this connection was accepted by the listener.
+    #[must_use]
+    pub const fn is_inbound(&self) -> bool {
+        self.inbound
+    }
+
+    /// Live traffic and ping telemetry for this connection.
+    #[must_use]
+    pub fn stats(&self) -> &PeerStats {
+        &self.stats
+    }
+
+    /// Shared handle to this connection's telemetry.
+    #[must_use]
+    pub fn stats_handle(&self) -> Arc<PeerStats> {
+        Arc::clone(&self.stats)
     }
 
     /// Stamps an inbound event with this connection's identity and address.
@@ -117,5 +313,73 @@ mod tests {
         lease.cancel();
 
         assert!(clone.is_cancelled());
+    }
+
+    #[test]
+    fn node_ids_are_stable_and_distinct() {
+        let (first_tx, _first_rx) = crossbeam_channel::unbounded();
+        let (second_tx, _second_rx) = crossbeam_channel::unbounded();
+        let first = PeerLease::new(first_tx);
+        let clone = first.clone();
+        let second = PeerLease::new(second_tx);
+
+        assert_eq!(first.node_id(), clone.node_id());
+        assert_ne!(first.node_id(), second.node_id());
+    }
+
+    #[test]
+    fn direction_distinguishes_inbound_from_outbound_leases() {
+        let (tx, _rx) = crossbeam_channel::unbounded();
+        assert!(!PeerLease::new(tx.clone()).is_inbound());
+        assert!(PeerLease::new_inbound(tx).is_inbound());
+    }
+
+    #[test]
+    fn ping_round_trip_records_last_and_min_durations() {
+        let stats = super::PeerStats::default();
+
+        let first = stats.begin_ping(1_000);
+        assert_eq!(stats.complete_ping(first, 3_000), Some(2_000));
+        let second = stats.begin_ping(10_000);
+        assert_eq!(stats.complete_ping(second, 11_000), Some(1_000));
+
+        assert_eq!(stats.ping_time(), Some(std::time::Duration::from_millis(1)));
+        assert_eq!(stats.min_ping(), Some(std::time::Duration::from_millis(1)));
+        assert_eq!(stats.ping_wait(12_000), None);
+    }
+
+    #[test]
+    fn stale_ping_nonce_does_not_complete_outstanding_ping() {
+        let stats = super::PeerStats::default();
+
+        let superseded = stats.begin_ping(1_000);
+        let current = stats.begin_ping(2_000);
+
+        assert_eq!(stats.complete_ping(superseded, 9_000), None);
+        assert_eq!(
+            stats.ping_wait(3_000),
+            Some(std::time::Duration::from_millis(1))
+        );
+        assert_eq!(stats.complete_ping(current, 9_000), Some(7_000));
+    }
+
+    #[test]
+    fn traffic_and_offset_counters_accumulate() {
+        let stats = super::PeerStats::default();
+        assert_eq!(stats.time_offset(), None);
+
+        stats.record_recv(120);
+        stats.record_recv(24);
+        stats.record_sent(48);
+        stats.record_msg_recv();
+        stats.record_msg_recv();
+        stats.record_msg_sent();
+        stats.set_time_offset(-3);
+
+        assert_eq!(stats.bytes_recv(), 144);
+        assert_eq!(stats.bytes_sent(), 48);
+        assert_eq!(stats.msgs_recv(), 2);
+        assert_eq!(stats.msgs_sent(), 1);
+        assert_eq!(stats.time_offset(), Some(-3));
     }
 }

--- a/crates/p2p/src/handshake.rs
+++ b/crates/p2p/src/handshake.rs
@@ -1,11 +1,14 @@
 use std::io::{Cursor, Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::sync::Arc;
+use std::time::Instant;
 
 use bitcoin::p2p::ServiceFlags;
 use bitcoin::p2p::address::Address;
 use bitcoin::p2p::message_network::VersionMessage;
 use bitcoin_rs_primitives::USER_AGENT;
 
+use crate::connection::PeerLease;
 use crate::dispatch::dispatch_inbound;
 use crate::peer::{Peer, PeerState};
 use crate::wire::{Message, PROTOCOL_VERSION, PeerError, read_message};
@@ -67,36 +70,117 @@ pub fn handshake_cursors(
 /// `Version`, sends our `Version` followed by feature-negotiation messages and
 /// `Verack`, then dispatches inbound messages until the peer is ready.
 ///
+/// Reads tolerate transient `WouldBlock`/`TimedOut` errors so the caller can
+/// poll a short stream timeout: the handshake fails with a timeout error once
+/// `deadline` passes and with a lease-revoked protocol error as soon as the
+/// connection is cancelled, leaving connection teardown to the caller.
+///
 /// # Errors
 ///
-/// Returns [`PeerError`] if reading or writing the wire stream fails, or if the
-/// finite-state machine rejects any inbound message.
+/// Returns [`PeerError`] if reading or writing the wire stream fails, if the
+/// finite-state machine rejects any inbound message, if `deadline` passes
+/// before the peer reaches the ready state, or if the connection's lease is
+/// revoked mid-handshake.
 pub fn run_inbound_handshake<S: Read + Write>(
     peer: &mut Peer<S>,
     our_nonce: u64,
     our_start_height: i32,
+    lease: &PeerLease,
+    totals: Option<&Arc<crate::TrafficTotals>>,
+    deadline: Instant,
 ) -> Result<(), PeerError> {
-    let (remote_version, _) = read_message(&mut peer.stream, peer.magic)?;
+    let (remote_version, _) = read_handshake_message(peer, lease, totals, deadline)?;
     let responses = dispatch_inbound(peer, &remote_version)?;
 
     peer.state = PeerState::VersionExchange;
-    peer.send(&Message::Version(version_message(
-        our_nonce,
-        our_start_height,
-    )))?;
+    send_handshake_message(
+        peer,
+        &Message::Version(version_message(our_nonce, our_start_height)),
+        lease,
+        totals,
+    )?;
     for response in responses {
-        peer.send(&response)?;
+        send_handshake_message(peer, &response, lease, totals)?;
     }
 
     while peer.state != PeerState::Ready {
-        let (inbound, _) = read_message(&mut peer.stream, peer.magic)?;
+        let (inbound, _) = read_handshake_message(peer, lease, totals, deadline)?;
         let responses = dispatch_inbound(peer, &inbound)?;
         for response in responses {
-            peer.send(&response)?;
+            send_handshake_message(peer, &response, lease, totals)?;
         }
     }
 
     Ok(())
+}
+
+/// Sends one handshake message, accounting its wire bytes on the connection.
+///
+/// Handshake writes leave the connection thread directly, before the
+/// per-connection writer exists, so this phase's telemetry owner is the
+/// connection itself: bytes land on the lease's [`crate::PeerStats`] and,
+/// when the entry point was built from a `NetworkControls` instance, on the
+/// shared aggregate totals.
+pub(crate) fn send_handshake_message<S: Read + Write>(
+    peer: &mut Peer<S>,
+    message: &Message,
+    lease: &PeerLease,
+    totals: Option<&Arc<crate::TrafficTotals>>,
+) -> Result<(), PeerError> {
+    peer.send(message)?;
+    let wire_len =
+        u64::try_from(crate::wire::HEADER_LEN + crate::wire::encode_payload(message)?.len())
+            .unwrap_or(u64::MAX);
+    lease.stats().record_sent(wire_len);
+    lease.stats().record_msg_sent();
+    if let Some(totals) = totals {
+        totals.record_sent(wire_len);
+    }
+    Ok(())
+}
+
+/// Reads one handshake message, retrying transient poll timeouts.
+///
+/// Wire bytes of every message read are accounted on the connection's
+/// telemetry and, when present, the shared aggregate totals, mirroring the
+/// message loop's reader accounting so handshake traffic is observable.
+pub(crate) fn read_handshake_message<S: Read>(
+    peer: &mut Peer<S>,
+    lease: &PeerLease,
+    totals: Option<&Arc<crate::TrafficTotals>>,
+    deadline: Instant,
+) -> Result<(Message, bytes::Bytes), PeerError> {
+    loop {
+        if lease.is_cancelled() {
+            return Err(PeerError::Protocol("peer lease revoked during handshake"));
+        }
+        if Instant::now() >= deadline {
+            return Err(PeerError::Io(std::io::Error::from(
+                std::io::ErrorKind::TimedOut,
+            )));
+        }
+        match read_message(&mut peer.stream, peer.magic) {
+            Ok((message, raw)) => {
+                let wire_len =
+                    u64::try_from(raw.len() + crate::wire::HEADER_LEN).unwrap_or(u64::MAX);
+                lease.stats().record_recv(wire_len);
+                lease.stats().record_msg_recv();
+                if let Some(totals) = totals {
+                    totals.record_recv(wire_len);
+                }
+                return Ok((message, raw));
+            }
+            Err(PeerError::Io(error))
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                continue;
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 fn exchange<A, B>(
@@ -173,7 +257,17 @@ mod tests {
         let stream = ScriptedStream::new(remote_outbound);
         let mut peer = Peer::new(stream, magic);
 
-        run_inbound_handshake(&mut peer, 1, 0)?;
+        let (lease_tx, _lease_rx) = crossbeam_channel::unbounded();
+        let lease = crate::PeerLease::new_inbound(lease_tx);
+
+        run_inbound_handshake(
+            &mut peer,
+            1,
+            0,
+            &lease,
+            None,
+            std::time::Instant::now() + std::time::Duration::from_secs(5),
+        )?;
 
         assert_eq!(peer.state, PeerState::Ready, "inbound peer reaches Ready");
         assert!(

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -30,11 +30,15 @@ pub mod wire;
 /// BIP339 wtxid-relay state.
 pub mod wtxid;
 
-pub use connection::{ConnectionId, PeerLease, PeerSource};
+pub use connection::{ConnectionId, PeerLease, PeerSource, PeerStats};
 pub use dispatch::{ChainQuery, InventoryResponse};
 pub use inbound::{InboundBlock, InboundHeaders};
 pub use listener::spawn_outbound_connection;
-pub use peer::{DnsResolver, Peer, PeerManager, PeerState, SystemDnsResolver};
+pub use peer::{
+    AddNodeError, AddedNodeInfo, BanError, ConnectedPeer, ConnectionCounts, DnsResolver,
+    MAX_BLOCK_SERIALIZED_SIZE, NetworkActivity, NetworkControls, NodeAddress, Peer, PeerManager,
+    PeerState, SystemDnsResolver, TrafficTotals, UPLOAD_TIMEFRAME_SECS, UploadTarget,
+};
 pub use peer_info::PeerInfo;
 pub use subnet::{BannedSubnet, IpSubnet, SubnetParseError};
 pub use wire::{Message, PeerError};

--- a/crates/p2p/src/listener.rs
+++ b/crates/p2p/src/listener.rs
@@ -2,24 +2,119 @@ use std::io;
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bitcoin::p2p::Magic;
 use crossbeam_channel::Sender;
 use parking_lot::RwLock;
-
 use thiserror::Error;
 
 use crate::handshake::run_inbound_handshake;
 use crate::peer::Peer;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+/// Maximum backoff for transient accept errors (ECONNABORTED, EMFILE, …).
+/// Bounded so the listener recovers quickly once the pressure clears.
+const ACCEPT_BACKOFF_MAX: Duration = Duration::from_secs(10);
 const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_mins(1);
+/// Stream read timeout used while polling handshake and message reads.
+const STREAM_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
 type ChainQueryHandle = Option<Arc<dyn crate::dispatch::ChainQuery + 'static>>;
 type SyncWakeHandle = Option<Sender<()>>;
 type PeerRegistrationHandle =
     Option<Arc<dyn Fn(SocketAddr, crate::PeerLease, crate::PeerInfo) -> bool + Send + Sync>>;
 
+/// State shared by the listener and every connection thread it spawns.
+///
+/// The peer maps and ban list are the authoritative stores shared with the
+/// node and its network control plane; `activity` and `totals` carry the
+/// kill-switch and aggregate traffic accounting and are present only when the
+/// entry point was built from a [`crate::NetworkControls`] instance.
+#[derive(Clone)]
+struct ConnectionShared {
+    peer_registry: Arc<RwLock<Vec<crate::PeerInfo>>>,
+    peer_outbound: Arc<RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>>,
+    banned: Arc<RwLock<Vec<crate::BannedSubnet>>>,
+    activity: Option<Arc<crate::NetworkActivity>>,
+    totals: Option<Arc<crate::TrafficTotals>>,
+    chain_query: ChainQueryHandle,
+    peer_registered: PeerRegistrationHandle,
+}
+
+impl ConnectionShared {
+    fn from_parts(
+        peer_registry: Arc<RwLock<Vec<crate::PeerInfo>>>,
+        peer_outbound: Arc<RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>>,
+        banned: Arc<RwLock<Vec<crate::BannedSubnet>>>,
+        chain_query: ChainQueryHandle,
+        peer_registered: PeerRegistrationHandle,
+    ) -> Self {
+        Self {
+            peer_registry,
+            peer_outbound,
+            banned,
+            activity: None,
+            totals: None,
+            chain_query,
+            peer_registered,
+        }
+    }
+
+    fn from_controls(
+        controls: &Arc<crate::NetworkControls>,
+        chain_query: ChainQueryHandle,
+        peer_registered: PeerRegistrationHandle,
+    ) -> Self {
+        Self {
+            peer_registry: Arc::clone(controls.peer_registry()),
+            peer_outbound: Arc::clone(controls.peer_outbound()),
+            banned: Arc::clone(controls.banned()),
+            activity: Some(Arc::clone(controls.activity())),
+            totals: Some(Arc::clone(controls.totals())),
+            chain_query,
+            peer_registered,
+        }
+    }
+}
+
+/// Registers one connection's lease at connection start, cancelling any live
+/// predecessor at the same address.
+///
+/// Registration happens before the handshake so live-connection accounting
+/// covers handshaking peers exactly like Core's connection manager.
+fn register_connection(
+    peer_outbound: &RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>,
+    peer_addr: SocketAddr,
+    lease: crate::PeerLease,
+) -> bool {
+    let mut outbound = peer_outbound.write();
+    outbound.insert(peer_addr, lease).is_some_and(|prior| {
+        prior.cancel();
+        true
+    })
+}
+
+/// Publishes handshake metadata for an already-registered connection.
+fn publish_peer_info(
+    peer_registry: &RwLock<Vec<crate::PeerInfo>>,
+    peer_registered: Option<
+        &(dyn Fn(SocketAddr, crate::PeerLease, crate::PeerInfo) -> bool + Send + Sync),
+    >,
+    peer_addr: SocketAddr,
+    lease: crate::PeerLease,
+    info: crate::PeerInfo,
+) {
+    if let Some(peer_registered) = peer_registered {
+        peer_registered(peer_addr, lease, info);
+        return;
+    }
+    let mut registry = peer_registry.write();
+    registry.retain(|peer| peer.addr != peer_addr);
+    registry.push(info);
+}
+
+#[cfg(test)]
 fn register_peer(
     peer_registry: &RwLock<Vec<crate::PeerInfo>>,
     peer_outbound: &RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>,
@@ -30,18 +125,8 @@ fn register_peer(
     lease: crate::PeerLease,
     info: crate::PeerInfo,
 ) -> bool {
-    if let Some(peer_registered) = peer_registered {
-        return peer_registered(peer_addr, lease, info);
-    }
-
-    let mut outbound = peer_outbound.write();
-    let replaced = outbound.insert(peer_addr, lease).is_some_and(|prior| {
-        prior.cancel();
-        true
-    });
-    let mut registry = peer_registry.write();
-    registry.retain(|peer| peer.addr != peer_addr);
-    registry.push(info);
+    let replaced = register_connection(peer_outbound, peer_addr, lease.clone());
+    publish_peer_info(peer_registry, peer_registered, peer_addr, lease, info);
     replaced
 }
 
@@ -177,42 +262,121 @@ pub fn serve_with_shutdown_with_chain_and_sync_wake(
     sync_wake_tx: Option<Sender<()>>,
     peer_registered: PeerRegistrationHandle,
 ) -> Result<(), ListenerError> {
+    let shared = ConnectionShared::from_parts(
+        peer_registry,
+        peer_outbound,
+        banned,
+        chain_query,
+        peer_registered,
+    );
     let inbound_sync_sinks = InboundSyncSinks {
         headers_tx: inbound_headers_tx,
         blocks_tx: inbound_blocks_tx,
         wake_tx: sync_wake_tx,
     };
+    serve_connections(addr, &shutdown, magic, &shared, &inbound_sync_sinks)
+}
+
+/// Accept-loop core shared by every listener entry point.
+///
+/// Bind and `set_nonblocking` failures are fatal and propagated as
+/// [`ListenerError::Bind`]. Transient `accept` errors (ECONNABORTED,
+/// EMFILE/ENFILE under fd pressure, etc.) are logged at warn and the loop
+/// continues after a bounded backoff — matching Bitcoin Core's tolerant
+/// accept loop so inbound P2P stays alive through temporary resource
+/// exhaustion rather than permanently killing the listener thread.
+fn serve_connections(
+    addr: SocketAddr,
+    shutdown: &AtomicBool,
+    magic: Magic,
+    shared: &ConnectionShared,
+    inbound_sync_sinks: &InboundSyncSinks,
+) -> Result<(), ListenerError> {
     let listener =
         TcpListener::bind(addr).map_err(|source| ListenerError::Bind { addr, source })?;
     listener
         .set_nonblocking(true)
         .map_err(|source| ListenerError::Bind { addr, source })?;
+    let mut accept_backoff = POLL_INTERVAL;
     while !shutdown.load(Ordering::Relaxed) {
+        #[cfg(test)]
+        if ACCEPT_ERROR_INJECT.swap(false, Ordering::Relaxed) {
+            tracing::warn!(addr = %addr, "test-injected accept error; backing off");
+            std::thread::sleep(POLL_INTERVAL);
+            continue;
+        }
         match listener.accept() {
             Ok((stream, peer_addr)) => {
-                if crate::subnet::is_banned(&banned.read(), peer_addr.ip(), SystemTime::now()) {
+                accept_backoff = POLL_INTERVAL;
+                if crate::subnet::is_banned(
+                    &shared.banned.read(),
+                    peer_addr.ip(),
+                    SystemTime::now(),
+                ) {
                     drop(stream);
                     tracing::debug!(peer_addr = %peer_addr, "p2p inbound rejected: banned");
+                    continue;
+                }
+                if shared
+                    .activity
+                    .as_ref()
+                    .is_some_and(|activity| !activity.is_active())
+                {
+                    drop(stream);
+                    tracing::debug!(peer_addr = %peer_addr, "p2p inbound rejected: network inactive");
                     continue;
                 }
                 spawn_handshake_thread(
                     stream,
                     peer_addr,
                     magic,
-                    Arc::clone(&peer_registry),
-                    Arc::clone(&peer_outbound),
+                    shared.clone(),
                     inbound_sync_sinks.clone(),
-                    chain_query.clone(),
-                    peer_registered.clone(),
                 );
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
                 std::thread::sleep(POLL_INTERVAL);
             }
-            Err(error) => return Err(ListenerError::Accept(error)),
+            Err(error) => {
+                tracing::warn!(
+                    addr = %addr,
+                    %error,
+                    backoff_ms = accept_backoff.as_millis(),
+                    "p2p accept error; backing off and continuing",
+                );
+                std::thread::sleep(accept_backoff);
+                accept_backoff = std::cmp::min(accept_backoff * 2, ACCEPT_BACKOFF_MAX);
+            }
         }
     }
     Ok(())
+}
+
+/// Binds `addr` and runs the accept loop driven by one
+/// [`crate::NetworkControls`] instance.
+///
+/// Unlike the part-wise entry points, the listener enforces the control
+/// plane's network-activity switch on new inbound connections and accounts
+/// aggregate traffic into its shared totals.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+pub fn serve_with_controls(
+    addr: SocketAddr,
+    shutdown: Arc<AtomicBool>,
+    magic: Magic,
+    controls: Arc<crate::NetworkControls>,
+    inbound_headers_tx: Sender<crate::InboundHeaders>,
+    inbound_blocks_tx: Sender<crate::InboundBlock>,
+    chain_query: Option<Arc<dyn crate::dispatch::ChainQuery + 'static>>,
+    sync_wake_tx: Option<Sender<()>>,
+    peer_registered: PeerRegistrationHandle,
+) -> Result<(), ListenerError> {
+    let shared = ConnectionShared::from_controls(&controls, chain_query, peer_registered);
+    let inbound_sync_sinks = InboundSyncSinks {
+        headers_tx: inbound_headers_tx,
+        blocks_tx: inbound_blocks_tx,
+        wake_tx: sync_wake_tx,
+    };
+    serve_connections(addr, &shutdown, magic, &shared, &inbound_sync_sinks)
 }
 
 /// Spawns an outbound TCP connection to `addr`, performs the outbound P2P
@@ -258,26 +422,64 @@ pub fn spawn_outbound_connection_with_chain_and_sync_wake(
     sync_wake_tx: Option<Sender<()>>,
     peer_registered: PeerRegistrationHandle,
 ) -> std::thread::JoinHandle<Result<(), crate::wire::PeerError>> {
-    let inbound_sync_sinks = InboundSyncSinks {
-        headers_tx: inbound_headers_tx,
-        blocks_tx: inbound_blocks_tx,
-        wake_tx: sync_wake_tx,
-    };
+    let shared = ConnectionShared::from_parts(
+        peer_registry,
+        peer_outbound,
+        banned,
+        chain_query,
+        peer_registered,
+    );
+    spawn_outbound(
+        addr,
+        magic,
+        shared,
+        InboundSyncSinks {
+            headers_tx: inbound_headers_tx,
+            blocks_tx: inbound_blocks_tx,
+            wake_tx: sync_wake_tx,
+        },
+    )
+}
+
+/// Spawns an outbound connection driven by one [`crate::NetworkControls`]
+/// instance.
+///
+/// The dial is refused while the control plane's network-activity switch is
+/// off, and aggregate traffic is accounted into the shared totals.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+pub fn spawn_outbound_connection_with_controls(
+    addr: SocketAddr,
+    magic: Magic,
+    controls: Arc<crate::NetworkControls>,
+    inbound_headers_tx: Sender<crate::InboundHeaders>,
+    inbound_blocks_tx: Sender<crate::InboundBlock>,
+    chain_query: Option<Arc<dyn crate::dispatch::ChainQuery + 'static>>,
+    sync_wake_tx: Option<Sender<()>>,
+    peer_registered: PeerRegistrationHandle,
+) -> std::thread::JoinHandle<Result<(), crate::wire::PeerError>> {
+    let shared = ConnectionShared::from_controls(&controls, chain_query, peer_registered);
+    spawn_outbound(
+        addr,
+        magic,
+        shared,
+        InboundSyncSinks {
+            headers_tx: inbound_headers_tx,
+            blocks_tx: inbound_blocks_tx,
+            wake_tx: sync_wake_tx,
+        },
+    )
+}
+
+fn spawn_outbound(
+    addr: SocketAddr,
+    magic: Magic,
+    shared: ConnectionShared,
+    inbound_sync_sinks: InboundSyncSinks,
+) -> std::thread::JoinHandle<Result<(), crate::wire::PeerError>> {
     let thread_name = format!("bitcoin-rs-p2p-outbound-{addr}");
     let result = std::thread::Builder::new()
         .name(thread_name)
-        .spawn(move || {
-            run_outbound_connection(
-                addr,
-                magic,
-                &peer_registry,
-                &peer_outbound,
-                &inbound_sync_sinks,
-                &banned,
-                &chain_query,
-                peer_registered.as_deref(),
-            )
-        });
+        .spawn(move || run_outbound_connection(addr, magic, &shared, &inbound_sync_sinks));
 
     match result {
         Ok(handle) => handle,
@@ -295,111 +497,99 @@ pub fn spawn_outbound_connection_with_chain_and_sync_wake(
 fn run_outbound_connection(
     addr: SocketAddr,
     magic: Magic,
-    peer_registry: &RwLock<Vec<crate::PeerInfo>>,
-    peer_outbound: &RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>,
+    shared: &ConnectionShared,
     inbound_sync_sinks: &InboundSyncSinks,
-    banned: &RwLock<Vec<crate::BannedSubnet>>,
-    chain_query: &ChainQueryHandle,
-    peer_registered: Option<
-        &(dyn Fn(SocketAddr, crate::PeerLease, crate::PeerInfo) -> bool + Send + Sync),
-    >,
 ) -> Result<(), crate::wire::PeerError> {
-    if crate::subnet::is_banned(&banned.read(), addr.ip(), SystemTime::now()) {
+    if crate::subnet::is_banned(&shared.banned.read(), addr.ip(), SystemTime::now()) {
         return Err(crate::wire::PeerError::BannedDestination(addr.ip()));
+    }
+    if shared
+        .activity
+        .as_ref()
+        .is_some_and(|activity| !activity.is_active())
+    {
+        return Err(crate::wire::PeerError::Protocol("network inactive"));
     }
 
     let stream = TcpStream::connect_timeout(&addr, Duration::from_secs(10))
         .map_err(crate::wire::PeerError::Io)?;
     stream
-        .set_read_timeout(Some(HANDSHAKE_READ_TIMEOUT))
+        .set_read_timeout(Some(STREAM_POLL_INTERVAL))
         .map_err(crate::wire::PeerError::Io)?;
     stream
         .set_write_timeout(Some(HANDSHAKE_READ_TIMEOUT))
         .map_err(crate::wire::PeerError::Io)?;
 
+    // Register the connection before the handshake so live-connection
+    // accounting covers handshaking peers exactly like Core's connman.
+    let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded::<crate::Message>();
+    let lease = crate::PeerLease::new(outbound_tx);
+    register_connection(&shared.peer_outbound, addr, lease.clone());
+
     let nonce = generate_nonce(addr);
     let mut peer = Peer::new(stream, magic);
-    run_outbound_handshake(&mut peer, nonce, 0)?;
+    let handshake_deadline = Instant::now() + HANDSHAKE_READ_TIMEOUT;
+    if let Err(error) = run_outbound_handshake(
+        &mut peer,
+        nonce,
+        0,
+        &lease,
+        shared.totals.as_ref(),
+        handshake_deadline,
+    ) {
+        remove_current_peer(&shared.peer_registry, &shared.peer_outbound, addr, &lease);
+        let _ = peer.stream.shutdown(std::net::Shutdown::Both);
+        if lease.is_cancelled() {
+            tracing::debug!(peer_addr = %addr, "p2p outbound lease revoked during handshake");
+            return Ok(());
+        }
+        return Err(error);
+    }
 
     let Some(remote_version) = peer.remote_version.as_ref() else {
+        remove_current_peer(&shared.peer_registry, &shared.peer_outbound, addr, &lease);
+        let _ = peer.stream.shutdown(std::net::Shutdown::Both);
         return Err(crate::wire::PeerError::Protocol(
             "missing remote version after outbound handshake",
         ));
     };
-    let conn_time = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_secs());
+    let handshake_now = SystemTime::now();
+    let conn_time = unix_secs(handshake_now);
     let info = crate::PeerInfo::outbound_from_version(addr, remote_version, conn_time);
+    lease
+        .stats()
+        .set_time_offset(remote_version.timestamp - unix_secs_i64(handshake_now));
 
-    let writer_stream = peer
-        .stream
-        .try_clone()
-        .map_err(crate::wire::PeerError::Io)?;
-    let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded::<crate::Message>();
-    let writer = spawn_connection_writer(writer_stream, magic, outbound_rx, addr)
-        .map_err(crate::wire::PeerError::Io)?;
-    let lease = crate::PeerLease::new(outbound_tx);
-    register_peer(
-        peer_registry,
-        peer_outbound,
-        peer_registered,
+    run_connected_session(
+        &mut peer,
         addr,
-        lease.clone(),
+        magic,
+        shared,
+        inbound_sync_sinks,
+        lease,
+        outbound_rx,
         info,
-    );
-
-    tracing::info!(
-        peer_addr = %addr,
-        "p2p outbound handshake complete; entering message loop",
-    );
-
-    let loop_result = (|| {
-        peer.stream
-            .set_read_timeout(Some(Duration::from_secs(1)))
-            .map_err(crate::wire::PeerError::Io)?;
-        run_message_loop(
-            &mut peer,
-            addr,
-            &lease,
-            inbound_sync_sinks,
-            chain_query.as_deref(),
-        )
-    })();
-
-    let removed_current = remove_current_peer(peer_registry, peer_outbound, addr, &lease);
-    debug_assert!(
-        removed_current
-            || peer_outbound
-                .read()
-                .get(&addr)
-                .is_none_or(|current| !current.same_connection(&lease))
-    );
-    let _ = peer.stream.shutdown(std::net::Shutdown::Both);
-    drop(lease);
-    let _ = writer.join();
-    if let Err(error) = &loop_result {
-        tracing::warn!(peer_addr = %addr, %error, "p2p outbound peer disconnected with error");
-    } else {
-        tracing::debug!(peer_addr = %addr, "p2p outbound peer disconnected cleanly");
-    }
-    loop_result
+    )
 }
 
 fn run_outbound_handshake<S: std::io::Read + std::io::Write>(
     peer: &mut Peer<S>,
     nonce: u64,
     start_height: i32,
+    lease: &crate::PeerLease,
+    totals: Option<&Arc<crate::TrafficTotals>>,
+    deadline: Instant,
 ) -> Result<(), crate::wire::PeerError> {
     let outbound_messages = crate::handshake::start(peer, nonce, start_height);
     for message in outbound_messages {
-        peer.send(&message)?;
+        crate::handshake::send_handshake_message(peer, &message, lease, totals)?;
     }
 
     while peer.state != crate::peer::PeerState::Ready {
-        let (inbound, _) = crate::wire::read_message(&mut peer.stream, peer.magic)?;
+        let (inbound, _) = crate::handshake::read_handshake_message(peer, lease, totals, deadline)?;
         let responses = crate::dispatch::dispatch_inbound(peer, &inbound)?;
         for response in responses {
-            peer.send(&response)?;
+            crate::handshake::send_handshake_message(peer, &response, lease, totals)?;
         }
     }
 
@@ -410,26 +600,16 @@ fn spawn_handshake_thread(
     stream: TcpStream,
     peer_addr: SocketAddr,
     magic: Magic,
-    registry: Arc<RwLock<Vec<crate::PeerInfo>>>,
-    peer_outbound: Arc<RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>>,
+    shared: ConnectionShared,
     inbound_sync_sinks: InboundSyncSinks,
-    chain_query: ChainQueryHandle,
-    peer_registered: PeerRegistrationHandle,
 ) {
     let thread_name = format!("bitcoin-rs-p2p-handshake-{peer_addr}");
     let spawn_result = std::thread::Builder::new()
         .name(thread_name)
         .spawn(move || {
-            if let Err(error) = run_handshake(
-                stream,
-                peer_addr,
-                magic,
-                &registry,
-                &peer_outbound,
-                &inbound_sync_sinks,
-                &chain_query,
-                peer_registered.as_deref(),
-            ) {
+            if let Err(error) =
+                run_handshake(stream, peer_addr, magic, &shared, &inbound_sync_sinks)
+            {
                 tracing::warn!(
                     peer_addr = %peer_addr,
                     %error,
@@ -453,77 +633,169 @@ fn run_handshake(
     stream: TcpStream,
     peer_addr: SocketAddr,
     magic: Magic,
-    registry: &RwLock<Vec<crate::PeerInfo>>,
-    peer_outbound: &RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>,
+    shared: &ConnectionShared,
     inbound_sync_sinks: &InboundSyncSinks,
-    chain_query: &ChainQueryHandle,
-    peer_registered: Option<
-        &(dyn Fn(SocketAddr, crate::PeerLease, crate::PeerInfo) -> bool + Send + Sync),
-    >,
 ) -> Result<(), crate::wire::PeerError> {
     stream
         .set_nonblocking(false)
         .map_err(crate::wire::PeerError::Io)?;
     stream
-        .set_read_timeout(Some(HANDSHAKE_READ_TIMEOUT))
+        .set_read_timeout(Some(STREAM_POLL_INTERVAL))
         .map_err(crate::wire::PeerError::Io)?;
     stream
         .set_write_timeout(Some(HANDSHAKE_READ_TIMEOUT))
         .map_err(crate::wire::PeerError::Io)?;
 
+    // Register the connection before the handshake so live-connection
+    // accounting covers handshaking peers exactly like Core's connman.
+    let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded::<crate::Message>();
+    let lease = crate::PeerLease::new_inbound(outbound_tx);
+    register_connection(&shared.peer_outbound, peer_addr, lease.clone());
+
     let nonce = generate_nonce(peer_addr);
     let mut peer = Peer::new(stream, magic);
-    run_inbound_handshake(&mut peer, nonce, 0)?;
+    let handshake_deadline = Instant::now() + HANDSHAKE_READ_TIMEOUT;
+    if let Err(error) = run_inbound_handshake(
+        &mut peer,
+        nonce,
+        0,
+        &lease,
+        shared.totals.as_ref(),
+        handshake_deadline,
+    ) {
+        remove_current_peer(
+            &shared.peer_registry,
+            &shared.peer_outbound,
+            peer_addr,
+            &lease,
+        );
+        let _ = peer.stream.shutdown(std::net::Shutdown::Both);
+        if lease.is_cancelled() {
+            tracing::debug!(peer_addr = %peer_addr, "p2p inbound lease revoked during handshake");
+            return Ok(());
+        }
+        return Err(error);
+    }
 
     let Some(remote_version) = peer.remote_version.as_ref() else {
+        remove_current_peer(
+            &shared.peer_registry,
+            &shared.peer_outbound,
+            peer_addr,
+            &lease,
+        );
+        let _ = peer.stream.shutdown(std::net::Shutdown::Both);
         return Err(crate::wire::PeerError::Protocol(
             "missing remote version after successful handshake",
         ));
     };
-    let conn_time = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_secs());
+    let handshake_now = SystemTime::now();
+    let conn_time = unix_secs(handshake_now);
     let info = crate::PeerInfo::inbound_from_version(peer_addr, remote_version, conn_time);
+    lease
+        .stats()
+        .set_time_offset(remote_version.timestamp - unix_secs_i64(handshake_now));
 
-    let writer_stream = peer
-        .stream
-        .try_clone()
-        .map_err(crate::wire::PeerError::Io)?;
-    let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded::<crate::Message>();
-    let writer = spawn_connection_writer(writer_stream, magic, outbound_rx, peer_addr)
-        .map_err(crate::wire::PeerError::Io)?;
-    let lease = crate::PeerLease::new(outbound_tx);
-    register_peer(
-        registry,
-        peer_outbound,
-        peer_registered,
+    run_connected_session(
+        &mut peer,
+        peer_addr,
+        magic,
+        shared,
+        inbound_sync_sinks,
+        lease,
+        outbound_rx,
+        info,
+    )
+}
+
+fn run_connected_session(
+    peer: &mut Peer<TcpStream>,
+    peer_addr: SocketAddr,
+    magic: Magic,
+    shared: &ConnectionShared,
+    inbound_sync_sinks: &InboundSyncSinks,
+    lease: crate::PeerLease,
+    outbound_rx: crossbeam_channel::Receiver<crate::Message>,
+    info: crate::PeerInfo,
+) -> Result<(), crate::wire::PeerError> {
+    let setup_result: Result<std::thread::JoinHandle<()>, crate::wire::PeerError> = (|| {
+        #[cfg(test)]
+        if WRITER_SETUP_FAIL.swap(false, Ordering::Relaxed) {
+            return Err(crate::wire::PeerError::Io(io::Error::other(
+                "test-injected writer setup failure",
+            )));
+        }
+        let writer_stream = peer
+            .stream
+            .try_clone()
+            .map_err(crate::wire::PeerError::Io)?;
+        spawn_connection_writer(
+            writer_stream,
+            magic,
+            outbound_rx,
+            peer_addr,
+            lease.stats_handle(),
+            shared.totals.clone(),
+        )
+        .map_err(crate::wire::PeerError::Io)
+    })();
+    let writer = match setup_result {
+        Ok(handle) => handle,
+        Err(error) => {
+            // The lease was already registered into peer_outbound at
+            // handshake time.  Run the same cleanup the normal exit path
+            // does so a spawn failure (e.g. EAGAIN under thread/fd
+            // pressure) does not leave a phantom peer registered.
+            remove_current_peer(
+                &shared.peer_registry,
+                &shared.peer_outbound,
+                peer_addr,
+                &lease,
+            );
+            let _ = peer.stream.shutdown(std::net::Shutdown::Both);
+            drop(lease);
+            return Err(error);
+        }
+    };
+    publish_peer_info(
+        &shared.peer_registry,
+        shared.peer_registered.as_deref(),
         peer_addr,
         lease.clone(),
         info,
     );
 
+    let inbound = lease.is_inbound();
     tracing::info!(
         peer_addr = %peer_addr,
-        "p2p inbound handshake complete; entering message loop",
+        inbound,
+        "p2p handshake complete; entering message loop",
     );
 
     let loop_result = (|| {
         peer.stream
-            .set_read_timeout(Some(Duration::from_secs(1)))
+            .set_read_timeout(Some(STREAM_POLL_INTERVAL))
             .map_err(crate::wire::PeerError::Io)?;
         run_message_loop(
-            &mut peer,
+            peer,
             peer_addr,
             &lease,
             inbound_sync_sinks,
-            chain_query.as_deref(),
+            shared.chain_query.as_deref(),
+            shared.totals.as_ref(),
         )
     })();
 
-    let removed_current = remove_current_peer(registry, peer_outbound, peer_addr, &lease);
+    let removed_current = remove_current_peer(
+        &shared.peer_registry,
+        &shared.peer_outbound,
+        peer_addr,
+        &lease,
+    );
     debug_assert!(
         removed_current
-            || peer_outbound
+            || shared
+                .peer_outbound
                 .read()
                 .get(&peer_addr)
                 .is_none_or(|current| !current.same_connection(&lease))
@@ -532,9 +804,9 @@ fn run_handshake(
     drop(lease);
     let _ = writer.join();
     if let Err(error) = &loop_result {
-        tracing::warn!(peer_addr = %peer_addr, %error, "p2p peer disconnected with error");
+        tracing::warn!(peer_addr = %peer_addr, inbound, %error, "p2p peer disconnected with error");
     } else {
-        tracing::debug!(peer_addr = %peer_addr, "p2p peer disconnected cleanly");
+        tracing::debug!(peer_addr = %peer_addr, inbound, "p2p peer disconnected cleanly");
     }
     loop_result
 }
@@ -545,6 +817,7 @@ fn run_message_loop<S: std::io::Read + std::io::Write>(
     lease: &crate::PeerLease,
     inbound_sync_sinks: &InboundSyncSinks,
     chain_query: Option<&dyn crate::dispatch::ChainQuery>,
+    totals: Option<&Arc<crate::TrafficTotals>>,
 ) -> Result<(), crate::wire::PeerError> {
     use crate::peer::PeerState;
     use std::time::Instant;
@@ -576,6 +849,14 @@ fn run_message_loop<S: std::io::Read + std::io::Write>(
         match read_result {
             Ok((message, raw)) => {
                 last_inbound = Instant::now();
+                let wire_len = raw.len() + crate::wire::HEADER_LEN;
+                lease
+                    .stats()
+                    .record_recv(u64::try_from(wire_len).unwrap_or(u64::MAX));
+                lease.stats().record_msg_recv();
+                if let Some(totals) = totals {
+                    totals.record_recv(u64::try_from(wire_len).unwrap_or(u64::MAX));
+                }
                 tracing::trace!(
                     peer_addr = %peer_addr,
                     command = ?std::mem::discriminant(&message),
@@ -589,6 +870,9 @@ fn run_message_loop<S: std::io::Read + std::io::Write>(
                     }
                     bitcoin::p2p::message::NetworkMessage::Block(block) => {
                         inbound_sync_sinks.send_block(lease.source(peer_addr), block, raw);
+                    }
+                    bitcoin::p2p::message::NetworkMessage::Pong(nonce) => {
+                        lease.stats().complete_ping(nonce, unix_micros());
                     }
                     _ => {}
                 }
@@ -616,22 +900,53 @@ fn run_message_loop<S: std::io::Read + std::io::Write>(
 /// Spawns a per-connection writer thread that drains queued outbound messages
 /// and writes them to the peer. Decoupling writes from the blocking inbound
 /// read ensures a momentarily silent peer can never delay outbound sends (the
-/// next `getdata` during IBD). Exits when every sender drops or a write fails.
+/// next `getdata` during IBD). Sent bytes are accounted on the connection's
+/// telemetry and, when present, the shared aggregate totals. Exits when every
+/// sender drops or a write fails.
 fn spawn_connection_writer(
     mut stream: TcpStream,
     magic: Magic,
     outbound_rx: crossbeam_channel::Receiver<crate::Message>,
     peer_addr: SocketAddr,
+    stats: Arc<crate::PeerStats>,
+    totals: Option<Arc<crate::TrafficTotals>>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     std::thread::Builder::new()
         .name(format!("bitcoin-rs-p2p-writer-{peer_addr}"))
         .spawn(move || {
             while let Ok(message) = outbound_rx.recv() {
-                if let Err(error) = crate::wire::write_message(&mut stream, magic, &message) {
-                    tracing::debug!(peer_addr = %peer_addr, %error, "p2p writer thread exiting");
-                    break;
+                match crate::wire::write_message(&mut stream, magic, &message) {
+                    Ok(bytes) => {
+                        stats.record_sent(u64::try_from(bytes).unwrap_or(u64::MAX));
+                        stats.record_msg_sent();
+                        if let Some(totals) = totals.as_ref() {
+                            totals.record_sent(u64::try_from(bytes).unwrap_or(u64::MAX));
+                        }
+                    }
+                    Err(error) => {
+                        tracing::debug!(peer_addr = %peer_addr, %error, "p2p writer thread exiting");
+                        break;
+                    }
                 }
             }
+        })
+}
+
+fn unix_secs(now: SystemTime) -> u64 {
+    now.duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
+}
+
+fn unix_secs_i64(now: SystemTime) -> i64 {
+    now.duration_since(UNIX_EPOCH).map_or(0, |duration| {
+        i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
+    })
+}
+fn unix_micros() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| {
+            u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
         })
 }
 
@@ -844,7 +1159,7 @@ mod lease_tests {
         let mut peer = Peer::new(UnreadableStream, Magic::BITCOIN);
         peer.state = PeerState::Ready;
 
-        assert!(run_message_loop(&mut peer, addr, &lease, &sinks(), None).is_ok());
+        assert!(run_message_loop(&mut peer, addr, &lease, &sinks(), None, None).is_ok());
     }
 
     #[test]
@@ -884,7 +1199,7 @@ mod lease_tests {
         );
         peer.state = PeerState::Ready;
 
-        assert!(run_message_loop(&mut peer, addr, &old, &test_sinks, None).is_ok());
+        assert!(run_message_loop(&mut peer, addr, &old, &test_sinks, None, None).is_ok());
         assert!(
             headers_rx.try_recv().is_err(),
             "a message completed after replacement must not be enqueued"
@@ -907,7 +1222,7 @@ mod lease_tests {
         let mut peer = Peer::new(ContinuingStream(Arc::clone(&reads)), Magic::BITCOIN);
         peer.state = PeerState::Ready;
 
-        assert!(run_message_loop(&mut peer, addr, &lease, &sinks(), None).is_err());
+        assert!(run_message_loop(&mut peer, addr, &lease, &sinks(), None, None).is_err());
         assert_eq!(reads.load(Ordering::Relaxed), 2);
     }
 
@@ -989,5 +1304,176 @@ mod sync_wake_tests {
     #[test]
     fn missing_sync_wake_is_noop() {
         wake_sync(None);
+    }
+}
+
+#[cfg(test)]
+static ACCEPT_ERROR_INJECT: AtomicBool = AtomicBool::new(false);
+
+#[cfg(test)]
+static WRITER_SETUP_FAIL: AtomicBool = AtomicBool::new(false);
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod resilient_accept_tests {
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use bitcoin::p2p::Magic;
+    use parking_lot::RwLock;
+
+    use super::{ACCEPT_ERROR_INJECT, ConnectionShared, InboundSyncSinks, serve_connections};
+
+    fn shared_state() -> ConnectionShared {
+        let peer_registry = Arc::new(RwLock::new(Vec::new()));
+        let peer_outbound = Arc::new(RwLock::new(hashbrown::HashMap::new()));
+        let banned = Arc::new(RwLock::new(Vec::new()));
+        ConnectionShared::from_parts(peer_registry, peer_outbound, banned, None, None)
+    }
+
+    fn sinks() -> InboundSyncSinks {
+        let (headers_tx, _headers_rx) = crossbeam_channel::unbounded();
+        let (blocks_tx, _blocks_rx) = crossbeam_channel::unbounded();
+        InboundSyncSinks {
+            headers_tx,
+            blocks_tx,
+            wake_tx: None,
+        }
+    }
+
+    /// A transient accept error must not kill the listener thread — the loop
+    /// logs, backs off, and continues until shutdown.
+    #[test]
+    fn serve_connections_survives_transient_accept_error() {
+        // Grab an ephemeral port, then release it so serve_connections can bind.
+        let probe =
+            TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("bind probe");
+        let addr = probe.local_addr().expect("local_addr");
+        drop(probe);
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shared = shared_state();
+        let sinks = sinks();
+
+        // Inject one transient accept error.
+        ACCEPT_ERROR_INJECT.store(true, Ordering::Relaxed);
+
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_shared = shared;
+        let handle = std::thread::spawn(move || {
+            serve_connections(
+                addr,
+                &thread_shutdown,
+                Magic::BITCOIN,
+                &thread_shared,
+                &sinks,
+            )
+        });
+
+        // Give the loop time to process the injected error and continue.
+        std::thread::sleep(Duration::from_millis(300));
+
+        // The listener must still be alive — connect a real client to prove it.
+        let _client = TcpStream::connect(addr).expect("listener should still accept");
+
+        // Shut down cleanly.
+        shutdown.store(true, Ordering::Relaxed);
+        let result = handle.join().expect("listener thread panicked");
+        assert!(
+            result.is_ok(),
+            "serve_connections must return Ok after shutdown, got {result:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod writer_setup_cleanup_tests {
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+
+    use bitcoin::p2p::Magic;
+    use parking_lot::RwLock;
+
+    use super::{
+        ConnectionShared, InboundSyncSinks, WRITER_SETUP_FAIL, register_connection,
+        run_connected_session,
+    };
+    use crate::peer::Peer;
+
+    type OutboundMap = Arc<RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>>;
+
+    fn peer_info(addr: SocketAddr, conn_time: u64) -> crate::PeerInfo {
+        crate::PeerInfo {
+            addr,
+            version: 70_016,
+            services: 0,
+            user_agent: String::from("/test/"),
+            start_height: 0,
+            conn_time,
+            inbound: false,
+        }
+    }
+
+    fn sinks() -> InboundSyncSinks {
+        let (headers_tx, _headers_rx) = crossbeam_channel::unbounded();
+        let (blocks_tx, _blocks_rx) = crossbeam_channel::unbounded();
+        InboundSyncSinks {
+            headers_tx,
+            blocks_tx,
+            wake_tx: None,
+        }
+    }
+
+    /// When the writer-thread setup fails (`try_clone` or `spawn`), the lease
+    #[test]
+    fn writer_setup_failure_cleans_up_lease() {
+        let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+
+        let client = TcpStream::connect(addr).expect("connect");
+        let (server_stream, peer_addr) = listener.accept().expect("accept");
+        drop(server_stream);
+
+        let peer_registry = Arc::new(RwLock::new(Vec::new()));
+        let outbound: OutboundMap = Arc::new(RwLock::new(hashbrown::HashMap::new()));
+        let banned = Arc::new(RwLock::new(Vec::new()));
+        let shared =
+            ConnectionShared::from_parts(peer_registry, outbound.clone(), banned, None, None);
+
+        let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded();
+        let lease = crate::PeerLease::new(outbound_tx);
+        register_connection(&shared.peer_outbound, peer_addr, lease.clone());
+
+        // Lease must be registered before the failure.
+        assert!(
+            outbound.read().contains_key(&peer_addr),
+            "lease must be registered before writer setup"
+        );
+
+        // Inject writer setup failure.
+        WRITER_SETUP_FAIL.store(true, Ordering::Relaxed);
+
+        let mut peer = Peer::new(client, Magic::BITCOIN);
+        let info = peer_info(peer_addr, 0);
+        let result = run_connected_session(
+            &mut peer,
+            peer_addr,
+            Magic::BITCOIN,
+            &shared,
+            &sinks(),
+            lease,
+            outbound_rx,
+            info,
+        );
+
+        assert!(result.is_err(), "writer setup failure must return Err");
+        assert!(
+            outbound.read().is_empty(),
+            "peer_outbound must be cleaned up after writer setup failure"
+        );
     }
 }

--- a/crates/p2p/src/peer.rs
+++ b/crates/p2p/src/peer.rs
@@ -1,11 +1,17 @@
 use std::io::{Read, Write};
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use std::time::{Duration, SystemTime};
 
 use bitcoin::p2p::Magic;
 use bitcoin::p2p::message_compact_blocks::SendCmpct;
 use bitcoin::p2p::message_network::VersionMessage;
 use crossbeam_channel::{Receiver, Sender, unbounded};
+use parking_lot::RwLock;
+use thiserror::Error;
 
+use crate::connection::PeerStats;
 use crate::wire::{Message, PeerError, write_message};
 use crate::wtxid::WtxidRelayState;
 
@@ -124,7 +130,7 @@ impl<S: Read + Write> Peer<S> {
         self.sender
             .send(message.clone())
             .map_err(|_| PeerError::Protocol("outbound peer queue disconnected"))?;
-        write_message(&mut self.stream, self.magic, message)
+        write_message(&mut self.stream, self.magic, message).map(|_| ())
     }
 }
 
@@ -188,6 +194,763 @@ impl DnsResolver for SystemDnsResolver {
     }
 }
 
+/// Authoritative p2p activity switch behind `setnetworkactive`.
+///
+/// Mirrors Core's `CConnman::fNetworkActive`: flipping the flag never
+/// disconnects existing peers; it only stops new inbound accepts and new
+/// outbound dials while inactive.
+#[derive(Debug)]
+pub struct NetworkActivity {
+    active: AtomicBool,
+}
+
+impl NetworkActivity {
+    /// Creates a switch that is active unless `active` is `false`.
+    #[must_use]
+    pub const fn new(active: bool) -> Self {
+        Self {
+            active: AtomicBool::new(active),
+        }
+    }
+
+    /// Applies the requested state and returns the state now in effect.
+    pub fn set_active(&self, active: bool) -> bool {
+        self.active.store(active, Ordering::Release);
+        active
+    }
+
+    /// Returns whether p2p network activity is enabled.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+}
+
+/// Length of the upload-target measuring window in seconds
+/// (Core `MAX_UPLOAD_TIMEFRAME`, one day).
+pub const UPLOAD_TIMEFRAME_SECS: u64 = 86_400;
+/// Consensus maximum serialized block size, the per-10-minute relay buffer
+/// unit in Core's historical-block serving rule.
+pub const MAX_BLOCK_SERIALIZED_SIZE: u64 = 4_000_000;
+
+/// Aggregate traffic totals and upload-target accounting behind `getnettotals`.
+///
+/// Byte totals accumulate since construction; the upload-target cycle mirrors
+/// Core `CConnman::RecordBytesSent`: a cycle resets when the last reset lies
+/// more than [`UPLOAD_TIMEFRAME_SECS`] in the past, and a target of `0` means
+/// unlimited (all derived fields then report Core's unlimited defaults).
+#[derive(Debug)]
+pub struct TrafficTotals {
+    bytes_recv: AtomicU64,
+    bytes_sent: AtomicU64,
+    max_upload_bytes: u64,
+    cycle_start_secs: AtomicI64,
+    sent_in_cycle: AtomicU64,
+}
+
+impl TrafficTotals {
+    /// Creates totals with an upload target in bytes; `0` means unlimited.
+    #[must_use]
+    pub const fn new(max_upload_bytes: u64) -> Self {
+        Self {
+            bytes_recv: AtomicU64::new(0),
+            bytes_sent: AtomicU64::new(0),
+            max_upload_bytes,
+            cycle_start_secs: AtomicI64::new(0),
+            sent_in_cycle: AtomicU64::new(0),
+        }
+    }
+
+    /// Accounts received bytes against the running total.
+    pub fn record_recv(&self, bytes: u64) {
+        self.bytes_recv.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Accounts sent bytes against the running total and the upload cycle.
+    pub fn record_sent(&self, bytes: u64) {
+        let now = unix_time_secs();
+        self.record_sent_at(bytes, now);
+    }
+
+    /// Time-injectable core of [`Self::record_sent`].
+    pub fn record_sent_at(&self, bytes: u64, now_secs: i64) {
+        self.bytes_sent.fetch_add(bytes, Ordering::Relaxed);
+        let cycle_start = self.cycle_start_secs.load(Ordering::Relaxed);
+        if cycle_start + i64::try_from(UPLOAD_TIMEFRAME_SECS).unwrap_or(i64::MAX) < now_secs {
+            self.cycle_start_secs.store(now_secs, Ordering::Relaxed);
+            self.sent_in_cycle.store(0, Ordering::Relaxed);
+        }
+        self.sent_in_cycle.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Total bytes received since construction.
+    #[must_use]
+    pub fn total_bytes_recv(&self) -> u64 {
+        self.bytes_recv.load(Ordering::Relaxed)
+    }
+
+    /// Total bytes sent since construction.
+    #[must_use]
+    pub fn total_bytes_sent(&self) -> u64 {
+        self.bytes_sent.load(Ordering::Relaxed)
+    }
+
+    /// Live upload-target projection at `now_secs` (Core `getnettotals`
+    /// `uploadtarget` object).
+    #[must_use]
+    pub fn upload_target(&self, now_secs: i64) -> UploadTarget {
+        let target = self.max_upload_bytes;
+        if target == 0 {
+            return UploadTarget {
+                timeframe_secs: UPLOAD_TIMEFRAME_SECS,
+                target_bytes: 0,
+                target_reached: false,
+                serve_historical_blocks: true,
+                bytes_left_in_cycle: 0,
+                time_left_in_cycle_secs: 0,
+            };
+        }
+
+        let sent = self.sent_in_cycle.load(Ordering::Relaxed);
+        let cycle_start = self.cycle_start_secs.load(Ordering::Relaxed);
+        let cycle_end = cycle_start + i64::try_from(UPLOAD_TIMEFRAME_SECS).unwrap_or(i64::MAX);
+        let time_left = if cycle_start == 0 {
+            i64::try_from(UPLOAD_TIMEFRAME_SECS).unwrap_or(i64::MAX)
+        } else {
+            (cycle_end - now_secs).max(0)
+        };
+
+        let reached = sent >= target;
+        // Core keeps a buffer large enough to relay each block once per
+        // remaining ten-minute slice of the cycle before declaring the
+        // historical-block budget reached.
+        let buffer = u64::try_from(time_left).unwrap_or(0) / 600 * MAX_BLOCK_SERIALIZED_SIZE;
+        let historical_reached = buffer >= target || sent >= target.saturating_sub(buffer);
+
+        UploadTarget {
+            timeframe_secs: UPLOAD_TIMEFRAME_SECS,
+            target_bytes: target,
+            target_reached: reached,
+            serve_historical_blocks: !historical_reached,
+            bytes_left_in_cycle: target.saturating_sub(sent),
+            time_left_in_cycle_secs: u64::try_from(time_left).unwrap_or(0),
+        }
+    }
+}
+
+/// One `getnettotals` upload-target reading.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UploadTarget {
+    /// Length of the measuring timeframe in seconds.
+    pub timeframe_secs: u64,
+    /// Upload target in bytes (`0` reports an unlimited configuration).
+    pub target_bytes: u64,
+    /// Whether the raw target has been reached.
+    pub target_reached: bool,
+    /// Whether historical blocks are still served.
+    pub serve_historical_blocks: bool,
+    /// Bytes left in the current time cycle.
+    pub bytes_left_in_cycle: u64,
+    /// Seconds left in the current time cycle.
+    pub time_left_in_cycle_secs: u64,
+}
+
+/// Directional split of live connections.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ConnectionCounts {
+    /// Live inbound connections.
+    pub inbound: usize,
+    /// Live outbound connections.
+    pub outbound: usize,
+}
+
+impl ConnectionCounts {
+    /// Total live connections in both directions.
+    #[must_use]
+    pub fn total(self) -> usize {
+        self.inbound + self.outbound
+    }
+}
+
+/// Failure modes of manual ban operations, mirroring Core `setban` semantics.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum BanError {
+    /// An active ban already covers the requested subnet.
+    #[error("ip/subnet already banned")]
+    AlreadyBanned,
+    /// An absolute ban timestamp lies in the past.
+    #[error("absolute timestamp is in the past")]
+    AbsoluteTimestampInPast,
+    /// No manual ban matches the requested subnet.
+    #[error("address/subnet was not previously manually banned")]
+    NotBanned,
+}
+
+/// Failure modes of added-node operations, mirroring Core `addnode` semantics.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum AddNodeError {
+    /// The node is already in the added-node list.
+    #[error("node already added")]
+    AlreadyAdded,
+    /// The node is not in the added-node list.
+    #[error("node could not be removed. it has not been added previously.")]
+    NotAdded,
+}
+
+/// One added-node entry joined with its live connection state
+/// (Core `getaddednodeinfo` record).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AddedNodeInfo {
+    /// The node string exactly as it was added.
+    pub spec: String,
+    /// Resolved socket address captured when the node was added, when it
+    /// resolved.
+    pub resolved: Option<SocketAddr>,
+    /// Whether a live connection currently matches the resolved address.
+    pub connected: bool,
+}
+
+/// One address-book entry returned by [`NetworkControls::node_addresses`]
+/// (Core `getnodeaddresses` record).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeAddress {
+    /// UNIX epoch seconds when the address was last observed.
+    pub time: u64,
+    /// Advertised service flags bitmask (`0` when unknown).
+    pub services: u64,
+    /// Host portion only (no port).
+    pub address: String,
+    /// TCP port.
+    pub port: u16,
+    /// Network name: `ipv4`, `ipv6`, `onion`, `i2p`, or `cjdns`.
+    pub network: String,
+}
+
+/// One durable observed-address book entry owned by [`NetworkControls`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ObservedAddressEntry {
+    addr: SocketAddr,
+    services: u64,
+    time: u64,
+}
+
+/// One live connection snapshot joined from the lease map and the handshake
+/// registry, backing `getpeerinfo`/`getconnectioncount` projections.
+#[derive(Clone, Debug)]
+pub struct ConnectedPeer {
+    /// Remote socket address.
+    pub addr: SocketAddr,
+    /// Stable process-unique connection id (Core `nodeid`).
+    pub node_id: u64,
+    /// Whether the connection was accepted inbound.
+    pub inbound: bool,
+    /// Handshake metadata, `None` while the handshake is still in progress.
+    pub info: Option<crate::PeerInfo>,
+    /// Live traffic and ping telemetry.
+    pub stats: Arc<PeerStats>,
+}
+
+/// One stored added-node entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AddedNodeEntry {
+    spec: String,
+    resolved: Option<SocketAddr>,
+}
+
+/// Authoritative network control plane over the shared peer, lease, and ban
+/// state owned by the P2P listener.
+///
+/// All operations act on the same `Arc` handles the live listener uses, so
+/// control calls are immediately observable in the connection state and vice
+/// versa. The kill switch and aggregate traffic totals are authoritative here;
+/// dials requested by added-node operations are queued onto the optional dial
+/// channel exactly like RPC-triggered outbound connections.
+#[derive(Clone)]
+pub struct NetworkControls {
+    peer_registry: Arc<RwLock<Vec<crate::PeerInfo>>>,
+    peer_outbound: Arc<RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>>,
+    banned: Arc<RwLock<Vec<crate::BannedSubnet>>>,
+    activity: Arc<NetworkActivity>,
+    totals: Arc<TrafficTotals>,
+    added_nodes: Arc<RwLock<Vec<AddedNodeEntry>>>,
+    /// Durable address-book distinct from the live peer map (Core addrman facts
+    /// reachable through `getnodeaddresses`).
+    observed_addresses: Arc<RwLock<hashbrown::HashMap<SocketAddr, ObservedAddressEntry>>>,
+    dial_tx: Option<Sender<SocketAddr>>,
+    default_port: u16,
+}
+
+impl NetworkControls {
+    /// Builds the control plane over the listener's shared state.
+    #[must_use]
+    pub fn new(
+        peer_registry: Arc<RwLock<Vec<crate::PeerInfo>>>,
+        peer_outbound: Arc<RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>>,
+        banned: Arc<RwLock<Vec<crate::BannedSubnet>>>,
+        default_port: u16,
+    ) -> Self {
+        Self {
+            peer_registry,
+            peer_outbound,
+            banned,
+            activity: Arc::new(NetworkActivity::new(true)),
+            totals: Arc::new(TrafficTotals::new(0)),
+            added_nodes: Arc::new(RwLock::new(Vec::new())),
+            observed_addresses: Arc::new(RwLock::new(hashbrown::HashMap::new())),
+            dial_tx: None,
+            default_port,
+        }
+    }
+
+    /// Returns `self` with a dial channel for added-node connection attempts.
+    #[must_use]
+    pub fn with_dial_sender(mut self, dial_tx: Sender<SocketAddr>) -> Self {
+        self.dial_tx = Some(dial_tx);
+        self
+    }
+
+    /// Returns `self` with an upload target in bytes (`0` keeps unlimited).
+    #[must_use]
+    pub fn with_max_upload(mut self, max_upload_bytes: u64) -> Self {
+        self.totals = Arc::new(TrafficTotals::new(max_upload_bytes));
+        self
+    }
+
+    /// Shared handshake registry, also published to RPC projections.
+    #[must_use]
+    pub fn peer_registry(&self) -> &Arc<RwLock<Vec<crate::PeerInfo>>> {
+        &self.peer_registry
+    }
+
+    /// Shared live-connection lease map.
+    #[must_use]
+    pub fn peer_outbound(&self) -> &Arc<RwLock<hashbrown::HashMap<SocketAddr, crate::PeerLease>>> {
+        &self.peer_outbound
+    }
+
+    /// Shared manual ban list, also enforced by the listener.
+    #[must_use]
+    pub fn banned(&self) -> &Arc<RwLock<Vec<crate::BannedSubnet>>> {
+        &self.banned
+    }
+
+    /// The network activity switch.
+    #[must_use]
+    pub fn activity(&self) -> &Arc<NetworkActivity> {
+        &self.activity
+    }
+
+    /// The aggregate traffic totals.
+    #[must_use]
+    pub fn totals(&self) -> &Arc<TrafficTotals> {
+        &self.totals
+    }
+
+    /// Live connection count in both directions, including connections whose
+    /// handshake has not completed (Core `GetNodeCount(Both)`).
+    #[must_use]
+    pub fn connection_counts(&self) -> ConnectionCounts {
+        let outbound = self.peer_outbound.read();
+        let mut counts = ConnectionCounts::default();
+        for lease in outbound.values() {
+            if lease.is_inbound() {
+                counts.inbound += 1;
+            } else {
+                counts.outbound += 1;
+            }
+        }
+        counts
+    }
+
+    /// Snapshot of every live connection joined with handshake metadata.
+    #[must_use]
+    pub fn connected_peers(&self) -> Vec<ConnectedPeer> {
+        let infos: hashbrown::HashMap<SocketAddr, crate::PeerInfo> = self
+            .peer_registry
+            .read()
+            .iter()
+            .map(|info| (info.addr, info.clone()))
+            .collect();
+        self.peer_outbound
+            .read()
+            .iter()
+            .map(|(addr, lease)| ConnectedPeer {
+                addr: *addr,
+                node_id: lease.node_id(),
+                inbound: lease.is_inbound(),
+                info: infos.get(addr).cloned(),
+                stats: lease.stats_handle(),
+            })
+            .collect()
+    }
+
+    /// Median remote clock offset in seconds across peers that completed a
+    /// handshake, when any offset has been observed.
+    #[must_use]
+    pub fn time_offset(&self) -> Option<i64> {
+        let mut offsets: Vec<i64> = self
+            .peer_outbound
+            .read()
+            .values()
+            .filter_map(|lease| lease.stats().time_offset())
+            .collect();
+        offsets.sort_unstable();
+        offsets.get(offsets.len() / 2).copied()
+    }
+
+    /// Queues one ping toward every live connection and returns the number of
+    /// pings successfully queued (Core `PeerManager::SendPings`).
+    pub fn send_pings(&self, now_us: u64) -> usize {
+        let mut scheduled = 0;
+        for lease in self.peer_outbound.read().values() {
+            let nonce = lease.stats().begin_ping(now_us);
+            if lease.send(crate::Message::Ping(nonce)).is_ok() {
+                scheduled += 1;
+            }
+        }
+        scheduled
+    }
+
+    /// Applies the network activity switch; existing peers stay connected.
+    pub fn set_network_active(&self, active: bool) -> bool {
+        self.activity.set_active(active)
+    }
+
+    /// Reads back the effective network activity state.
+    #[must_use]
+    pub fn network_active(&self) -> bool {
+        self.activity.is_active()
+    }
+
+    /// Adds a manual ban following Core `setban add` semantics and disconnects
+    /// every live peer matching the subnet, returning the disconnected
+    /// addresses.
+    pub fn ban(
+        &self,
+        subnet: crate::IpSubnet,
+        ban_time_secs: i64,
+        absolute: bool,
+        now: SystemTime,
+        reason: &str,
+    ) -> Result<Vec<SocketAddr>, BanError> {
+        let now_secs = unix_time_secs_at(now);
+        if self.banned.read().iter().any(|entry| {
+            entry.subnet == subnet && entry.banned_until.is_none_or(|until| until > now)
+        }) {
+            return Err(BanError::AlreadyBanned);
+        }
+        if absolute && ban_time_secs < now_secs {
+            return Err(BanError::AbsoluteTimestampInPast);
+        }
+
+        let offset_secs = if ban_time_secs <= 0 {
+            DEFAULT_BAN_TIME_SECS
+        } else {
+            ban_time_secs
+        };
+        let until_epoch = (if absolute { 0 } else { now_secs }).saturating_add(offset_secs);
+        self.banned.write().push(crate::BannedSubnet {
+            subnet,
+            banned_until: Some(
+                SystemTime::UNIX_EPOCH
+                    + Duration::from_secs(until_epoch.max(0).try_into().unwrap_or(u64::MAX)),
+            ),
+            ban_created: now,
+            reason: reason.to_owned(),
+        });
+
+        let disconnected = self.disconnect_matching(|addr, _| subnet.contains(addr.ip()));
+        if !disconnected.is_empty() {
+            tracing::info!(
+                subnet = %subnet,
+                disconnected = disconnected.len(),
+                "manual ban applied; matching peers disconnected"
+            );
+        }
+        Ok(disconnected)
+    }
+
+    /// Removes the manual ban exactly matching `subnet`
+    /// (Core `setban remove`).
+    pub fn unban(&self, subnet: &crate::IpSubnet) -> Result<(), BanError> {
+        let mut banned = self.banned.write();
+        let before = banned.len();
+        banned.retain(|entry| &entry.subnet != subnet);
+        if banned.len() == before {
+            return Err(BanError::NotBanned);
+        }
+        Ok(())
+    }
+
+    /// Active manual bans with expired entries swept first
+    /// (Core `BanMan::GetBanned`).
+    #[must_use]
+    pub fn banned_list(&self, now: SystemTime) -> Vec<crate::BannedSubnet> {
+        let mut banned = self.banned.write();
+        banned.retain(|entry| entry.banned_until.is_none_or(|until| until > now));
+        banned.clone()
+    }
+
+    /// Clears every manual ban (Core `clearbanned`).
+    pub fn clear_banned(&self) {
+        self.banned.write().clear();
+    }
+
+    /// Whether `ip` is covered by an active manual ban.
+    #[must_use]
+    pub fn is_banned(&self, ip: IpAddr, now: SystemTime) -> bool {
+        crate::subnet::is_banned(&self.banned.read(), ip, now)
+    }
+
+    /// Records a persistent added node and queues a best-effort connection
+    /// (Core `addnode add`).
+    pub fn add_node(&self, spec: &str) -> Result<(), AddNodeError> {
+        let resolved = resolve_node(spec, self.default_port);
+        let mut added = self.added_nodes.write();
+        for entry in added.iter() {
+            if entry.spec == spec {
+                return Err(AddNodeError::AlreadyAdded);
+            }
+            if let (Some(existing), Some(new)) = (entry.resolved, resolved) {
+                if existing == new {
+                    return Err(AddNodeError::AlreadyAdded);
+                }
+            }
+        }
+        added.push(AddedNodeEntry {
+            spec: spec.to_owned(),
+            resolved,
+        });
+        drop(added);
+        if let Some(addr) = resolved {
+            self.observe_address(addr, 0, SystemTime::now());
+            self.dial(addr);
+        }
+        Ok(())
+    }
+
+    /// Removes a persistent added node by its exact spec string; the current
+    /// connection, if any, is left running (Core `addnode remove`).
+    pub fn remove_added_node(&self, spec: &str) -> Result<(), AddNodeError> {
+        let mut added = self.added_nodes.write();
+        let before = added.len();
+        added.retain(|entry| entry.spec != spec);
+        if added.len() == before {
+            return Err(AddNodeError::NotAdded);
+        }
+        Ok(())
+    }
+
+    /// Queues a one-shot connection attempt without recording the node
+    /// (Core `addnode onetry`).
+    pub fn try_node_connection(&self, spec: &str) {
+        if let Some(addr) = resolve_node(spec, self.default_port) {
+            self.observe_address(addr, 0, SystemTime::now());
+            self.dial(addr);
+        }
+    }
+
+    /// Added-node entries joined with live connection state
+    /// (Core `getaddednodeinfo`).
+    #[must_use]
+    pub fn added_node_infos(&self) -> Vec<AddedNodeInfo> {
+        let entries = self.added_nodes.read().clone();
+        let connected: hashbrown::HashSet<SocketAddr> =
+            self.peer_outbound.read().keys().copied().collect();
+        entries
+            .into_iter()
+            .map(|entry| {
+                let connected_flag = entry.resolved.is_some_and(|addr| connected.contains(&addr));
+                AddedNodeInfo {
+                    spec: entry.spec,
+                    resolved: entry.resolved,
+                    connected: connected_flag,
+                }
+            })
+            .collect()
+    }
+
+    /// Records an observed peer address into the durable address book
+    /// (Core addrman-style fact used by `getnodeaddresses`).
+    pub fn observe_address(&self, addr: SocketAddr, services: u64, now: SystemTime) {
+        let time = u64::try_from(unix_time_secs_at(now).max(0)).unwrap_or(0);
+        let mut book = self.observed_addresses.write();
+        book.entry(addr)
+            .and_modify(|entry| {
+                entry.time = time;
+                if services != 0 {
+                    entry.services = services;
+                }
+            })
+            .or_insert(ObservedAddressEntry {
+                addr,
+                services,
+                time,
+            });
+    }
+
+    /// Ingests connection and added-node facts already owned by this control
+    /// plane into the durable address book without replacing prior entries.
+    fn ingest_known_address_facts(&self, now: SystemTime) {
+        let infos: hashbrown::HashMap<SocketAddr, u64> = self
+            .peer_registry
+            .read()
+            .iter()
+            .map(|info| (info.addr, info.services))
+            .collect();
+        for (addr, services) in &infos {
+            self.observe_address(*addr, *services, now);
+        }
+        for addr in self.peer_outbound.read().keys().copied() {
+            let services = infos.get(&addr).copied().unwrap_or(0);
+            self.observe_address(addr, services, now);
+        }
+        for entry in self.added_nodes.read().iter() {
+            if let Some(addr) = entry.resolved {
+                let services = infos.get(&addr).copied().unwrap_or(0);
+                self.observe_address(addr, services, now);
+            }
+        }
+    }
+
+    /// Returns up to `count` observed addresses, optionally filtered by
+    /// network name (Core `getnodeaddresses`).
+    ///
+    /// `count == 0` returns every matching address. `network` of `None` or
+    /// `"all"` disables the network filter. Addresses persist after the peer
+    /// disconnects because the book is distinct from the live lease map.
+    #[must_use]
+    pub fn node_addresses(&self, count: usize, network: Option<&str>) -> Vec<NodeAddress> {
+        let now = SystemTime::now();
+        self.ingest_known_address_facts(now);
+        let filter = network
+            .map(str::trim)
+            .filter(|name| !name.is_empty() && !name.eq_ignore_ascii_case("all"));
+        let mut addresses: Vec<NodeAddress> = self
+            .observed_addresses
+            .read()
+            .values()
+            .filter(|entry| filter.is_none_or(|wanted| address_network_name(entry.addr) == wanted))
+            .map(|entry| NodeAddress {
+                time: entry.time,
+                services: entry.services,
+                address: entry.addr.ip().to_string(),
+                port: entry.addr.port(),
+                network: address_network_name(entry.addr).to_owned(),
+            })
+            .collect();
+        addresses.sort_by(|left, right| {
+            right
+                .time
+                .cmp(&left.time)
+                .then_with(|| left.address.cmp(&right.address))
+                .then_with(|| left.port.cmp(&right.port))
+        });
+        if count != 0 && count < addresses.len() {
+            addresses.truncate(count);
+        }
+        addresses
+    }
+
+    /// Cancels and removes every live lease matching `predicate`, also
+    /// dropping its handshake-registry entry; returns the disconnected
+    /// addresses in registry order.
+    fn disconnect_matching(
+        &self,
+        predicate: impl Fn(&SocketAddr, &crate::PeerLease) -> bool,
+    ) -> Vec<SocketAddr> {
+        let targets: Vec<SocketAddr> = {
+            let outbound = self.peer_outbound.read();
+            outbound
+                .iter()
+                .filter(|(addr, lease)| predicate(addr, lease))
+                .map(|(addr, _)| *addr)
+                .collect()
+        };
+        if targets.is_empty() {
+            return Vec::new();
+        }
+        let mut outbound = self.peer_outbound.write();
+        let mut registry = self.peer_registry.write();
+        let mut disconnected = Vec::new();
+        for addr in targets {
+            if let Some(lease) = outbound.remove(&addr) {
+                lease.cancel();
+                registry.retain(|peer| peer.addr != addr);
+                disconnected.push(addr);
+            }
+        }
+        disconnected
+    }
+
+    /// Disconnects the live connection at `addr`, removing its registry entry;
+    /// returns `false` when no live connection matches.
+    pub fn disconnect_node(&self, addr: &SocketAddr) -> bool {
+        !self
+            .disconnect_matching(|lease_addr, _| lease_addr == addr)
+            .is_empty()
+    }
+
+    /// Disconnects the live connection with stable id `node_id`.
+    pub fn disconnect_node_by_id(&self, node_id: u64) -> bool {
+        !self
+            .disconnect_matching(|_, lease| lease.node_id() == node_id)
+            .is_empty()
+    }
+
+    /// Queues one dial onto the shared outbound channel unless networking is
+    /// switched off (Core `OpenNetworkConnection` early-returns when
+    /// inactive).
+    fn dial(&self, addr: SocketAddr) {
+        // Dial targets are observed even when networking is inactive so the
+        // address book still learns about attempted peers.
+        self.observe_address(addr, 0, SystemTime::now());
+        if !self.activity.is_active() {
+            return;
+        }
+        if let Some(dial_tx) = &self.dial_tx {
+            let _ = dial_tx.try_send(addr);
+        }
+    }
+}
+
+/// Core `-bantime` default: 24 hours.
+const DEFAULT_BAN_TIME_SECS: i64 = 86_400;
+
+/// Resolves one addnode-style destination: `host:port`, `host` (default
+/// port), a bare IP, or a bracketed IPv6 literal.
+fn resolve_node(spec: &str, default_port: u16) -> Option<SocketAddr> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return None;
+    }
+    if let Ok(addr) = spec.parse::<SocketAddr>() {
+        return Some(addr);
+    }
+    if let Ok(ip) = spec.parse::<IpAddr>() {
+        return Some(SocketAddr::new(ip, default_port));
+    }
+    (spec, default_port).to_socket_addrs().ok()?.next()
+}
+
+fn address_network_name(addr: SocketAddr) -> &'static str {
+    match addr.ip() {
+        IpAddr::V4(_) => "ipv4",
+        IpAddr::V6(_) => "ipv6",
+    }
+}
+
+fn unix_time_secs() -> i64 {
+    unix_time_secs_at(SystemTime::now())
+}
+
+fn unix_time_secs_at(now: SystemTime) -> i64 {
+    now.duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |duration| {
+            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,5 +994,185 @@ mod tests {
                 .contains(&SocketAddr::from(([127, 0, 0, 1], 8333)))
         );
         Ok(())
+    }
+
+    #[test]
+    fn upload_target_defaults_match_core_unlimited_configuration() {
+        let totals = TrafficTotals::new(0);
+        totals.record_sent_at(123_456, 1_000);
+        assert_eq!(
+            totals.upload_target(2_000),
+            UploadTarget {
+                timeframe_secs: UPLOAD_TIMEFRAME_SECS,
+                target_bytes: 0,
+                target_reached: false,
+                serve_historical_blocks: true,
+                bytes_left_in_cycle: 0,
+                time_left_in_cycle_secs: 0,
+            }
+        );
+        assert_eq!(totals.total_bytes_sent(), 123_456);
+    }
+
+    #[test]
+    fn network_activity_switch_flips() {
+        let activity = NetworkActivity::new(true);
+        assert!(activity.is_active());
+        assert!(!activity.set_active(false));
+        assert!(!activity.is_active());
+        assert!(activity.set_active(true));
+    }
+
+    fn controls_with_no_peers() -> NetworkControls {
+        NetworkControls::new(
+            Arc::new(RwLock::new(Vec::new())),
+            Arc::new(RwLock::new(hashbrown::HashMap::new())),
+            Arc::new(RwLock::new(Vec::new())),
+            8_333,
+        )
+    }
+
+    fn lease_in_map(
+        controls: &NetworkControls,
+        addr: SocketAddr,
+        inbound: bool,
+    ) -> crate::PeerLease {
+        let (tx, _rx) = crossbeam_channel::unbounded();
+        let lease = if inbound {
+            crate::PeerLease::new_inbound(tx)
+        } else {
+            crate::PeerLease::new(tx)
+        };
+        controls.peer_outbound().write().insert(addr, lease.clone());
+        lease
+    }
+
+    #[test]
+    fn connection_counts_split_by_direction() {
+        let controls = controls_with_no_peers();
+        let a = SocketAddr::from(([127, 0, 0, 1], 1));
+        let b = SocketAddr::from(([127, 0, 0, 1], 2));
+        lease_in_map(&controls, a, true);
+        lease_in_map(&controls, b, false);
+        let counts = controls.connection_counts();
+        assert_eq!(counts.inbound, 1);
+        assert_eq!(counts.outbound, 1);
+        assert_eq!(counts.total(), 2);
+    }
+
+    #[test]
+    fn disconnect_node_removes_lease_and_registry_entry() {
+        let controls = controls_with_no_peers();
+        let addr = SocketAddr::from(([127, 0, 0, 1], 3));
+        let lease = lease_in_map(&controls, addr, false);
+        controls.peer_registry().write().push(crate::PeerInfo {
+            addr,
+            version: 70_016,
+            services: 0,
+            user_agent: String::from("/test/"),
+            start_height: 0,
+            conn_time: 0,
+            inbound: false,
+        });
+        assert!(controls.disconnect_node(&addr));
+        assert!(lease.is_cancelled());
+        assert!(controls.peer_outbound().read().is_empty());
+        assert!(controls.peer_registry().read().is_empty());
+        assert!(!controls.disconnect_node(&addr));
+    }
+
+    #[test]
+    fn send_pings_queues_nonce_per_live_lease() {
+        let controls = controls_with_no_peers();
+        let addr = SocketAddr::from(([127, 0, 0, 1], 5));
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let lease = crate::PeerLease::new_inbound(tx);
+        controls.peer_outbound().write().insert(addr, lease.clone());
+        assert_eq!(controls.send_pings(10_000), 1);
+        assert!(matches!(rx.try_recv(), Ok(Message::Ping(_))));
+        assert!(lease.stats().ping_wait(10_500).is_some());
+    }
+
+    #[test]
+    fn add_node_records_and_dials() {
+        let (dial_tx, dial_rx) = crossbeam_channel::unbounded();
+        let controls = controls_with_no_peers().with_dial_sender(dial_tx);
+        controls
+            .add_node("127.0.0.1:8333")
+            .unwrap_or_else(|err| panic!("{err}"));
+        assert_eq!(
+            dial_rx.try_recv(),
+            Ok(SocketAddr::from(([127, 0, 0, 1], 8333)))
+        );
+        assert_eq!(controls.added_node_infos().len(), 1);
+        assert!(matches!(
+            controls.add_node("127.0.0.1:8333"),
+            Err(AddNodeError::AlreadyAdded)
+        ));
+    }
+
+    #[test]
+    fn dials_are_suppressed_while_network_inactive() {
+        let (dial_tx, dial_rx) = crossbeam_channel::unbounded();
+        let controls = controls_with_no_peers().with_dial_sender(dial_tx);
+        controls.set_network_active(false);
+        controls.try_node_connection("127.0.0.3:18444");
+        assert!(dial_rx.try_recv().is_err());
+        // Address book still observes the attempt.
+        assert_eq!(controls.node_addresses(0, None).len(), 1);
+    }
+
+    #[test]
+    fn node_addresses_persist_observed_peers_and_added_nodes() {
+        let controls = controls_with_no_peers();
+        let connected = SocketAddr::from(([198, 51, 100, 1], 8333));
+        lease_in_map(&controls, connected, false);
+        controls.peer_registry().write().push(crate::PeerInfo {
+            addr: connected,
+            version: 70_016,
+            services: 9,
+            user_agent: String::from("/test/"),
+            start_height: 1,
+            conn_time: 10,
+            inbound: false,
+        });
+        controls
+            .add_node("198.51.100.2:8333")
+            .unwrap_or_else(|err| panic!("add_node failed: {err}"));
+
+        let all = controls.node_addresses(0, None);
+        assert_eq!(all.len(), 2);
+        let first = all
+            .iter()
+            .find(|entry| entry.address == "198.51.100.1")
+            .unwrap_or_else(|| panic!("missing connected observation"));
+        assert_eq!(first.port, 8333);
+        assert_eq!(first.services, 9);
+        assert_eq!(first.network, "ipv4");
+
+        assert!(controls.disconnect_node(&connected));
+        let after = controls.node_addresses(0, Some("ipv4"));
+        assert!(
+            after.iter().any(|entry| entry.address == "198.51.100.1"),
+            "observed address must survive disconnect: {after:?}"
+        );
+        assert!(
+            after.iter().any(|entry| entry.address == "198.51.100.2"),
+            "added-node observation missing: {after:?}"
+        );
+        assert_eq!(controls.node_addresses(1, Some("ipv4")).len(), 1);
+        assert!(controls.node_addresses(0, Some("ipv6")).is_empty());
+    }
+
+    #[test]
+    fn observe_address_updates_services_without_dropping_entry() {
+        let controls = controls_with_no_peers();
+        let addr = SocketAddr::from(([203, 0, 113, 9], 18444));
+        controls.observe_address(addr, 0, SystemTime::UNIX_EPOCH);
+        controls.observe_address(addr, 73, SystemTime::UNIX_EPOCH + Duration::from_secs(50));
+        let entries = controls.node_addresses(0, None);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].services, 73);
+        assert_eq!(entries[0].time, 50);
     }
 }

--- a/crates/p2p/src/subnet.rs
+++ b/crates/p2p/src/subnet.rs
@@ -53,8 +53,11 @@ pub enum SubnetParseError {
 }
 
 impl IpSubnet {
-    /// Constructs a subnet after validating the prefix and zeroing host bits.
+    /// Constructs a subnet after canonicalizing an IPv4-mapped IPv6 base to
+    /// its IPv4 form (Core `CNetAddr` normalization), validating the prefix
+    /// against the canonical family, and zeroing host bits.
     pub fn new(base: IpAddr, prefix: u8) -> Result<Self, SubnetParseError> {
+        let base = base.to_canonical();
         match base {
             IpAddr::V4(ip) => {
                 validate_prefix(prefix, 32)?;
@@ -75,6 +78,7 @@ impl IpSubnet {
 
     /// Constructs a single-address subnet for the IP address family.
     pub fn from_ip(ip: IpAddr) -> Self {
+        let ip = ip.to_canonical();
         match ip {
             IpAddr::V4(ip) => Self {
                 base: IpAddr::V4(ip),
@@ -97,8 +101,10 @@ impl IpSubnet {
         self.prefix
     }
 
-    /// Returns whether `ip` is in this subnet.
+    /// Returns whether `ip` is in this subnet; IPv4-mapped IPv6 queries are
+    /// canonicalized first.
     pub fn contains(&self, ip: IpAddr) -> bool {
+        let ip = ip.to_canonical();
         match (self.base, ip) {
             (IpAddr::V4(base), IpAddr::V4(ip)) => mask_v4(ip, self.prefix) == base,
             (IpAddr::V6(base), IpAddr::V6(ip)) => mask_v6(ip, self.prefix) == base,
@@ -127,8 +133,7 @@ impl FromStr for IpSubnet {
             }
             None => (raw, None),
         };
-
-        let ip = parse_ip(ip_part)?;
+        let ip = parse_ip(ip_part)?.to_canonical();
         let prefix = match prefix_part {
             Some(prefix_part) => parse_prefix(prefix_part)?,
             None => match ip {

--- a/crates/p2p/src/wire.rs
+++ b/crates/p2p/src/wire.rs
@@ -28,7 +28,8 @@ pub const MAX_HEADERS_MESSAGE_COUNT: usize = 2_000;
 pub const MAX_LOCATOR_HASHES: usize = 101;
 /// Maximum address entries accepted in one `addr` or `addrv2` message.
 pub const MAX_ADDR_MESSAGE_COUNT: usize = 1_000;
-const HEADER_LEN: usize = 24;
+/// Fixed size of a Bitcoin v1 network message header.
+pub(crate) const HEADER_LEN: usize = 24;
 const COMMAND_LEN: usize = 12;
 
 /// Bitcoin P2P message payload type.
@@ -72,11 +73,14 @@ pub enum PeerError {
 }
 
 /// Write a Bitcoin v1 network message.
+///
+/// Returns the number of bytes written to the wire (header plus payload) so
+/// callers can account per-connection and aggregate traffic.
 pub fn write_message<W: Write>(
     writer: &mut W,
     magic: Magic,
     message: &Message,
-) -> Result<(), PeerError> {
+) -> Result<usize, PeerError> {
     let command = message.command();
     let payload = encode_payload(message)?;
     if payload.len() > MAX_MESSAGE_PAYLOAD {
@@ -90,7 +94,7 @@ pub fn write_message<W: Write>(
     writer.write_all(&len.to_le_bytes())?;
     writer.write_all(&checksum(&payload))?;
     writer.write_all(&payload)?;
-    Ok(())
+    Ok(HEADER_LEN + payload.len())
 }
 
 /// Read and validate a Bitcoin v1 network message.

--- a/crates/p2p/tests/listener_ban.rs
+++ b/crates/p2p/tests/listener_ban.rs
@@ -1,4 +1,4 @@
-//! P2P listener manual ban enforcement coverage.
+//! P2P listener manual-ban and network-control enforcement coverage.
 use std::error::Error;
 use std::io::{self, Read};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream};
@@ -8,8 +8,11 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
 use bitcoin::p2p::Magic;
-use bitcoin_rs_p2p::listener::{serve_with_shutdown, spawn_outbound_connection};
-use bitcoin_rs_p2p::{BannedSubnet, IpSubnet, PeerError};
+use bitcoin_rs_p2p::listener::{
+    serve_with_controls, serve_with_shutdown, spawn_outbound_connection,
+    spawn_outbound_connection_with_controls,
+};
+use bitcoin_rs_p2p::{BannedSubnet, IpSubnet, NetworkControls, PeerError};
 use parking_lot::RwLock;
 
 #[test]
@@ -197,4 +200,283 @@ fn join_listener(
         Ok(Err(error)) => Err(error.into()),
         Err(_) => Err(io::Error::other("listener thread panicked").into()),
     }
+}
+
+type LoopbackPeer = (
+    Arc<NetworkControls>,
+    SocketAddr,
+    thread::JoinHandle<Result<(), bitcoin_rs_p2p::listener::ListenerError>>,
+);
+/// Spawns a controls-driven listener and dials it with a controls-driven
+/// outbound connection; both sides register into the same shared state.
+fn loopback_peer_pair(shutdown: &Arc<AtomicBool>) -> Result<LoopbackPeer, Box<dyn Error>> {
+    let bind_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    let helper = TcpListener::bind(bind_addr)?;
+    let addr = helper.local_addr()?;
+    drop(helper);
+
+    let registry = Arc::new(RwLock::new(Vec::new()));
+    let outbound = Arc::new(RwLock::new(hashbrown::HashMap::new()));
+    let banned = Arc::new(RwLock::new(Vec::new()));
+    let controls = Arc::new(NetworkControls::new(
+        Arc::clone(&registry),
+        Arc::clone(&outbound),
+        Arc::clone(&banned),
+        8_333,
+    ));
+
+    let (headers_tx, _headers_rx) = crossbeam_channel::unbounded();
+    let (blocks_tx, _blocks_rx) = crossbeam_channel::unbounded();
+    let listener_shutdown = Arc::clone(shutdown);
+    let listener_controls = Arc::clone(&controls);
+    let listener = thread::spawn(move || {
+        serve_with_controls(
+            addr,
+            listener_shutdown,
+            Magic::BITCOIN,
+            listener_controls,
+            headers_tx,
+            blocks_tx,
+            None,
+            None,
+            None,
+        )
+    });
+
+    // Retry outbound dials until the controls map shows the outbound lease, or
+    // a finished attempt fails for a reason other than ConnectionRefused.
+    // Joining each refused attempt avoids silently losing a race against the
+    // asynchronously started listener.
+    let dial_deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        let (dial_headers_tx, _dial_headers_rx) = crossbeam_channel::unbounded();
+        let (dial_blocks_tx, _dial_blocks_rx) = crossbeam_channel::unbounded();
+        let dial_controls = Arc::clone(&controls);
+        let dial = spawn_outbound_connection_with_controls(
+            addr,
+            Magic::BITCOIN,
+            dial_controls,
+            dial_headers_tx,
+            dial_blocks_tx,
+            None,
+            None,
+            None,
+        );
+
+        while !dial.is_finished() {
+            if controls.peer_outbound().read().contains_key(&addr) {
+                // Successful dial stays attached to shared state; detach the
+                // handle the same way as before so tests join only the listener.
+                drop(dial);
+                return Ok((controls, addr, listener));
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let result = match dial.join() {
+            Ok(result) => result,
+            Err(error) => std::panic::resume_unwind(error),
+        };
+        match result {
+            Ok(()) => {
+                if controls.peer_outbound().read().contains_key(&addr) {
+                    return Ok((controls, addr, listener));
+                }
+                shutdown.store(true, Ordering::Relaxed);
+                let _ = join_listener(listener);
+                return Err("outbound dial finished without registering a lease".into());
+            }
+            Err(PeerError::Io(error))
+                if error.kind() == io::ErrorKind::ConnectionRefused
+                    && Instant::now() < dial_deadline => {}
+            Err(error) => {
+                shutdown.store(true, Ordering::Relaxed);
+                let _ = join_listener(listener);
+                return Err(error.into());
+            }
+        }
+    }
+}
+
+fn wait_until(deadline: Duration, predicate: impl Fn() -> bool) -> bool {
+    let deadline = Instant::now() + deadline;
+    while Instant::now() < deadline {
+        if predicate() {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    predicate()
+}
+
+fn unix_micros_now() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |duration| {
+            u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+        })
+}
+
+#[test]
+fn controls_see_both_connection_directions_and_handshake_registry() -> Result<(), Box<dyn Error>> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let (controls, addr, listener) = loopback_peer_pair(&shutdown)?;
+
+    let handshake_done = wait_until(Duration::from_secs(5), || {
+        controls
+            .peer_registry()
+            .read()
+            .iter()
+            .any(|p| p.addr == addr)
+    });
+    shutdown.store(true, Ordering::Relaxed);
+    join_listener(listener)?;
+
+    assert!(handshake_done, "inbound handshake must publish peer info");
+    let counts = controls.connection_counts();
+    assert_eq!(counts.total(), 2, "one inbound and one outbound connection");
+    assert_eq!(counts.inbound, 1);
+    assert_eq!(counts.outbound, 1);
+
+    let peers = controls.connected_peers();
+    assert_eq!(peers.len(), 2);
+    assert!(peers.iter().all(|peer| peer.info.is_some()));
+    assert!(peers.iter().any(|peer| peer.inbound && peer.node_id > 0));
+    Ok(())
+}
+
+#[test]
+fn ping_round_trip_measures_duration_on_both_sides() -> Result<(), Box<dyn Error>> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let (controls, addr, listener) = loopback_peer_pair(&shutdown)?;
+
+    let handshake_done = wait_until(Duration::from_secs(5), || {
+        controls
+            .peer_registry()
+            .read()
+            .iter()
+            .any(|p| p.addr == addr)
+    });
+    assert!(handshake_done, "handshake must complete before pinging");
+    assert_eq!(controls.send_pings(unix_micros_now()), 2);
+
+    let measured = wait_until(Duration::from_secs(5), || {
+        controls
+            .connected_peers()
+            .iter()
+            .all(|peer| peer.stats.ping_time().is_some())
+    });
+    shutdown.store(true, Ordering::Relaxed);
+    join_listener(listener)?;
+
+    assert!(
+        measured,
+        "both peers must answer their ping with a measured round trip"
+    );
+    Ok(())
+}
+
+#[test]
+fn traffic_totals_accumulate_from_live_connections() -> Result<(), Box<dyn Error>> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let (controls, addr, listener) = loopback_peer_pair(&shutdown)?;
+
+    let traffic_flowed = wait_until(Duration::from_secs(5), || {
+        controls
+            .peer_registry()
+            .read()
+            .iter()
+            .any(|p| p.addr == addr)
+            && controls.totals().total_bytes_recv() > 0
+            && controls.totals().total_bytes_sent() > 0
+    });
+    shutdown.store(true, Ordering::Relaxed);
+    join_listener(listener)?;
+
+    assert!(traffic_flowed, "handshake traffic must reach the totals");
+    assert_eq!(
+        controls.connection_counts().total(),
+        2,
+        "both connection directions stay live until shutdown"
+    );
+    Ok(())
+}
+
+#[test]
+fn setnetworkactive_refuses_new_outbound_activity() -> Result<(), Box<dyn Error>> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let (controls, addr, listener) = loopback_peer_pair(&shutdown)?;
+    let handshake_done = wait_until(Duration::from_secs(5), || {
+        controls
+            .peer_registry()
+            .read()
+            .iter()
+            .any(|p| p.addr == addr)
+    });
+    assert!(handshake_done);
+    assert!(!controls.set_network_active(false));
+    assert!(!controls.network_active());
+
+    // A further dial while inactive must fail without opening activity.
+    let (headers_tx, _headers_rx) = crossbeam_channel::unbounded();
+    let (blocks_tx, _blocks_rx) = crossbeam_channel::unbounded();
+    let dial_controls = Arc::clone(&controls);
+    let refused = spawn_outbound_connection_with_controls(
+        addr,
+        Magic::BITCOIN,
+        dial_controls,
+        headers_tx,
+        blocks_tx,
+        None,
+        None,
+        None,
+    );
+    let refused_result = match refused.join() {
+        Ok(result) => result,
+        Err(error) => std::panic::resume_unwind(error),
+    };
+    shutdown.store(true, Ordering::Relaxed);
+    join_listener(listener)?;
+
+    assert!(
+        matches!(refused_result, Err(PeerError::Protocol("network inactive"))),
+        "inactive networking must refuse the dial, got {refused_result:?}"
+    );
+
+    assert!(controls.set_network_active(true));
+    assert!(controls.network_active());
+    Ok(())
+}
+
+#[test]
+fn controls_disconnect_node_promptly_removes_the_lease() -> Result<(), Box<dyn Error>> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let (controls, addr, listener) = loopback_peer_pair(&shutdown)?;
+    let handshake_done = wait_until(Duration::from_secs(5), || {
+        controls
+            .peer_registry()
+            .read()
+            .iter()
+            .any(|p| p.addr == addr)
+    });
+    assert!(handshake_done);
+    assert!(controls.disconnect_node(&addr));
+
+    let outbound_gone = wait_until(Duration::from_secs(5), || {
+        !controls.peer_outbound().read().contains_key(&addr)
+            || !controls
+                .peer_registry()
+                .read()
+                .iter()
+                .any(|peer| peer.addr == addr)
+    });
+    shutdown.store(true, Ordering::Relaxed);
+    join_listener(listener)?;
+
+    assert!(
+        outbound_gone,
+        "disconnect_node must remove the lease and its registry entry"
+    );
+    assert!(!controls.disconnect_node(&addr));
+    Ok(())
 }

--- a/crates/p2p/tests/subnet.rs
+++ b/crates/p2p/tests/subnet.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_used)]
 //! Subnet primitive coverage: parsing, normalization, expiry, and matching.
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -85,6 +86,50 @@ fn zero_prefix_matches_entire_same_family_only() {
     assert_eq!(v6_subnet.to_string(), "::/0");
     assert!(v6_subnet.contains(v6([0x2001, 0x0db8, 0, 0, 0, 0, 0, 1])));
     assert!(!v6_subnet.contains(v4(203, 0, 113, 1)));
+}
+
+#[test]
+fn ipv4_mapped_ipv6_base_canonicalizes_to_ipv4_subnet() {
+    let subnet = parse_subnet("::ffff:192.0.2.7");
+
+    assert_eq!(subnet.to_string(), "192.0.2.7/32");
+    assert!(subnet.contains(v4(192, 0, 2, 7)));
+    assert!(
+        subnet.contains(
+            "::ffff:192.0.2.7"
+                .parse::<std::net::IpAddr>()
+                .expect("mapped v6 literal parses")
+        )
+    );
+    assert!(!subnet.contains(v4(192, 0, 2, 8)));
+}
+
+#[test]
+fn ipv4_mapped_ipv6_prefix_validates_against_canonical_family() {
+    assert_eq!(
+        "::ffff:192.0.2.0/24"
+            .parse::<IpSubnet>()
+            .expect("mapped subnet with v4-width prefix parses")
+            .to_string(),
+        "192.0.2.0/24"
+    );
+    assert_eq!(
+        "::ffff:192.0.2.0/120".parse::<IpSubnet>(),
+        Err(SubnetParseError::PrefixTooLarge {
+            width: 32,
+            prefix: 120,
+        })
+    );
+}
+
+#[test]
+fn mapped_v4_query_matches_plain_v4_subnet() {
+    let subnet = parse_subnet("192.0.2.0/24");
+    let mapped: std::net::IpAddr = "::ffff:192.0.2.9"
+        .parse()
+        .expect("mapped v6 literal parses");
+
+    assert!(subnet.contains(mapped));
 }
 
 #[test]


### PR DESCRIPTION
Peer control, ban state, traffic totals, ping, added-node, and
active-state operations become authoritative in the p2p crate.

Listener helpers that run.rs already calls stay public so this
unit compiles on main without later mining-control wiring.

Independent of the mining stack. Base is main.

Verification: pre-commit fmt, both Clippy lanes, workspace tests,
and full-node tests passed on this commit.


Closes #187
