### PR TITLE
fix(explorer): route Esplora paths to bitcoin-rs

### DIFF
--- a/tools/btc-mempool-explorer/README.md
+++ b/tools/btc-mempool-explorer/README.md
@@ -31,7 +31,8 @@ MEMPOOL_DATABASE_ROOT_PASSWORD='choose-a-third-long-secret' \
 docker compose up --build
 ```
 
-Open <http://127.0.0.1:8080>. The Bitcoin RPC listener is host-loopback only at
+Open <http://127.0.0.1:8080>. The explorer HTTP port is published on all
+interfaces (`0.0.0.0`). The Bitcoin RPC listener stays host-loopback only at
 <http://127.0.0.1:8332> by default; P2P is published on port `8333`.
 
 The following variables are optional:
@@ -45,7 +46,7 @@ The following variables are optional:
 | `MEMPOOL_DATABASE_ROOT_PASSWORD` | `change-me` | MariaDB root password; set explicitly. |
 | `BITCOIN_RS_RPC_PORT` | `8332` | Loopback host RPC port. |
 | `BITCOIN_RS_P2P_PORT` | `8333` | Host P2P port. |
-| `MEMPOOL_EXPLORER_PORT` | `8080` | Loopback explorer HTTP port. |
+| `MEMPOOL_EXPLORER_PORT` | `8080` | Host explorer HTTP port (`0.0.0.0`). |
 
 All persistent data is stored beneath the repository-root `data/` directory:
 `data/bitcoin-rs`, `data/mempool-cache`, and `data/mempool-db`. Stop the stack

--- a/tools/btc-mempool-explorer/README.md
+++ b/tools/btc-mempool-explorer/README.md
@@ -5,6 +5,12 @@ This Compose example runs the upstream `mempool/mempool` explorer against
 endpoints (`MEMPOOL_BACKEND=esplora`) and its Core-compatible JSON-RPC methods
 on the same node listener. It starts no Electrum or electrs service.
 
+The stock Mempool frontend proxies every `/api/` path to the Mempool backend
+`/api/v1/` prefix, which does not serve Esplora routes. This example mounts
+`nginx-mempool.conf` so `/api/tx`, `/api/block`, `/api/address`,
+`/api/scripthash`, and `/api/mempool` go to bitcoin-rs on `:8332`, the same
+split Mempool's own compose uses for electrs.
+
 The Mempool project has a frontend, backend, and MariaDB dependency, so this
 stack contains those three services plus `bitcoin-rs`. The frontend is the only
 public explorer service; the backend and database stay on the Compose network.

--- a/tools/btc-mempool-explorer/docker-compose.yaml
+++ b/tools/btc-mempool-explorer/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
     volumes:
       - ./nginx-mempool.conf:/etc/nginx/conf.d/nginx-mempool.conf
     ports:
-      - "127.0.0.1:${MEMPOOL_EXPLORER_PORT:-8080}:8080"
+      - "0.0.0.0:${MEMPOOL_EXPLORER_PORT:-8080}:8080"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --silent http://localhost:8080/ | grep -q '<html'"]
       interval: 30s

--- a/tools/btc-mempool-explorer/docker-compose.yaml
+++ b/tools/btc-mempool-explorer/docker-compose.yaml
@@ -81,6 +81,8 @@ services:
       FRONTEND_HTTP_PORT: "8080"
       BACKEND_MAINNET_HTTP_HOST: api
       BACKEND_MAINNET_HTTP_PORT: "8999"
+    volumes:
+      - ./nginx-mempool.conf:/etc/nginx/conf.d/nginx-mempool.conf
     ports:
       - "127.0.0.1:${MEMPOOL_EXPLORER_PORT:-8080}:8080"
     healthcheck:

--- a/tools/btc-mempool-explorer/nginx-mempool.conf
+++ b/tools/btc-mempool-explorer/nginx-mempool.conf
@@ -1,0 +1,92 @@
+	access_log /var/log/nginx/access_mempool.log;
+	error_log /var/log/nginx/error_mempool.log;
+
+	root /var/www/mempool/browser;
+
+	index index.html;
+
+	# enable browser and proxy caching
+	add_header Cache-Control "public, no-transform";
+
+	# vary cache if user changes language preference
+	add_header Vary Accept-Language;
+	add_header Vary Cookie;
+
+	# fallback for all URLs i.e. /address/foo /tx/foo /block/000
+	location / {
+		try_files /$lang/$uri /$lang/$uri/ $uri $uri/ /en-US/$uri @index-redirect;
+		expires 10m;
+	}
+	location /resources {
+		try_files $uri @index-redirect;
+		expires 1h;
+	}
+
+	# only cache /resources/config.* for 5 minutes since it changes often
+	location /resources/config. {
+		try_files $uri =404;
+		expires 5m;
+	}
+	# only cache /resources/customize.* for 5 minutes since it changes often
+	location /resources/customize. {
+		try_files $uri =404;
+		expires 5m;
+	}
+
+	location @index-redirect {
+		rewrite (.*) /$lang/index.html;
+	}
+
+	# location block using regex are matched in order
+
+	# used for cookie override
+	location ~ ^/(ar|bg|bs|cs|da|de|et|el|es|eo|eu|fa|fr|gl|ko|hr|id|it|he|ka|lv|lt|hu|mk|ms|nl|ja|nb|nn|pl|pt|pt-BR|ro|ru|sk|sl|sr|sh|fi|sv|th|tr|uk|vi|zh|hi)/ {
+		try_files $uri $uri/ /$1/index.html =404;
+	}
+
+	# static API docs
+	location = /api {
+		try_files $uri $uri/ /en-US/index.html =404;
+	}
+	location = /api/ {
+		try_files $uri $uri/ /en-US/index.html =404;
+	}
+
+	location /api/v1/ws {
+		proxy_pass http://api:8999/;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "Upgrade";
+	}
+	location /api/v1/services {
+		proxy_pass https://mempool.space;
+	}
+	location /api/v1 {
+		proxy_pass http://api:8999/api/v1;
+	}
+
+	# bitcoin-rs serves Esplora at :8332 without an /api prefix. Stock
+	# mempool/frontend maps /api/ to backend /api/v1/, which has no
+	# /tx or /block/.../txs routes. This stack has no electrs, so those
+	# paths go to the node the same way Mempool's compose splits electrs.
+	location /api/tx/ { proxy_pass http://node:8332/tx/; }
+	location = /api/tx { proxy_pass http://node:8332/tx; }
+	location /api/block/ { proxy_pass http://node:8332/block/; }
+	location /api/address/ { proxy_pass http://node:8332/address/; }
+	location /api/scripthash/ { proxy_pass http://node:8332/scripthash/; }
+	location /api/mempool/ { proxy_pass http://node:8332/mempool/; }
+	location = /api/mempool { proxy_pass http://node:8332/mempool; }
+	location = /api/fee-estimates { proxy_pass http://node:8332/fee-estimates; }
+	location = /api/blocks/tip/hash { proxy_pass http://node:8332/blocks/tip/hash; }
+
+	location /api/ {
+		proxy_pass http://api:8999/api/v1/;
+	}
+
+	# mainnet API
+	location /ws {
+		proxy_pass http://api:8999/;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "Upgrade";
+	}


### PR DESCRIPTION
Opening a block in the example explorer showed a transaction count and pagination, but the list itself was empty. The SPA still calls Esplora `/api/tx` and `/api/block/.../txs`; stock Mempool frontend nginx rewrites those to backend `/api/v1/`, which 404s.

This example has no electrs. The mounted `nginx-mempool.conf` sends those paths to bitcoin-rs `:8332`, the same split Mempool's compose uses for electrs. `/api/v1/*` stays on the Mempool backend. The explorer HTTP port is published on `0.0.0.0`; JSON-RPC stays loopback.

Verified on the live stack: `/api/block/<tip>/txs/0` and `/api/tx/<coinbase>` return 200 through `:8080`; `/api/v1/blocks` is unchanged. The web container publishes `0.0.0.0:8080->8080`. Unconfirmed Recent Transactions stay empty while the node mempool is size 0.
