### PR TITLE
ci: reduce PR validation cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,19 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Fast PR gate: fmt, pure-Rust clippy/tests, and dependency checks. Full-node,
+# kernel, benchmark, and portable validation run in `main.yml` on main only.
 env:
   CARGO_TERM_COLOR: never
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
-  # Full-node production feature set: all four storage backends plus the
-  # bitcoinkernel script-verification engine (the kernel is the default build).
-  FULL_NODE_FEATURES: "rocksdb,fjall,redb,mdbx,kernel"
 
 jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -44,104 +43,50 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
-      # The kernel engine is built from C++ (cmake + libboost-dev); the default
-      # feature set now includes it, so every production lane installs the
-      # prerequisites up front.
-      - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
-      # In a virtual workspace (no root [package]), `--features` flags are not
-      # forwarded to library crates; use `-p bitcoin-rs` so the binary's feature
-      # table propagates all backends and the kernel to bitcoin-rs-node and its deps.
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      # consensus and node default to the C++ kernel feature. Exclude them from
+      # the workspace pass and lint their pure-Rust feature surfaces separately.
       - run: |
-          cargo clippy -p bitcoin-rs --all-targets \
-            --no-default-features --features "${FULL_NODE_FEATURES}" \
+          cargo clippy --workspace \
+            --exclude bitcoin-rs --exclude bitcoin-rs-consensus \
+            --exclude bitcoin-rs-node \
             -- -D warnings
-          # -p bitcoin-rs-node catches test-target lints invisible to the line above
-          # (virtual workspace: -p bitcoin-rs does not forward features to node's own
-          # test targets, so their lints are silently skipped without this step).
-          cargo clippy -p bitcoin-rs-node --all-targets -- -D warnings
+          cargo clippy -p bitcoin-rs-consensus \
+            --no-default-features -- -D warnings
+          cargo clippy -p bitcoin-rs-node \
+            --no-default-features --features fjall,zmq -- -D warnings
+          cargo clippy -p bitcoin-rs \
+            --no-default-features --features fjall,zmq -- -D warnings
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.95.0
-      - uses: Swatinem/rust-cache@v2
-      # The kernel engine is built from C++ (cmake + libboost-dev); the default
-      # feature set now includes it, so every production lane installs the
-      # prerequisites up front.
-      - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
-      # Library unit tests run with each crate's own default features.
-      - run: cargo test --workspace --no-fail-fast
-      # Isolated so node's default `zmq` feature cannot unify this package on.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      # Keep the PR test gate free of the C++ kernel build. consensus and node
+      # are excluded because their defaults include kernel.
+      - run: |
+          cargo test --workspace --no-fail-fast \
+            --exclude bitcoin-rs --exclude bitcoin-rs-consensus \
+            --exclude bitcoin-rs-node
+          cargo test -p bitcoin-rs-consensus --no-default-features --no-fail-fast
+          cargo test -p bitcoin-rs-node \
+            --no-default-features --features fjall,zmq --no-fail-fast
+          cargo test -p bitcoin-rs \
+            --no-default-features --features fjall,zmq --no-fail-fast
+      # Isolate the RPC feature surface from node's `zmq` feature.
       - run: cargo test -p bitcoin-rs-rpc --no-default-features --no-fail-fast
-      # Node / binary tests run with the full-node feature set.  -p is
-      # required because `--workspace --features` silently ignores --features in
-      # a virtual workspace (no root [package] section in the top-level Cargo.toml).
-      - run: |
-          cargo test -p bitcoin-rs --no-fail-fast \
-            --no-default-features --features "${FULL_NODE_FEATURES}"
-
-  bench-smoke:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.95.0
-      - uses: Swatinem/rust-cache@v2
-      # The kernel engine is built from C++ (cmake + libboost-dev); the default
-      # feature set now includes it, so every production lane installs the
-      # prerequisites up front.
-      - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
-      - run: |
-          cargo bench -p bitcoin-rs --no-run \
-            --no-default-features --features "${FULL_NODE_FEATURES}"
-      # Crate-level UTXO bench target is unreachable from -p bitcoin-rs; compile
-      # the production-allocator benchmark so bench breakage is visible to CI.
-      - run: cargo bench -p bitcoin-rs-utxo --no-run
 
   deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: EmbarkStudios/cargo-deny-action@b66acf5e9fe20f8aba065be86778a8a4c846f902 # v2
         with:
           rust-version: "1.95.0"
-          arguments: --workspace --no-default-features --features ${{ env.FULL_NODE_FEATURES }}
-
-  # Kernel-default parity gate (plan 2026-06-10-001 R5): the consensus parity
-  # suite (committed fixture corpus, --include-ignored by design) and clippy on
-  # both package roots — all under the production default build.
-  # The kernel is the default engine, so no special feature selection is needed
-  # on this lane; binary tests and the four-backend storage surface are covered
-  # by the `test` job and the no-C++ posture by `portable-check` below.
-  kernel-parity:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
-      - uses: dtolnay/rust-toolchain@1.95.0
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - run: |
-          cargo test -p bitcoin-rs-consensus --no-fail-fast -- --include-ignored
-      - run: cargo clippy -p bitcoin-rs --all-targets -- -D warnings
-      - run: cargo clippy -p bitcoin-rs-consensus --all-targets -- -D warnings
-
-  # Explicit no-C++ lane: proves the workspace still compiles and tests with
-  # the kernel engine disabled (per-crate `--no-default-features`). Deliberately
-  # no apt step — its point is that this lane needs no CMake/Boost toolchain.
-  portable-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.95.0
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo check -p bitcoin-rs-consensus --no-default-features
-      - run: cargo test -p bitcoin-rs-consensus --no-default-features
-      - run: cargo test -p bitcoin-rs-script
-      - run: cargo check -p bitcoin-rs-node --no-default-features --features fjall
+          arguments: --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,12 @@ on:
     # the branch below it, and `branches: [main]` excluded those by
     # construction -- five open PRs had never been built or tested, while
     # reporting no failing checks, which reads exactly like green.
-    branches: ['**']
+    branches: ["**"]
+
+# The PR gate only needs to read repository contents. Keep the token scope
+# explicit so repository-level default permissions cannot grant more access.
+permissions:
+  contents: read
 
 # Bounded because the trigger above is wider: a superseded pull-request run is
 # cancelled when a newer commit lands on the same PR.
@@ -50,6 +55,9 @@ jobs:
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
       # consensus and node default to the C++ kernel feature. Exclude them from
       # the workspace pass and lint their pure-Rust feature surfaces separately.
+      # This fast PR gate intentionally checks only the default targets. The
+      # test/example/bench target lint surface is deferred to main.yml, where
+      # the production full-node lane runs clippy with --all-targets.
       - run: |
           cargo clippy --workspace \
             --exclude bitcoin-rs --exclude bitcoin-rs-consensus \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# The deep validation lanes only need to read repository contents. Keep the
+# token scope explicit instead of inheriting repository defaults.
+permissions:
+  contents: read
+
 # Same design as ci.yml's concurrency block: one group per run, so `main`
 # pushes never queue against each other and so are never cancelled (a pending
 # run in a shared group would be cancelled by a third push and leave the
@@ -48,7 +53,9 @@ jobs:
       # Full-node feature lint surface. In a virtual workspace (no root
       # [package]), `--features` flags are not forwarded to library crates; use
       # `-p bitcoin-rs` so the binary's feature table propagates all backends
-      # and the kernel to bitcoin-rs-node and its deps.
+      # and the kernel to bitcoin-rs-node and its deps. This --all-targets
+      # coverage deliberately complements the fast PR gate's default-target
+      # clippy scope.
       - run: |
           cargo clippy -p bitcoin-rs --all-targets \
             --no-default-features --features "${FULL_NODE_FEATURES}" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,91 @@
+name: ci-main
+
+# Deep lanes for backend, kernel, benchmark, and portable validation. Never
+# triggered by pull requests; `ci.yml` is the PR gate.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Same design as ci.yml's concurrency block: one group per run, so `main`
+# pushes never queue against each other and so are never cancelled (a pending
+# run in a shared group would be cancelled by a third push and leave the
+# commit with no CI record). This workflow never sees pull_request events, so
+# there is nothing to cancel-in-progress.
+concurrency:
+  group: ci-main-${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: never
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  # Full-node production feature set: all four storage backends plus the
+  # bitcoinkernel script-verification engine (the kernel is built from C++ --
+  # this workflow is the only place that installs its prerequisites).
+  FULL_NODE_FEATURES: "rocksdb,fjall,redb,mdbx,kernel"
+
+jobs:
+  full-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      # The kernel engine is built from C++ (cmake + libboost-dev); the
+      # full-node feature set includes it, so this lane installs the
+      # prerequisites up front.
+      - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      # Node / binary tests run with the full-node feature set. -p is
+      # required because `--workspace --features` silently ignores --features
+      # in a virtual workspace (no root [package] section in the top-level
+      # Cargo.toml).
+      - run: |
+          cargo test -p bitcoin-rs --no-fail-fast \
+            --no-default-features --features "${FULL_NODE_FEATURES}"
+      # Full-node feature lint surface. In a virtual workspace (no root
+      # [package]), `--features` flags are not forwarded to library crates; use
+      # `-p bitcoin-rs` so the binary's feature table propagates all backends
+      # and the kernel to bitcoin-rs-node and its deps.
+      - run: |
+          cargo clippy -p bitcoin-rs --all-targets \
+            --no-default-features --features "${FULL_NODE_FEATURES}" \
+            -- -D warnings
+          # -p bitcoin-rs-node catches node test-target lints.
+          cargo clippy -p bitcoin-rs-node --all-targets -- -D warnings
+          cargo clippy -p bitcoin-rs-consensus --all-targets -- -D warnings
+
+  bench-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - run: |
+          cargo bench -p bitcoin-rs --no-run \
+            --no-default-features --features "${FULL_NODE_FEATURES}"
+      # Crate-level bench targets are unreachable from -p bitcoin-rs.
+      - run: cargo bench -p bitcoin-rs-utxo --no-run
+
+  kernel-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - run: cargo test -p bitcoin-rs-consensus --no-fail-fast -- --include-ignored
+
+  portable-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - run: cargo check -p bitcoin-rs-consensus --no-default-features
+      - run: cargo test -p bitcoin-rs-consensus --no-default-features
+      - run: cargo test -p bitcoin-rs-script
+      - run: cargo check -p bitcoin-rs-node --no-default-features --features fjall

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -182,4 +182,13 @@ A throughput change is measured against CPU time as well as wall time, because a
 A parallelism constant tuned while the harness competes with the node for CPU, so the optimum measures the contention. Never tune a parallelism constant against a harness sharing CPU with the node, and never on wall alone.
 
 ### CI lane parity
-A branch is green only against the commands in `.github/workflows/ci.yml`, never a local approximation: `-D warnings` on the `clippy` and `kernel-parity` lanes promotes warnings the workspace lint job merely reports; a virtual workspace drops `--workspace --features`, so the full surface is only reached through the per-crate `-p` invocations; `kernel-parity` adds `--include-ignored`. `cargo deny` failures are bug reports, not lint noise.
+A branch is green only against the commands in the workflow that validates it,
+never a local approximation. The PR gate in `.github/workflows/ci.yml` is the
+fast, pure-Rust surface: its clippy commands intentionally omit `--all-targets`,
+while the main-only `.github/workflows/main.yml` full-node lane restores
+test/example/bench-target lint coverage with `--all-targets` and its
+kernel-parity lane adds `--include-ignored`. A virtual workspace drops
+`--workspace --features`, so feature-specific coverage is reached through the
+per-crate `-p` invocations. `-D warnings` promotes warnings that a plain
+workspace lint reports, and `cargo deny` failures are bug reports, not lint
+noise.


### PR DESCRIPTION
Closes #171

## Summary

- Keep the PR gate limited to `fmt`, pure-Rust `clippy`, workspace tests, and
  `deny`.
- Exclude the kernel-default binary, consensus, and node packages from the PR
  workspace pass; check their pure-Rust feature surfaces separately.
- Move full-node, benchmark, kernel-parity, and portable validation to
  `main.yml`, triggered only by `main` pushes or manual dispatch.
- Remove duplicated clippy work from `kernel-parity`.
- Preserve stacked pull-request coverage and PR cancellation semantics.

## Validation

- Python/PyYAML workflow parse passed.
- `cargo fmt --all -- --check` passed.
- PR clippy commands passed in WSL without a C++ kernel build.
- PR test commands passed in WSL for workspace, consensus, node, binary, and
  RPC targets.
- `git diff --check` passed.
- `cargo-deny` was unavailable locally because it is not installed in the WSL
  environment.
