### PR TITLE
Integrate RPC through shared handles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         always_run: true
       - id: cargo-clippy-full-node
         name: cargo clippy (full node)
-        entry: cargo +1.95.0 clippy -p bitcoin-rs --all-targets --no-default-features --features rocksdb,fjall,redb,mdbx,kernel -- -D warnings
+        entry: cargo +1.95.0 clippy -p bitcoin-rs --all-targets --no-default-features --features rocksdb,fjall,redb,mdbx,kernel,zmq -- -D warnings
         language: unsupported
         pass_filenames: false
         always_run: true
@@ -37,7 +37,7 @@ repos:
         always_run: true
       - id: cargo-test-full-node
         name: cargo test (full node)
-        entry: cargo +1.95.0 test -p bitcoin-rs --no-fail-fast --no-default-features --features rocksdb,fjall,redb,mdbx,kernel
+        entry: cargo +1.95.0 test -p bitcoin-rs --no-fail-fast --no-default-features --features rocksdb,fjall,redb,mdbx,kernel,zmq
         language: unsupported
         pass_filenames: false
         always_run: true

--- a/bin/bitcoin-rs/Cargo.toml
+++ b/bin/bitcoin-rs/Cargo.toml
@@ -27,12 +27,13 @@ sha2.workspace = true
 tempfile = "3"
 
 [features]
-default = ["rocksdb", "fjall", "redb", "mdbx", "kernel"]
+default = ["rocksdb", "fjall", "redb", "mdbx", "kernel", "zmq"]
 rocksdb = ["bitcoin-rs-node/rocksdb"]
 fjall = ["bitcoin-rs-node/fjall"]
 redb = ["bitcoin-rs-node/redb"]
 mdbx = ["bitcoin-rs-node/mdbx"]
 kernel = ["bitcoin-rs-node/kernel"]
+zmq = ["bitcoin-rs-node/zmq"]
 
 [[test]]
 name = "g01_headers_only_sync"

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -65,7 +65,7 @@ mdbx = [
     "bitcoin-rs-storage/mdbx",
 ]
 kernel = ["bitcoin-rs-consensus/kernel"]
-zmq = ["dep:zmq"]
+zmq = ["dep:zmq", "bitcoin-rs-rpc/zmq"]
 checksig-census = [
     "kernel",
     "bitcoin-rs-consensus/checksig-census",

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -579,27 +579,28 @@ pub fn run(mut config: Config) -> Result<()> {
     let peer_registered = sync.peer_registration_handle();
     let loop_handle = EventLoop::with_sync_wake(shutdown_rx, sync, sync_wake_rx);
     let rpc_auth = Arc::new(build_rpc_auth(&state.config().rpc_auth)?);
-    let mut rpc_context = bitcoin_rs_rpc::context::Context::from_handles(
-        state.chain_tip(),
-        state.applied_tip(),
-        state.mempool(),
-        state.blocks(),
-        state.transactions(),
-        state.utxo(),
-        state.coin_stats(),
-        state.network(),
-        state.mining_template_id(),
-        state.peers(),
-        state.block_tree(),
-        state.config().network,
-        Some(state.inbound_blocks_sender()),
-        Some(state.p2p_outbound_sender()),
-        Arc::clone(&banned),
-        Arc::new(parking_lot::RwLock::new(Vec::new())),
-        state.tx_index_query(),
-        state.script_index_query(),
-    )
-    .with_esplora_tx_index(state.esplora_tx_index_query());
+    let mut rpc_context =
+        bitcoin_rs_rpc::context::Context::from_handles(bitcoin_rs_rpc::context::ContextHandles {
+            chain_tip: state.chain_tip(),
+            applied_tip: state.applied_tip(),
+            mempool: state.mempool(),
+            blocks: state.blocks(),
+            transactions: state.transactions(),
+            utxo: state.utxo(),
+            coin_stats: state.coin_stats(),
+            network: state.network(),
+            mining_template_id: state.mining_template_id(),
+            peers: state.peers(),
+            block_tree: state.block_tree(),
+            chain_network: state.config().network,
+            inbound_blocks_sender: Some(state.inbound_blocks_sender()),
+            p2p_outbound_sender: Some(state.p2p_outbound_sender()),
+            banned: Arc::clone(&banned),
+            added_nodes: Arc::new(parking_lot::RwLock::new(Vec::new())),
+            tx_index: state.tx_index_query(),
+            script_index: state.script_index_query(),
+        })
+        .with_esplora_tx_index(state.esplora_tx_index_query());
     rpc_context = rpc_context.with_block_body_source(block_body_source);
     rpc_context = rpc_context.with_chain_tx_count(state.chain_tx_count_handle());
     rpc_context =

--- a/crates/node/tests/rpc_wiring.rs
+++ b/crates/node/tests/rpc_wiring.rs
@@ -47,26 +47,26 @@ fn rpc_context_shares_arc_identity_with_node_state() -> Result<()> {
     let Some(tx_index) = state.tx_index_query() else {
         panic!("txindex query engine missing when enabled");
     };
-    let ctx = Context::from_handles(
-        Arc::clone(&chain_tip),
-        Arc::clone(&applied_tip),
-        Arc::clone(&mempool),
-        Arc::clone(&blocks),
-        Arc::clone(&transactions),
-        Arc::clone(&utxo),
-        Arc::clone(&coin_stats),
-        Arc::clone(&network),
-        Arc::clone(&mining_template_id),
-        Arc::clone(&peers),
-        Arc::clone(&block_tree),
+    let ctx = Context::from_handles(bitcoin_rs_rpc::context::ContextHandles {
+        chain_tip: Arc::clone(&chain_tip),
+        applied_tip: Arc::clone(&applied_tip),
+        mempool: Arc::clone(&mempool),
+        blocks: Arc::clone(&blocks),
+        transactions: Arc::clone(&transactions),
+        utxo: Arc::clone(&utxo),
+        coin_stats: Arc::clone(&coin_stats),
+        network: Arc::clone(&network),
         chain_network,
-        Some(inbound_blocks_sender),
-        p2p_outbound,
-        Arc::clone(&banned),
-        Arc::clone(&added_nodes),
-        Some(tx_index),
-        None,
-    )
+        mining_template_id: Arc::clone(&mining_template_id),
+        peers: Arc::clone(&peers),
+        block_tree: Arc::clone(&block_tree),
+        inbound_blocks_sender: Some(inbound_blocks_sender),
+        p2p_outbound_sender: p2p_outbound,
+        banned: Arc::clone(&banned),
+        added_nodes: Arc::clone(&added_nodes),
+        tx_index: Some(tx_index),
+        script_index: None,
+    })
     .with_zmq_notifications(state.active_zmq_notifications());
 
     assert!(

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -17,6 +17,7 @@ rocksdb = ["bitcoin-rs-utxo/rocksdb", "bitcoin-rs-storage/rocksdb", "bitcoin-rs-
 fjall = ["bitcoin-rs-utxo/fjall", "bitcoin-rs-storage/fjall", "bitcoin-rs-p2p/fjall"]
 redb = ["bitcoin-rs-utxo/redb", "bitcoin-rs-storage/redb", "bitcoin-rs-p2p/redb"]
 mdbx = ["bitcoin-rs-storage/mdbx"]
+zmq = []
 
 [dependencies]
 bitcoin-rs-primitives.workspace = true

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -924,6 +924,47 @@ impl TxQueryError {
     }
 }
 
+/// Handles owned by the node and observed by the RPC context.
+#[derive(Clone)]
+pub struct ContextHandles {
+    /// Best header-chain tip.
+    pub chain_tip: Arc<ArcSwapOption<TipSnapshot>>,
+    /// Best fully-applied block tip.
+    pub applied_tip: Arc<ArcSwapOption<TipSnapshot>>,
+    /// In-memory mempool.
+    pub mempool: Arc<RwLock<Mempool>>,
+    /// Applied block metadata log.
+    pub blocks: Arc<RwLock<BlockLog>>,
+    /// Transactions retained for direct RPC lookup.
+    pub transactions: Arc<RwLock<HashMap<Txid, Transaction>>>,
+    /// Authoritative UTXO set.
+    pub utxo: Arc<bitcoin_rs_utxo::UtxoSet>,
+    /// Incremental UTXO statistics.
+    pub coin_stats: Arc<bitcoin_rs_utxo::stats::CoinStatsListener>,
+    /// Network state.
+    pub network: Arc<RwLock<NetworkState>>,
+    /// Current getblocktemplate long-poll id.
+    pub mining_template_id: Arc<ArcSwap<CompactString>>,
+    /// Connected peer registry.
+    pub peers: Arc<RwLock<Vec<bitcoin_rs_p2p::PeerInfo>>>,
+    /// Shared block tree.
+    pub block_tree: Arc<parking_lot::RwLock<bitcoin_rs_chain::BlockTree>>,
+    /// Consensus network.
+    pub chain_network: Network,
+    /// Channel that submits decoded blocks to the node's apply path.
+    pub inbound_blocks_sender: Option<crossbeam_channel::Sender<bitcoin_rs_p2p::InboundBlock>>,
+    /// Channel that requests outbound P2P connections.
+    pub p2p_outbound_sender: Option<crossbeam_channel::Sender<std::net::SocketAddr>>,
+    /// Manual IP/CIDR bans.
+    pub banned: Arc<parking_lot::RwLock<Vec<bitcoin_rs_p2p::BannedSubnet>>>,
+    /// Persisted `addnode add` entries.
+    pub added_nodes: Arc<parking_lot::RwLock<Vec<std::net::SocketAddr>>>,
+    /// Complete transaction-index query adapter.
+    pub tx_index: Option<Arc<dyn TxIndexQuery>>,
+    /// Generic script-index query adapter.
+    pub script_index: Option<Arc<dyn ScriptIndexQuery>>,
+}
+
 /// Shared state consumed by JSON-RPC handlers.
 pub struct Context {
     /// Best-chain tip snapshot published by chain validation.
@@ -1069,60 +1110,35 @@ impl Context {
             mining_sender,
         }
     }
-    /// Builds a context that shares pre-existing handles owned elsewhere
-    /// (typically by `bitcoin-rs-node::state::NodeState`).
-    ///
-    /// This is the wiring path for the integration layer: subsystem owners
-    /// pass in their authoritative Arc handles, and RPC handlers observe
-    /// the same state.
+    /// Builds a context that shares pre-existing handles owned elsewhere.
     #[must_use]
-    #[allow(clippy::too_many_arguments)]
-    pub fn from_handles(
-        chain_tip: Arc<ArcSwapOption<TipSnapshot>>,
-        applied_tip: Arc<ArcSwapOption<TipSnapshot>>,
-        mempool: Arc<RwLock<Mempool>>,
-        blocks: Arc<RwLock<BlockLog>>,
-        transactions: Arc<RwLock<HashMap<Txid, Transaction>>>,
-        utxo: Arc<bitcoin_rs_utxo::UtxoSet>,
-        coin_stats: Arc<bitcoin_rs_utxo::stats::CoinStatsListener>,
-        network: Arc<RwLock<NetworkState>>,
-        mining_template_id: Arc<ArcSwap<CompactString>>,
-        peers: Arc<RwLock<Vec<bitcoin_rs_p2p::PeerInfo>>>,
-        block_tree: Arc<parking_lot::RwLock<bitcoin_rs_chain::BlockTree>>,
-        chain_network: Network,
-        inbound_blocks_sender: Option<crossbeam_channel::Sender<bitcoin_rs_p2p::InboundBlock>>,
-        p2p_outbound_sender: Option<crossbeam_channel::Sender<std::net::SocketAddr>>,
-        banned: Arc<parking_lot::RwLock<Vec<bitcoin_rs_p2p::BannedSubnet>>>,
-        added_nodes: Arc<parking_lot::RwLock<Vec<std::net::SocketAddr>>>,
-        tx_index: Option<Arc<dyn TxIndexQuery>>,
-        script_index: Option<Arc<dyn ScriptIndexQuery>>,
-    ) -> Self {
+    pub fn from_handles(handles: ContextHandles) -> Self {
         let (mining_sender, mining_notifications) = unbounded();
         Self {
-            chain_tip,
-            applied_tip,
+            chain_tip: handles.chain_tip,
+            applied_tip: handles.applied_tip,
             chain_transition: Arc::new(Mutex::new(())),
             chain_tx_count: Arc::new(core::sync::atomic::AtomicU64::new(0)),
             left_initial_block_download: Arc::new(core::sync::atomic::AtomicBool::new(false)),
-            mempool,
-            blocks,
-            transactions,
-            utxo,
-            coin_stats,
-            tx_index,
+            mempool: handles.mempool,
+            blocks: handles.blocks,
+            transactions: handles.transactions,
+            utxo: handles.utxo,
+            coin_stats: handles.coin_stats,
+            tx_index: handles.tx_index,
             esplora_tx_index: None,
-            script_index,
-            network,
-            chain_network,
-            peers,
-            block_tree,
+            script_index: handles.script_index,
+            network: handles.network,
+            chain_network: handles.chain_network,
+            peers: handles.peers,
+            block_tree: handles.block_tree,
             block_body_source: None,
-            mining_template_id,
+            mining_template_id: handles.mining_template_id,
             mining_notifications,
-            inbound_blocks_sender,
-            p2p_outbound_sender,
-            banned,
-            added_nodes,
+            inbound_blocks_sender: handles.inbound_blocks_sender,
+            p2p_outbound_sender: handles.p2p_outbound_sender,
+            banned: handles.banned,
+            added_nodes: handles.added_nodes,
             prune_service: None,
             chain_control: None,
             zmq_notifications: Arc::from(Vec::<ZmqNotification>::new()),
@@ -1771,30 +1787,26 @@ mod tests {
         let block_tree = Arc::new(RwLock::new(bitcoin_rs_chain::BlockTree::new()));
         let banned = Arc::new(RwLock::new(Vec::<bitcoin_rs_p2p::BannedSubnet>::new()));
         let added_nodes = Arc::new(RwLock::new(Vec::new()));
-        let ctx = Context::from_handles(
-            Arc::clone(&chain_tip),
-            Arc::clone(&applied_tip),
-            Arc::new(RwLock::new(Mempool::new(MempoolLimits::default()))),
-            Arc::new(RwLock::new(BlockLog::new())),
-            Arc::new(RwLock::new(HashMap::new())),
-            Arc::clone(&utxo),
-            Arc::clone(&coin_stats),
-            Arc::new(RwLock::new(NetworkState::default())),
-            Arc::new(ArcSwap::from_pointee(CompactString::new("0"))),
-            Arc::new(RwLock::new(Vec::new())),
-            Arc::clone(&block_tree),
-            Network::Mainnet,
-            None,
-            None,
-            Arc::clone(&banned),
-            Arc::clone(&added_nodes),
-            None,
-            None,
-        );
-        assert!(
-            Arc::ptr_eq(&ctx.chain_tip, &chain_tip),
-            "chain_tip must be shared with caller"
-        );
+        let ctx = Context::from_handles(ContextHandles {
+            chain_tip: Arc::clone(&chain_tip),
+            applied_tip: Arc::clone(&applied_tip),
+            mempool: Arc::new(RwLock::new(Mempool::new(MempoolLimits::default()))),
+            blocks: Arc::new(RwLock::new(BlockLog::new())),
+            transactions: Arc::new(RwLock::new(HashMap::new())),
+            utxo: Arc::clone(&utxo),
+            coin_stats: Arc::clone(&coin_stats),
+            network: Arc::new(RwLock::new(NetworkState::default())),
+            mining_template_id: Arc::new(ArcSwap::from_pointee(CompactString::new("0"))),
+            peers: Arc::new(RwLock::new(Vec::new())),
+            block_tree: Arc::clone(&block_tree),
+            chain_network: Network::Mainnet,
+            inbound_blocks_sender: None,
+            p2p_outbound_sender: None,
+            banned: Arc::clone(&banned),
+            added_nodes: Arc::clone(&added_nodes),
+            tx_index: None,
+            script_index: None,
+        });
         assert!(
             Arc::ptr_eq(&ctx.applied_tip, &applied_tip),
             "applied_tip must be shared with caller"

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -71,6 +71,7 @@ impl Handler {
             "getrpcinfo" => util::getrpcinfo(&self.ctx, params),
             "getmemoryinfo" => util::getmemoryinfo(&self.ctx, params),
             "estimaterawfee" => util::estimaterawfee(&self.ctx, params),
+            #[cfg(feature = "zmq")]
             "getzmqnotifications" => util::getzmqnotifications(&self.ctx, params),
             "validateaddress" => util::validateaddress(&self.ctx, params),
             "getdescriptorinfo" => util::getdescriptorinfo(&self.ctx, params),

--- a/crates/rpc/src/handlers/util.rs
+++ b/crates/rpc/src/handlers/util.rs
@@ -109,6 +109,7 @@ fn read_linux_rss_bytes() -> Option<u64> {
     None
 }
 
+#[cfg(feature = "zmq")]
 pub(crate) fn getzmqnotifications(ctx: &Arc<Context>, params: &Value) -> Result<Value, RpcError> {
     crate::handlers::ensure_no_params(params)?;
     let notifications: Vec<_> = ctx
@@ -416,6 +417,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(feature = "zmq")]
     #[test]
     fn getzmqnotifications_returns_empty_array() {
         use alloc::sync::Arc;
@@ -429,6 +431,7 @@ mod tests {
         assert!(arr.is_empty());
     }
 
+    #[cfg(feature = "zmq")]
     #[test]
     fn getzmqnotifications_returns_active_metadata() {
         use alloc::sync::Arc;


### PR DESCRIPTION
## Summary

RPC context is built from one handle record instead of an
18-argument constructor. ZMQ is a default-on feature through the
node, binary, dispatcher, and full-node verification lanes.

Stacked on the chain-methods PR.

## Validation

Focused `from_handles` sharing tests passed. Full-node Clippy and
test lanes include the `zmq` feature.
