### PR TITLE
Expose Core lifecycle facts

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 # Note: `--workspace --features "..."` in a virtual workspace (no root [package])
 # does NOT forward CLI features to library crates; always use -p when features
 # must reach a specific crate.
-default = ["fjall", "kernel"]
+default = ["fjall", "kernel", "zmq"]
 rocksdb = [
     "bitcoin-rs-chain/rocksdb",
     "bitcoin-rs-consensus/rocksdb",
@@ -65,6 +65,7 @@ mdbx = [
     "bitcoin-rs-storage/mdbx",
 ]
 kernel = ["bitcoin-rs-consensus/kernel"]
+zmq = ["dep:zmq"]
 checksig-census = [
     "kernel",
     "bitcoin-rs-consensus/checksig-census",
@@ -109,7 +110,7 @@ quanta.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 rayon.workspace = true
-zmq.workspace = true
+zmq = { workspace = true, optional = true }
 sha2.workspace = true
 cap-std.workspace = true
 cap-fs-ext.workspace = true

--- a/crates/node/benches/sync_apply_metrics.rs
+++ b/crates/node/benches/sync_apply_metrics.rs
@@ -20,7 +20,7 @@ use bitcoin::{
 use bitcoin_rs_chain::{BlockTree, NodeStatus};
 use bitcoin_rs_node::{
     Config, Network,
-    metrics::{MetricValue, MetricsHandle, install_metrics},
+    metrics::{MetricValue, MetricsHandle},
     state::NodeState,
 };
 use bitcoin_rs_p2p::{Message, PeerInfo};
@@ -215,7 +215,7 @@ fn print_utxo_fanout_commit_metrics(name: &str, with_listener: bool) {
 
 fn install_diagnostic_metrics() -> MetricsHandle {
     let bind = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-    install_metrics(Some(bind))
+    bitcoin_rs_node::metrics::install_diagnostic_metrics(Some(bind))
         .unwrap_or_else(|error| panic!("install metrics recorder failed: {error}"))
         .unwrap_or_else(|| panic!("metrics recorder was not installed"))
 }

--- a/crates/node/examples/mainnet_prefix_replay.rs
+++ b/crates/node/examples/mainnet_prefix_replay.rs
@@ -353,10 +353,9 @@ fn main() -> Result<()> {
     config.txindex = args.txindex;
     config.assume_valid_height = args.assume_valid_height;
 
-    // In-memory recorder for the apply path's per-stage histograms; the bind
-    // address only names the future exporter endpoint and is never served.
+    // In-memory recorder for the apply path's per-stage histograms.
     let metrics_handle =
-        bitcoin_rs_node::metrics::install_metrics(Some(([127, 0, 0, 1], 0).into()))
+        bitcoin_rs_node::metrics::install_diagnostic_metrics(Some(([127, 0, 0, 1], 0).into()))
             .context("install metrics recorder")?;
 
     // Validate manifest identity, range, and archive size before opening state.

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -69,6 +69,6 @@ pub use state::{ApplyError, DisconnectError};
 pub use sync::BlockSync;
 pub use txindex_worker::TxIndexRuntime;
 pub use utxo_view::UtxoSetView;
-pub use zmq_publisher::{
-    NoOpZmqPublisher, SequenceEvent, SocketZmqPublisher, TracingZmqPublisher, ZmqPublisher,
-};
+#[cfg(feature = "zmq")]
+pub use zmq_publisher::SocketZmqPublisher;
+pub use zmq_publisher::{NoOpZmqPublisher, SequenceEvent, TracingZmqPublisher, ZmqPublisher};

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -1,8 +1,17 @@
 extern crate alloc;
 
+use alloc::collections::BTreeMap;
+use alloc::string::String;
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use hashbrown::HashMap;
-use std::net::SocketAddr;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use metrics::{
@@ -21,7 +30,7 @@ pub struct MetricsHandle {
 }
 
 impl MetricsHandle {
-    /// Address requested for the future Prometheus exporter.
+    /// Address associated with this diagnostic recorder.
     #[must_use]
     pub const fn bind(&self) -> SocketAddr {
         self.bind
@@ -170,6 +179,42 @@ impl HistogramFn for HistogramHandle {
     }
 }
 
+/// Monotonic process start, recorded once at node startup.
+///
+/// Core initializes its uptime clock at process start (`GetUptime`,
+/// `src/common/system.cpp`), so every later query reports true elapsed
+/// runtime. A lazily initialized clock would restart on first read, which is
+/// the first-call-reports-approximately-zero bug the utility parity audit
+/// records for `uptime`; the earliest-wins record here makes the node, not
+/// the first RPC caller, own the origin.
+static PROCESS_START: OnceLock<Instant> = OnceLock::new();
+
+/// Records the authoritative process start instant for uptime accounting.
+///
+/// Idempotent and earliest-wins: the first caller fixes the uptime origin,
+/// mirroring Core's static initialization. `run` records this before wiring
+/// subsystems so the clock covers the whole node lifecycle.
+pub fn record_process_start(start: Instant) {
+    let _ = PROCESS_START.set(start);
+}
+
+/// Returns the recorded process start instant, or `None` before
+/// [`record_process_start`] has run.
+#[must_use]
+pub fn process_start() -> Option<Instant> {
+    PROCESS_START.get().copied()
+}
+
+/// Returns monotonic uptime since the recorded process start, or `None`
+/// before [`record_process_start`] has run.
+///
+/// `None` keeps the not-yet-started state observable instead of silently
+/// restarting the clock on read.
+#[must_use]
+pub fn process_uptime() -> Option<Duration> {
+    PROCESS_START.get().map(Instant::elapsed)
+}
+
 /// Resident set size of this process in bytes, or `None` where the platform
 /// cannot report it.
 ///
@@ -233,16 +278,97 @@ fn parse_ps_rss(output: &str) -> Option<u64> {
     output.trim().parse::<u64>().ok()?.checked_mul(1024)
 }
 
-/// Installs in-memory process metrics and returns its handle when configured.
+/// Warning kinds the node can raise, mirroring Core's kernel and node warning
+/// ids.
 ///
-/// The workspace pins `metrics-exporter-prometheus` without its HTTP listener.
-/// This recorder keeps v1 metrics in process; wiring the Prometheus endpoint is
-/// left to the follow-up feature that enables the exporter listener.
-pub fn install_metrics(bind: Option<SocketAddr>) -> Result<Option<MetricsHandle>> {
-    install_metrics_with(bind, metrics::set_global_recorder)
+/// Declaration order is the report order: Core keys its registry by
+/// `std::variant<kernel::Warning, node::Warning>`, so kernel-issued warnings
+/// sort before node-issued ones.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum WarningKind {
+    /// A versionbit unknown to this node activated on the network.
+    UnknownNewRulesActivated,
+    /// An invalid chain with substantially more work than the best chain was
+    /// found.
+    LargeWorkInvalidChain,
+    /// The system clock is far out of sync with peer clocks.
+    ClockOutOfSync,
+    /// An internal error put the node in a state it cannot recover from.
+    FatalInternalError,
 }
 
-fn install_metrics_with(
+/// Node warning registry, mirroring Core's `node::Warnings`.
+///
+/// At most one message per [`WarningKind`]: setting an already-active kind
+/// keeps the original message, and [`Warnings::messages`] reports in kind
+/// order. The registry is node-owned state; RPC projections read it live at
+/// call time instead of copying warnings into transport-owned storage.
+pub struct Warnings {
+    active: Mutex<BTreeMap<WarningKind, String>>,
+}
+
+impl Default for Warnings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Warnings {
+    /// Creates an empty registry.
+    pub const fn new() -> Self {
+        Self {
+            active: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Activates the warning for `kind` with `message`.
+    ///
+    /// Returns `true` when the warning was newly set. An already-active kind
+    /// keeps its original message and returns `false`, matching Core's
+    /// `Warnings::Set`.
+    pub fn set(&self, kind: WarningKind, message: impl Into<String>) -> bool {
+        let mut active = self.active.lock();
+        if active.contains_key(&kind) {
+            return false;
+        }
+        active.insert(kind, message.into());
+        true
+    }
+
+    /// Deactivates the warning for `kind`, returning whether one was active.
+    pub fn unset(&self, kind: WarningKind) -> bool {
+        self.active.lock().remove(&kind).is_some()
+    }
+
+    /// Returns the active warning messages ordered by kind.
+    #[must_use]
+    pub fn messages(&self) -> Vec<String> {
+        self.active.lock().values().cloned().collect()
+    }
+}
+
+static NODE_WARNINGS: Warnings = Warnings::new();
+
+/// Returns the process-wide node warning registry.
+///
+/// This is the authoritative warnings fact source: the `getblockchaininfo`,
+/// `getnetworkinfo`, and `getmininginfo` projections read it at invocation,
+/// the way Core reads `NodeContext::warnings` through `GetWarningsForRpc`.
+#[must_use]
+pub fn node_warnings() -> &'static Warnings {
+    &NODE_WARNINGS
+}
+
+/// Installs the in-memory diagnostic recorder and returns its handle when a
+/// bind address is provided.
+///
+/// This path does not serve HTTP. Production scrape exposition uses
+/// [`start_metrics`] / [`MetricsServer`].
+pub fn install_diagnostic_metrics(bind: Option<SocketAddr>) -> Result<Option<MetricsHandle>> {
+    install_diagnostic_metrics_with(bind, metrics::set_global_recorder)
+}
+
+fn install_diagnostic_metrics_with(
     bind: Option<SocketAddr>,
     install_recorder: impl FnOnce(
         InMemoryRecorder,
@@ -256,7 +382,11 @@ fn install_metrics_with(
     install_recorder(recorder.clone())?;
 
     let handle = MetricsHandle { bind, recorder };
+    describe_node_metrics();
+    Ok(Some(handle))
+}
 
+fn describe_node_metrics() {
     metrics::describe_counter!("node.event_loop.mempool_ticks", "mempool maintenance ticks");
     metrics::describe_counter!("node.event_loop.metrics_scrapes", "metrics scrape ticks");
     metrics::describe_counter!("node.event_loop.sync_ticks", "block sync ticks");
@@ -272,8 +402,125 @@ fn install_metrics_with(
         "node.event_loop.tick_seconds",
         "event loop tick latency seconds"
     );
+}
 
-    Ok(Some(handle))
+static PROMETHEUS_HANDLE: Mutex<Option<PrometheusHandle>> = Mutex::new(None);
+
+fn prometheus_handle() -> Result<PrometheusHandle> {
+    let mut slot = PROMETHEUS_HANDLE.lock();
+    if let Some(handle) = slot.as_ref() {
+        return Ok(handle.clone());
+    }
+    let handle = PrometheusBuilder::new()
+        .install_recorder()
+        .map_err(|error| anyhow::anyhow!("install prometheus recorder: {error}"))?;
+    *slot = Some(handle.clone());
+    Ok(handle)
+}
+
+/// Process-global Prometheus scrape listener bound by [`start_metrics`].
+pub struct MetricsServer {
+    local_addr: SocketAddr,
+    stop: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl MetricsServer {
+    /// Binds `addr` before installing the recorder, then serves Prometheus text.
+    ///
+    /// Listener-first ordering keeps an occupied-address failure from consuming
+    /// the process-global recorder slot, so a later in-process retry cannot hit
+    /// `SetRecorderError`.
+    pub fn bind(addr: SocketAddr, shutdown: Arc<AtomicBool>) -> Result<Self> {
+        let listener = TcpListener::bind(addr)?;
+        let local_addr = listener.local_addr()?;
+        let handle = prometheus_handle()?;
+        describe_node_metrics();
+        listener.set_nonblocking(true)?;
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let thread = thread::Builder::new()
+            .name("bitcoin-rs-metrics".into())
+            .spawn(move || serve_metrics(&listener, &handle, &thread_stop, &shutdown))?;
+        Ok(Self {
+            local_addr,
+            stop,
+            thread: Some(thread),
+        })
+    }
+
+    /// Address the scrape thread is listening on.
+    #[must_use]
+    pub const fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Signals the scrape thread and waits for it to exit.
+    pub fn join(mut self) {
+        self.stop_and_join();
+    }
+
+    fn stop_and_join(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for MetricsServer {
+    fn drop(&mut self) {
+        self.stop_and_join();
+    }
+}
+
+/// Starts the production scrape listener when `metrics_bind` is configured.
+///
+/// This is the entry `run` uses after [`crate::state::NodeState::open`].
+pub(crate) fn start_metrics(
+    bind: Option<SocketAddr>,
+    shutdown: Arc<AtomicBool>,
+) -> Result<Option<MetricsServer>> {
+    bind.map(|addr| MetricsServer::bind(addr, shutdown))
+        .transpose()
+}
+
+fn serve_metrics(
+    listener: &TcpListener,
+    handle: &PrometheusHandle,
+    stop: &Arc<AtomicBool>,
+    shutdown: &Arc<AtomicBool>,
+) {
+    loop {
+        if stop.load(Ordering::Acquire) || shutdown.load(Ordering::Acquire) {
+            break;
+        }
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                let _ = stream.set_nonblocking(false);
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+                let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
+                serve_scrape(&mut stream, handle);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(_) => break,
+        }
+    }
+}
+
+fn serve_scrape(stream: &mut TcpStream, handle: &PrometheusHandle) {
+    let mut buf = [0_u8; 1024];
+    let _ = stream.read(&mut buf);
+    let body = handle.render();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
 }
 
 #[cfg(test)]
@@ -287,7 +534,11 @@ pub(crate) fn test_recorder() -> (impl Recorder, MetricsHandle) {
 }
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::io::{Read, Write};
+    use std::net::{IpAddr, Ipv4Addr, TcpListener, TcpStream};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     use super::*;
 
@@ -393,14 +644,72 @@ Threads:\t17
     }
 
     #[test]
-    fn install_metrics_returns_error_when_global_recorder_install_fails() {
+    fn install_diagnostic_metrics_returns_error_when_global_recorder_install_fails() {
         let bind = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
-        let result = install_metrics_with(Some(bind), |recorder| {
+        let result = install_diagnostic_metrics_with(Some(bind), |recorder| {
             Err(metrics::SetRecorderError(recorder))
         });
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn process_start_is_recorded_once_and_uptime_advances() {
+        use std::thread;
+        use std::time::Duration;
+
+        record_process_start(Instant::now());
+        let first = process_start();
+        let before = process_uptime();
+
+        thread::sleep(Duration::from_millis(25));
+        // A second record must not move the clock — earliest-wins is what
+        // makes the node, rather than the latest caller, own the origin.
+        record_process_start(Instant::now());
+
+        assert_eq!(
+            process_start(),
+            first,
+            "a second record_process_start must not move the start instant"
+        );
+        let Some(before) = before else {
+            panic!("uptime must be observable after record_process_start");
+        };
+        let after = process_uptime().unwrap_or_else(|| panic!("uptime must stay observable"));
+        assert!(
+            after >= before + Duration::from_millis(20),
+            "uptime must advance with elapsed time: {before:?} -> {after:?}"
+        );
+    }
+
+    #[test]
+    fn warnings_keep_first_message_and_report_in_kind_order() {
+        let warnings = Warnings::new();
+        assert!(warnings.messages().is_empty());
+
+        assert!(warnings.set(WarningKind::ClockOutOfSync, "clock out of sync"));
+        // Core ignores a later message for an already-active kind.
+        assert!(!warnings.set(WarningKind::ClockOutOfSync, "superseded message"));
+        assert!(warnings.set(WarningKind::FatalInternalError, "fatal"));
+        assert!(warnings.set(WarningKind::UnknownNewRulesActivated, "unknown rules"));
+
+        assert_eq!(
+            warnings.messages(),
+            [
+                "unknown rules".to_owned(),
+                "clock out of sync".to_owned(),
+                "fatal".to_owned(),
+            ],
+            "kernel warnings must sort before node warnings regardless of set order"
+        );
+
+        assert!(warnings.unset(WarningKind::ClockOutOfSync));
+        assert!(!warnings.unset(WarningKind::ClockOutOfSync));
+        assert_eq!(
+            warnings.messages(),
+            ["unknown rules".to_owned(), "fatal".to_owned()]
+        );
     }
 
     #[test]
@@ -455,5 +764,142 @@ Threads:\t17
             snapshot.get("node.test.repeat_histogram"),
             Some(&MetricValue::Histogram { count: 2, sum: 5.0 })
         );
+    }
+
+    fn unused_ephemeral() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)
+    }
+
+    fn scrape(addr: SocketAddr) -> (u16, String) {
+        let mut last = None;
+        for _ in 0..50 {
+            match TcpStream::connect_timeout(&addr, Duration::from_millis(100)) {
+                Ok(mut stream) => {
+                    stream
+                        .write_all(b"GET /metrics HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+                        .unwrap_or_else(|error| panic!("write scrape request: {error}"));
+                    stream
+                        .flush()
+                        .unwrap_or_else(|error| panic!("flush scrape request: {error}"));
+                    let mut body = String::new();
+                    stream
+                        .read_to_string(&mut body)
+                        .unwrap_or_else(|error| panic!("read scrape response: {error}"));
+                    let status = body
+                        .split_whitespace()
+                        .nth(1)
+                        .and_then(|token| token.parse().ok())
+                        .unwrap_or(0);
+                    return (status, body);
+                }
+                Err(error) => last = Some(error),
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        panic!("scrape connect failed: {last:?}");
+    }
+
+    #[test]
+    fn occupied_address_bind_errors_and_in_process_retry_succeeds() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let occupied = TcpListener::bind(unused_ephemeral())
+            .unwrap_or_else(|error| panic!("occupy port: {error}"));
+        let addr = occupied
+            .local_addr()
+            .unwrap_or_else(|error| panic!("occupied local addr: {error}"));
+        let installed_before = PROMETHEUS_HANDLE.lock().is_some();
+
+        let first = start_metrics(Some(addr), Arc::clone(&shutdown));
+        assert!(first.is_err(), "occupied bind must fail");
+        assert_eq!(
+            PROMETHEUS_HANDLE.lock().is_some(),
+            installed_before,
+            "failed bind must not install the process recorder"
+        );
+
+        drop(occupied);
+        let server = start_metrics(Some(unused_ephemeral()), shutdown)
+            .unwrap_or_else(|error| panic!("retry after occupied bind: {error}"))
+            .unwrap_or_else(|| panic!("metrics server"));
+        metrics::counter!("node_metrics_retry_probe").increment(1);
+        let (status, body) = scrape(server.local_addr());
+        assert_eq!(status, 200);
+        assert!(
+            body.contains("node_metrics_retry_probe"),
+            "retry scrape missing recorded metric: {body}"
+        );
+        server.join();
+    }
+
+    #[test]
+    fn scrape_returns_prometheus_text_with_recorded_metrics() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let server = MetricsServer::bind(unused_ephemeral(), shutdown)
+            .unwrap_or_else(|error| panic!("bind metrics: {error}"));
+        metrics::counter!("node_metrics_scrape_probe").increment(1);
+        let (status, body) = scrape(server.local_addr());
+        assert_eq!(status, 200);
+        assert!(
+            body.contains("text/plain"),
+            "content-type must be prometheus text: {body}"
+        );
+        assert!(
+            body.contains("node_metrics_scrape_probe"),
+            "body must include recorded metric: {body}"
+        );
+        server.join();
+    }
+
+    #[test]
+    fn two_sequential_servers_in_one_process_both_serve() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let first = MetricsServer::bind(unused_ephemeral(), Arc::clone(&shutdown))
+            .unwrap_or_else(|error| panic!("first: {error}"));
+        metrics::counter!("node_metrics_sequential_probe").increment(1);
+        let (status, body) = scrape(first.local_addr());
+        assert_eq!(status, 200);
+        assert!(body.contains("node_metrics_sequential_probe"));
+        first.join();
+
+        let second = MetricsServer::bind(unused_ephemeral(), shutdown)
+            .unwrap_or_else(|error| panic!("second: {error}"));
+        metrics::counter!("node_metrics_sequential_probe").increment(1);
+        let (status, body) = scrape(second.local_addr());
+        assert_eq!(status, 200);
+        assert!(body.contains("node_metrics_sequential_probe"));
+        second.join();
+    }
+
+    #[test]
+    fn shutdown_exits_the_listener_thread() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let server = MetricsServer::bind(unused_ephemeral(), Arc::clone(&shutdown))
+            .unwrap_or_else(|error| panic!("bind: {error}"));
+        let addr = server.local_addr();
+        shutdown.store(true, Ordering::Release);
+        server.join();
+        TcpListener::bind(addr)
+            .unwrap_or_else(|error| panic!("port released after listener join: {error}"));
+    }
+
+    #[test]
+    fn run_retries_metrics_bind_after_occupied_address() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let occupied =
+            TcpListener::bind(unused_ephemeral()).unwrap_or_else(|error| panic!("occupy: {error}"));
+        let busy = occupied
+            .local_addr()
+            .unwrap_or_else(|error| panic!("busy addr: {error}"));
+        assert!(
+            start_metrics(Some(busy), Arc::clone(&shutdown)).is_err(),
+            "run-path bind must fail on an occupied address"
+        );
+        drop(occupied);
+        let server = start_metrics(Some(unused_ephemeral()), shutdown)
+            .unwrap_or_else(|error| panic!("run-path retry: {error}"))
+            .unwrap_or_else(|| panic!("server"));
+        let (status, _) = scrape(server.local_addr());
+        assert_eq!(status, 200);
+        server.join();
     }
 }

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -556,16 +556,18 @@ pub fn run(mut config: Config) -> Result<()> {
         "bitcoin-rs node booting"
     );
 
+    crate::metrics::start_metrics(state.config().metrics_bind, state.shutdown())?;
+
+    let shutdown = state.shutdown();
     let shutdown_rx: Receiver<()> = if let Some(rx) = injected_shutdown {
         rx
     } else {
         let (tx, rx) = bounded(1);
         // Forwards process signals into our channel; the JoinHandle outlives `run`.
-        let _signal_thread = crate::signal::install_shutdown_handler(tx)?;
+        let _signal_thread =
+            crate::signal::install_shutdown_handler(std::sync::Arc::clone(&shutdown), tx)?;
         rx
     };
-
-    let shutdown = state.shutdown();
     let banned = state.banned_subnets();
     let block_body_source = state.block_body_source();
     let p2p_chain_query: P2pChainQuery = Arc::new(

--- a/crates/node/src/shutdown.rs
+++ b/crates/node/src/shutdown.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -5,6 +6,66 @@ use parking_lot::{Condvar, Mutex, const_mutex};
 
 static DRAINED: Mutex<bool> = const_mutex(true);
 static DRAINED_CVAR: Condvar = Condvar::new();
+
+/// Broadcast state for a shutdown request.
+///
+/// Split from the process-wide static as a type so the request/wake contract
+/// is testable on isolated instances; the free functions delegate to the one
+/// process-wide instance.
+struct ShutdownBroadcast {
+    requested: Mutex<bool>,
+    wake: Condvar,
+}
+
+impl ShutdownBroadcast {
+    const fn new() -> Self {
+        Self {
+            requested: const_mutex(false),
+            wake: Condvar::new(),
+        }
+    }
+
+    /// Marks the first request and wakes every parked waiter exactly once.
+    fn request(&self) -> bool {
+        let mut requested = self.requested.lock();
+        if *requested {
+            return false;
+        }
+        *requested = true;
+        self.wake.notify_all();
+        true
+    }
+
+    /// Stores `flag` with Release ordering, then publishes the first broadcast.
+    fn trigger(&self, flag: &AtomicBool) -> bool {
+        if flag
+            .compare_exchange(false, true, Ordering::Release, Ordering::Acquire)
+            .is_err()
+        {
+            return false;
+        }
+        self.request()
+    }
+
+    fn requested(&self) -> bool {
+        *self.requested.lock()
+    }
+
+    /// Parks until the request arrives or `deadline` elapses.
+    ///
+    /// Returns whether shutdown is requested; a request that raced ahead of
+    /// the park is observed through the flag, so no wake can be lost.
+    fn wait_for(&self, deadline: Duration) -> bool {
+        let mut requested = self.requested.lock();
+        if *requested {
+            return true;
+        }
+        let _timed_out = self.wake.wait_for(&mut requested, deadline);
+        *requested
+    }
+}
+
+static SHUTDOWN: ShutdownBroadcast = ShutdownBroadcast::new();
 
 /// Marks subsystem draining as active.
 pub(crate) fn mark_draining() {
@@ -24,4 +85,125 @@ pub fn drain_and_shutdown(deadline: Duration) -> Result<()> {
         let _timeout = DRAINED_CVAR.wait_for(&mut drained, deadline);
     }
     Ok(())
+}
+
+/// Sets `flag` before publishing the process-wide shutdown broadcast.
+///
+/// The store uses `Release` so any waiter that wakes from the broadcast can
+/// observe the flag with `Acquire`. Repeated calls stay idempotent: the flag
+/// remains true and the broadcast is published again without a second state
+/// transition.
+pub fn trigger_shutdown(flag: &AtomicBool) -> bool {
+    SHUTDOWN.trigger(flag)
+}
+
+/// Marks shutdown as requested and wakes every [`wait_for_shutdown`] waiter.
+///
+/// Idempotent. Long-poll style waiters block in [`wait_for_shutdown`] and must
+/// observe a shutdown decision the moment it is made — not at their next
+/// timeout slice — which is the wake Core's shutdown sequence gives its own
+/// long-lived waiters. Production signal and event-loop paths call
+/// [`trigger_shutdown`] so the node-owned flag is visible before this wake.
+pub fn request_shutdown() -> bool {
+    SHUTDOWN.request()
+}
+
+/// Returns whether shutdown has been requested.
+#[must_use]
+pub fn shutdown_requested() -> bool {
+    SHUTDOWN.requested()
+}
+
+/// Blocks until shutdown is requested or `deadline` elapses.
+///
+/// Returns `true` when shutdown is (or became) requested; `false` only when
+/// the deadline elapsed without a request.
+pub fn wait_for_shutdown(deadline: Duration) -> bool {
+    SHUTDOWN.wait_for(deadline)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    use super::ShutdownBroadcast;
+
+    #[test]
+    fn request_wakes_a_blocked_waiter() {
+        let broadcast = Arc::new(ShutdownBroadcast::new());
+        let waiter = {
+            let broadcast = Arc::clone(&broadcast);
+            thread::spawn(move || broadcast.wait_for(Duration::from_secs(30)))
+        };
+
+        thread::sleep(Duration::from_millis(25));
+        broadcast.request();
+
+        // The waiter parks for 30s; only the wake can return it promptly, so
+        // joining at all proves the wake fired.
+        assert!(
+            waiter.join().unwrap_or(false),
+            "waiter must wake on request rather than time out"
+        );
+    }
+
+    #[test]
+    fn wait_for_times_out_when_never_requested() {
+        let broadcast = ShutdownBroadcast::new();
+
+        assert!(!broadcast.wait_for(Duration::from_millis(25)));
+    }
+
+    #[test]
+    fn request_is_idempotent_and_pre_requested_wait_returns_immediately() {
+        let broadcast = ShutdownBroadcast::new();
+
+        assert!(broadcast.request());
+        assert!(!broadcast.request());
+
+        assert!(broadcast.requested());
+        assert!(broadcast.wait_for(Duration::ZERO));
+    }
+
+    #[test]
+    fn process_wide_functions_share_one_registry() {
+        super::request_shutdown();
+
+        assert!(super::shutdown_requested());
+        assert!(super::wait_for_shutdown(Duration::ZERO));
+    }
+
+    #[test]
+    fn trigger_stores_the_flag_before_waiters_observe_the_wake() {
+        let broadcast = Arc::new(ShutdownBroadcast::new());
+        let flag = Arc::new(AtomicBool::new(false));
+        let waiters: Vec<_> = (0..3)
+            .map(|_| {
+                let broadcast = Arc::clone(&broadcast);
+                let flag = Arc::clone(&flag);
+                thread::spawn(move || {
+                    assert!(broadcast.wait_for(Duration::from_secs(5)));
+                    assert!(
+                        flag.load(Ordering::Acquire),
+                        "every waiter must see the flag after the broadcast"
+                    );
+                })
+            })
+            .collect();
+
+        thread::sleep(Duration::from_millis(25));
+        assert!(broadcast.trigger(&flag));
+        assert!(!broadcast.trigger(&flag));
+
+        for waiter in waiters {
+            waiter
+                .join()
+                .unwrap_or_else(|_| panic!("shutdown waiter panicked"));
+        }
+        assert!(flag.load(Ordering::Acquire));
+        assert!(broadcast.requested());
+    }
 }

--- a/crates/node/src/signal.rs
+++ b/crates/node/src/signal.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::thread::{self, JoinHandle};
 
 use anyhow::Result;
@@ -8,10 +10,19 @@ use signal_hook::{
 };
 
 /// Installs SIGINT/SIGTERM handling on a dedicated forwarding thread.
-pub fn install_shutdown_handler(shutdown_tx: Sender<()>) -> Result<JoinHandle<()>> {
+///
+/// The forwarding thread trips the unified shutdown trigger so the node-owned
+/// flag is stored before the process-wide broadcast, then forwards into the
+/// event-loop channel. Waiters parked in [`crate::shutdown::wait_for_shutdown`]
+/// therefore wake at signal receipt even when that bounded channel is full.
+pub fn install_shutdown_handler(
+    shutdown: Arc<AtomicBool>,
+    shutdown_tx: Sender<()>,
+) -> Result<JoinHandle<()>> {
     let mut signals = Signals::new([SIGTERM, SIGINT])?;
     let handle = thread::spawn(move || {
         for _signal in signals.forever() {
+            crate::shutdown::trigger_shutdown(&shutdown);
             if shutdown_tx.try_send(()).is_err() {
                 break;
             }

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -968,10 +968,16 @@ impl NodeState {
                 )
             })
             .collect();
+        #[cfg(feature = "zmq")]
         let zmq_publisher: Arc<dyn crate::ZmqPublisher> = if zmq_publications.is_empty() {
             Arc::new(crate::NoOpZmqPublisher)
         } else {
             Arc::new(crate::SocketZmqPublisher::bind(&zmq_publications)?)
+        };
+        #[cfg(not(feature = "zmq"))]
+        let zmq_publisher: Arc<dyn crate::ZmqPublisher> = {
+            let _ = &zmq_publications;
+            Arc::new(crate::NoOpZmqPublisher)
         };
         let (
             mut utxo_set,

--- a/crates/node/src/zmq_publisher.rs
+++ b/crates/node/src/zmq_publisher.rs
@@ -4,17 +4,22 @@
 //! via ZMQ for client subscribers. `bitcoin-rs` keeps the apply path behind a
 //! small trait so notification failures cannot affect block connection.
 
-use core::fmt;
-use std::sync::atomic::{AtomicU32, Ordering};
-
+#[cfg(feature = "zmq")]
+use crate::config::ZmqPublication;
+#[cfg(feature = "zmq")]
 use anyhow::{Context as _, Result, bail};
 use bitcoin::Txid;
+#[cfg(any(feature = "zmq", test))]
 use bitcoin::hashes::Hash as _;
 use bitcoin_rs_primitives::Hash256;
-use hashbrown::HashMap;
+#[cfg(feature = "zmq")]
+use core::fmt;
+#[cfg(feature = "zmq")]
+use hashbrown::{HashMap, HashSet};
+#[cfg(feature = "zmq")]
 use parking_lot::Mutex;
-
-use crate::config::ZmqPublication;
+#[cfg(feature = "zmq")]
+use std::sync::atomic::{AtomicU32, Ordering};
 
 /// ZMQ PUB notification topic.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -56,6 +61,7 @@ impl ZmqTopic {
         }
     }
 
+    #[cfg(feature = "zmq")]
     const fn index(self) -> usize {
         match self {
             Self::HashBlock => 0,
@@ -91,6 +97,23 @@ impl SequenceEvent {
     }
 }
 
+/// One live bound notifier, the fact Core's `getzmqnotifications` reports per
+/// active notifier.
+///
+/// Core enumerates `CZMQNotificationInterface::GetActiveNotifiers()` at call
+/// time, each carrying its type, address, and high-water mark. The projection
+/// layer owns the JSON rendering: `topic` maps to the `pub…` type string and
+/// `endpoint` to the `address` key.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ZmqNotifier {
+    /// Topic this notifier publishes.
+    pub topic: ZmqTopic,
+    /// Endpoint the PUB socket bound.
+    pub endpoint: String,
+    /// PUB socket send high-water mark.
+    pub hwm: u32,
+}
+
 /// Publishes block + transaction notification events.
 ///
 /// Implementations should be best-effort — publish failures must NOT propagate
@@ -120,6 +143,17 @@ pub trait ZmqPublisher: Send + Sync + core::fmt::Debug {
     /// rawblock payloads unless an implementation proves they are unobservable.
     fn wants_rawblock(&self) -> bool {
         true
+    }
+
+    /// Returns the notifiers this publisher has live-bound, enumerated at
+    /// call time.
+    ///
+    /// The default reports none: publishers without enumerable bound
+    /// endpoints (the no-op and tracing publishers) have no live notifier,
+    /// matching Core's empty result when the ZMQ notification interface is
+    /// absent.
+    fn active_notifiers(&self) -> Vec<ZmqNotifier> {
+        Vec::new()
     }
 
     /// Publish a `hashblock` notification (block hash big-endian display bytes).
@@ -218,12 +252,14 @@ impl ZmqPublisher for TracingZmqPublisher {
     }
 }
 
+#[cfg(feature = "zmq")]
 struct EndpointSocket {
     endpoint: String,
     socket: Mutex<zmq::Socket>,
 }
 
 /// Socket-backed ZMQ PUB publisher.
+#[cfg(feature = "zmq")]
 pub struct SocketZmqPublisher {
     _context: zmq::Context,
     endpoints: Vec<EndpointSocket>,
@@ -232,19 +268,27 @@ pub struct SocketZmqPublisher {
     rawblock_endpoints: Vec<usize>,
     rawtx_endpoints: Vec<usize>,
     sequence_endpoints: Vec<usize>,
+    notifiers: Vec<ZmqNotifier>,
     counters: [AtomicU32; 5],
 }
 
+#[cfg(feature = "zmq")]
 impl fmt::Debug for SocketZmqPublisher {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SocketZmqPublisher")
             .field("endpoints", &self.endpoints.len())
+            .field("notifiers", &self.notifiers.len())
             .finish_non_exhaustive()
     }
 }
 
+#[cfg(feature = "zmq")]
 impl SocketZmqPublisher {
     /// Binds one PUB socket per unique endpoint in `publications`.
+    ///
+    /// Exact `(topic, endpoint)` pairs are recorded once so layered duplicate
+    /// config cannot double-publish or double-report the same notifier, while
+    /// distinct topics sharing an endpoint remain separate.
     pub fn bind(publications: &[ZmqPublication]) -> Result<Self> {
         let context = zmq::Context::new();
         let mut endpoints = Vec::new();
@@ -255,6 +299,8 @@ impl SocketZmqPublisher {
         let mut rawblock_endpoints = Vec::new();
         let mut rawtx_endpoints = Vec::new();
         let mut sequence_endpoints = Vec::new();
+        let mut notifiers = Vec::new();
+        let mut seen_notifiers = HashSet::<(ZmqTopic, String)>::new();
 
         for publication in publications {
             if let Some(existing_hwm) = endpoint_hwms.get(&publication.endpoint) {
@@ -298,6 +344,21 @@ impl SocketZmqPublisher {
                 index
             };
 
+            // Recorded in publication order so enumeration mirrors Core's
+            // notifier creation order; the facts are read live from the bound
+            // publisher, never from pre-bind configuration elsewhere.
+            // Exact `(topic, endpoint)` duplicates are skipped so layered
+            // config cannot invent a second identical notifier or publish path.
+            if !seen_notifiers.insert((publication.topic, publication.endpoint.clone())) {
+                continue;
+            }
+
+            notifiers.push(ZmqNotifier {
+                topic: publication.topic,
+                endpoint: publication.endpoint.clone(),
+                hwm: publication.hwm,
+            });
+
             match publication.topic {
                 ZmqTopic::HashBlock => hashblock_endpoints.push(endpoint_index),
                 ZmqTopic::HashTx => hashtx_endpoints.push(endpoint_index),
@@ -315,6 +376,7 @@ impl SocketZmqPublisher {
             rawblock_endpoints,
             rawtx_endpoints,
             sequence_endpoints,
+            notifiers,
             counters: core::array::from_fn(|_| AtomicU32::new(0)),
         })
     }
@@ -351,6 +413,7 @@ impl SocketZmqPublisher {
     }
 }
 
+#[cfg(feature = "zmq")]
 impl ZmqPublisher for SocketZmqPublisher {
     fn wants_notifications(&self) -> bool {
         !self.endpoints.is_empty()
@@ -362,6 +425,10 @@ impl ZmqPublisher for SocketZmqPublisher {
 
     fn wants_rawblock(&self) -> bool {
         !self.rawblock_endpoints.is_empty()
+    }
+
+    fn active_notifiers(&self) -> Vec<ZmqNotifier> {
+        self.notifiers.clone()
     }
 
     fn publish_hashblock(&self, hash: Hash256) {
@@ -387,12 +454,14 @@ impl ZmqPublisher for SocketZmqPublisher {
     }
 }
 
+#[cfg(any(feature = "zmq", test))]
 pub(crate) fn hash_body_from_hash(hash: Hash256) -> [u8; 32] {
     let mut body = hash.to_le_bytes();
     body.reverse();
     body
 }
 
+#[cfg(any(feature = "zmq", test))]
 pub(crate) fn sequence_payload(event: SequenceEvent) -> [u8; 33] {
     let mut body = [0_u8; 33];
     body[..32].copy_from_slice(&hash_body_from_hash(event.hash()));
@@ -400,16 +469,19 @@ pub(crate) fn sequence_payload(event: SequenceEvent) -> [u8; 33] {
     body
 }
 
+#[cfg(feature = "zmq")]
 pub(crate) fn hash_body_from_txid(txid: Txid) -> [u8; 32] {
     let mut body = *txid.as_byte_array();
     body.reverse();
     body
 }
 
+#[cfg(any(feature = "zmq", test))]
 pub(crate) const fn sequence_body(sequence: u32) -> [u8; 4] {
     sequence.to_le_bytes()
 }
 
+#[cfg(any(feature = "zmq", test))]
 fn is_ipv6_tcp_endpoint(endpoint: &str) -> bool {
     let Some(rest) = endpoint.strip_prefix("tcp://[") else {
         return false;
@@ -423,7 +495,9 @@ fn is_ipv6_tcp_endpoint(endpoint: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "zmq")]
     use std::thread;
+    #[cfg(feature = "zmq")]
     use std::time::{Duration, Instant};
 
     #[test]
@@ -496,6 +570,7 @@ mod tests {
         assert!(!is_ipv6_tcp_endpoint("ipc://[::1]:28332"));
     }
 
+    #[cfg(feature = "zmq")]
     #[test]
     fn socket_publisher_rejects_conflicting_hwm_for_same_endpoint() {
         let endpoint = "inproc://bitcoin-rs-zmq-conflict".to_owned();
@@ -515,6 +590,7 @@ mod tests {
         assert!(SocketZmqPublisher::bind(&publications).is_err());
     }
 
+    #[cfg(feature = "zmq")]
     #[test]
     fn socket_publisher_reports_rawtx_interest_from_configured_topics() -> anyhow::Result<()> {
         let without_rawtx = SocketZmqPublisher::bind(&[ZmqPublication {
@@ -546,6 +622,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "zmq")]
     #[test]
     fn socket_publisher_delivers_pub_sub_multipart_notification() -> anyhow::Result<()> {
         let socket_dir = tempfile::tempdir()?;
@@ -584,6 +661,7 @@ mod tests {
         anyhow::bail!("timed out waiting for ZMQ PUB/SUB notification")
     }
 
+    #[cfg(feature = "zmq")]
     #[test]
     fn socket_publisher_delivers_shared_sequence_stream() -> anyhow::Result<()> {
         let socket_dir = tempfile::tempdir()?;
@@ -626,6 +704,129 @@ mod tests {
         let connected_sequence = u32::from_le_bytes(connected[2].as_slice().try_into()?);
         let disconnected_sequence = u32::from_le_bytes(disconnected[2].as_slice().try_into()?);
         assert_eq!(disconnected_sequence, connected_sequence + 1);
+        Ok(())
+    }
+
+    #[cfg(feature = "zmq")]
+    #[test]
+    fn socket_publisher_enumerates_live_notifiers_in_publication_order() -> anyhow::Result<()> {
+        use std::sync::Arc;
+
+        let shared = "inproc://bitcoin-rs-zmq-enumerate-shared".to_owned();
+        let dedicated = "inproc://bitcoin-rs-zmq-enumerate-dedicated".to_owned();
+        let publisher = SocketZmqPublisher::bind(&[
+            ZmqPublication {
+                topic: ZmqTopic::HashBlock,
+                endpoint: shared.clone(),
+                hwm: 5,
+            },
+            ZmqPublication {
+                topic: ZmqTopic::RawTx,
+                endpoint: shared.clone(),
+                hwm: 5,
+            },
+            ZmqPublication {
+                topic: ZmqTopic::Sequence,
+                endpoint: dedicated.clone(),
+                hwm: 9,
+            },
+        ])?;
+
+        // Read through the trait object — the path RPC consumers take — so the
+        // enumeration is proven to live on the `dyn ZmqPublisher` surface.
+        let publisher: Arc<dyn ZmqPublisher> = Arc::new(publisher);
+        assert_eq!(
+            publisher.active_notifiers(),
+            vec![
+                ZmqNotifier {
+                    topic: ZmqTopic::HashBlock,
+                    endpoint: shared.clone(),
+                    hwm: 5,
+                },
+                ZmqNotifier {
+                    topic: ZmqTopic::RawTx,
+                    endpoint: shared,
+                    hwm: 5,
+                },
+                ZmqNotifier {
+                    topic: ZmqTopic::Sequence,
+                    endpoint: dedicated,
+                    hwm: 9,
+                },
+            ],
+            "enumeration must report every bound publication in bind order with its own hwm"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn non_socket_publishers_report_no_live_notifiers() {
+        use std::sync::Arc;
+
+        let noop: Arc<dyn ZmqPublisher> = Arc::new(NoOpZmqPublisher);
+        assert!(
+            noop.active_notifiers().is_empty(),
+            "a publisher with no bound endpoints has no live notifier"
+        );
+        let tracing: Arc<dyn ZmqPublisher> = Arc::new(TracingZmqPublisher);
+        assert!(tracing.active_notifiers().is_empty());
+    }
+
+    #[cfg(feature = "zmq")]
+    #[test]
+    fn socket_publisher_deduplicates_exact_topic_endpoint_pairs() -> anyhow::Result<()> {
+        use std::sync::Arc;
+
+        let shared = "inproc://bitcoin-rs-zmq-dedupe-shared".to_owned();
+        let other = "inproc://bitcoin-rs-zmq-dedupe-other".to_owned();
+        let publisher = SocketZmqPublisher::bind(&[
+            ZmqPublication {
+                topic: ZmqTopic::HashBlock,
+                endpoint: shared.clone(),
+                hwm: 5,
+            },
+            // Layered duplicate of the exact (topic, endpoint) pair.
+            ZmqPublication {
+                topic: ZmqTopic::HashBlock,
+                endpoint: shared.clone(),
+                hwm: 5,
+            },
+            // Distinct topic on the same endpoint must remain separate.
+            ZmqPublication {
+                topic: ZmqTopic::RawTx,
+                endpoint: shared.clone(),
+                hwm: 5,
+            },
+            // Same topic on a different endpoint remains separate.
+            ZmqPublication {
+                topic: ZmqTopic::HashBlock,
+                endpoint: other.clone(),
+                hwm: 5,
+            },
+        ])?;
+
+        let publisher: Arc<dyn ZmqPublisher> = Arc::new(publisher);
+        assert_eq!(
+            publisher.active_notifiers(),
+            vec![
+                ZmqNotifier {
+                    topic: ZmqTopic::HashBlock,
+                    endpoint: shared.clone(),
+                    hwm: 5,
+                },
+                ZmqNotifier {
+                    topic: ZmqTopic::RawTx,
+                    endpoint: shared,
+                    hwm: 5,
+                },
+                ZmqNotifier {
+                    topic: ZmqTopic::HashBlock,
+                    endpoint: other,
+                    hwm: 5,
+                },
+            ],
+            "exact (topic, endpoint) duplicates collapse; distinct topics/endpoints remain"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Uptime, memory info, warnings, a Prometheus scrape listener,
and live ZMQ notifier facts become node-owned.

zmq is an optional default-enabled feature. Socket publisher
items are gated on it. Signals trip the unified shutdown flag
before the event-loop channel.

Independent of the mining stack. Base is main.

Verification: pre-commit fmt, both Clippy lanes, workspace tests,
and full-node tests passed on this commit.


Closes #189
