### PR TITLE
feat(index): add the ScriptLive capability with anchored, ordered mutations

### DIFF
--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -97,6 +97,29 @@ pub enum IndexError {
     /// A prepared transition cannot mix with legacy buffered rows.
     #[error("cannot write prepared TxIndex mutations with buffered legacy rows")]
     PendingLegacyRows,
+    /// A capability set containing `ScriptLive` was prepared through a path
+    /// that carries no spent-coin script source. Live deletes need the spent
+    /// coin's exact script (#225), and a prevout-only block parse cannot
+    /// produce it.
+    #[error("ScriptLive preparation requires a spent-coin script source")]
+    MissingSpentScripts,
+    /// The spent-coin source could not resolve an external input's script.
+    /// Failing closed here is deliberate: a missing anchor means the Live view
+    /// would silently keep a spent output alive.
+    #[error("no spent-coin script for outpoint {txid:02x?}:{vout} in block at height {height}")]
+    MissingSpentCoin {
+        /// Spent transaction id (little-endian bytes).
+        txid: [u8; 32],
+        /// Spent output index.
+        vout: u32,
+        /// Height of the spending block.
+        height: u32,
+    },
+    /// `seed_script_live` was asked to seed over an existing live watermark.
+    /// Seeding assumes a fresh (or reset) capability; overwriting a live view
+    /// in place is how partial states become queryable.
+    #[error("ScriptLive is already seeded; reset the capability first")]
+    LiveAlreadySeeded,
     /// `TxIndex` tables exist but the format-version key is missing.
     #[error("TxIndex tables are present without a versioned watermark")]
     LegacyCursorlessIndex,
@@ -111,6 +134,7 @@ const FORMAT_VERSION_KEY: &[u8] = &[0x00, b'V'];
 const FORMAT_VERSION_VALUE: [u8; 4] = [0x03, 0x00, 0x00, 0x00];
 const TX_LOOKUP_WATERMARK_KEY: &[u8] = &[0x00, b'T'];
 const SCRIPT_HISTORY_WATERMARK_KEY: &[u8] = &[0x00, b'S'];
+const SCRIPT_LIVE_WATERMARK_KEY: &[u8] = &[0x00, b'L'];
 const RESET_CAPABILITIES_KEY: &[u8] = &[0x00, b'R'];
 const WATERMARK_LEN: usize = crate::types::HEIGHT_SIZE + 32;
 const RESET_SCAN_LIMIT: PrefixScanLimit = PrefixScanLimit {
@@ -122,6 +146,7 @@ const fn watermark_key(capability: IndexCapability) -> &'static [u8] {
     match capability {
         IndexCapability::TxLookup => TX_LOOKUP_WATERMARK_KEY,
         IndexCapability::ScriptHistory => SCRIPT_HISTORY_WATERMARK_KEY,
+        IndexCapability::ScriptLive => SCRIPT_LIVE_WATERMARK_KEY,
     }
 }
 
@@ -157,6 +182,10 @@ pub enum IndexCapability {
     TxLookup,
     /// `ScriptIndex` scripthash funding and spending rows.
     ScriptHistory,
+    /// `ScriptIndex` live-output rows: one row per currently unspent outpoint,
+    /// filed under its script (#225). Rebuildable from the authoritative UTXO
+    /// set alone, unlike history.
+    ScriptLive,
 }
 
 /// Capabilities included in one prepared index transition.
@@ -166,6 +195,8 @@ pub struct IndexCapabilities {
     pub tx_lookup: bool,
     /// Build `ScriptIndex` funding and spending rows.
     pub script_history: bool,
+    /// Build `ScriptIndex` live-output rows.
+    pub script_live: bool,
 }
 
 impl IndexCapabilities {
@@ -173,21 +204,40 @@ impl IndexCapabilities {
     pub const NONE: Self = Self {
         tx_lookup: false,
         script_history: false,
+        script_live: false,
     };
     /// Transaction lookup only.
     pub const TX_LOOKUP: Self = Self {
         tx_lookup: true,
         script_history: false,
+        script_live: false,
     };
     /// `ScriptIndex` history only.
     pub const SCRIPT_HISTORY: Self = Self {
         tx_lookup: false,
         script_history: true,
+        script_live: false,
     };
-    /// Both capabilities.
+    /// `ScriptIndex` live outputs only.
+    pub const SCRIPT_LIVE: Self = Self {
+        tx_lookup: false,
+        script_history: false,
+        script_live: true,
+    };
+    /// Every capability.
     pub const ALL: Self = Self {
         tx_lookup: true,
         script_history: true,
+        script_live: true,
+    };
+    /// The pre-#225 pair: everything derivable from a block body alone.
+    ///
+    /// Anchorless paths use this, because `ScriptLive` cannot be prepared
+    /// without a spent-coin script source.
+    pub const HISTORICAL: Self = Self {
+        tx_lookup: true,
+        script_history: true,
+        script_live: false,
     };
 
     /// Returns whether `capability` is selected.
@@ -195,25 +245,31 @@ impl IndexCapabilities {
         match capability {
             IndexCapability::TxLookup => self.tx_lookup,
             IndexCapability::ScriptHistory => self.script_history,
+            IndexCapability::ScriptLive => self.script_live,
         }
     }
 
     /// Returns whether no capability is selected.
     pub const fn is_empty(self) -> bool {
-        !self.tx_lookup && !self.script_history
+        !self.tx_lookup && !self.script_history && !self.script_live
     }
 
     fn to_mask(self) -> u8 {
-        u8::from(self.tx_lookup) | (u8::from(self.script_history) << 1)
+        u8::from(self.tx_lookup)
+            | (u8::from(self.script_history) << 1)
+            | (u8::from(self.script_live) << 2)
     }
 
     fn from_mask(mask: u8) -> Result<Self, IndexError> {
-        if mask == 0 || mask & !0b11 != 0 {
+        // A pre-#225 marker never carries bit 2, and reading one with the bit
+        // absent is exactly right: the store had no live rows to reset.
+        if mask == 0 || mask & !0b111 != 0 {
             return Err(IndexError::InvalidResetMarker);
         }
         Ok(Self {
-            tx_lookup: mask & 0b01 != 0,
-            script_history: mask & 0b10 != 0,
+            tx_lookup: mask & 0b001 != 0,
+            script_history: mask & 0b010 != 0,
+            script_live: mask & 0b100 != 0,
         })
     }
 }
@@ -225,6 +281,9 @@ pub struct IndexWatermarks {
     pub tx_lookup: Option<IndexWatermark>,
     /// `ScriptIndex` history cursor.
     pub script_history: Option<IndexWatermark>,
+    /// `ScriptIndex` live-output cursor. Independent of history by design:
+    /// a ready live view stays queryable while history backfills (#225).
+    pub script_live: Option<IndexWatermark>,
 }
 
 impl IndexWatermarks {
@@ -233,6 +292,7 @@ impl IndexWatermarks {
         match capability {
             IndexCapability::TxLookup => self.tx_lookup,
             IndexCapability::ScriptHistory => self.script_history,
+            IndexCapability::ScriptLive => self.script_live,
         }
     }
 }
@@ -266,10 +326,7 @@ impl IndexWatermark {
         snapshot: &dyn KvSnapshot,
         capability: IndexCapability,
     ) -> Result<Option<Self>, IndexError> {
-        let key = match capability {
-            IndexCapability::TxLookup => TX_LOOKUP_WATERMARK_KEY,
-            IndexCapability::ScriptHistory => SCRIPT_HISTORY_WATERMARK_KEY,
-        };
+        let key = watermark_key(capability);
         snapshot
             .get(ColumnFamily::UtxoMeta, key)?
             .as_deref()
@@ -277,6 +334,55 @@ impl IndexWatermark {
             .transpose()
     }
 }
+
+/// Source of exact scripts for coins an incoming block spends.
+///
+/// A block body carries only each input's previous outpoint; the spent coin's
+/// `script_pubkey` lives in authoritative UTXO state, and on disconnect in the
+/// block's undo record. #225 requires Live deletes to be anchored to that
+/// authoritative script, so preparation of a `ScriptLive` transition takes one
+/// of these instead of guessing from the parse.
+pub trait SpentCoinScripts {
+    /// The exact `script_pubkey` bytes of the coin `txid:vout`, if known.
+    ///
+    /// `txid` is in little-endian byte order, as serialized in the input.
+    fn script_bytes(&self, txid: &[u8; 32], vout: u32) -> Option<&[u8]>;
+}
+
+/// The anchorless source: answers nothing.
+///
+/// Used by the legacy prepare path, which refuses `ScriptLive` outright rather
+/// than producing a Live transition with unanchored deletes.
+pub struct NoSpentScripts;
+
+impl SpentCoinScripts for NoSpentScripts {
+    fn script_bytes(&self, _txid: &[u8; 32], _vout: u32) -> Option<&[u8]> {
+        None
+    }
+}
+
+/// One ordered live-view mutation produced by a block.
+///
+/// Order is semantic, unlike every other pending row family: a later block in
+/// the same committed batch may delete a key an earlier block inserted, so
+/// these are applied first-to-last with the last operation per key winning.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum LiveOp {
+    /// The block created this currently-unspent output.
+    Insert(crate::types::ScriptLiveRow),
+    /// The block spent this previously-live output.
+    Delete(crate::types::ScriptLiveRow),
+}
+
+/// Upper bound on a `script_pubkey` admitted into the authoritative UTXO set.
+///
+/// Mirrors `bitcoin_rs_consensus::MAX_SCRIPT_SIZE` as applied by the node's
+/// `build_utxo_changes`: outputs with `is_op_return()` or a script longer than
+/// this never enter the UTXO set, so they must never enter the Live view
+/// either -- #225 requires the spendability predicate to match authoritative
+/// UTXO admission exactly. Duplicated as a literal because this crate does not
+/// depend on the consensus crate; the node crate asserts the two are equal.
+pub const MAX_LIVE_SCRIPT_SIZE: usize = 10_000;
 
 /// Hard limits for one prepared forward write.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -416,6 +522,8 @@ pub struct IndexRowCounts {
     pub spending: usize,
     /// Header rows written to [`ColumnFamily::BlockHeaders`].
     pub headers: usize,
+    /// Live-output mutations applied to [`ColumnFamily::ScriptLive`].
+    pub live: usize,
 }
 
 /// Electrs-shaped block indexer backed by a workspace [`KvStore`].
@@ -470,6 +578,7 @@ impl<S: KvStore> Indexer<S> {
         Ok(IndexWatermarks {
             tx_lookup: self.capability_watermark(IndexCapability::TxLookup)?,
             script_history: self.capability_watermark(IndexCapability::ScriptHistory)?,
+            script_live: self.capability_watermark(IndexCapability::ScriptLive)?,
         })
     }
 
@@ -489,6 +598,31 @@ impl<S: KvStore> Indexer<S> {
         let prefix = ScriptHashRow::scan_prefix(scripthash);
         let iter = self.store.iter_prefix(ColumnFamily::Funding, &prefix)?;
         collect_prefix_rows(iter)
+    }
+
+    /// Iterates live-output rows for `scripthash`.
+    ///
+    /// Returns the outpoint locators currently filed under the scripthash's
+    /// 8-byte scan prefix, decoded from [`ColumnFamily::ScriptLive`]. The
+    /// prefix is lossy exactly like `Funding`'s: two scripts may share it, so
+    /// callers MUST resolve each outpoint against authoritative UTXO state and
+    /// exact-check the resolved coin's full `script_pubkey` before serving it
+    /// (#225). This scan is read-only by contract -- live deletion is always a
+    /// whole-key point delete, never a prefix-range operation.
+    pub fn iter_live_outpoints(
+        &self,
+        scripthash: crate::ScriptHash,
+    ) -> Result<Vec<bitcoin::OutPoint>, IndexError> {
+        let prefix = ScriptHashRow::scan_prefix(scripthash);
+        let iter = self.store.iter_prefix(ColumnFamily::ScriptLive, &prefix)?;
+        let mut outpoints = Vec::new();
+        for row in iter {
+            let (key, _value) = row?;
+            let row = crate::types::ScriptLiveRow::from_db_row(&key)
+                .ok_or(IndexError::InvalidWatermark)?;
+            outpoints.push(row.outpoint());
+        }
+        Ok(outpoints)
     }
 
     /// Resolves confirmed script-history entries for `scripthash` via `source`.
@@ -913,7 +1047,7 @@ impl<S: KvStore> Indexer<S> {
     fn flush(&mut self) -> Result<IndexRowCounts, IndexError> {
         self.pending_rows.sort();
         let counts = self.pending_rows.counts();
-        if counts.txids + counts.funding + counts.spending + counts.headers == 0 {
+        if counts.txids + counts.funding + counts.spending + counts.headers + counts.live == 0 {
             return Ok(counts);
         }
         let mut batch = self.store.new_batch();
@@ -937,6 +1071,7 @@ impl<S: KvStore> Indexer<S> {
         for row in &self.pending_rows.header_rows {
             batch.put(ColumnFamily::BlockHeaders, row, &[]);
         }
+        apply_live_ops(&mut batch, &self.pending_rows.live_ops, false);
         self.store.write(batch)?;
         self.last_counts = counts;
         self.pending_rows = PendingRows::default();
@@ -969,6 +1104,7 @@ fn pending_rows_for_block_with_header(
     block: &[u8],
     height: u32,
     capabilities: IndexCapabilities,
+    spent_scripts: &dyn SpentCoinScripts,
 ) -> Result<(PendingRows, Option<[u8; crate::types::HEADER_ROW_SIZE]>), IndexError> {
     let mut rows = PendingRows::default();
     let mut header = None;
@@ -979,22 +1115,97 @@ fn pending_rows_for_block_with_header(
         invalid_header_len: None,
         block,
         pending_funding: Vec::new(),
+        pending_live: Vec::new(),
+        live_created: Vec::new(),
+        live_spent: Vec::new(),
         capabilities,
     };
     match bsl::Block::visit(block, &mut visitor) {
-        Ok(_) => Ok((rows, header)),
+        Ok(_) => {}
         Err(bitcoin_slices::Error::VisitBreak) => {
             if let Some(len) = visitor.invalid_header_len {
                 return Err(IndexError::InvalidHeaderLength { len });
             }
-            Err(IndexError::BlockParse(bitcoin_slices::Error::VisitBreak))
+            return Err(IndexError::BlockParse(bitcoin_slices::Error::VisitBreak));
         }
-        Err(error) => Err(IndexError::BlockParse(error)),
+        Err(error) => return Err(IndexError::BlockParse(error)),
     }
+    if capabilities.script_live {
+        let IndexBlockVisitor {
+            live_created,
+            live_spent,
+            ..
+        } = visitor;
+        push_live_ops(&mut rows, live_created, live_spent, height, spent_scripts)?;
+    }
+    Ok((rows, header))
+}
+
+/// Turns a block's created and spent outputs into ordered live mutations.
+///
+/// Outputs created **and** spent within the same block cancel here and never
+/// touch the store, matching authoritative UTXO semantics: such an output
+/// never exists in the committed set, so it must never exist in the Live view
+/// (#225). Every surviving spend is external and resolves its exact script
+/// through `spent_scripts` -- an unresolvable one fails the whole preparation
+/// closed, because guessing would leave a spent output alive.
+fn push_live_ops(
+    rows: &mut PendingRows,
+    created: Vec<([u8; 32], u32, ScriptHash)>,
+    spent: Vec<([u8; 32], u32)>,
+    height: u32,
+    spent_scripts: &dyn SpentCoinScripts,
+) -> Result<(), IndexError> {
+    use bitcoin::hashes::Hash as _;
+    let created_keys: hashbrown::HashSet<([u8; 32], u32)> = created
+        .iter()
+        .map(|(txid, vout, _)| (*txid, *vout))
+        .collect();
+    let mut cancelled: hashbrown::HashSet<([u8; 32], u32)> = hashbrown::HashSet::new();
+    let mut deletes = Vec::new();
+    for (txid, vout) in spent {
+        if created_keys.contains(&(txid, vout)) {
+            cancelled.insert((txid, vout));
+            continue;
+        }
+        let script = spent_scripts
+            .script_bytes(&txid, vout)
+            .ok_or(IndexError::MissingSpentCoin { txid, vout, height })?;
+        let outpoint = bitcoin::OutPoint {
+            txid: bitcoin::Txid::from_byte_array(txid),
+            vout,
+        };
+        deletes.push(LiveOp::Delete(crate::types::ScriptLiveRow::new(
+            ScriptHash::from_script_bytes(script),
+            &outpoint,
+        )));
+    }
+    for (txid, vout, scripthash) in created {
+        if cancelled.contains(&(txid, vout)) {
+            continue;
+        }
+        let outpoint = bitcoin::OutPoint {
+            txid: bitcoin::Txid::from_byte_array(txid),
+            vout,
+        };
+        rows.live_ops
+            .push(LiveOp::Insert(crate::types::ScriptLiveRow::new(
+                scripthash, &outpoint,
+            )));
+    }
+    rows.live_ops.extend(deletes);
+    Ok(())
 }
 
 fn pending_rows_for_block(block: &[u8], height: u32) -> Result<PendingRows, IndexError> {
-    let (rows, _) = pending_rows_for_block_with_header(block, height, IndexCapabilities::ALL)?;
+    // The legacy ingest path predates the Live view and carries no spent-coin
+    // source, so it builds the historical capabilities only.
+    let (rows, _) = pending_rows_for_block_with_header(
+        block,
+        height,
+        IndexCapabilities::HISTORICAL,
+        &NoSpentScripts,
+    )?;
     Ok(rows)
 }
 
@@ -1072,6 +1283,10 @@ struct PendingRows {
     funding_rows: Vec<PositionedRow>,
     spending_rows: Vec<HashPrefixRow>,
     header_rows: Vec<[u8; crate::types::HEADER_ROW_SIZE]>,
+    /// Ordered live-view mutations. Never sorted: unlike the append-only
+    /// families above, this one mixes puts and deletes, and a later block's
+    /// delete of an earlier block's insert must stay later.
+    live_ops: Vec<LiveOp>,
 }
 
 /// Counts distinct row keys in a sorted `PositionedRow` slice.
@@ -1132,6 +1347,7 @@ impl PendingRows {
             funding: distinct_row_count(&self.funding_rows),
             spending: self.spending_rows.len(),
             headers: self.header_rows.len(),
+            live: self.live_ops.len(),
         }
     }
     fn append(&mut self, other: Self) {
@@ -1139,11 +1355,12 @@ impl PendingRows {
         self.funding_rows.extend(other.funding_rows);
         self.spending_rows.extend(other.spending_rows);
         self.header_rows.extend(other.header_rows);
+        self.live_ops.extend(other.live_ops);
     }
 
     fn total(&self) -> usize {
         let counts = self.counts();
-        counts.txids + counts.funding + counts.spending + counts.headers
+        counts.txids + counts.funding + counts.spending + counts.headers + counts.live
     }
 
     fn is_empty(&self) -> bool {
@@ -1171,10 +1388,48 @@ impl PendingRows {
             .len()
             .checked_mul(crate::types::HEADER_ROW_SIZE)
             .ok_or(IndexError::MutationSizeOverflow)?;
+        let live_bytes = self
+            .live_ops
+            .len()
+            .checked_mul(crate::types::SCRIPT_LIVE_ROW_SIZE)
+            .ok_or(IndexError::MutationSizeOverflow)?;
         prefix_bytes
             .checked_add(position_bytes)
             .and_then(|s| s.checked_add(header_bytes))
+            .and_then(|s| s.checked_add(live_bytes))
             .ok_or(IndexError::MutationSizeOverflow)
+    }
+}
+
+/// Applies ordered live mutations to `batch`, last operation per key winning.
+///
+/// Coalescing in memory rather than relying on the backend's write-batch
+/// ordering keeps the semantics backend-independent: after this, each key
+/// appears in the batch at most once. `invert` swaps inserts and deletes,
+/// which is exactly a block's live rollback; inverted ops are applied in
+/// reverse order so the coalescing rule stays "the chronologically last
+/// forward operation decides".
+fn apply_live_ops<B: WriteBatch>(batch: &mut B, ops: &[LiveOp], invert: bool) {
+    let mut last: hashbrown::HashMap<[u8; crate::types::SCRIPT_LIVE_ROW_SIZE], bool> =
+        hashbrown::HashMap::new();
+    let ordered: Box<dyn Iterator<Item = &LiveOp>> = if invert {
+        Box::new(ops.iter().rev())
+    } else {
+        Box::new(ops.iter())
+    };
+    for op in ordered {
+        let (row, insert) = match op {
+            LiveOp::Insert(row) => (row, !invert),
+            LiveOp::Delete(row) => (row, invert),
+        };
+        last.insert(*row.as_bytes(), insert);
+    }
+    for (key, insert) in last {
+        if insert {
+            batch.put(ColumnFamily::ScriptLive, &key, &[]);
+        } else {
+            batch.delete(ColumnFamily::ScriptLive, &key);
+        }
     }
 }
 
@@ -1199,6 +1454,7 @@ fn put_rows<B: WriteBatch>(batch: &mut B, rows: &PendingRows) {
     for row in &rows.header_rows {
         batch.put(ColumnFamily::BlockHeaders, row, &[]);
     }
+    apply_live_ops(batch, &rows.live_ops, false);
 }
 
 fn put_selected_watermarks<B: WriteBatch>(
@@ -1206,7 +1462,11 @@ fn put_selected_watermarks<B: WriteBatch>(
     capabilities: IndexCapabilities,
     watermark: Option<IndexWatermark>,
 ) {
-    for capability in [IndexCapability::TxLookup, IndexCapability::ScriptHistory] {
+    for capability in [
+        IndexCapability::TxLookup,
+        IndexCapability::ScriptHistory,
+        IndexCapability::ScriptLive,
+    ] {
         if !capabilities.contains(capability) {
             continue;
         }
@@ -1223,18 +1483,28 @@ fn selected_watermark(
     watermarks: IndexWatermarks,
     capabilities: IndexCapabilities,
 ) -> Result<Option<IndexWatermark>, IndexError> {
-    match (capabilities.tx_lookup, capabilities.script_history) {
-        (true, false) => Ok(watermarks.tx_lookup),
-        (false, true) => Ok(watermarks.script_history),
-        (true, true) if watermarks.tx_lookup == watermarks.script_history => {
-            Ok(watermarks.tx_lookup)
+    let mut selected: Option<Option<IndexWatermark>> = None;
+    for capability in [
+        IndexCapability::TxLookup,
+        IndexCapability::ScriptHistory,
+        IndexCapability::ScriptLive,
+    ] {
+        if !capabilities.contains(capability) {
+            continue;
         }
-        (true, true) => Err(IndexError::WatermarkMismatch {
-            expected: watermarks.tx_lookup,
-            actual: watermarks.script_history,
-        }),
-        (false, false) => Err(IndexError::NonContiguousPrepared { watermark: None }),
+        let cursor = watermarks.get(capability);
+        match selected {
+            None => selected = Some(cursor),
+            Some(first) if first == cursor => {}
+            Some(first) => {
+                return Err(IndexError::WatermarkMismatch {
+                    expected: first,
+                    actual: cursor,
+                });
+            }
+        }
     }
+    selected.ok_or(IndexError::NonContiguousPrepared { watermark: None })
 }
 
 fn delete_rows<B: WriteBatch>(batch: &mut B, rows: &PendingRows, delete_shared_identity: bool) {
@@ -1247,6 +1517,9 @@ fn delete_rows<B: WriteBatch>(batch: &mut B, rows: &PendingRows, delete_shared_i
     for row in &rows.spending_rows {
         batch.delete(ColumnFamily::Spending, row.as_bytes());
     }
+    // The live rollback is the inverse authoritative transition (#225):
+    // outputs the block created leave the view, outputs it spent return.
+    apply_live_ops(batch, &rows.live_ops, true);
     if delete_shared_identity {
         for row in &rows.header_rows {
             batch.delete(ColumnFamily::BlockHeaders, row);
@@ -1268,6 +1541,15 @@ struct IndexBlockVisitor<'a> {
     /// the first point where the position exists. Outputs are therefore buffered
     /// here and drained once, in emission order.
     pending_funding: Vec<crate::types::HashPrefix>,
+    /// Live-eligible outputs of the transaction currently being parsed, as
+    /// `(vout, scripthash)` -- buffered for the same reason as
+    /// `pending_funding`, and additionally because the txid is unknown until
+    /// `visit_transaction`.
+    pending_live: Vec<(u32, ScriptHash)>,
+    /// Outputs this block created that pass UTXO admission, pre-cancellation.
+    live_created: Vec<([u8; 32], u32, ScriptHash)>,
+    /// Full previous outpoints this block spends, pre-cancellation.
+    live_spent: Vec<([u8; 32], u32)>,
     capabilities: IndexCapabilities,
 }
 
@@ -1324,6 +1606,14 @@ impl Visitor for IndexBlockVisitor<'_> {
                 position,
             });
         }
+        if !self.pending_live.is_empty() {
+            let txid = tx.txid_sha2();
+            let mut txid_bytes = [0_u8; 32];
+            txid_bytes.copy_from_slice(txid.as_slice());
+            for (vout, scripthash) in self.pending_live.drain(..) {
+                self.live_created.push((txid_bytes, vout, scripthash));
+            }
+        }
         if !self.capabilities.tx_lookup {
             return ControlFlow::Continue(());
         }
@@ -1333,28 +1623,45 @@ impl Visitor for IndexBlockVisitor<'_> {
     }
 
     fn visit_tx_in(&mut self, _vin: usize, tx_in: &bsl::TxIn<'_>) -> ControlFlow<()> {
-        if !self.capabilities.script_history {
+        let prevout = tx_in.prevout();
+        if is_null_prevout(prevout) {
             return ControlFlow::Continue(());
         }
-        let prevout = tx_in.prevout();
-        if !is_null_prevout(prevout) {
+        if self.capabilities.script_history {
             self.rows.spending_rows.push(SpendingPrefixRow::row_parts(
                 prevout.txid(),
                 prevout.vout(),
                 self.height_bytes,
             ));
         }
+        if self.capabilities.script_live {
+            let mut txid = [0_u8; 32];
+            txid.copy_from_slice(prevout.txid());
+            self.live_spent.push((txid, prevout.vout()));
+        }
         ControlFlow::Continue(())
     }
 
-    fn visit_tx_out(&mut self, _vout: usize, tx_out: &bsl::TxOut<'_>) -> ControlFlow<()> {
-        if !self.capabilities.script_history {
-            return ControlFlow::Continue(());
-        }
+    fn visit_tx_out(&mut self, vout: usize, tx_out: &bsl::TxOut<'_>) -> ControlFlow<()> {
         let script = tx_out.script_pubkey();
-        if !is_op_return_script(script) {
+        if self.capabilities.script_history && !is_op_return_script(script) {
             self.pending_funding
                 .push(ScriptHash::from_script_bytes(script).prefix());
+        }
+        // The live predicate is UTXO admission, not the history predicate:
+        // `build_utxo_changes` skips `is_op_return()` and oversized scripts,
+        // and the genesis coinbase never enters the UTXO set at all. History
+        // deliberately keeps oversized-script outputs (they are historical
+        // activity); Live must not, or it would carry locators no
+        // authoritative lookup can resolve.
+        if self.capabilities.script_live
+            && self.height_bytes != [0_u8; crate::types::HEIGHT_SIZE]
+            && !is_op_return_script(script)
+            && script.len() <= MAX_LIVE_SCRIPT_SIZE
+            && let Ok(vout) = u32::try_from(vout)
+        {
+            self.pending_live
+                .push((vout, ScriptHash::from_script_bytes(script)));
         }
         ControlFlow::Continue(())
     }
@@ -1681,6 +1988,11 @@ pub struct IndexWriter<S: KvStore> {
 }
 
 impl<S: KvStore> IndexWriter<S> {
+    /// Read access to the owned indexer, for queries beside the write path.
+    pub fn indexer(&self) -> &Indexer<S> {
+        &self.indexer
+    }
+
     /// Opens a writer over `store`, rejecting unversioned index tables.
     pub fn open(store: std::sync::Arc<S>) -> Result<Self, IndexError> {
         let indexer = Indexer::new(store);
@@ -1759,6 +2071,63 @@ impl<S: KvStore> IndexWriter<S> {
         Ok(())
     }
 
+    /// Seeds the live view from a scan of the authoritative UTXO set.
+    ///
+    /// `coins` is every live `(outpoint, scripthash)` at `seed_tip`, in any
+    /// order. Rows are written in bounded deferred batches, and the watermark
+    /// is stamped **once, durably, after the last row** -- so a crash mid-seed
+    /// leaves the capability without a watermark, which is exactly "not
+    /// ready": partial rows are never queryable, and the recovery is a
+    /// capability reset followed by a fresh seed (#225).
+    ///
+    /// Refuses to run over an existing live watermark. Seeding is for a fresh
+    /// or reset capability; re-seeding a live view in place would have to
+    /// reconcile stale rows, which is the reset path's job.
+    pub fn seed_script_live<I>(
+        &mut self,
+        coins: I,
+        seed_tip: IndexWatermark,
+    ) -> Result<usize, IndexError>
+    where
+        I: IntoIterator<Item = (bitcoin::OutPoint, crate::ScriptHash)>,
+    {
+        const SEED_BATCH_ROWS: usize = 4_096;
+        self.ensure_prepared_ready()?;
+        if self
+            .indexer
+            .capability_watermark(IndexCapability::ScriptLive)?
+            .is_some()
+        {
+            return Err(IndexError::LiveAlreadySeeded);
+        }
+        let mut written = 0_usize;
+        let mut batch = self.indexer.store.new_batch();
+        let mut in_batch = 0_usize;
+        for (outpoint, scripthash) in coins {
+            let row = crate::types::ScriptLiveRow::new(scripthash, &outpoint);
+            batch.put(ColumnFamily::ScriptLive, row.as_bytes(), &[]);
+            written = written.saturating_add(1);
+            in_batch += 1;
+            if in_batch >= SEED_BATCH_ROWS {
+                self.indexer.store.write_deferred(batch)?;
+                batch = self.indexer.store.new_batch();
+                in_batch = 0;
+            }
+        }
+        batch.put(
+            ColumnFamily::UtxoMeta,
+            FORMAT_VERSION_KEY,
+            &FORMAT_VERSION_VALUE,
+        );
+        batch.put(
+            ColumnFamily::UtxoMeta,
+            SCRIPT_LIVE_WATERMARK_KEY,
+            &seed_tip.to_bytes(),
+        );
+        self.indexer.store.write_durable(batch)?;
+        Ok(written)
+    }
+
     /// Marks selected derived rows unavailable, deletes them in bounded batches,
     /// and leaves their durable cursors empty so the worker can rebuild from genesis.
     ///
@@ -1786,6 +2155,9 @@ impl<S: KvStore> IndexWriter<S> {
         if capabilities.script_history {
             batch.delete(ColumnFamily::UtxoMeta, SCRIPT_HISTORY_WATERMARK_KEY);
         }
+        if capabilities.script_live {
+            batch.delete(ColumnFamily::UtxoMeta, SCRIPT_LIVE_WATERMARK_KEY);
+        }
         self.indexer.store.write_durable(batch)?;
         Self::resume_capability_reset(self.indexer.store.as_ref())
     }
@@ -1806,6 +2178,9 @@ impl<S: KvStore> IndexWriter<S> {
             column_families.push(ColumnFamily::Funding);
             column_families.push(ColumnFamily::Spending);
         }
+        if capabilities.script_live {
+            column_families.push(ColumnFamily::ScriptLive);
+        }
         let unselected_cursor_remains = (!capabilities.tx_lookup
             && store
                 .get(ColumnFamily::UtxoMeta, TX_LOOKUP_WATERMARK_KEY)?
@@ -1813,6 +2188,10 @@ impl<S: KvStore> IndexWriter<S> {
             || (!capabilities.script_history
                 && store
                     .get(ColumnFamily::UtxoMeta, SCRIPT_HISTORY_WATERMARK_KEY)?
+                    .is_some())
+            || (!capabilities.script_live
+                && store
+                    .get(ColumnFamily::UtxoMeta, SCRIPT_LIVE_WATERMARK_KEY)?
                     .is_some());
         if !unselected_cursor_remains {
             column_families.push(ColumnFamily::BlockHeaders);
@@ -1847,7 +2226,7 @@ impl<S: KvStore> IndexWriter<S> {
         hash: [u8; 32],
         body: &[u8],
     ) -> Result<PreparedBlock, IndexError> {
-        self.prepare_block_for(IndexCapabilities::ALL, height, hash, body)
+        self.prepare_block_for(IndexCapabilities::HISTORICAL, height, hash, body)
     }
 
     /// Derives capability-selected row mutations from one serialized block scan.
@@ -1858,12 +2237,29 @@ impl<S: KvStore> IndexWriter<S> {
         hash: [u8; 32],
         body: &[u8],
     ) -> Result<PreparedBlock, IndexError> {
+        if capabilities.script_live {
+            return Err(IndexError::MissingSpentScripts);
+        }
+        self.prepare_block_with_spent_scripts(capabilities, height, hash, body, &NoSpentScripts)
+    }
+
+    /// [`Self::prepare_block_for`] with the spent-coin script source
+    /// `ScriptLive` preparation requires (#225).
+    pub fn prepare_block_with_spent_scripts(
+        &self,
+        capabilities: IndexCapabilities,
+        height: u32,
+        hash: [u8; 32],
+        body: &[u8],
+        spent_scripts: &dyn SpentCoinScripts,
+    ) -> Result<PreparedBlock, IndexError> {
         if capabilities.is_empty() {
             return Err(IndexError::NonContiguousPrepared {
                 watermark: self.watermark()?,
             });
         }
-        let (mut rows, header) = pending_rows_for_block_with_header(body, height, capabilities)?;
+        let (mut rows, header) =
+            pending_rows_for_block_with_header(body, height, capabilities, spent_scripts)?;
         let header = header.ok_or(IndexError::InvalidHeaderLength { len: 0 })?;
         let actual_hash = bitcoin::BlockHash::hash(header.as_slice()).to_byte_array();
         if actual_hash != hash {
@@ -1953,26 +2349,55 @@ impl<S: KvStore> IndexWriter<S> {
     }
 
     /// Atomically rolls back one tip block and writes the parent watermark.
+    ///
+    /// Covers the historical pair. `ScriptLive` rollback needs the block's
+    /// undo record and goes through
+    /// [`Self::commit_rollback_one_with_spent_scripts`].
     pub fn commit_rollback_one(
         &mut self,
         prev: Option<IndexWatermark>,
         body: &[u8],
     ) -> Result<(), IndexError> {
-        self.commit_rollback_one_for(IndexCapabilities::ALL, prev, body)
+        self.commit_rollback_one_for(IndexCapabilities::HISTORICAL, prev, body)
     }
 
     /// Atomically rolls back one block for the selected capabilities.
+    ///
+    /// Refuses `ScriptLive`: its rollback re-inserts the coins the block
+    /// spent, and those scripts come from the block's undo record, not its
+    /// body. Use [`Self::commit_rollback_one_with_spent_scripts`].
     pub fn commit_rollback_one_for(
         &mut self,
         capabilities: IndexCapabilities,
         prev: Option<IndexWatermark>,
         body: &[u8],
     ) -> Result<(), IndexError> {
+        if capabilities.script_live {
+            return Err(IndexError::MissingSpentScripts);
+        }
+        self.commit_rollback_one_with_spent_scripts(capabilities, prev, body, &NoSpentScripts)
+    }
+
+    /// [`Self::commit_rollback_one_for`] with the spent-coin script source a
+    /// `ScriptLive` rollback needs to restore the block's spent outputs.
+    pub fn commit_rollback_one_with_spent_scripts(
+        &mut self,
+        capabilities: IndexCapabilities,
+        prev: Option<IndexWatermark>,
+        body: &[u8],
+        spent_scripts: &dyn SpentCoinScripts,
+    ) -> Result<(), IndexError> {
         self.ensure_prepared_ready()?;
         let watermarks = self.watermarks()?;
         let current = selected_watermark(watermarks, capabilities)?
             .ok_or(IndexError::NonContiguousPrepared { watermark: None })?;
-        let prepared = self.prepare_block_for(capabilities, current.height, current.hash, body)?;
+        let prepared = self.prepare_block_with_spent_scripts(
+            capabilities,
+            current.height,
+            current.hash,
+            body,
+            spent_scripts,
+        )?;
         if let Some(prev) = &prev {
             let expected_prev_height =
                 current
@@ -2023,6 +2448,10 @@ impl<S: KvStore> IndexWriter<S> {
             || (!capabilities.script_history
                 && watermarks
                     .script_history
+                    .is_some_and(|watermark| watermark.height >= current.height))
+            || (!capabilities.script_live
+                && watermarks
+                    .script_live
                     .is_some_and(|watermark| watermark.height >= current.height));
         delete_rows(&mut store_batch, &prepared.rows, !unselected_keeps_identity);
         store_batch.put(

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -11,11 +11,12 @@ pub mod types;
 pub use index::{
     BlockSource, INDEX_FORMAT_VERSION, IndexCapabilities, IndexCapability, IndexError, IndexFormat,
     IndexReader, IndexRowCounts, IndexWatermark, IndexWatermarks, IndexWriter, Indexer,
-    IndexerLike, PreparedBatch, PreparedBatchLimits, PreparedBlock, ScriptHistoryEntry,
-    TxIndexScan, TxIndexScanRow, TxIndexSnapshot,
+    IndexerLike, MAX_LIVE_SCRIPT_SIZE, NoSpentScripts, PreparedBatch, PreparedBatchLimits,
+    PreparedBlock, ScriptHistoryEntry, SpentCoinScripts, TxIndexScan, TxIndexScanRow,
+    TxIndexSnapshot,
 };
 pub use mempool::{MempoolRowCounts, MempoolRowWriter};
 pub use types::{
     HASH_PREFIX_LEN, HASH_PREFIX_ROW_SIZE, HEADER_ROW_SIZE, HashPrefix, HashPrefixRow, HeaderRow,
-    ScriptHash, ScriptHashRow, SpendingPrefixRow, TxidRow,
+    SCRIPT_LIVE_ROW_SIZE, ScriptHash, ScriptHashRow, ScriptLiveRow, SpendingPrefixRow, TxidRow,
 };

--- a/crates/index/src/types.rs
+++ b/crates/index/src/types.rs
@@ -219,6 +219,63 @@ impl HeaderRow {
     }
 }
 
+/// Byte width of one live script-index row key: `scan-prefix || txid || vout`.
+pub const SCRIPT_LIVE_ROW_SIZE: usize = HASH_PREFIX_LEN + 32 + 4;
+
+/// One live-output row: a currently unspent outpoint filed under its script.
+///
+/// The key is the whole row -- `scan-prefix(8) || txid(32, little-endian as
+/// rust-bitcoin serializes it) || vout(4, little-endian)` -- and the value is
+/// empty. This is #225's full-outpoint baseline locator: the 8-byte prefix is
+/// lossy exactly like `Funding`'s (readers exact-check the resolved coin's
+/// `script_pubkey`), but the outpoint half is complete, so two scripts that
+/// collide on the prefix can never collide on a whole key. That is what makes
+/// a **point delete collision-safe**: removing a spent output deletes one
+/// exact key and cannot touch a colliding script's rows. Prefix-range scans
+/// over this family are read-only by contract; a delete is always a whole-key
+/// point delete (#226 Q5 may later select a smaller locator, and owes an
+/// equivalent identity-safety proof if it does).
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ScriptLiveRow {
+    key: [u8; SCRIPT_LIVE_ROW_SIZE],
+}
+
+impl ScriptLiveRow {
+    /// Builds the row for `outpoint` held by a script hashing to `scripthash`.
+    pub fn new(scripthash: ScriptHash, outpoint: &bitcoin::OutPoint) -> Self {
+        let mut key = [0_u8; SCRIPT_LIVE_ROW_SIZE];
+        key[..HASH_PREFIX_LEN].copy_from_slice(&ScriptHashRow::scan_prefix(scripthash));
+        key[HASH_PREFIX_LEN..HASH_PREFIX_LEN + 32].copy_from_slice(outpoint.txid.as_byte_array());
+        key[HASH_PREFIX_LEN + 32..].copy_from_slice(&outpoint.vout.to_le_bytes());
+        Self { key }
+    }
+
+    /// Rebuilds a row from stored key bytes, refusing any other length.
+    pub fn from_db_row(bytes: &[u8]) -> Option<Self> {
+        let key: [u8; SCRIPT_LIVE_ROW_SIZE] = bytes.try_into().ok()?;
+        Some(Self { key })
+    }
+
+    /// The exact stored key.
+    pub const fn as_bytes(&self) -> &[u8; SCRIPT_LIVE_ROW_SIZE] {
+        &self.key
+    }
+
+    /// The outpoint this row locates, for resolution against authoritative
+    /// UTXO state.
+    pub fn outpoint(&self) -> bitcoin::OutPoint {
+        use bitcoin::hashes::Hash as _;
+        let mut txid = [0_u8; 32];
+        txid.copy_from_slice(&self.key[HASH_PREFIX_LEN..HASH_PREFIX_LEN + 32]);
+        let mut vout = [0_u8; 4];
+        vout.copy_from_slice(&self.key[HASH_PREFIX_LEN + 32..]);
+        bitcoin::OutPoint {
+            txid: bitcoin::Txid::from_byte_array(txid),
+            vout: u32::from_le_bytes(vout),
+        }
+    }
+}
+
 /// Serialized byte length of one [`TxPosition`].
 pub const TX_POSITION_SIZE: usize = 8;
 

--- a/crates/index/tests/index_roundtrip.rs
+++ b/crates/index/tests/index_roundtrip.rs
@@ -226,6 +226,7 @@ fn ingest_golden_blocks_writes_expected_electrs_rows() -> Result<(), Box<dyn std
                 funding: 1,
                 spending: 0,
                 headers: 1,
+                live: 0,
             },
         ),
         (
@@ -235,6 +236,7 @@ fn ingest_golden_blocks_writes_expected_electrs_rows() -> Result<(), Box<dyn std
                 funding: 3,
                 spending: 1,
                 headers: 1,
+                live: 0,
             },
         ),
         (
@@ -244,6 +246,7 @@ fn ingest_golden_blocks_writes_expected_electrs_rows() -> Result<(), Box<dyn std
                 funding: 3_740,
                 spending: 5_192,
                 headers: 1,
+                live: 0,
             },
         ),
     ];
@@ -553,6 +556,7 @@ fn capability_commits_own_only_their_rows_and_watermarks() -> Result<(), Box<dyn
         bitcoin_rs_index::IndexWatermarks {
             tx_lookup: Some(watermark),
             script_history: None,
+            script_live: None,
         }
     );
     assert_eq!(store.count(ColumnFamily::TxConfirmed), 1);
@@ -575,6 +579,7 @@ fn capability_commits_own_only_their_rows_and_watermarks() -> Result<(), Box<dyn
         bitcoin_rs_index::IndexWatermarks {
             tx_lookup: Some(watermark),
             script_history: Some(watermark),
+            script_live: None,
         }
     );
     assert_eq!(store.count(ColumnFamily::TxConfirmed), 1);
@@ -590,7 +595,7 @@ fn aligned_capabilities_share_one_atomic_commit() -> Result<(), Box<dyn std::err
     let mut writer = IndexWriter::open(Arc::clone(&store))?;
     let body = read_fixture(0)?;
     let hash = block_hash(&body);
-    let block = writer.prepare_block_for(IndexCapabilities::ALL, 0, hash, &body)?;
+    let block = writer.prepare_block_for(IndexCapabilities::HISTORICAL, 0, hash, &body)?;
     let mut batch = PreparedBatch::new(PreparedBatchLimits {
         max_rows: 100,
         max_bytes: 1_000_000,
@@ -606,6 +611,7 @@ fn aligned_capabilities_share_one_atomic_commit() -> Result<(), Box<dyn std::err
         bitcoin_rs_index::IndexWatermarks {
             tx_lookup: Some(watermark),
             script_history: Some(watermark),
+            script_live: None,
         }
     );
     Ok(())
@@ -618,7 +624,7 @@ fn script_index_reset_preserves_tx_lookup_and_shared_identity()
     let mut writer = IndexWriter::open(Arc::clone(&store))?;
     let body = read_fixture(0)?;
     let hash = block_hash(&body);
-    let block = writer.prepare_block_for(IndexCapabilities::ALL, 0, hash, &body)?;
+    let block = writer.prepare_block_for(IndexCapabilities::HISTORICAL, 0, hash, &body)?;
     let mut batch = PreparedBatch::new(PreparedBatchLimits {
         max_rows: 100,
         max_bytes: 1_000_000,
@@ -633,6 +639,7 @@ fn script_index_reset_preserves_tx_lookup_and_shared_identity()
         bitcoin_rs_index::IndexWatermarks {
             tx_lookup: Some(IndexWatermark { height: 0, hash }),
             script_history: None,
+            script_live: None,
         }
     );
     assert_eq!(store.count(ColumnFamily::TxConfirmed), 1);
@@ -650,8 +657,10 @@ fn rollback_preserves_shared_ancestors_for_a_disabled_capability()
     let mut writer = IndexWriter::open(Arc::clone(&store))?;
     let body0 = read_fixture(0)?;
     let body1 = read_fixture(1)?;
-    let block0 = writer.prepare_block_for(IndexCapabilities::ALL, 0, block_hash(&body0), &body0)?;
-    let block1 = writer.prepare_block_for(IndexCapabilities::ALL, 1, block_hash(&body1), &body1)?;
+    let block0 =
+        writer.prepare_block_for(IndexCapabilities::HISTORICAL, 0, block_hash(&body0), &body0)?;
+    let block1 =
+        writer.prepare_block_for(IndexCapabilities::HISTORICAL, 1, block_hash(&body1), &body1)?;
     let watermark0 = block0.watermark();
     let mut batch = PreparedBatch::new(PreparedBatchLimits {
         max_rows: 100,
@@ -698,7 +707,7 @@ fn open_resumes_interrupted_capability_reset() -> Result<(), Box<dyn std::error:
     let mut writer = IndexWriter::open(Arc::clone(&store))?;
     let body = read_fixture(0)?;
     let hash = block_hash(&body);
-    let block = writer.prepare_block_for(IndexCapabilities::ALL, 0, hash, &body)?;
+    let block = writer.prepare_block_for(IndexCapabilities::HISTORICAL, 0, hash, &body)?;
     let mut prepared = PreparedBatch::new(PreparedBatchLimits {
         max_rows: 100,
         max_bytes: 1_000_000,

--- a/crates/index/tests/script_live.rs
+++ b/crates/index/tests/script_live.rs
@@ -1,0 +1,558 @@
+//! `ScriptLive` behavior over the prepared/commit path (#225).
+//!
+//! Everything here drives the same `IndexWriter` API the node's worker uses,
+//! with a map-backed [`SpentCoinScripts`] standing in for the undo-record
+//! anchor the node supplies in production. The properties under test are the
+//! ones #225 names as acceptance criteria: anchored deletes, same-block
+//! cancellation, the UTXO-admission spendability predicate, identity-specific
+//! point deletes, fail-closed unresolvable spends, watermark independence
+//! from history, and seed-then-stamp ordering.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use bitcoin::absolute::LockTime;
+use bitcoin::block::{self, Header};
+use bitcoin::consensus::encode::serialize;
+use bitcoin::hashes::Hash as _;
+use bitcoin::transaction::Version;
+use bitcoin::{
+    Amount, Block, BlockHash, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
+    TxMerkleNode, TxOut, Txid, Witness,
+};
+use bitcoin_rs_index::{
+    IndexCapabilities, IndexCapability, IndexError, IndexWatermark, IndexWriter,
+    MAX_LIVE_SCRIPT_SIZE, PreparedBatch, PreparedBatchLimits, ScriptHash, SpentCoinScripts,
+};
+use bitcoin_rs_storage::{
+    ColumnFamily, KvIter, KvSnapshot, KvStore, PrefixScanLimit, StorageError, WriteBatch,
+};
+use parking_lot::RwLock;
+
+// --- Minimal in-memory KvStore -------------------------------------------
+
+#[derive(Default)]
+struct MemoryStore {
+    cfs: RwLock<[BTreeMap<Vec<u8>, Vec<u8>>; ColumnFamily::ALL.len()]>,
+}
+
+struct MemoryBatch {
+    ops: Vec<(ColumnFamily, Vec<u8>, Option<Vec<u8>>)>,
+}
+
+impl WriteBatch for MemoryBatch {
+    fn put(&mut self, cf: ColumnFamily, key: &[u8], value: &[u8]) {
+        self.ops.push((cf, key.to_vec(), Some(value.to_vec())));
+    }
+    fn delete(&mut self, cf: ColumnFamily, key: &[u8]) {
+        self.ops.push((cf, key.to_vec(), None));
+    }
+    fn delete_range(&mut self, _cf: ColumnFamily, _start: &[u8], _end: &[u8]) {
+        panic!("range deletes are not exercised by these tests")
+    }
+}
+
+impl KvStore for MemoryStore {
+    type WriteBatch = MemoryBatch;
+
+    fn get(&self, cf: ColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
+        Ok(self.cfs.read()[cf.index()].get(key).cloned())
+    }
+    fn new_batch(&self) -> Self::WriteBatch {
+        MemoryBatch { ops: Vec::new() }
+    }
+    fn write(&self, batch: Self::WriteBatch) -> Result<(), StorageError> {
+        let mut guard = self.cfs.write();
+        for (cf, key, value) in batch.ops {
+            match value {
+                Some(value) => {
+                    guard[cf.index()].insert(key, value);
+                }
+                None => {
+                    guard[cf.index()].remove(&key);
+                }
+            }
+        }
+        Ok(())
+    }
+    fn write_deferred(&self, batch: Self::WriteBatch) -> Result<(), StorageError> {
+        self.write(batch)
+    }
+    fn write_durable(&self, batch: Self::WriteBatch) -> Result<(), StorageError> {
+        self.write(batch)
+    }
+    fn flush(&self) -> Result<(), StorageError> {
+        Ok(())
+    }
+    // The collect is what ends the borrow of the RwLock guard; handing the
+    // iterator out directly would return a reference into a dropped guard.
+    #[expect(clippy::needless_collect, reason = "decouples from the lock guard")]
+    fn iter_prefix<'a>(
+        &'a self,
+        cf: ColumnFamily,
+        prefix: &[u8],
+    ) -> Result<KvIter<'a>, StorageError> {
+        let rows = self.cfs.read()[cf.index()]
+            .range(prefix.to_vec()..)
+            .take_while(|(key, _)| key.starts_with(prefix))
+            .map(|(key, value)| Ok((key.clone(), value.clone())))
+            .collect::<Vec<_>>();
+        Ok(Box::new(rows.into_iter()))
+    }
+    fn snapshot(&self) -> Result<Box<dyn KvSnapshot + '_>, StorageError> {
+        panic!("snapshots are not exercised by these tests")
+    }
+    fn scan_prefix_bounded(
+        &self,
+        cf: ColumnFamily,
+        prefix: &[u8],
+        limit: PrefixScanLimit,
+    ) -> Result<bitcoin_rs_storage::PrefixScan, StorageError> {
+        let mut rows = Vec::new();
+        let mut bytes = 0_usize;
+        let mut complete = true;
+        for (key, value) in self.cfs.read()[cf.index()]
+            .range(prefix.to_vec()..)
+            .take_while(|(key, _)| key.starts_with(prefix))
+        {
+            if rows.len() >= limit.max_rows || bytes >= limit.max_bytes {
+                complete = false;
+                break;
+            }
+            bytes += key.len() + value.len();
+            rows.push((key.clone(), value.clone()));
+        }
+        Ok(bitcoin_rs_storage::PrefixScan { rows, complete })
+    }
+}
+
+// --- Anchor + block fixtures ---------------------------------------------
+
+/// Map-backed spent-coin source: the test's stand-in for the undo record.
+#[derive(Default)]
+struct MapScripts(hashbrown::HashMap<(Txid, u32), Vec<u8>>);
+
+impl MapScripts {
+    fn insert(&mut self, outpoint: OutPoint, script: &ScriptBuf) {
+        self.0
+            .insert((outpoint.txid, outpoint.vout), script.to_bytes());
+    }
+}
+
+impl SpentCoinScripts for MapScripts {
+    fn script_bytes(&self, txid: &[u8; 32], vout: u32) -> Option<&[u8]> {
+        self.0
+            .get(&(Txid::from_byte_array(*txid), vout))
+            .map(Vec::as_slice)
+    }
+}
+
+fn coinbase(tag: u8) -> Transaction {
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::from_bytes(vec![tag]),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50),
+            script_pubkey: script(0xc0 ^ tag),
+        }],
+    }
+}
+
+fn script(tag: u8) -> ScriptBuf {
+    ScriptBuf::from_bytes(vec![0x51, tag])
+}
+
+fn spend(inputs: &[OutPoint], outputs: &[ScriptBuf]) -> Transaction {
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: inputs
+            .iter()
+            .map(|previous_output| TxIn {
+                previous_output: *previous_output,
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            })
+            .collect(),
+        output: outputs
+            .iter()
+            .map(|script_pubkey| TxOut {
+                value: Amount::from_sat(10),
+                script_pubkey: script_pubkey.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn block_bytes(prev: [u8; 32], txdata: Vec<Transaction>) -> (Vec<u8>, [u8; 32]) {
+    let block = Block {
+        header: Header {
+            version: block::Version::ONE,
+            prev_blockhash: BlockHash::from_byte_array(prev),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 0,
+        },
+        txdata,
+    };
+    let hash = block.block_hash().to_byte_array();
+    (serialize(&block), hash)
+}
+
+struct Chain {
+    writer: IndexWriter<MemoryStore>,
+    tip: [u8; 32],
+    height: u32,
+}
+
+impl Chain {
+    fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let store = Arc::new(MemoryStore::default());
+        let writer = IndexWriter::open(store)?;
+        Ok(Self {
+            writer,
+            tip: [0_u8; 32],
+            height: 0,
+        })
+    }
+
+    /// Prepares and commits one block carrying `txdata` with the given anchor.
+    fn connect(
+        &mut self,
+        txdata: Vec<Transaction>,
+        anchor: &MapScripts,
+    ) -> Result<[u8; 32], IndexError> {
+        let (body, hash) = block_bytes(self.tip, txdata);
+        let prepared = self.writer.prepare_block_with_spent_scripts(
+            IndexCapabilities::ALL,
+            self.height,
+            hash,
+            &body,
+            anchor,
+        )?;
+        let mut batch = PreparedBatch::new(PreparedBatchLimits {
+            max_rows: 10_000,
+            max_bytes: 10_000_000,
+        });
+        assert!(batch.try_push(prepared).is_ok(), "batch must admit block");
+        self.writer.commit_forward(batch)?;
+        self.tip = hash;
+        self.height += 1;
+        Ok(hash)
+    }
+
+    fn live(&self, script: &ScriptBuf) -> Vec<OutPoint> {
+        let mut outpoints = self
+            .writer
+            .indexer()
+            .iter_live_outpoints(ScriptHash::from_script_bytes(script.as_bytes()))
+            .unwrap_or_else(|error| panic!("live scan failed: {error}"));
+        outpoints.sort_unstable();
+        outpoints
+    }
+}
+
+// --- Tests ----------------------------------------------------------------
+
+/// Connect writes live rows for created outputs; a later block's anchored
+/// spend removes exactly the spent outpoint and no other row of the same
+/// script; disconnect restores it from the anchor.
+#[test]
+fn live_rows_follow_connect_spend_and_disconnect() -> Result<(), Box<dyn std::error::Error>> {
+    let mut chain = Chain::new()?;
+    let empty = MapScripts::default();
+
+    // Height 0: genesis-shaped block. Its coinbase must produce no live rows.
+    chain.connect(vec![coinbase(0)], &empty)?;
+
+    // Height 1: a payment creating two outputs of one script.
+    let wallet = script(0xaa);
+    let pay = spend(&[OutPoint::null()], &[wallet.clone(), wallet.clone()]);
+    // A null-prevout non-coinbase would be nonsense; give it a fake external
+    // input the anchor can resolve.
+    let external = OutPoint {
+        txid: Txid::from_byte_array([7_u8; 32]),
+        vout: 0,
+    };
+    let funding_script = script(0xbb);
+    let pay = {
+        let mut pay = pay;
+        pay.input[0].previous_output = external;
+        pay
+    };
+    let pay_txid = pay.compute_txid();
+    let mut anchor = MapScripts::default();
+    anchor.insert(external, &funding_script);
+    chain.connect(vec![coinbase(1), pay], &anchor)?;
+
+    let o0 = OutPoint {
+        txid: pay_txid,
+        vout: 0,
+    };
+    let o1 = OutPoint {
+        txid: pay_txid,
+        vout: 1,
+    };
+    assert_eq!(chain.live(&wallet), sorted(vec![o0, o1]));
+
+    // Height 2: spend vout 0 only. The point delete must leave vout 1 alone --
+    // both rows share the full 8-byte script prefix, so anything short of an
+    // exact-key delete would take both.
+    let sweep = spend(&[o0], &[script(0xcc)]);
+    let mut anchor2 = MapScripts::default();
+    anchor2.insert(o0, &wallet);
+    let (body2, hash2) = block_bytes(chain.tip, vec![coinbase(2), sweep]);
+    let prepared = chain.writer.prepare_block_with_spent_scripts(
+        IndexCapabilities::ALL,
+        chain.height,
+        hash2,
+        &body2,
+        &anchor2,
+    )?;
+    let mut batch = PreparedBatch::new(PreparedBatchLimits {
+        max_rows: 10_000,
+        max_bytes: 10_000_000,
+    });
+    assert!(batch.try_push(prepared).is_ok());
+    chain.writer.commit_forward(batch)?;
+    assert_eq!(chain.live(&wallet), vec![o1]);
+
+    // Disconnect height 2: the spent output returns, the block's own outputs
+    // leave. The restore script comes from the anchor, exactly as the node
+    // reads it from the undo record.
+    let prev = IndexWatermark {
+        height: 1,
+        hash: chain.tip,
+    };
+    chain.writer.commit_rollback_one_with_spent_scripts(
+        IndexCapabilities::ALL,
+        Some(prev),
+        &body2,
+        &anchor2,
+    )?;
+    assert_eq!(chain.live(&wallet), sorted(vec![o0, o1]));
+    assert_eq!(chain.live(&script(0xcc)), Vec::<OutPoint>::new());
+    Ok(())
+}
+
+/// An output created and spent inside one block never touches the live view,
+/// and needs no anchor entry -- the cancellation happens before resolution.
+#[test]
+fn same_block_create_and_spend_cancels_without_an_anchor() -> Result<(), Box<dyn std::error::Error>>
+{
+    let mut chain = Chain::new()?;
+    let empty = MapScripts::default();
+    chain.connect(vec![coinbase(0)], &empty)?;
+
+    let transient = script(0xdd);
+    let survivor = script(0xee);
+    let external = OutPoint {
+        txid: Txid::from_byte_array([9_u8; 32]),
+        vout: 3,
+    };
+    let creator = {
+        let mut tx = spend(&[external], std::slice::from_ref(&transient));
+        tx.input[0].previous_output = external;
+        tx
+    };
+    let creator_txid = creator.compute_txid();
+    let spender = spend(
+        &[OutPoint {
+            txid: creator_txid,
+            vout: 0,
+        }],
+        std::slice::from_ref(&survivor),
+    );
+    let spender_txid = spender.compute_txid();
+
+    let mut anchor = MapScripts::default();
+    anchor.insert(external, &script(0xef));
+    // Deliberately no entry for the transient outpoint: if cancellation did
+    // not precede resolution, this connect would fail with MissingSpentCoin.
+    chain.connect(vec![coinbase(1), creator, spender], &anchor)?;
+
+    assert_eq!(chain.live(&transient), Vec::<OutPoint>::new());
+    assert_eq!(
+        chain.live(&survivor),
+        vec![OutPoint {
+            txid: spender_txid,
+            vout: 0,
+        }]
+    );
+    Ok(())
+}
+
+/// An external spend the anchor cannot resolve fails the whole preparation,
+/// and the anchorless prepare path refuses `ScriptLive` outright.
+#[test]
+fn unresolvable_spends_fail_closed() -> Result<(), Box<dyn std::error::Error>> {
+    let mut chain = Chain::new()?;
+    let empty = MapScripts::default();
+    chain.connect(vec![coinbase(0)], &empty)?;
+
+    let external = OutPoint {
+        txid: Txid::from_byte_array([5_u8; 32]),
+        vout: 1,
+    };
+    let tx = {
+        let mut tx = spend(&[external], &[script(0x11)]);
+        tx.input[0].previous_output = external;
+        tx
+    };
+    let (body, hash) = block_bytes(chain.tip, vec![coinbase(1), tx]);
+
+    let unresolved = chain.writer.prepare_block_with_spent_scripts(
+        IndexCapabilities::ALL,
+        chain.height,
+        hash,
+        &body,
+        &empty,
+    );
+    let unresolved_err = unresolved.err();
+    assert!(
+        matches!(
+            unresolved_err,
+            Some(IndexError::MissingSpentCoin { vout: 1, .. })
+        ),
+        "a spend the anchor cannot resolve must refuse the block: {unresolved_err:?}"
+    );
+
+    let anchorless =
+        chain
+            .writer
+            .prepare_block_for(IndexCapabilities::ALL, chain.height, hash, &body);
+    let anchorless_err = anchorless.err();
+    assert!(
+        matches!(anchorless_err, Some(IndexError::MissingSpentScripts)),
+        "the anchorless path must refuse ScriptLive: {anchorless_err:?}"
+    );
+    Ok(())
+}
+
+/// The live predicate is UTXO admission: `OP_RETURN` and oversized scripts never
+/// enter, while history deliberately keeps the oversized ones.
+#[test]
+fn live_predicate_matches_utxo_admission_not_history() -> Result<(), Box<dyn std::error::Error>> {
+    let mut chain = Chain::new()?;
+    let empty = MapScripts::default();
+    chain.connect(vec![coinbase(0)], &empty)?;
+
+    let op_return = ScriptBuf::from_bytes(vec![0x6a, 0x01, 0x02]);
+    let oversized = ScriptBuf::from_bytes(vec![0x51; MAX_LIVE_SCRIPT_SIZE + 1]);
+    let normal = script(0x22);
+    let external = OutPoint {
+        txid: Txid::from_byte_array([6_u8; 32]),
+        vout: 0,
+    };
+    let tx = {
+        let mut tx = spend(
+            &[external],
+            &[op_return.clone(), oversized.clone(), normal.clone()],
+        );
+        tx.input[0].previous_output = external;
+        tx
+    };
+    let txid = tx.compute_txid();
+    let mut anchor = MapScripts::default();
+    anchor.insert(external, &script(0x23));
+    chain.connect(vec![coinbase(1), tx], &anchor)?;
+
+    assert_eq!(chain.live(&op_return), Vec::<OutPoint>::new());
+    assert_eq!(chain.live(&oversized), Vec::<OutPoint>::new());
+    assert_eq!(chain.live(&normal), vec![OutPoint { txid, vout: 2 }]);
+
+    // History keeps the oversized output: it is real historical activity,
+    // and this asymmetry against Live is deliberate.
+    let funding = chain
+        .writer
+        .indexer()
+        .iter_funding_rows(ScriptHash::from_script_bytes(oversized.as_bytes()))?;
+    assert_eq!(
+        funding.len(),
+        1,
+        "history must keep the oversized-script funding row"
+    );
+    Ok(())
+}
+
+/// The live watermark is stamped by live-selecting commits and only those, so
+/// a ready history is never invalidated by adding the live capability, and
+/// vice versa.
+#[test]
+fn live_and_history_watermarks_advance_independently() -> Result<(), Box<dyn std::error::Error>> {
+    let mut chain = Chain::new()?;
+    let (body, hash) = block_bytes(chain.tip, vec![coinbase(0)]);
+    let prepared = chain
+        .writer
+        .prepare_block_for(IndexCapabilities::HISTORICAL, 0, hash, &body)?;
+    let mut batch = PreparedBatch::new(PreparedBatchLimits {
+        max_rows: 10_000,
+        max_bytes: 10_000_000,
+    });
+    assert!(batch.try_push(prepared).is_ok());
+    chain.writer.commit_forward(batch)?;
+
+    let watermarks = chain.writer.watermarks()?;
+    assert!(watermarks.script_history.is_some());
+    assert!(
+        watermarks.script_live.is_none(),
+        "a historical commit must not stamp the live cursor"
+    );
+    Ok(())
+}
+
+/// Seeding writes rows and stamps the watermark last; a second seed over the
+/// stamped watermark is refused.
+#[test]
+fn seeding_stamps_once_and_refuses_a_second_pass() -> Result<(), Box<dyn std::error::Error>> {
+    let store = Arc::new(MemoryStore::default());
+    let mut writer = IndexWriter::open(Arc::clone(&store))?;
+
+    let wallet = script(0x44);
+    let scripthash = ScriptHash::from_script_bytes(wallet.as_bytes());
+    let coins = (0_u32..3)
+        .map(|vout| {
+            (
+                OutPoint {
+                    txid: Txid::from_byte_array([0x33_u8; 32]),
+                    vout,
+                },
+                scripthash,
+            )
+        })
+        .collect::<Vec<_>>();
+    let seed_tip = IndexWatermark {
+        height: 42,
+        hash: [0x42_u8; 32],
+    };
+
+    let written = writer.seed_script_live(coins.clone(), seed_tip)?;
+    assert_eq!(written, 3);
+    assert_eq!(
+        writer
+            .indexer()
+            .capability_watermark(IndexCapability::ScriptLive)?,
+        Some(seed_tip)
+    );
+    assert_eq!(writer.indexer().iter_live_outpoints(scripthash)?.len(), 3);
+
+    let again = writer.seed_script_live(coins, seed_tip);
+    assert!(
+        matches!(again, Err(IndexError::LiveAlreadySeeded)),
+        "re-seeding over a stamped watermark must be refused: {again:?}"
+    );
+    Ok(())
+}
+
+fn sorted(mut outpoints: Vec<OutPoint>) -> Vec<OutPoint> {
+    outpoints.sort_unstable();
+    outpoints
+}

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -7523,7 +7523,7 @@ mod consensus_rule_tests {
             Arc::clone(&handles.block_tree),
             None,
             crate::txindex_worker::DEFAULT_BATCH_LIMITS,
-            bitcoin_rs_index::IndexCapabilities::ALL,
+            bitcoin_rs_index::IndexCapabilities::HISTORICAL,
             wake_rx,
         )?;
 

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -758,6 +758,10 @@ fn tx_index_capabilities(config: &Config) -> bitcoin_rs_index::IndexCapabilities
         // RPCs only for an explicit --txindex configuration.
         tx_lookup: config.txindex || config.script_index,
         script_history: config.script_index,
+        // The live view arrives with #225's mode configuration; nothing
+        // enables it yet, so existing deployments build exactly what they
+        // built before.
+        script_live: false,
     }
 }
 

--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -231,6 +231,7 @@ pub(crate) trait TxIndexWriter: Send + Sync {
         Ok(IndexWatermarks {
             tx_lookup: watermark,
             script_history: watermark,
+            script_live: None,
         })
     }
     fn prepare_block(
@@ -653,6 +654,7 @@ impl Worker {
             IndexCapabilities {
                 tx_lookup: tx == Some(selected) && needs_rollback(selected),
                 script_history: script_index == Some(selected) && needs_rollback(selected),
+                script_live: false,
             },
             selected,
         ))
@@ -698,6 +700,7 @@ impl Worker {
                 script_history: script_index.is_some_and(|watermark| {
                     needs_forward(watermark) && start_height(watermark) == selected_start
                 }),
+                script_live: false,
             },
             selected_watermark,
         ))

--- a/crates/node/src/txindex_worker_query_tests.rs
+++ b/crates/node/src/txindex_worker_query_tests.rs
@@ -95,6 +95,7 @@ impl TxIndexSnapshot for QuerySnapshot {
                 ScriptHistoryWatermark::MatchTx => Some(self.watermark),
                 ScriptHistoryWatermark::Override(watermark) => watermark,
             },
+            IndexCapability::ScriptLive => None,
         })
     }
 

--- a/crates/storage/src/column_families.rs
+++ b/crates/storage/src/column_families.rs
@@ -22,6 +22,11 @@ pub enum ColumnFamily {
     BlockBodies = 8,
     /// Per-block UTXO undo records, needed to disconnect a block during a reorg.
     UndoData = 9,
+    /// Live script-index rows: `script-prefix || outpoint` for currently
+    /// unspent outputs (#225). Appended after every existing discriminant so
+    /// the addition is additive -- renumbering these is a breaking change
+    /// (`docs/policies/db-migration.md` 3.1).
+    ScriptLive = 10,
 }
 
 impl ColumnFamily {
@@ -37,6 +42,7 @@ impl ColumnFamily {
         Self::UtxoMeta,
         Self::BlockBodies,
         Self::UndoData,
+        Self::ScriptLive,
     ];
 
     /// Stable backend column-family/table name.
@@ -52,6 +58,7 @@ impl ColumnFamily {
             Self::UtxoMeta => "utxo_meta",
             Self::BlockBodies => "block_bodies",
             Self::UndoData => "undo_data",
+            Self::ScriptLive => "script_live",
         }
     }
 
@@ -73,6 +80,7 @@ impl ColumnFamily {
             7 => Some(Self::UtxoMeta),
             8 => Some(Self::BlockBodies),
             9 => Some(Self::UndoData),
+            10 => Some(Self::ScriptLive),
             _ => None,
         }
     }
@@ -90,6 +98,7 @@ impl ColumnFamily {
             Self::UtxoMeta => 7,
             Self::BlockBodies => 8,
             Self::UndoData => 9,
+            Self::ScriptLive => 10,
         }
     }
 }

--- a/crates/storage/src/redb_impl.rs
+++ b/crates/storage/src/redb_impl.rs
@@ -577,6 +577,7 @@ const fn table_for(cf: ColumnFamily) -> ByteTable {
         ColumnFamily::UtxoMeta => TableDefinition::new("utxo_meta"),
         ColumnFamily::BlockBodies => TableDefinition::new("block_bodies"),
         ColumnFamily::UndoData => TableDefinition::new("undo_data"),
+        ColumnFamily::ScriptLive => TableDefinition::new("script_live"),
     }
 }
 


### PR DESCRIPTION
The index-crate half of #225: the `ScriptLive` capability, with the row format #226 names as the baseline. Node wiring — the undo-record anchor, boot-time seeding, `scriptindex=utxo|full` modes, and query routing — is the next slice; **nothing enables the capability yet**, so existing deployments build exactly what they built before.

Sequenced the way the two issues themselves ask: #226 pins Q5 (the Live locator) as the *only* format blocker, and both issues state the full-outpoint baseline — `scan-prefix(8) || txid(32) || vout(4)`, empty value — as the reference representation. If the #226 campaign later selects a smaller locator, Live is the cheap capability to migrate: selective reset plus a re-seed from a UTXO scan, no history replay.

## What the acceptance criteria forced, and how each is held

**Anchored deletes — the unanchored path refuses to exist.** A block body carries an input's prevout but not the spent coin's script, so preparation of a live transition takes a `SpentCoinScripts` source (in production: the undo record, whose restores hold the full spent `TxOut`). `prepare_block_for` returns `MissingSpentScripts` the moment `ScriptLive` is selected; an anchor that cannot resolve an external spend fails the whole preparation with `MissingSpentCoin`. Fail-closed, because the alternative is a spent output that stays visible.

**Ordered mutations in an otherwise order-free pipeline.** Every existing row family is append-only puts, which is why `PendingRows::sort` could always sort and dedup them. Live ops mix puts and deletes, and a later block in one committed batch may delete a key an earlier block inserted — so `live_ops` is never sorted, and `apply_live_ops` coalesces last-operation-per-key in memory instead of trusting any backend's write-batch ordering. Rollback is the same walk inverted, in reverse.

**The spendability predicate is UTXO admission, not the history predicate.** `build_utxo_changes` skips `is_op_return()`, scripts over 10,000 bytes, and the genesis coinbase. Live now skips exactly those; history deliberately keeps oversized-script outputs, and a test asserts that asymmetry on purpose. The bound is duplicated as `MAX_LIVE_SCRIPT_SIZE` (this crate does not depend on consensus); the node slice adds the cross-crate equality assertion.

**Same-block create-and-spend cancels before resolution** — such an output never reaches the committed UTXO set, and its spend needs no anchor entry, because the undo record would not have one either.

**Point deletes are identity-safe by construction.** Colliding scripts share the lossy 8-byte prefix but never a whole key. Prefix scans over the family are read-only by contract.

**Independent watermarks.** `ScriptLive` gets its own cursor, reset-selector bit (mask bit 2 — absent from every pre-#225 marker, which still reads back), and column-family mapping in the reset machinery. A historical commit does not stamp the live cursor and vice versa, so adding Live cannot invalidate a ready history backfill.

**Seeding stamps last.** Rows go out in bounded deferred batches; the watermark lands in one final durable write. A crash mid-seed leaves no cursor — not ready, partial rows unqueryable, recovery is reset-and-reseed. Re-seeding over a stamped cursor is refused.

## `IndexCapabilities::ALL` changed meaning, and call sites now say what they meant

Six roundtrip tests and the `commit_rollback_one` convenience used `ALL` to mean the historical pair. With a third capability, that reading changes silently — and the prepared path rightly refused them with `MissingSpentScripts`, which is how they were found. They now use the new `HISTORICAL` constant, the semantic they always had, rather than `ALL` keeping a name that no longer covers everything.

## Mutation audit

Each mutant killed by exactly the test aimed at its property:

| mutation | killed by |
| --- | --- |
| resolve external spends before same-block cancellation | `same_block_create_and_spend_cancels_without_an_anchor` |
| drop the oversized-script bound | `live_predicate_matches_utxo_admission_not_history` |
| rollback stops inverting in `apply_live_ops` | `live_rows_follow_connect_spend_and_disconnect` |

## An incidental toolchain finding

rustc 1.95.0 ICEs in `check_match` instead of reporting E0004 when a `ColumnFamily` match goes non-exhaustive — so the compiler cannot enumerate the sites a new enum variant breaks. The affected matches were found by grepping for the previous last arm. Recorded for whoever next adds a variant here.

## Verified

```
cargo fmt --all -- --check                                              ok
cargo clippy -p bitcoin-rs-index --all-targets --features rocksdb \
  -- -D warnings                                                        0 errors
cargo clippy -p bitcoin-rs --all-targets --no-default-features \
  --features "rocksdb,fjall,redb,mdbx,kernel" -- -D warnings            0 errors
cargo clippy -p bitcoin-rs-node --all-targets -- -D warnings            0 errors
cargo test -p bitcoin-rs-index --features rocksdb                       62 passed
cargo check --workspace                                                 ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
