### PR TITLE
fix(index): reconcile the funding-row ordering contract with the bytes

### DIFF
--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -477,8 +477,13 @@ impl<S: KvStore> Indexer<S> {
     ///
     /// Returns every `HashPrefixRow` whose 8-byte prefix matches the scripthash's
     /// scan prefix, decoded from `ColumnFamily::Funding`. Rows are returned in
-    /// the iteration order of the underlying store (typically lexicographic, so
-    /// (prefix, height) ascending).
+    /// the iteration order of the underlying store: byte-lexicographic over
+    /// `prefix || height`, where the height is **little-endian** -- so within
+    /// one prefix this is NOT numeric height order (height 256, `[0,1,0,0]`,
+    /// sorts before height 1, `[1,0,0,0]`). Callers that need chronological
+    /// order must sort; every production consumer does, and bounded scans that
+    /// truncate fail closed instead of serving a byte-order prefix of the rows.
+    /// Pinned by `funding_row_iteration_order_is_not_numeric_height_order`.
     ///
     /// The 8-byte prefix is lossy: callers MUST resolve heights back to full
     /// transactions via block storage to confirm scripthash identity.
@@ -498,7 +503,10 @@ impl<S: KvStore> Indexer<S> {
     /// `ScriptHistoryEntry::confirmed` for every transaction in that block that has
     /// at least one output matching `scripthash` exactly.
     ///
-    /// Entries are returned in iteration order (lexicographic by prefix||height).
+    /// Entries are returned in storage iteration order, which is not numeric
+    /// height order (heights are little-endian in the key -- see
+    /// [`Self::iter_funding_rows`]). Callers that present history
+    /// chronologically must sort above this layer, and do.
     /// Heights not resolvable by `source` are skipped.
     ///
     /// The lossy 8-byte prefix is exact-resolved here: only transactions whose
@@ -2292,6 +2300,48 @@ mod tests {
         assert_eq!(
             indexer.iter_funding_rows(scripthash)?,
             vec![ScriptHashRow::row(scripthash, HEIGHT)]
+        );
+        Ok(())
+    }
+
+    /// The stored iteration order is byte order, not height order.
+    ///
+    /// Heights are little-endian in the key, so 256 (`[0,1,0,0]`) sorts before
+    /// 1 (`[1,0,0,0]`) within one prefix. #226's audit found the previous doc
+    /// contract claiming "(prefix, height) ascending", which this order
+    /// falsifies; no production reader relies on it -- the Esplora and worker
+    /// paths sort in memory, and truncated bounded scans fail closed -- but
+    /// nothing pinned that fact, so a reader could have started relying on the
+    /// documented order and been wrong only at heights past 255. This test is
+    /// that pin: if the height encoding ever becomes sortable (#226 Q3), the
+    /// expectation below flips and the doc contract must flip with it.
+    #[test]
+    fn funding_row_iteration_order_is_not_numeric_height_order()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let script = ScriptBuf::from_bytes(vec![0x51, 0x03]);
+        let (_dir, mut indexer) = indexer()?;
+
+        // Same script funded at numeric heights 1 and 256, ingested in
+        // numeric order.
+        indexer.ingest_block(
+            &serialize(&block(vec![tx(spent_outpoint(3, 0), script.clone())])),
+            1,
+        )?;
+        indexer.ingest_block(
+            &serialize(&block(vec![tx(spent_outpoint(4, 0), script.clone())])),
+            256,
+        )?;
+
+        let scripthash = ScriptHash::from_script_bytes(script.as_bytes());
+        let rows = indexer.iter_funding_rows(scripthash)?;
+        let heights: Vec<u32> = rows.iter().map(|row| row.height()).collect();
+
+        assert_eq!(
+            heights,
+            vec![256, 1],
+            "little-endian heights iterate in byte order, not numeric order; \
+             if this starts returning [1, 256] the encoding became sortable and \
+             every ordering doc contract in this file must be revisited"
         );
         Ok(())
     }


### PR DESCRIPTION
First slice of #226 — the audit's stated precondition, which is a defect in the tree today and blocks nothing else.

## The contract and the bytes disagree

Heights in index keys are little-endian, so byte-lexicographic iteration within one prefix is **not** numeric height order: 256 encodes as `[0,1,0,0]` and sorts before 1, `[1,0,0,0]`. Two doc contracts claimed otherwise:

- `iter_funding_rows` — *"typically lexicographic, so (prefix, height) ascending"*
- `resolve_script_history` — *"iteration order (lexicographic by prefix||height)"*

That equivalence holds only below height 256, which is exactly the height range test fixtures live in — a reader written against the documented order would pass every unit test and be wrong on mainnet.

## Which side was wrong

Checked every consumer before picking: **the docs are wrong, the readers are fine.**

- The Esplora projection sorts confirmed activity in memory ([projection.rs:404](crates/rpc/src/esplora/projection.rs#L404)), as do the worker's history, funding, and unspent paths ([txindex_worker.rs:1554-1596](crates/node/src/txindex_worker.rs#L1554-L1596)).
- Bounded prefix scans **fail closed** on truncation — `accept_scan` rejects `!scan.complete` — so no path can serve a byte-order prefix of the rows as if it were the earliest history.

So this is a documentation defect today. It stays one only while nothing new trusts the stated order, which is what the test is for.

## The change

- Both docs now state the real order (byte-lexicographic over `prefix || LE-height`, not numeric within a prefix) and where chronological order is restored (in memory, above storage; truncation fails closed).
- `funding_row_iteration_order_is_not_numeric_height_order` ingests one script at heights 1 and 256 and asserts iteration returns `[256, 1]`. **If #226's Q3 later adopts a sortable height encoding, this assertion flips and drags every ordering contract in the file back into review** — the test is deliberately coupled to the encoding, because the contract must move with it.

Q3 itself (whether to *adopt* sortable heights) is untouched — that is the audit's benchmark question, and this slice closes its precondition without prejudging it:

> *"The incorrect lexicographic-height-order contract is reconciled and API ordering is tested regardless of the chosen endian encoding."*

## Verified

```
cargo fmt --all -- --check                                            ok
cargo clippy -p bitcoin-rs-index --all-targets --features rocksdb \
  -- -D warnings                                                      0 errors
cargo clippy -p bitcoin-rs --all-targets --no-default-features \
  --features "rocksdb,fjall,redb,mdbx,kernel" -- -D warnings          0 errors
cargo test -p bitcoin-rs-index --features rocksdb                     57 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
