### PR TITLE
Replace the boot-time legacy-body scan with lazy fail-closed body-position validation

### DIFF
--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -514,7 +514,7 @@ pub(crate) struct FlatFilePruneBodyStore<S: KvStore> {
 enum PositionLookup {
     Direct,
     Prefetched {
-        entries: Vec<(u32, Hash256, Option<BlockFilePosition>)>,
+        entries: Vec<(u32, Hash256, BlockFilePosition)>,
         next: usize,
     },
 }
@@ -554,13 +554,17 @@ impl PruneBodyReader for FlatFilePruneBodyReader<'_> {
             .copied()
             .zip(values)
             .map(|((height, hash), value)| {
-                (
-                    height,
-                    hash,
-                    value.as_deref().and_then(BlockFilePosition::decode),
-                )
+                let position = value
+                    .as_deref()
+                    .and_then(BlockFilePosition::decode)
+                    .ok_or_else(|| {
+                        StorageError::IncompatibleData(format!(
+                            "block-body index row for height {height} is not a 16-byte flat-file position"
+                        ))
+                    })?;
+                Ok((height, hash, position))
             })
-            .collect();
+            .collect::<Result<Vec<_>, StorageError>>()?;
         self.positions = PositionLookup::Prefetched { entries, next: 0 };
         Ok(())
     }
@@ -579,7 +583,11 @@ impl PruneBodyReader for FlatFilePruneBodyReader<'_> {
                 else {
                     return Ok(None);
                 };
-                BlockFilePosition::decode(&encoded)
+                BlockFilePosition::decode(&encoded).ok_or_else(|| {
+                    StorageError::IncompatibleData(format!(
+                        "block-body index row for height {height} is not a 16-byte flat-file position"
+                    ))
+                })?
             }
             PositionLookup::Prefetched { entries, next } => {
                 let Some(&(expected_height, expected_hash, position)) = entries.get(*next) else {
@@ -596,33 +604,19 @@ impl PruneBodyReader for FlatFilePruneBodyReader<'_> {
                 position
             }
         };
-        let Some(position) = position else {
-            return Ok(None);
-        };
         self.files.load(position, height, *hash.as_byte_array())
     }
 }
 
 impl<S: KvStore> FlatFilePruneBodyStore<S> {
-    pub(crate) fn open(
-        index: Arc<S>,
-        files: Arc<FlatFileBlockStore>,
-        data_dir: &std::path::Path,
-    ) -> Result<Self, StorageError> {
-        for row in index.iter_prefix(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, b"b")? {
-            let (key, value) = row?;
-            if key.len() == 37 && value.len() != BlockFilePosition::ENCODED_LEN {
-                return Err(StorageError::IncompatibleData(format!(
-                    "datadir {} predates the flat-file block store and must be resynced",
-                    data_dir.display()
-                )));
-            }
-        }
-        Ok(Self { index, files })
+    pub(crate) fn open(index: Arc<S>, files: Arc<FlatFileBlockStore>) -> Self {
+        Self { index, files }
     }
-
     /// Resolves the flat-file position of a block body, or `None` when the
-    /// block is unknown or its index row is not a decodable position.
+    /// block is unknown. An index row that is not a decodable 16-byte
+    /// flat-file position is `IncompatibleData`, never a silent `None`: the
+    /// row's presence means the body must exist, so treating a decode failure
+    /// as absence would hide a schema mismatch behind a missing-block answer.
     ///
     /// Every read path starts here, so it is written once rather than three
     /// times: divergence between the whole-body, ranged, and metadata lookups
@@ -640,7 +634,13 @@ impl<S: KvStore> FlatFilePruneBodyStore<S> {
         else {
             return Ok(None);
         };
-        Ok(BlockFilePosition::decode(&encoded))
+        Ok(Some(BlockFilePosition::decode(&encoded).ok_or_else(
+            || {
+                StorageError::IncompatibleData(format!(
+                    "block-body index row for height {height} is not a 16-byte flat-file position"
+                ))
+            },
+        )?))
     }
 }
 
@@ -771,7 +771,7 @@ mod body_position_prefetch_tests {
             temp.path().join("index"),
         )?);
         let files = Arc::new(FlatFileBlockStore::open(temp.path())?);
-        let store = FlatFilePruneBodyStore::open(index, files, temp.path())?;
+        let store = FlatFilePruneBodyStore::open(index, files);
         let hash1 = Hash256::from_le_bytes(&[1_u8; 32]);
         let hash2 = Hash256::from_le_bytes(&[2_u8; 32]);
         store.persist_block_body(1, hash1, b"first body")?;
@@ -799,6 +799,33 @@ mod body_position_prefetch_tests {
                 "prefetched body positions are exhausted"
             ))
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_body_row_is_incompatible_not_missing() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let index = Arc::new(bitcoin_rs_storage::FjallStore::open(
+            temp.path().join("index"),
+        )?);
+        let files = Arc::new(FlatFileBlockStore::open(temp.path())?);
+        let store = FlatFilePruneBodyStore::open(index.clone(), files);
+        let hash = Hash256::from_le_bytes(&[9_u8; 32]);
+        store.persist_block_body(7, hash, b"body")?;
+        // Overwrite the position row with a legacy inline body: same key, not
+        // a decodable flat-file position.
+        let key = bitcoin_rs_storage::pruning::block_body_key(7, hash);
+        let mut batch = index.new_batch();
+        batch.put(
+            bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
+            &key,
+            b"legacy-inline-body",
+        );
+        index.write(batch)?;
+        let Err(error) = store.load_block_body(7, hash) else {
+            return Err("malformed body row must fail closed".into());
+        };
+        assert!(matches!(error, StorageError::IncompatibleData(_)));
         Ok(())
     }
 }

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -514,9 +514,24 @@ pub(crate) struct FlatFilePruneBodyStore<S: KvStore> {
 enum PositionLookup {
     Direct,
     Prefetched {
-        entries: Vec<(u32, Hash256, BlockFilePosition)>,
+        entries: Vec<(u32, Hash256, Option<BlockFilePosition>)>,
         next: usize,
     },
+}
+
+fn decode_body_position(
+    height: u32,
+    encoded: Option<&[u8]>,
+) -> Result<Option<BlockFilePosition>, StorageError> {
+    encoded
+        .map(|bytes| {
+            BlockFilePosition::decode(bytes).ok_or_else(|| {
+                StorageError::IncompatibleData(format!(
+                    "block-body index row for height {height} is not a 16-byte flat-file position"
+                ))
+            })
+        })
+        .transpose()
 }
 
 struct FlatFilePruneBodyReader<'a> {
@@ -554,14 +569,7 @@ impl PruneBodyReader for FlatFilePruneBodyReader<'_> {
             .copied()
             .zip(values)
             .map(|((height, hash), value)| {
-                let position = value
-                    .as_deref()
-                    .and_then(BlockFilePosition::decode)
-                    .ok_or_else(|| {
-                        StorageError::IncompatibleData(format!(
-                            "block-body index row for height {height} is not a 16-byte flat-file position"
-                        ))
-                    })?;
+                let position = decode_body_position(height, value.as_deref())?;
                 Ok((height, hash, position))
             })
             .collect::<Result<Vec<_>, StorageError>>()?;
@@ -577,17 +585,10 @@ impl PruneBodyReader for FlatFilePruneBodyReader<'_> {
         let position = match &mut self.positions {
             PositionLookup::Direct => {
                 let key = bitcoin_rs_storage::pruning::block_body_key(height, hash);
-                let Some(encoded) = self
+                let encoded = self
                     .index
-                    .get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?
-                else {
-                    return Ok(None);
-                };
-                BlockFilePosition::decode(&encoded).ok_or_else(|| {
-                    StorageError::IncompatibleData(format!(
-                        "block-body index row for height {height} is not a 16-byte flat-file position"
-                    ))
-                })?
+                    .get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?;
+                decode_body_position(height, encoded.as_deref())?
             }
             PositionLookup::Prefetched { entries, next } => {
                 let Some(&(expected_height, expected_hash, position)) = entries.get(*next) else {
@@ -603,6 +604,9 @@ impl PruneBodyReader for FlatFilePruneBodyReader<'_> {
                 *next += 1;
                 position
             }
+        };
+        let Some(position) = position else {
+            return Ok(None);
         };
         self.files.load(position, height, *hash.as_byte_array())
     }
@@ -628,19 +632,12 @@ impl<S: KvStore> FlatFilePruneBodyStore<S> {
         hash: bitcoin_rs_primitives::Hash256,
     ) -> Result<Option<BlockFilePosition>, StorageError> {
         let key = bitcoin_rs_storage::pruning::block_body_key(height, hash);
-        let Some(encoded) = self
-            .index
-            .get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?
-        else {
-            return Ok(None);
-        };
-        Ok(Some(BlockFilePosition::decode(&encoded).ok_or_else(
-            || {
-                StorageError::IncompatibleData(format!(
-                    "block-body index row for height {height} is not a 16-byte flat-file position"
-                ))
-            },
-        )?))
+        decode_body_position(
+            height,
+            self.index
+                .get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?
+                .as_deref(),
+        )
     }
 }
 
@@ -656,17 +653,12 @@ impl<S: KvStore> PruneBodyStore for FlatFilePruneBodyStore<S> {
         body: &[u8],
     ) -> Result<(), StorageError> {
         let key = bitcoin_rs_storage::pruning::block_body_key(height, hash);
-        let existing = self
-            .index
-            .get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?
-            .map(|bytes| {
-                BlockFilePosition::decode(&bytes).ok_or_else(|| {
-                    StorageError::IncompatibleData(
-                        "block-body index row is not a 16-byte flat-file position".to_owned(),
-                    )
-                })
-            })
-            .transpose()?;
+        let existing = decode_body_position(
+            height,
+            self.index
+                .get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?
+                .as_deref(),
+        )?;
         let position = self
             .files
             .persist(existing, height, *hash.as_byte_array(), body)?;
@@ -824,6 +816,56 @@ mod body_position_prefetch_tests {
         index.write(batch)?;
         let Err(error) = store.load_block_body(7, hash) else {
             return Err("malformed body row must fail closed".into());
+        };
+        assert!(matches!(error, StorageError::IncompatibleData(_)));
+
+        let mut reader = store.reader()?;
+        let Err(error) = reader.load_block_body(7, hash) else {
+            return Err("malformed body row must fail closed in the direct reader".into());
+        };
+        assert!(matches!(error, StorageError::IncompatibleData(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn missing_prefetched_body_row_is_missing_not_incompatible()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let index = Arc::new(bitcoin_rs_storage::FjallStore::open(
+            temp.path().join("index"),
+        )?);
+        let files = Arc::new(FlatFileBlockStore::open(temp.path())?);
+        let store = FlatFilePruneBodyStore::open(index, files);
+        let hash = Hash256::from_le_bytes(&[8_u8; 32]);
+        let mut reader = store.reader()?;
+
+        reader.prefetch_positions(&[(7, hash)])?;
+        assert_eq!(reader.load_block_body(7, hash)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_prefetched_body_row_is_incompatible_not_missing()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let index = Arc::new(bitcoin_rs_storage::FjallStore::open(
+            temp.path().join("index"),
+        )?);
+        let files = Arc::new(FlatFileBlockStore::open(temp.path())?);
+        let store = FlatFilePruneBodyStore::open(index.clone(), files);
+        let hash = Hash256::from_le_bytes(&[7_u8; 32]);
+        let key = bitcoin_rs_storage::pruning::block_body_key(7, hash);
+        let mut batch = index.new_batch();
+        batch.put(
+            bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
+            &key,
+            b"legacy-inline-body",
+        );
+        index.write(batch)?;
+
+        let mut reader = store.reader()?;
+        let Err(error) = reader.prefetch_positions(&[(7, hash)]) else {
+            return Err("malformed prefetched body row must fail closed".into());
         };
         assert!(matches!(error, StorageError::IncompatibleData(_)));
         Ok(())

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -353,33 +353,28 @@ impl NodeStorage {
     fn block_body_store(
         &self,
         files: Arc<FlatFileBlockStore>,
-        data_dir: &Path,
-    ) -> Result<Arc<dyn crate::apply::PruneBodyStore>> {
+    ) -> Arc<dyn crate::apply::PruneBodyStore> {
         match self {
             #[cfg(feature = "rocksdb")]
-            Self::RocksDb(store) => Ok(Arc::new(crate::apply::FlatFilePruneBodyStore::open(
+            Self::RocksDb(store) => Arc::new(crate::apply::FlatFilePruneBodyStore::open(
                 Arc::clone(store),
                 files,
-                data_dir,
-            )?)),
+            )),
             #[cfg(feature = "fjall")]
-            Self::Fjall(store) => Ok(Arc::new(crate::apply::FlatFilePruneBodyStore::open(
+            Self::Fjall(store) => Arc::new(crate::apply::FlatFilePruneBodyStore::open(
                 Arc::clone(store),
                 files,
-                data_dir,
-            )?)),
+            )),
             #[cfg(feature = "redb")]
-            Self::Redb(store) => Ok(Arc::new(crate::apply::FlatFilePruneBodyStore::open(
+            Self::Redb(store) => Arc::new(crate::apply::FlatFilePruneBodyStore::open(
                 Arc::clone(store),
                 files,
-                data_dir,
-            )?)),
+            )),
             #[cfg(feature = "mdbx")]
-            Self::Mdbx(store) => Ok(Arc::new(crate::apply::FlatFilePruneBodyStore::open(
+            Self::Mdbx(store) => Arc::new(crate::apply::FlatFilePruneBodyStore::open(
                 Arc::clone(store),
                 files,
-                data_dir,
-            )?)),
+            )),
         }
     }
 
@@ -910,8 +905,7 @@ impl NodeState {
         }
         let block_files =
             Arc::new(FlatFileBlockStore::open(&config.data_dir).map_err(anyhow::Error::new)?);
-        let block_body_store =
-            storage.block_body_store(Arc::clone(&block_files), &config.data_dir)?;
+        let block_body_store = storage.block_body_store(Arc::clone(&block_files));
 
         let zmq_publications = config.zmq_publications();
         let active_zmq_notifications: Vec<_> = zmq_publications
@@ -1503,17 +1497,6 @@ mod tests {
         })));
     }
 
-    fn write_current_schema_marker(config: &Config) -> anyhow::Result<()> {
-        let bytes = crate::checkpoint_fs::current_schema_bytes();
-        std::fs::write(
-            config
-                .data_dir
-                .join(crate::checkpoint_fs::CURRENT_SCHEMA_FILE),
-            bytes,
-        )?;
-        Ok(())
-    }
-
     #[test]
     fn open_constructs_empty_handles() -> anyhow::Result<()> {
         use tempfile::tempdir;
@@ -1948,38 +1931,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "fjall")]
-    #[test]
-    fn legacy_block_body_datadir_is_refused() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let mut config = crate::Config::default_for_network(crate::Network::Regtest);
-        config.data_dir = dir.path().join("legacy-node");
-        config.p2p_listen.clear();
-        std::fs::create_dir_all(&config.data_dir)?;
-        write_current_schema_marker(&config)?;
-        std::fs::create_dir_all(config.data_dir.join("chainstate"))?;
-        let store = bitcoin_rs_storage::FjallStore::open(config.data_dir.join("chainstate"))?;
-        store.put(
-            bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
-            &bitcoin_rs_storage::pruning::block_body_key(
-                1,
-                bitcoin_rs_primitives::Hash256::from_le_bytes(&[1_u8; 32]),
-            ),
-            b"legacy-inline-body",
-        )?;
-        drop(store);
-
-        let datadir = config.data_dir.display().to_string();
-        let Err(error) = NodeState::open(config) else {
-            anyhow::bail!("legacy inline block body unexpectedly opened");
-        };
-        let message = format!("{error:#}");
-        assert!(message.contains(&datadir));
-        assert!(message.contains("predates the flat-file block store"));
-        assert!(message.contains("must be resynced"));
-        Ok(())
-    }
-
     #[test]
     fn new_datadir_initializes_current_schema_before_storage() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -2311,7 +2262,6 @@ mod tests {
         config.p2p_listen.clear();
         config.prune_target_mb = 1;
         std::fs::create_dir_all(&config.data_dir)?;
-        write_current_schema_marker(&config)?;
         let blocks_dir = config.data_dir.join("blocks");
         std::fs::create_dir_all(&blocks_dir)?;
         let prunable_file = blocks_dir.join("blk00000.dat");
@@ -2389,7 +2339,6 @@ mod tests {
         config.prune_target_mb = 1;
 
         std::fs::create_dir_all(&config.data_dir)?;
-        write_current_schema_marker(&config)?;
 
         // Two files present before the store opens, so the earlier one is not
         // the append target and is therefore prunable. Same shape as

--- a/docs/policies/db-migration.md
+++ b/docs/policies/db-migration.md
@@ -51,6 +51,9 @@ The marker covers all persistent surfaces in the datadir:
   layout and have no historical translation layer.
 - Flat block files use the current `BRSB` record format.
 - UTXO checkpoints use only `utxo-v4.dat` and the strict v4 reader.
+- Block-body index rows must decode to 16-byte flat-file positions. That
+  validation is lazy (per read, not a boot-time column-family scan): a
+  non-decoding row is `IncompatibleData` — never a missing body.
 - Chainstate checkpoints use the current `CURRENT`, generation, manifest,
   headers, UTXO, and CoinStats artifacts. Manifest fields and component
   versions are required; absent historical fields are not defaulted.


### PR DESCRIPTION
## What

Replaces the boot-time `BLOCK_DATA` legacy-body scan with lazy fail-closed body-position validation, after review. **The `CURRENT_SCHEMA` datadir epoch marker is kept** — per #236/#237 it is the complete startup-time schema discriminator for KV layouts, cheap fail-fast metadata rather than a legacy reader, and an untagged repo does not imply no persisted datadirs exist (a real pre-#237 mainnet datadir was exercised from this branch).

## Review findings addressed

1. **Marker restored.** `CURRENT_SCHEMA` machinery, its boot-path call in `NodeState::open`, and the three epoch tests are restored unchanged from `main`.
2. **Lazy fail-closed instead of a boot-time column-family scan.** The scan walked the whole `BLOCK_DATA` CF on every startup and is removed. In its place, every body-position decode distinguishes malformed rows from missing rows: `BlockFilePosition::decode` failure returns `StorageError::IncompatibleData` from `body_position`, the direct reader path, and `prefetch_positions` — never a silent `None` masquerading as a missing body.
3. **Policy text matches reality.** `docs/policies/db-migration.md` keeps the marker contract and gains an explicit lazy-validation bullet: body-position rows validate per read, fail-closed, never reported as absence.
4. **Clippy fixed.** `FlatFilePruneBodyStore::open` is infallible (`unnecessary_wraps`); `block_body_store` follows and drops its `data_dir` plumbing. `legacy_block_body_datadir_is_refused` (open-time refusal no longer true) is replaced by `malformed_body_row_is_incompatible_not_missing`.

## Verification

- `cargo check -p bitcoin-rs-node` clean
- `cargo clippy -p bitcoin-rs-node --all-targets` zero findings
- `cargo test -p bitcoin-rs-node --lib` **431 passed / 0 failed** (3 restored epoch tests + 1 new lazy-validation test)
- `docs/policies/db-migration.md` vs `main`: exactly the one lazy-validation bullet added
