### PR TITLE
Complete Core mempool query behavior

### DIFF
--- a/crates/mempool/src/eviction.rs
+++ b/crates/mempool/src/eviction.rs
@@ -33,3 +33,113 @@ fn lowest_fee_package(pool: &Mempool) -> Option<EntryId> {
         })
         .map(|(id, _, _)| id)
 }
+
+/// Dynamic mempool minimum fee under size pressure, matching Core's
+/// `mempoolminfee` heuristic used by `getmempoolinfo`.
+///
+/// When the pool occupies at least half of `max_total_bytes`, new admissions
+/// must pay more than the cheapest currently-evictable entry by
+/// `incremental_relay_fee_sat_per_kvb`. Below that pressure threshold the
+/// configured min-relay fee is returned unchanged.
+#[must_use]
+pub fn mempool_min_fee_sat_per_kvb(pool: &Mempool, incremental_relay_fee_sat_per_kvb: u64) -> u64 {
+    let maxmempool = pool.limits.max_total_bytes;
+    let live_min_relay = pool.min_relay_fee_sat_per_kvb();
+    if maxmempool > 0
+        && pool.total_vsize().saturating_mul(2) >= maxmempool
+        && let Some(lowest) = pool.lowest_fee_rate()
+    {
+        return live_min_relay.max(lowest.saturating_add(incremental_relay_fee_sat_per_kvb));
+    }
+    live_min_relay
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use alloc::sync::Arc;
+
+    use bitcoin::hashes::Hash as _;
+    use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
+
+    use super::{evict_lowest_fee_packages, mempool_min_fee_sat_per_kvb};
+    use crate::{Mempool, MempoolEntry, MempoolLimits};
+
+    #[test]
+    fn mempool_min_fee_equals_min_relay_below_half_full() {
+        let pool = Mempool::new(MempoolLimits {
+            max_total_bytes: 1_000,
+            min_relay_fee_sat_per_kvb: 1_000,
+            ..MempoolLimits::default()
+        });
+        assert_eq!(mempool_min_fee_sat_per_kvb(&pool, 1_000), 1_000);
+    }
+
+    #[test]
+    fn mempool_min_fee_rises_above_cheapest_when_at_least_half_full() {
+        let mut pool = Mempool::new(MempoolLimits {
+            max_total_bytes: 400,
+            min_relay_fee_sat_per_kvb: 1_000,
+            ..MempoolLimits::default()
+        });
+        // 200 vbytes is exactly half of 400 — pressure threshold.
+        pool.insert_entry(MempoolEntry::new(Arc::new(tx(1)), 200, 400, 1, 1))
+            .expect("insert");
+        // fee_rate = 400 * 1000 / 200 = 2_000 sat/kvB
+        assert_eq!(mempool_min_fee_sat_per_kvb(&pool, 1_000), 3_000);
+    }
+
+    #[test]
+    fn eviction_removes_lowest_descendant_package_first() {
+        let mut pool = Mempool::new(MempoolLimits {
+            min_relay_fee_sat_per_kvb: 0,
+            max_total_bytes: 10_000,
+            ..MempoolLimits::default()
+        });
+        let high = MempoolEntry::new(Arc::new(tx(2)), 100, 10_000, 1, 1);
+        let low = MempoolEntry::new(Arc::new(tx(3)), 100, 1_000, 2, 1);
+        pool.insert_entry(high).expect("high");
+        let low_id = pool.insert_entry(low).expect("low");
+
+        let evicted = evict_lowest_fee_packages(&mut pool, 100);
+        assert_eq!(evicted, vec![low_id]);
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn eviction_raises_lowest_fee_rate_and_mempool_min_fee() {
+        let mut pool = Mempool::new(MempoolLimits {
+            min_relay_fee_sat_per_kvb: 1_000,
+            max_total_bytes: 400,
+            ..MempoolLimits::default()
+        });
+        pool.insert_entry(MempoolEntry::new(Arc::new(tx(1)), 200, 400, 1, 1))
+            .expect("low");
+        pool.insert_entry(MempoolEntry::new(Arc::new(tx(2)), 200, 800, 1, 1))
+            .expect("high");
+        assert_eq!(pool.lowest_fee_rate(), Some(2_000));
+        assert_eq!(mempool_min_fee_sat_per_kvb(&pool, 1_000), 3_000);
+
+        let evicted = evict_lowest_fee_packages(&mut pool, 200);
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(pool.lowest_fee_rate(), Some(4_000));
+        assert_eq!(mempool_min_fee_sat_per_kvb(&pool, 1_000), 5_000);
+    }
+
+    fn tx(label: u8) -> Transaction {
+        Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::new(Txid::from_byte_array([label; 32]), 0),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::from_bytes(vec![0x51, label]),
+            }],
+        }
+    }
+}

--- a/crates/mempool/src/orphan.rs
+++ b/crates/mempool/src/orphan.rs
@@ -352,6 +352,7 @@ impl OrphanPool {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use alloc::vec::Vec;
 

--- a/crates/mempool/src/standardness.rs
+++ b/crates/mempool/src/standardness.rs
@@ -4,10 +4,15 @@
 //! that fails these checks may still be valid; it simply will not be accepted
 //! to the mempool or relayed by default.
 
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
 use bitcoin::blockdata::script::Instruction;
 use bitcoin::opcodes::all::{OP_PUSHNUM_1, OP_PUSHNUM_16, OP_PUSHNUM_NEG1};
-use bitcoin::{FeeRate, Script, Transaction, TxOut, VarInt};
+use bitcoin::{FeeRate, Script, Transaction, TxOut, Txid, VarInt, Wtxid};
 use thiserror::Error;
+
+use crate::{Mempool, RbfError, ReplacementCandidate};
 
 /// Maximum weight of a standard transaction (400 000 weight units).
 const MAX_STANDARD_TX_WEIGHT: u64 = 400_000;
@@ -100,6 +105,219 @@ pub fn is_standard_tx(
     // carries a non-standard output reports the output.
     check_min_size(tx)?;
     Ok(())
+}
+
+/// Bitcoin Core `MAX_PACKAGE_COUNT` for package acceptance / `testmempoolaccept`.
+pub const MAX_PACKAGE_COUNT: usize = 25;
+
+/// Caller-resolved fee and prevout context for one package transaction.
+///
+/// Prevout lookup and fee accounting live outside this module. The acceptance
+/// seam records the already-computed prevout-aware `sigop_cost` so RPC and
+/// admission can project it without recomputing script costs here.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PackageTxContext {
+    /// Actual fee in satoshis.
+    pub fee: u64,
+    /// Policy virtual size in vbytes.
+    pub vsize: u32,
+    /// Prevout-aware sigop cost.
+    pub sigop_cost: u32,
+    /// At least one input is neither confirmed nor satisfied by the mempool /
+    /// earlier package transactions.
+    pub missing_inputs: bool,
+}
+
+/// Per-transaction package acceptance fact for RPC / admission consumers.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TxAcceptanceFact {
+    /// Transaction id.
+    pub txid: Txid,
+    /// Witness transaction id.
+    pub wtxid: Wtxid,
+    /// Whether the transaction was accepted or rejected. `None` means package
+    /// evaluation stopped before this row was validated.
+    pub allowed: Option<bool>,
+    /// Policy virtual size in vbytes.
+    pub vsize: u32,
+    /// Consensus weight.
+    pub weight: u64,
+    /// Prevout-aware sigop cost supplied by the caller.
+    pub sigop_cost: u32,
+    /// Base fee when acceptance accounting succeeded far enough to know it.
+    pub base_fee: Option<u64>,
+    /// Rejection reason when `allowed` is false.
+    pub reject_reason: Option<AcceptanceRejectReason>,
+}
+
+/// Package-level acceptance facts: optional package error plus per-tx rows.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PackageAcceptanceFacts {
+    /// Package-wide failure (for example package count bounds).
+    pub package_error: Option<AcceptanceRejectReason>,
+    /// One row per submitted transaction, in input order.
+    pub results: Vec<TxAcceptanceFact>,
+}
+
+/// Policy rejection reason for dry-run package acceptance.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum AcceptanceRejectReason {
+    /// Package length is outside `1..=MAX_PACKAGE_COUNT`.
+    #[error("package-too-large")]
+    PackageTooLarge,
+    /// Transaction is already present in the mempool.
+    #[error("txn-already-in-mempool")]
+    AlreadyInMempool,
+    /// One or more inputs are unavailable.
+    #[error("missing-inputs")]
+    MissingInputs,
+    /// Fee rate is below the live min-relay / mempool-min floor.
+    #[error("min relay fee not met")]
+    MinRelayFeeNotMet,
+    /// Fee rate exceeds the caller-supplied maximum.
+    #[error("max-fee-exceeded")]
+    MaxFeeExceeded,
+    /// Transaction fails standardness policy.
+    #[error(transparent)]
+    NonStandard(#[from] StandardnessError),
+    /// Conflicting replacement fails BIP125.
+    #[error(transparent)]
+    Replacement(#[from] RbfError),
+    /// Next-block BIP68 relative sequence locks are unmet.
+    #[error("non-BIP68-final")]
+    NonBip68Final,
+    /// Consensus script verification failed.
+    #[error("script-verify-flag-failed")]
+    ScriptVerify,
+}
+
+/// Evaluates non-mutating package acceptance policy facts.
+///
+/// This is the mempool-owned seam behind `testmempoolaccept`: it composes
+/// standardness, presence, missing-input, min-relay / max-fee, and BIP125
+/// replacement checks against the live pool without inserting anything.
+/// Consensus script verification remains outside this module.
+///
+/// `contexts` must have the same length as `txs`. `incremental_relay_fee_sat_per_kvb`
+/// feeds the size-pressure mempool-min floor and BIP125 rule 4.
+#[must_use]
+pub fn evaluate_package_acceptance(
+    pool: &Mempool,
+    policy: &StandardnessPolicy,
+    txs: &[Transaction],
+    contexts: &[PackageTxContext],
+    max_feerate_sat_per_kvb: Option<u64>,
+    incremental_relay_fee_sat_per_kvb: u64,
+) -> PackageAcceptanceFacts {
+    assert_eq!(
+        txs.len(),
+        contexts.len(),
+        "package txs and contexts must align"
+    );
+
+    if txs.is_empty() || txs.len() > MAX_PACKAGE_COUNT {
+        return PackageAcceptanceFacts {
+            package_error: Some(AcceptanceRejectReason::PackageTooLarge),
+            results: Vec::new(),
+        };
+    }
+
+    let mempool_min_fee =
+        crate::eviction::mempool_min_fee_sat_per_kvb(pool, incremental_relay_fee_sat_per_kvb);
+
+    let mut results = Vec::with_capacity(txs.len());
+    let mut package_failed = false;
+
+    for (tx, context) in txs.iter().zip(contexts.iter()) {
+        if package_failed {
+            results.push(TxAcceptanceFact {
+                txid: tx.compute_txid(),
+                wtxid: tx.compute_wtxid(),
+                allowed: None,
+                vsize: context.vsize,
+                weight: tx.weight().to_wu(),
+                sigop_cost: context.sigop_cost,
+                base_fee: None,
+                reject_reason: None,
+            });
+            continue;
+        }
+
+        let fact = evaluate_one(
+            pool,
+            policy,
+            tx,
+            *context,
+            max_feerate_sat_per_kvb,
+            mempool_min_fee,
+            incremental_relay_fee_sat_per_kvb,
+        );
+        if fact.allowed == Some(false) {
+            package_failed = true;
+        }
+        results.push(fact);
+    }
+
+    PackageAcceptanceFacts {
+        package_error: None,
+        results,
+    }
+}
+
+fn evaluate_one(
+    pool: &Mempool,
+    policy: &StandardnessPolicy,
+    tx: &Transaction,
+    context: PackageTxContext,
+    max_feerate_sat_per_kvb: Option<u64>,
+    mempool_min_fee_sat_per_kvb: u64,
+    incremental_relay_fee_sat_per_kvb: u64,
+) -> TxAcceptanceFact {
+    let txid = tx.compute_txid();
+    let wtxid = tx.compute_wtxid();
+    let weight = tx.weight().to_wu();
+    let vsize = context.vsize;
+    let fee_rate = if vsize == 0 {
+        0
+    } else {
+        context.fee.saturating_mul(1_000) / u64::from(vsize)
+    };
+
+    let reject = if pool.contains_txid(&txid) {
+        Some(AcceptanceRejectReason::AlreadyInMempool)
+    } else if context.missing_inputs {
+        Some(AcceptanceRejectReason::MissingInputs)
+    } else if let Err(err) = is_standard_tx(tx, policy) {
+        Some(AcceptanceRejectReason::NonStandard(err))
+    } else if fee_rate < mempool_min_fee_sat_per_kvb {
+        Some(AcceptanceRejectReason::MinRelayFeeNotMet)
+    } else if max_feerate_sat_per_kvb.is_some_and(|max| fee_rate > max) {
+        Some(AcceptanceRejectReason::MaxFeeExceeded)
+    } else if !pool.conflicts_for(tx).is_empty() {
+        let candidate = ReplacementCandidate::new(
+            Arc::new(tx.clone()),
+            vsize,
+            context.fee,
+            incremental_relay_fee_sat_per_kvb,
+        );
+        match pool.check_replacement(&candidate) {
+            Ok(_) => None,
+            Err(err) => Some(AcceptanceRejectReason::Replacement(err)),
+        }
+    } else {
+        None
+    };
+
+    TxAcceptanceFact {
+        txid,
+        wtxid,
+        allowed: Some(reject.is_none()),
+        vsize,
+        weight,
+        sigop_cost: context.sigop_cost,
+        base_fee: Some(context.fee),
+        reject_reason: reject,
+    }
 }
 
 /// Minimum non-witness serialization Core relays, `tx-size-small`.
@@ -286,6 +504,7 @@ fn is_standard_nulldata(script: &Script) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use bitcoin::absolute::LockTime;
@@ -641,6 +860,134 @@ mod tests {
         assert_eq!(
             is_standard_tx(&tx, &policy()),
             Err(StandardnessError::NonStandardOutput)
+        );
+    }
+
+    fn ctx(fee: u64, vsize: u32, missing_inputs: bool) -> PackageTxContext {
+        PackageTxContext {
+            fee,
+            vsize,
+            sigop_cost: 2,
+            missing_inputs,
+        }
+    }
+
+    #[test]
+    fn package_acceptance_rejects_empty_and_oversized_packages() {
+        let pool = crate::Mempool::new(crate::MempoolLimits::default());
+        let empty = evaluate_package_acceptance(&pool, &policy(), &[], &[], None, 1_000);
+        assert_eq!(
+            empty.package_error,
+            Some(AcceptanceRejectReason::PackageTooLarge)
+        );
+
+        let txs: Vec<Transaction> = (0..=MAX_PACKAGE_COUNT)
+            .map(|i| {
+                let mut tx = standard_tx(Version::ONE);
+                tx.output[0].script_pubkey = ScriptBuf::from_bytes(vec![
+                    0x51,
+                    u8::try_from(i).expect("package index fits u8"),
+                ]);
+                tx
+            })
+            .collect();
+        let contexts: Vec<PackageTxContext> = txs.iter().map(|_| ctx(1_000, 100, false)).collect();
+        let oversized = evaluate_package_acceptance(&pool, &policy(), &txs, &contexts, None, 1_000);
+        assert_eq!(
+            oversized.package_error,
+            Some(AcceptanceRejectReason::PackageTooLarge)
+        );
+        assert!(oversized.results.is_empty());
+    }
+
+    #[test]
+    fn package_acceptance_allows_standard_tx_and_records_sigop_cost() {
+        let pool = crate::Mempool::new(crate::MempoolLimits {
+            min_relay_fee_sat_per_kvb: 1_000,
+            ..crate::MempoolLimits::default()
+        });
+        let tx = standard_tx(Version::ONE);
+        let facts = evaluate_package_acceptance(
+            &pool,
+            &policy(),
+            std::slice::from_ref(&tx),
+            &[ctx(1_000, 100, false)],
+            None,
+            1_000,
+        );
+        assert!(facts.package_error.is_none());
+        let row = &facts.results[0];
+        assert_eq!(row.allowed, Some(true));
+        assert_eq!(row.sigop_cost, 2);
+        assert_eq!(row.base_fee, Some(1_000));
+        assert_eq!(row.txid, tx.compute_txid());
+        assert_eq!(row.wtxid, tx.compute_wtxid());
+    }
+
+    #[test]
+    fn package_acceptance_rejects_missing_inputs_and_stops_later_rows() {
+        let pool = crate::Mempool::new(crate::MempoolLimits::default());
+        let first = standard_tx(Version::ONE);
+        let mut second = standard_tx(Version::ONE);
+        second.output[0].script_pubkey = ScriptBuf::from_bytes(vec![0x51, 0x99]);
+        let facts = evaluate_package_acceptance(
+            &pool,
+            &policy(),
+            &[first, second.clone()],
+            &[ctx(1_000, 100, true), ctx(1_000, 100, false)],
+            None,
+            1_000,
+        );
+        assert_eq!(
+            facts.results[0].reject_reason,
+            Some(AcceptanceRejectReason::MissingInputs)
+        );
+        assert_eq!(facts.results[0].allowed, Some(false));
+        assert_eq!(facts.results[1].allowed, None);
+        assert_eq!(facts.results[1].reject_reason, None);
+        assert_eq!(facts.results[1].base_fee, None);
+    }
+
+    #[test]
+    fn package_acceptance_rejects_max_feerate_and_already_in_mempool() {
+        let mut pool = crate::Mempool::new(crate::MempoolLimits {
+            min_relay_fee_sat_per_kvb: 0,
+            ..crate::MempoolLimits::default()
+        });
+        let tx = standard_tx(Version::ONE);
+        let over = evaluate_package_acceptance(
+            &pool,
+            &policy(),
+            std::slice::from_ref(&tx),
+            &[ctx(10_000, 100, false)],
+            Some(50_000),
+            1_000,
+        );
+        // fee_rate = 100_000 sat/kvB > 50_000
+        assert_eq!(
+            over.results[0].reject_reason,
+            Some(AcceptanceRejectReason::MaxFeeExceeded)
+        );
+
+        pool.insert_entry(crate::MempoolEntry::new(
+            alloc::sync::Arc::new(tx.clone()),
+            100,
+            1_000,
+            1,
+            1,
+        ))
+        .expect("insert");
+        let dup = evaluate_package_acceptance(
+            &pool,
+            &policy(),
+            &[tx],
+            &[ctx(1_000, 100, false)],
+            None,
+            1_000,
+        );
+        assert_eq!(
+            dup.results[0].reject_reason,
+            Some(AcceptanceRejectReason::AlreadyInMempool)
         );
     }
 }

--- a/crates/mempool/tests/ancestor_limits.rs
+++ b/crates/mempool/tests/ancestor_limits.rs
@@ -1,4 +1,7 @@
 //! Ancestor package policy limit coverage.
+// A failed pool or fixture invariant is a test failure, and panicking reports
+// it with the offending call site. `expect` is deliberate.
+#![allow(clippy::expect_used)]
 
 extern crate alloc;
 
@@ -40,6 +43,163 @@ fn chain_of_twenty_six_unconfirmed_transactions_rejects_twenty_sixth() -> Result
     assert_eq!(pool.len(), 25);
 
     Ok(())
+}
+
+#[test]
+fn rpc_graph_facts_are_transitive_and_aggregates_are_inclusive() -> Result<(), Box<dyn Error>> {
+    let mut pool = Mempool::new(MempoolLimits::default());
+
+    let root = chained_tx(50, outpoint(49, 0));
+    let root_txid = root.compute_txid();
+    let root_id = pool.insert_entry(MempoolEntry::new(Arc::new(root), 100, 1_000, 1, 1))?;
+
+    let child = chained_tx(51, OutPoint::new(root_txid, 0));
+    let child_txid = child.compute_txid();
+    let child_id = pool.insert_entry(MempoolEntry::new(Arc::new(child), 200, 3_000, 2, 1))?;
+
+    let grandchild = chained_tx(52, OutPoint::new(child_txid, 0));
+    let grandchild_txid = grandchild.compute_txid();
+    let grandchild_id =
+        pool.insert_entry(MempoolEntry::new(Arc::new(grandchild), 300, 6_000, 3, 1))?;
+
+    assert_eq!(
+        pool.ancestor_ids_for_entry(grandchild_id),
+        vec![root_id, child_id]
+    );
+    assert_eq!(
+        pool.descendant_ids_for_entry(root_id),
+        vec![child_id, grandchild_id]
+    );
+    assert_eq!(pool.ancestor_count_inclusive(grandchild_id), 3);
+    assert_eq!(pool.descendant_count_inclusive(root_id), 3);
+    assert_eq!(pool.spender_txids(root_id), vec![child_txid]);
+    assert_eq!(pool.spender_txids(child_id), vec![grandchild_txid]);
+
+    let root_entry = pool.entry(root_id).ok_or("missing root entry")?;
+    assert_eq!(
+        (root_entry.descendant_size, root_entry.descendant_fee),
+        (600, 10_000)
+    );
+    let grandchild_entry = pool
+        .entry(grandchild_id)
+        .ok_or("missing grandchild entry")?;
+    assert_eq!(
+        (
+            grandchild_entry.ancestor_size,
+            grandchild_entry.ancestor_fee
+        ),
+        (600, 10_000)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn descendant_count_limit_rejects_the_twenty_sixth_member() -> Result<(), Box<dyn Error>> {
+    // Parent plus 24 children = 25 inclusive. The next child would make 26.
+    let mut pool = Mempool::new(MempoolLimits::default());
+    let parent_tx = multi_output_tx(70, 25);
+    let parent_txid = parent_tx.compute_txid();
+    pool.insert_entry(MempoolEntry::new(Arc::new(parent_tx), 100, 1_000, 1, 1))?;
+
+    for vout in 0_u32..24 {
+        let child = chained_tx(u8::try_from(vout + 71)?, OutPoint::new(parent_txid, vout));
+        pool.insert_entry(MempoolEntry::new(
+            Arc::new(child),
+            100,
+            1_000,
+            u64::from(vout) + 2,
+            1,
+        ))?;
+    }
+    assert_eq!(pool.len(), 25);
+
+    let rejected = chained_tx(100, OutPoint::new(parent_txid, 24));
+    let err = pool
+        .insert_entry(MempoolEntry::new(Arc::new(rejected), 100, 1_000, 30, 1))
+        .err();
+    assert_eq!(
+        err,
+        Some(MempoolError::Policy(PolicyError::TooManyDescendants))
+    );
+    Ok(())
+}
+
+#[test]
+fn raw_pool_view_and_entry_metadata_facts() -> Result<(), Box<dyn Error>> {
+    let mut pool = Mempool::new(MempoolLimits::default());
+    let before = pool.sequence_number();
+    let tx = chained_tx(80, outpoint(79, 0));
+    let txid = tx.compute_txid();
+    let entry = MempoolEntry::new(Arc::new(tx), 150, 3_000, 9, 42).with_sigop_cost(17);
+    assert_eq!(entry.sigop_cost, 17);
+    assert_eq!(entry.bip141_vsize, u32::try_from(entry.tx.vsize())?);
+    assert_eq!(entry.weight, entry.tx.weight().to_wu());
+    assert_eq!(entry.height, 42);
+    assert_eq!(entry.time, 9);
+    pool.insert_entry(entry)?;
+
+    assert!(pool.sequence_number() > before);
+    assert_eq!(pool.iter_txids(), vec![txid]);
+    let stats = pool.stats();
+    assert_eq!((stats.txs, stats.bytes, stats.total_fee), (1, 150, 3_000));
+    let loaded = pool.entry_by_txid(&txid).ok_or("missing entry")?;
+    assert_eq!(loaded.sigop_cost, 17);
+    assert_eq!(loaded.fee, 3_000);
+    Ok(())
+}
+
+#[test]
+fn fee_estimate_access_reuses_pool_owned_estimator() -> Result<(), Box<dyn Error>> {
+    let mut pool = Mempool::new(MempoolLimits::default());
+    assert_eq!(pool.estimate_fee_rate(2), None);
+
+    let first = chained_tx(81, outpoint(80, 0));
+    let first_txid = first.compute_txid();
+    let second = chained_tx(82, outpoint(81, 0));
+    let second_txid = second.compute_txid();
+    pool.insert_entry(MempoolEntry::new(
+        Arc::new(first.clone()),
+        100,
+        10_000,
+        1,
+        7,
+    ))?;
+    pool.insert_entry(MempoolEntry::new(
+        Arc::new(second.clone()),
+        100,
+        10_000,
+        1,
+        7,
+    ))?;
+    assert_eq!(pool.estimate_fee_rate(2), None);
+
+    pool.remove_for_block(&[&first, &second], &[first_txid, second_txid], 8);
+    assert!(pool.estimate_fee_rate(2).is_some());
+    Ok(())
+}
+
+fn multi_output_tx(label: u8, outputs: u32) -> Transaction {
+    Transaction {
+        version: bitcoin::transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: outpoint(label, 0),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: (0..outputs)
+            .map(|vout| TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::from_bytes(vec![
+                    0x51,
+                    label,
+                    u8::try_from(vout).expect("fixture vout fits u8"),
+                ]),
+            })
+            .collect(),
+    }
 }
 
 fn chained_tx(label: u8, previous_output: OutPoint) -> Transaction {

--- a/crates/mempool/tests/rbf_bip125.rs
+++ b/crates/mempool/tests/rbf_bip125.rs
@@ -1,4 +1,7 @@
 //! BIP125 replacement-by-fee policy vectors.
+// A failed pool or fixture invariant is a test failure, and panicking reports
+// it with the offending call site. `expect` is deliberate.
+#![allow(clippy::expect_used)]
 
 extern crate alloc;
 
@@ -6,8 +9,17 @@ use alloc::sync::Arc;
 use std::error::Error;
 
 use bitcoin::hashes::Hash as _;
-use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
-use bitcoin_rs_mempool::{Mempool, MempoolEntry, MempoolLimits, RbfError, ReplacementCandidate};
+use bitcoin::{
+    Amount, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, WPubkeyHash,
+    Witness,
+};
+use bitcoin_rs_mempool::standardness::{
+    AcceptanceRejectReason, PackageTxContext, StandardnessPolicy, evaluate_package_acceptance,
+};
+use bitcoin_rs_mempool::{
+    Mempool, MempoolEntry, MempoolError, MempoolLimits, MempoolStats, PolicyError, RbfError,
+    ReplacementCandidate,
+};
 
 #[derive(Clone, Copy)]
 struct OriginalSpec {
@@ -182,6 +194,48 @@ fn bip125_replacement_rules_are_enforced() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[test]
+fn package_acceptance_surfaces_bip125_replacement_boundaries() -> Result<(), Box<dyn Error>> {
+    let (pool, mut replacement_tx) = pool_with_conflict(
+        OriginalSpec {
+            sequence: Sequence::MAX,
+            fee: 1_000,
+            vsize: 100,
+        },
+        ReplacementSpec {
+            fee: 1_200,
+            vsize: 100,
+            min_relay_fee_rate: 1,
+            new_unconfirmed_input: false,
+            extra_descendants: 0,
+        },
+        false,
+    )?;
+    // insert_entry does not enforce standardness, but package acceptance does.
+    replacement_tx.output[0].script_pubkey =
+        ScriptBuf::new_p2wpkh(&WPubkeyHash::from_byte_array([0x02; 20]));
+
+    let policy = StandardnessPolicy {
+        dust_relay_fee: FeeRate::DUST,
+        max_datacarrier_bytes: Some(83),
+    };
+    let context = PackageTxContext {
+        fee: 1_200,
+        vsize: 100,
+        sigop_cost: 4,
+        missing_inputs: false,
+    };
+    let facts =
+        evaluate_package_acceptance(&pool, &policy, &[replacement_tx], &[context], None, 1_000);
+    assert_eq!(
+        facts.results[0].reject_reason,
+        Some(AcceptanceRejectReason::Replacement(RbfError::Rule1NoOptIn))
+    );
+    assert_eq!(facts.results[0].allowed, Some(false));
+    assert_eq!(facts.results[0].sigop_cost, 4);
+    Ok(())
+}
+
 fn pool_with_conflict(
     original: OriginalSpec,
     replacement: ReplacementSpec,
@@ -277,4 +331,211 @@ fn outpoint(label: u8, vout: u32) -> OutPoint {
     let mut bytes = [0_u8; 32];
     bytes[0] = label;
     OutPoint::new(Txid::from_byte_array(bytes), vout)
+}
+
+#[test]
+fn replace_transaction_leaves_only_the_replacement() -> Result<(), Box<dyn Error>> {
+    let (mut pool, replacement_tx) = pool_with_conflict(
+        OriginalSpec {
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            fee: 1_000,
+            vsize: 100,
+        },
+        ReplacementSpec {
+            fee: 1_200,
+            vsize: 100,
+            min_relay_fee_rate: 1,
+            new_unconfirmed_input: false,
+            extra_descendants: 0,
+        },
+        false,
+    )?;
+    let original_txid = pool
+        .iter_txids()
+        .into_iter()
+        .next()
+        .ok_or("original missing")?;
+    let replacement_txid = replacement_tx.compute_txid();
+    let candidate = ReplacementCandidate::new(Arc::new(replacement_tx), 100, 1_200, 1);
+    let _id = pool.replace_transaction(candidate, 10, 1, 4)?;
+    assert!(pool.contains_txid(&replacement_txid));
+    assert!(!pool.contains_txid(&original_txid));
+    assert_eq!(pool.len(), 1);
+    Ok(())
+}
+
+type PoolFingerprint = (Vec<(Txid, u64, u32, i64)>, MempoolStats, u64);
+
+fn pool_fingerprint(pool: &Mempool) -> PoolFingerprint {
+    let mut entries = pool
+        .iter_txids()
+        .into_iter()
+        .map(|txid| {
+            let entry = pool
+                .entry_by_txid(&txid)
+                .expect("txid indexed by iter_txids");
+            (txid, entry.fee, entry.vsize, entry.fee_delta)
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by_key(|(txid, ..)| *txid);
+    (entries, pool.stats(), pool.sequence_number())
+}
+
+#[test]
+fn replace_transaction_rejection_preserves_pool_state() -> Result<(), Box<dyn Error>> {
+    // (a) BIP125 rules pass, but the pool min-relay floor rejects before mutation.
+    {
+        let mut pool = Mempool::new(MempoolLimits::default());
+        let original = tx_from_inputs(20, &[(outpoint(1, 0), Sequence::ENABLE_RBF_NO_LOCKTIME)], 1);
+        // Admit under the default floor, then raise it so only the replacement
+        // hits BelowMinRelayFee after BIP125 validation succeeds.
+        pool.insert_entry(MempoolEntry::new(Arc::new(original), 300, 1_000, 2, 1))?;
+        pool.limits.min_relay_fee_sat_per_kvb = 5_000;
+        let replacement =
+            tx_from_inputs(40, &[(outpoint(1, 0), Sequence::ENABLE_RBF_NO_LOCKTIME)], 1);
+        let before = pool_fingerprint(&pool);
+        let err = pool
+            .replace_transaction(
+                ReplacementCandidate::new(Arc::new(replacement), 300, 1_300, 1),
+                10,
+                1,
+                4,
+            )
+            .expect_err("below-floor replacement must fail");
+        assert_eq!(
+            err,
+            RbfError::Mempool(MempoolError::Policy(PolicyError::BelowMinRelayFee {
+                tx_rate: 4_333,
+                min_rate: 5_000,
+            }))
+        );
+        assert_eq!(pool_fingerprint(&pool), before);
+    }
+
+    // (b) C' spends P while P sits inside the eviction set → EvictedParent.
+    {
+        let mut pool = Mempool::new(MempoolLimits::default());
+        let conflict1 =
+            tx_from_inputs(10, &[(outpoint(1, 0), Sequence::ENABLE_RBF_NO_LOCKTIME)], 1);
+        let conflict1_txid = conflict1.compute_txid();
+        pool.insert_entry(MempoolEntry::new(Arc::new(conflict1), 100, 500, 1, 1))?;
+        let parent = tx_from_inputs(11, &[(OutPoint::new(conflict1_txid, 0), Sequence::MAX)], 1);
+        let parent_txid = parent.compute_txid();
+        pool.insert_entry(MempoolEntry::new(Arc::new(parent), 100, 500, 2, 1))?;
+        let conflict2 = tx_from_inputs(
+            12,
+            &[(
+                OutPoint::new(parent_txid, 0),
+                Sequence::ENABLE_RBF_NO_LOCKTIME,
+            )],
+            1,
+        );
+        pool.insert_entry(MempoolEntry::new(Arc::new(conflict2), 100, 500, 3, 1))?;
+        // Conflicts with conflict1 on U1 and with conflict2 on P's output.
+        let replacement = tx_from_inputs(
+            40,
+            &[
+                (outpoint(1, 0), Sequence::ENABLE_RBF_NO_LOCKTIME),
+                (
+                    OutPoint::new(parent_txid, 0),
+                    Sequence::ENABLE_RBF_NO_LOCKTIME,
+                ),
+            ],
+            1,
+        );
+        let before = pool_fingerprint(&pool);
+        let err = pool
+            .replace_transaction(
+                ReplacementCandidate::new(Arc::new(replacement), 100, 2_000, 1),
+                10,
+                1,
+                4,
+            )
+            .expect_err("spending an evicted parent must fail");
+        assert_eq!(err, RbfError::Mempool(MempoolError::EvictedParent));
+        assert_eq!(pool_fingerprint(&pool), before);
+    }
+
+    // (c) Rule 1/3/4/5/6 rejections leave the pool fingerprint untouched.
+    for case in CASES.iter().filter(|case| case.expected.is_err()) {
+        let (mut pool, replacement_tx) =
+            pool_with_conflict(case.original, case.replacement, false)?;
+        let before = pool_fingerprint(&pool);
+        let err = pool
+            .replace_transaction(
+                ReplacementCandidate::new(
+                    Arc::new(replacement_tx),
+                    case.replacement.vsize,
+                    case.replacement.fee,
+                    case.replacement.min_relay_fee_rate,
+                ),
+                10,
+                1,
+                4,
+            )
+            .expect_err(case.name);
+        assert_eq!(Err(err), case.expected, "{}", case.name);
+        assert_eq!(pool_fingerprint(&pool), before, "{}", case.name);
+    }
+    Ok(())
+}
+
+#[test]
+fn replace_transaction_descendant_limits_use_post_eviction_projection() -> Result<(), Box<dyn Error>>
+{
+    // P + 23 retained children + conflict C = 25 inclusive. Excluding C leaves
+    // room for the replacement that re-spends P; counting C would over-reject.
+    let mut pool = Mempool::new(MempoolLimits {
+        max_descendants: 25,
+        max_replacement_evictions: 100,
+        ..MempoolLimits::default()
+    });
+    let parent = tx_from_inputs(
+        10,
+        &[(outpoint(1, 0), Sequence::ENABLE_RBF_NO_LOCKTIME)],
+        24,
+    );
+    let parent_txid = parent.compute_txid();
+    pool.insert_entry(MempoolEntry::new(Arc::new(parent), 100, 1_000, 1, 1))?;
+    for i in 0..23_u32 {
+        let child = tx_from_inputs(
+            u8::try_from(30 + i)?,
+            &[(OutPoint::new(parent_txid, i), Sequence::MAX)],
+            1,
+        );
+        pool.insert_entry(MempoolEntry::new(
+            Arc::new(child),
+            50,
+            100,
+            u64::from(i) + 2,
+            1,
+        ))?;
+    }
+    let conflict = tx_from_inputs(
+        60,
+        &[(
+            OutPoint::new(parent_txid, 23),
+            Sequence::ENABLE_RBF_NO_LOCKTIME,
+        )],
+        1,
+    );
+    pool.insert_entry(MempoolEntry::new(Arc::new(conflict), 50, 100, 30, 1))?;
+    let replacement = tx_from_inputs(
+        40,
+        &[(
+            OutPoint::new(parent_txid, 23),
+            Sequence::ENABLE_RBF_NO_LOCKTIME,
+        )],
+        1,
+    );
+    let replacement_txid = replacement.compute_txid();
+    let _id = pool.replace_transaction(
+        ReplacementCandidate::new(Arc::new(replacement), 50, 300, 1),
+        40,
+        1,
+        4,
+    )?;
+    assert!(pool.contains_txid(&replacement_txid));
+    assert_eq!(pool.len(), 25);
+    Ok(())
 }


### PR DESCRIPTION
RPC-required ancestry, descendants, entry, raw view, fee
estimates, and acceptance facts land in standardness,
eviction, and orphan handling.

Stacked on #182 so package topology already exists.

Verification: pre-commit fmt, both Clippy lanes, workspace tests,
and full-node tests passed on this commit.


Closes #192
