### PR TITLE
Restore datadir schema gate and test recorder

### DIFF
--- a/crates/mempool/src/gateway.rs
+++ b/crates/mempool/src/gateway.rs
@@ -2,7 +2,7 @@
 //!
 //! Every production mempool mutation routes through [`MempoolGateway`]: it
 //! owns the pool's write lock, commits the mutation, and then enqueues the
-//! ordered [`MutationResult`] for the optional [`MempoolObserver`] — always
+//! ordered [`MutationEnvelope`] for the optional [`MempoolObserver`] — always
 //! in commit order, by construction. Publication is eventual: a nested or
 //! concurrent mutation call may return before its callback runs, and the
 //! elected drainer completes every queued callback exactly once, in
@@ -114,7 +114,7 @@ pub enum AdmitError {
 /// and `shared` shrinks to run-time composition plus tests.
 use crate::EntryId;
 use crate::entry::MempoolEntry;
-use crate::mutation::{AdmissionOrigin, MutationResult};
+use crate::mutation::{AdmissionOrigin, MutationEnvelope, MutationResult};
 use crate::pool::{Mempool, MempoolError, PrioritiseError};
 use crate::rbf::{RbfError, ReplacementCandidate};
 
@@ -134,8 +134,8 @@ static REGISTRY: LazyLock<Mutex<Vec<Weak<MempoolGateway>>>> =
 /// — possibly after the nested call itself has already returned to its
 /// caller.
 pub trait MempoolObserver: Send + Sync {
-    /// Called once per committed, non-empty [`MutationResult`].
-    fn on_mutation(&self, result: &MutationResult);
+    /// Called once per committed, non-empty [`MutationEnvelope`].
+    fn on_mutation(&self, envelope: &MutationEnvelope);
 }
 
 /// Fans one committed mutation out to several named observers.
@@ -144,8 +144,8 @@ pub trait MempoolObserver: Send + Sync {
 /// leg is counted (`mempool_observer_leg_failed_total{leg}`) and logged
 /// with its name, and the later legs still run. The gateway's outer
 /// `catch_unwind` around the composite stays as the backstop. Legs inherit
-/// the [`MempoolObserver`] contract: best-effort, non-blocking, never
-/// touching the mempool lock.
+/// the [`MempoolObserver`] contract: best-effort mirrors that run with no
+/// gateway lock held, so a leg may re-enter the gateway.
 #[derive(Default)]
 pub struct CompositeObserver {
     /// Guarded because a subsystem may attach its leg after the gateway is
@@ -197,13 +197,13 @@ fn panic_message_and_dispose(panic_payload: Box<dyn core::any::Any + Send>) -> (
 }
 
 impl MempoolObserver for CompositeObserver {
-    fn on_mutation(&self, result: &MutationResult) {
+    fn on_mutation(&self, envelope: &MutationEnvelope) {
         // Clone the roster, then release: a leg is free to re-enter the
         // gateway, and a re-entrant attach must not deadlock behind us.
         let legs = self.legs.lock().clone();
         for (name, leg) in &legs {
             let outcome = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
-                leg.on_mutation(result);
+                leg.on_mutation(envelope);
             }));
             if let Err(panic_payload) = outcome {
                 metrics::counter!("mempool_observer_leg_failed_total", "leg" => *name).increment(1);
@@ -221,14 +221,14 @@ impl MempoolObserver for CompositeObserver {
 
 /// The mutation publication queue state, protected by the `publish` mutex.
 ///
-/// Non-empty results are enqueued under the pool write lock; one drainer is
+/// Non-empty envelopes are enqueued under the pool write lock; one drainer is
 /// elected if none exists. The drainer pops batches one at a time —
 /// releasing the publish-state lock before every observer call — and
 /// returns the state to idle only once the queue is empty.
 struct PublishState {
-    /// Committed, non-empty batches awaiting their observer callback, in
+    /// Committed, non-empty envelopes awaiting their observer callback, in
     /// commit order.
-    queue: VecDeque<MutationResult>,
+    queue: VecDeque<MutationEnvelope>,
     /// Whether exactly one caller is draining the queue.
     draining: bool,
 }
@@ -242,7 +242,7 @@ struct PublishState {
 ///
 /// 1. take the pool write lock,
 /// 2. mutate and assign per-change mempool sequences,
-/// 3. while still holding the write lock, enqueue the non-empty result on
+/// 3. while still holding the write lock, enqueue the non-empty envelope on
 ///    the publish state's FIFO queue and elect a drainer if none exists,
 /// 4. release the write lock and the publish-state lock,
 /// 5. the elected drainer pops batches one at a time — releasing the
@@ -614,7 +614,10 @@ impl MempoolGateway {
         let mut elected = false;
         if !result.changes.is_empty() && self.observer.is_some() {
             let mut publish = self.publish.lock();
-            publish.queue.push_back(result.clone());
+            publish.queue.push_back(MutationEnvelope {
+                origin: request.origin,
+                result: result.clone(),
+            });
             elected = !publish.draining;
             publish.draining = true;
         }
@@ -689,15 +692,16 @@ impl MempoolGateway {
         origin: AdmissionOrigin,
         mutate: impl FnOnce(&mut Mempool) -> Result<MutationResult, E>,
     ) -> Result<MutationResult, E> {
-        let _ = origin; // origin retained for API compatibility; the queue
-        // publishes results without it.
         let mut elected = false;
         let result = {
             let mut pool = self.pool.write();
             let result = mutate(&mut pool)?;
             if !result.changes.is_empty() && self.observer.is_some() {
                 let mut publish = self.publish.lock();
-                publish.queue.push_back(result.clone());
+                publish.queue.push_back(MutationEnvelope {
+                    origin,
+                    result: result.clone(),
+                });
                 elected = !publish.draining;
                 publish.draining = true;
             }
@@ -733,10 +737,10 @@ impl MempoolGateway {
     /// panic hook still prints the panic before it is caught here.
     fn drain(&self) {
         loop {
-            let result = {
+            let envelope = {
                 let mut publish = self.publish.lock();
-                if let Some(result) = publish.queue.pop_front() {
-                    result
+                if let Some(envelope) = publish.queue.pop_front() {
+                    envelope
                 } else {
                     publish.draining = false;
                     return;
@@ -746,7 +750,7 @@ impl MempoolGateway {
                 continue;
             };
             let outcome = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
-                observer.on_mutation(&result);
+                observer.on_mutation(&envelope);
             }));
             if let Err(panic_payload) = outcome {
                 let (message, payload_disposal_panicked) = panic_message_and_dispose(panic_payload);
@@ -887,7 +891,9 @@ mod tests {
         AdmissionRequest, AdmitError, AdmitOutcome, ChainChangeError, CompositeObserver,
         MempoolGateway, MempoolObserver,
     };
-    use crate::mutation::{AdmissionOrigin, MutationOutcome, MutationResult, RemovalReason};
+    use crate::mutation::{
+        AdmissionOrigin, MutationEnvelope, MutationOutcome, MutationResult, RemovalReason,
+    };
     use crate::standardness::PackageTxContext;
     use crate::{Mempool, MempoolEntry, MempoolLimits};
     use alloc::sync::Arc;
@@ -926,12 +932,14 @@ mod tests {
     #[derive(Default)]
     struct RecordingObserver {
         seen: Mutex<Vec<(Hash256, MutationOutcome)>>,
+        origins: Mutex<Vec<AdmissionOrigin>>,
     }
 
     impl MempoolObserver for RecordingObserver {
-        fn on_mutation(&self, result: &MutationResult) {
+        fn on_mutation(&self, envelope: &MutationEnvelope) {
+            self.origins.lock().push(envelope.origin);
             let mut seen = self.seen.lock();
-            for change in &result.changes {
+            for change in &envelope.result.changes {
                 seen.push((change.txid, change.outcome));
             }
         }
@@ -940,7 +948,7 @@ mod tests {
     struct PanickingObserver;
 
     impl MempoolObserver for PanickingObserver {
-        fn on_mutation(&self, _result: &MutationResult) {
+        fn on_mutation(&self, _envelope: &MutationEnvelope) {
             panic!("observer exploded");
         }
     }
@@ -1039,6 +1047,16 @@ mod tests {
                 (hash(&child.txid()), removed(RemovalReason::Explicit)),
             ],
             "one event per change, in commit order"
+        );
+        drop(seen);
+        assert_eq!(
+            *observer.origins.lock(),
+            vec![
+                AdmissionOrigin::Rpc,
+                AdmissionOrigin::Rpc,
+                AdmissionOrigin::Rpc
+            ],
+            "commit must publish the origin that entered the mutation"
         );
     }
 
@@ -1289,7 +1307,8 @@ mod tests {
     }
 
     impl MempoolObserver for GatedObserver {
-        fn on_mutation(&self, result: &MutationResult) {
+        fn on_mutation(&self, envelope: &MutationEnvelope) {
+            let result = &envelope.result;
             let mut stream = self.stream.lock();
             let first_call = stream.is_empty();
             for index in 0..result.len() {
@@ -1398,7 +1417,8 @@ mod tests {
     }
 
     impl MempoolObserver for ReentrantObserver {
-        fn on_mutation(&self, result: &MutationResult) {
+        fn on_mutation(&self, envelope: &MutationEnvelope) {
+            let result = &envelope.result;
             {
                 let mut stream = self.stream.lock();
                 for index in 0..result.len() {
@@ -1477,7 +1497,8 @@ mod tests {
     }
 
     impl MempoolObserver for ContiguityObserver {
-        fn on_mutation(&self, result: &MutationResult) {
+        fn on_mutation(&self, envelope: &MutationEnvelope) {
+            let result = &envelope.result;
             {
                 let mut stream = self.stream.lock();
                 for index in 0..result.len() {
@@ -1580,7 +1601,8 @@ mod tests {
     }
 
     impl MempoolObserver for SequenceStreamObserver {
-        fn on_mutation(&self, result: &MutationResult) {
+        fn on_mutation(&self, envelope: &MutationEnvelope) {
+            let result = &envelope.result;
             let mut stream = self.stream.lock();
             for index in 0..result.len() {
                 stream.push(result.sequence_of(index).unwrap_or(u64::MAX));

--- a/crates/mempool/src/mutation.rs
+++ b/crates/mempool/src/mutation.rs
@@ -137,10 +137,9 @@ pub struct PeerToken {
 
 /// How the transaction behind a committed mutation entered the node.
 ///
-/// [`AdmissionOrigin::Peer`] and [`AdmissionOrigin::Block`] are the
-/// pre-declared batch contract for the ingress relay (R6/R7) and the
-/// apply-path sweep migration (ING-R34); no production caller emits them
-/// yet.
+/// [`AdmissionOrigin::Peer`] is emitted by P2P ingress
+/// (`crates/node/src/tx_ingress.rs`). [`AdmissionOrigin::Block`] is emitted
+/// by the apply-path sweep (`crates/node/src/apply.rs`).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AdmissionOrigin {
     /// Submitted through RPC (`sendrawtransaction`).
@@ -156,10 +155,10 @@ pub enum AdmissionOrigin {
 /// What the gateway hands its observers: the committed result plus how the
 /// mutating transaction entered the node.
 ///
-/// The envelope is move-through and zero-alloc: [`MempoolGateway`] moves a
-/// committed [`MutationResult`] into it, publishes `&MutationEnvelope`, and
-/// hands `envelope.result` back to the caller — no clone, no lifetime on
-/// the observer trait.
+/// [`MempoolGateway`] clones one [`MutationResult`] into the envelope for
+/// each committed non-empty batch that has an observer attached, enqueues
+/// that envelope, then returns the original result to the caller. Observers
+/// receive `&MutationEnvelope` after the publish mutex is released.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MutationEnvelope {
     /// How the transaction entered the node.

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -10169,7 +10169,7 @@ mod chain_tx_count_tests {
 mod chain_generation_tests {
     use std::sync::Arc;
 
-    use bitcoin_rs_mempool::{MempoolObserver, MutationResult};
+    use bitcoin_rs_mempool::{MempoolObserver, MutationEnvelope};
     use bitcoin_rs_primitives::{BlockHash, Network, OutPoint, Tx, TxIn, TxOut, Txid};
     use bitcoin_rs_utxo::UtxoSet;
     use parking_lot::Mutex;
@@ -10198,7 +10198,7 @@ mod chain_generation_tests {
     }
 
     impl MempoolObserver for GatewayGenerationRecorder {
-        fn on_mutation(&self, _result: &MutationResult) {
+        fn on_mutation(&self, _envelope: &MutationEnvelope) {
             let generation = self
                 .gateway
                 .get()

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -6169,7 +6169,7 @@ mod consensus_rule_tests {
     #[allow(clippy::arc_with_non_send_sync)]
     fn a_window_skips_scripts_for_assume_valid_blocks_and_proves_nothing_for_them()
     -> Result<(), Box<dyn std::error::Error>> {
-        let (recorder, metrics_handle) = crate::metrics::test_recorder();
+        let recorder = crate::metrics::test_recorder();
 
         let genesis = Network::Regtest.genesis_block();
         let prevout = OutPoint::new(fixture_txid(0x71), 0);

--- a/crates/node/src/mempool_observer.rs
+++ b/crates/node/src/mempool_observer.rs
@@ -1,13 +1,13 @@
 //! Node-side mempool mutation observer.
 //!
-//! Bridges committed [`MutationResult`]s from the [`MempoolGateway`] onto
+//! Bridges committed [`MutationEnvelope`]s from the [`MempoolGateway`] onto
 //! Core's unified `sequence` ZMQ topic: accepted changes publish `A` events,
 //! removals publish `R` events — except block-inclusion removals, which Core
 //! suppresses because the block's own `C` event covers the departure.
 
 use std::sync::Arc;
 
-use bitcoin_rs_mempool::{MempoolObserver, MutationOutcome, MutationResult, RemovalReason};
+use bitcoin_rs_mempool::{MempoolObserver, MutationEnvelope, MutationOutcome, RemovalReason};
 use bitcoin_rs_primitives::Txid;
 
 use crate::zmq_publisher::{SequenceEvent, ZmqPublisher};
@@ -38,7 +38,8 @@ impl MempoolSequenceObserver {
 }
 
 impl MempoolObserver for MempoolSequenceObserver {
-    fn on_mutation(&self, result: &MutationResult) {
+    fn on_mutation(&self, envelope: &MutationEnvelope) {
+        let result = &envelope.result;
         for (offset, change) in result.changes.iter().enumerate() {
             let Some(sequence) = result.sequence_of(offset) else {
                 continue;
@@ -63,7 +64,7 @@ impl MempoolObserver for MempoolSequenceObserver {
 
 /// The node's one mutation observer: every committed mempool mutation fans
 /// out to the `sequence` wire events and the mining generation wake, in that
-/// order, under the gateway's publish mutex.
+/// order, after the gateway has released the publish mutex.
 ///
 /// Installed exactly once, on the node-owned [`MempoolGateway`] at
 /// [`crate::state::NodeState::open`], so both fan-outs stay ordered with the
@@ -93,17 +94,19 @@ impl NodeMutationObserver {
 }
 
 impl MempoolObserver for NodeMutationObserver {
-    fn on_mutation(&self, result: &MutationResult) {
+    fn on_mutation(&self, envelope: &MutationEnvelope) {
         if let Some(sequence) = &self.sequence {
-            sequence.on_mutation(result);
+            sequence.on_mutation(envelope);
         }
         // The last change's sequence is the pool's current sequence after this
         // mutation. Thread it directly so the coordinator never takes the
         // mempool read lock from the observer path.
+        let result = &envelope.result;
         let wake_sequence = result
             .sequence_of(result.changes.len().saturating_sub(1))
             .unwrap_or(result.sequence_base);
-        self.mining_generation.publish_generation_from(wake_sequence);
+        self.mining_generation
+            .publish_generation_from(wake_sequence);
     }
 }
 
@@ -301,7 +304,7 @@ mod tests {
     /// mutation that bypassed the gateway would satisfy neither assertion.
     #[test]
     fn node_mutation_observer_fans_out_to_sequence_and_mining_wake() {
-        use crate::mining::{MiningGenerationSignal, MempoolSequenceWake};
+        use crate::mining::{MempoolSequenceWake, MiningGenerationSignal};
         use bitcoin_rs_primitives::Block;
         use bitcoin_rs_rpc::context::{
             BlockTemplateRequest, BlockTemplateResult, MiningControl, MiningControlError,

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -309,7 +309,10 @@ fn serve_scrape(stream: &mut TcpStream, handle: &PrometheusHandle) {
     let _ = stream.write_all(response.as_bytes());
     let _ = stream.flush();
 }
-
+#[cfg(test)]
+pub(crate) fn test_recorder() -> metrics::NoopRecorder {
+    metrics::NoopRecorder
+}
 #[cfg(test)]
 mod tests {
     use std::io::{Read, Write};

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1195,6 +1195,12 @@ impl NodeState {
             .with_context(|| format!("create data_dir {}", config.data_dir.display()))?;
         let checkpoint_data_dir = crate::checkpoint_fs::open_data_dir(&config.data_dir)
             .with_context(|| format!("open data_dir {}", config.data_dir.display()))?;
+        crate::checkpoint_fs::ensure_current_schema(&checkpoint_data_dir).with_context(|| {
+            format!(
+                "validate CURRENT_SCHEMA for datadir {}",
+                config.data_dir.display()
+            )
+        })?;
         // Allocate the process epoch before anything else can consume one:
         // durable, strictly greater than every earlier run of this data dir.
         let epoch = allocate_process_epoch(&checkpoint_data_dir)?;
@@ -2764,23 +2770,20 @@ mod tests {
     #[test]
     fn new_datadir_initializes_current_schema_before_storage() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
-        let mut config = crate::Config::default_for_network(crate::Network::Regtest);
+        let mut config = crate::NodeConfig::default_for_network(crate::Network::Regtest);
         config.data_dir = dir.path().join("node");
         config.p2p_listen.clear();
         std::fs::create_dir_all(&config.data_dir)?;
         std::fs::write(config.data_dir.join(".CURRENT_SCHEMA.tmp"), b"partial")?;
 
-        let _state = NodeState::open(config.clone())?;
+        let data_dir = config.data_dir.clone();
+        let _state = NodeState::open(config, None)?;
         assert_eq!(
-            std::fs::read(
-                config
-                    .data_dir
-                    .join(crate::checkpoint_fs::CURRENT_SCHEMA_FILE)
-            )?,
+            std::fs::read(data_dir.join(crate::checkpoint_fs::CURRENT_SCHEMA_FILE))?,
             crate::checkpoint_fs::current_schema_bytes()
         );
-        assert!(!config.data_dir.join(".CURRENT_SCHEMA.tmp").exists());
-        assert!(config.data_dir.join("chainstate").exists());
+        assert!(!data_dir.join(".CURRENT_SCHEMA.tmp").exists());
+        assert!(data_dir.join("chainstate").exists());
         Ok(())
     }
 
@@ -2793,14 +2796,41 @@ mod tests {
         std::fs::create_dir_all(&config.data_dir)?;
         std::fs::write(config.data_dir.join("legacy-state"), b"old")?;
 
-        let datadir = config.data_dir.display().to_string();
+        let data_dir = config.data_dir.clone();
+        let _state = NodeState::open(config, None)?;
+        assert_eq!(
+            std::fs::read(data_dir.join(crate::checkpoint_fs::CURRENT_SCHEMA_FILE))?,
+            b"0\n"
+        );
+        assert!(
+            data_dir.join("chainstate").exists(),
+            "baseline adoption must initialize storage"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn mismatched_datadir_schema_is_refused_before_storage_opens() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut config = crate::NodeConfig::default_for_network(crate::Network::Regtest);
+        config.data_dir = dir.path().join("old-node");
+        config.p2p_listen.clear();
+        std::fs::create_dir_all(&config.data_dir)?;
+        std::fs::write(
+            config
+                .data_dir
+                .join(crate::checkpoint_fs::CURRENT_SCHEMA_FILE),
+            b"1\n",
+        )?;
+
+        let data_dir = config.data_dir.clone();
         let Err(error) = NodeState::open(config, None) else {
-            anyhow::bail!("legacy inline block body unexpectedly opened");
+            anyhow::bail!("mismatched datadir schema unexpectedly opened");
         };
         let message = format!("{error:#}");
         assert!(message.contains("CURRENT_SCHEMA is not the current datadir schema epoch"));
         assert!(message.contains("full resync"));
-        assert!(!config.data_dir.join("chainstate").exists());
+        assert!(!data_dir.join("chainstate").exists());
         Ok(())
     }
 

--- a/crates/node/src/tx_ingress.rs
+++ b/crates/node/src/tx_ingress.rs
@@ -21,7 +21,7 @@ use bitcoin_rs_mempool::{
     AdmissionOrigin, MempoolGateway, PeerToken, ReplacementCandidate,
     standardness::{PackageTxContext, evaluate_package_acceptance},
 };
-use bitcoin_rs_primitives::{Hash256, Tx, Txid, Wtxid};
+use bitcoin_rs_primitives::{Hash256, Tx, Txid};
 use bitcoin_rs_rpc::context::MiningControl;
 use bitcoin_rs_utxo::UtxoSet;
 use crossbeam_channel::Receiver;
@@ -217,7 +217,8 @@ impl TxIngressConsumer {
                         && matches!(c.outcome, bitcoin_rs_mempool::MutationOutcome::Accepted)
                 });
                 if accepted {
-                    self.relay.announce(txid, tx.wtxid(), Some(source.connection_id().get()));
+                    self.relay
+                        .announce(txid, tx.wtxid(), Some(source.connection_id().get()));
                     self.mining_control.publish_generation();
                     tracing::trace!(%txid, "p2p tx admitted and relayed");
                 }
@@ -490,7 +491,6 @@ mod tests {
             min_relay_fee_sat_per_kvb: 0,
             ..MempoolLimits::default()
         })));
-        let gateway = MempoolGateway::shared(Arc::clone(&pool));
 
         let recorded_origin = Arc::new(Mutex::new(None));
         struct OriginRecorder {
@@ -508,11 +508,12 @@ mod tests {
                 }
             }
         }
-        gateway
-            .install_observer(Arc::new(OriginRecorder {
+        let gateway = MempoolGateway::shared_with(
+            Arc::clone(&pool),
+            Arc::new(OriginRecorder {
                 captured: Arc::clone(&recorded_origin),
-            }))
-            .ok();
+            }),
+        );
 
         let source = test_source();
         let expected_conn_id = source.connection_id();

--- a/crates/node/tests/mining_e2e.rs
+++ b/crates/node/tests/mining_e2e.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Result, bail};
-use bitcoin_rs_mempool::{MempoolGateway, MempoolObserver, MutationOutcome, MutationResult};
+use bitcoin_rs_mempool::{MempoolGateway, MempoolObserver, MutationEnvelope, MutationOutcome};
 use bitcoin_rs_node::{MiningCoordinator, Network, NodeConfig, state::NodeState};
 use bitcoin_rs_primitives::encode::double_sha256;
 use bitcoin_rs_primitives::{
@@ -659,7 +659,8 @@ struct RecordingMempoolObserver {
 }
 
 impl MempoolObserver for RecordingMempoolObserver {
-    fn on_mutation(&self, result: &MutationResult) {
+    fn on_mutation(&self, envelope: &MutationEnvelope) {
+        let result = &envelope.result;
         let mut changes = self.changes.lock();
         for (offset, change) in result.changes.iter().enumerate() {
             let sequence = result.sequence_of(offset).unwrap_or(u64::MAX);

--- a/crates/rpc/tests/policy_contract.rs
+++ b/crates/rpc/tests/policy_contract.rs
@@ -16,7 +16,7 @@ use std::error::Error;
 use bitcoin_rs_mempool::eviction::mempool_min_fee_sat_per_kvb;
 use bitcoin_rs_mempool::{
     AdmissionOrigin, Mempool, MempoolEntry, MempoolGateway, MempoolLimits, MempoolObserver,
-    MutationOutcome, MutationResult, PolicyError, RbfError, RemovalReason, ReplacementCandidate,
+    MutationEnvelope, MutationOutcome, PolicyError, RbfError, RemovalReason, ReplacementCandidate,
 };
 use bitcoin_rs_node::reorg::{ReorgError, invalidate_block};
 use bitcoin_rs_node::{Network, NodeConfig, state::NodeState};
@@ -629,7 +629,8 @@ struct RecordingGatewayObserver {
 }
 
 impl MempoolObserver for RecordingGatewayObserver {
-    fn on_mutation(&self, result: &MutationResult) {
+    fn on_mutation(&self, envelope: &MutationEnvelope) {
+        let result = &envelope.result;
         let mut changes = self.changes.lock();
         for (offset, change) in result.changes.iter().enumerate() {
             let sequence = result.sequence_of(offset).unwrap_or(u64::MAX);

--- a/docs/contracts/mempool-mutations.md
+++ b/docs/contracts/mempool-mutations.md
@@ -15,38 +15,46 @@ in `crates/node/src/mempool_observer.rs`; payload encoding in
 - Every production mempool mutation routes through `MempoolGateway`. No
   production code outside the gateway takes the mempool write lock; lookups
   go through `MempoolGateway::read`.
-- Every mutating method flows through one path, `commit`, in this exact
-  order:
+- Every mutating method flows through one path, `commit` (and
+  `admit_transaction`, which enqueues the same way), in this exact order:
   1. take the pool write lock,
   2. mutate and assign per-change `mempool_sequence` values,
-  3. acquire the publish mutex while still holding the write lock,
-  4. drop the write lock,
-  5. call the observer under the publish mutex,
-  6. release the publish mutex.
-- Taking the publish mutex before the write lock is released (step 3 before
-  step 4) serializes publish acquisitions in commit order. An observer never
-  sees a later-committed batch before, or interleaved with, an earlier one.
-- The write lock is never held across an observer call. A slow or blocked
-  observer delays later publications; it can never roll anything back or
-  reorder the stream. Sequences were assigned in step 2, so a lagging
-  observer still sees a gap-free, ordered stream.
-- The observer receives a `&MutationEnvelope` — the committed `MutationResult`
-  paired with the `AdmissionOrigin` that identifies how the transaction
-  entered the node (`Rpc`, `Peer`, `Reorg`, or `Block`). The envelope is
-  move-through and zero-alloc: the gateway moves the result into the
-  envelope, publishes `&MutationEnvelope`, and hands `envelope.result` back
-  to the caller.
-- Observers are best-effort mirrors. Observer errors and panics never affect
-  the committed mutation. An observer must never route mutations back
-  through the gateway or otherwise take the mempool lock — read or write:
-  the callback runs under the gateway's publish mutex (step 5), so any pool
-  acquisition from the observer path can deadlock against a concurrent
-  writer or re-enter the gateway. The accepted-mutation mining wake threads
-  the last change's sequence into `MempoolSequenceWake::publish_generation_from`,
-  which builds the generation key from `applied_tip` plus that sequence and
-  never touches the mempool read lock (`crates/node/src/mining.rs`); the
-  node observer routes every mutation through it
-  (`crates/node/src/mempool_observer.rs`, `NodeMutationObserver::on_mutation`).
+  3. while still holding the write lock, enqueue a non-empty
+     `MutationEnvelope` on the publish FIFO and elect a drainer if none
+     exists,
+  4. release the write lock and the publish-state lock,
+  5. the elected drainer pops batches one at a time — releasing the
+     publish-state lock before every observer call — and returns the
+     publish state to idle only once the queue is empty.
+- Commits serialize under the write lock and step 3 enqueues under that
+  same ownership, so the queue order is the commit order and the sequence
+  order. An observer never sees a later-committed batch before, or
+  interleaved with, an earlier one.
+- Publication is eventual, not synchronous. A nested or concurrent
+  mutation enqueues and returns while a drainer exists; its callback may
+  run after that call has returned. A slow observer delays later
+  publications, not the caller. It can never roll anything back or reorder
+  the stream. Sequences were assigned in step 2, so a lagging observer
+  still sees a gap-free, ordered stream.
+- The observer receives a `&MutationEnvelope` — the committed
+  `MutationResult` paired with the `AdmissionOrigin` that identifies how
+  the transaction entered the node (`Rpc`, `Peer`, `Reorg`, or `Block`).
+  The gateway clones one `MutationResult` into the envelope for each
+  committed non-empty batch that has an observer attached, so it can both
+  enqueue publication and return the original result to the caller.
+  Empty results and an absent observer enqueue nothing, allocate nothing,
+  and spawn no thread.
+- Observers are best-effort mirrors. Observer errors and panics never
+  affect the committed mutation. No gateway lock is held across an
+  observer call, so an observer may re-enter the gateway: a nested call
+  commits, enqueues, and returns immediately, and its publication
+  completes after the in-flight callback. The accepted-mutation mining
+  wake threads the last change's sequence into
+  `MempoolSequenceWake::publish_generation_from`, which builds the
+  generation key from `applied_tip` plus that sequence and never touches
+  the mempool read lock (`crates/node/src/mining.rs`); the node observer
+  routes every mutation through it (`crates/node/src/mempool_observer.rs`,
+  `NodeMutationObserver::on_mutation`).
 
 ### `MPL-02`: Atomic mutation records and sequence assignment
 


### PR DESCRIPTION
## Why

HEAD was red for three reasons this commit closes:

- `metrics::test_recorder` was called by the assume-valid test (`apply.rs:6170`) but never defined — unresolved symbol at link.
- The `Config` path used for the datadir did not exist where `NodeState::open` looked, so the schema file was never read.
- `CURRENT_SCHEMA` gate was defined but never called: `NodeState::open` went straight to process-epoch allocation, so a foreign-epoch datadir was adopted silently instead of refused with a resync instruction.

## What changed

- **`state.rs`** — insert the `CURRENT_SCHEMA` validation gate before any storage is touched in `NodeState::open`; cover both gate outcomes (accept current epoch, reject foreign epoch with a resync instruction). Both schema tests restored.
- **`metrics.rs`** — add the bare `NoopRecorder` helper and `test_recorder()` function the assume-valid test binds.
- **`apply.rs`** — single binding change in the `a_window_skips_scripts_for_assume_valid_blocks_and_proves_nothing_for_them` test (line 6170) to call `crate::metrics::test_recorder()`.

## Verification

- 3 schema tests green.
- Assume-valid test green (4/4 in its module).
- `cargo check -p node` passes with the pre-existing `scratch.rs` dead_code warning only.

## Stacking

This PR stacks on #PR1 (`overhaul/one-session-envelope`, commit e1f0ff7 — Route observer callbacks through MutationEnvelope). The `apply.rs` hunk is disjoint from PR1's `apply.rs` changes; no conflict on merge.

## Known red (pre-existing baseline)

Same pre-existing red as PR1, inherited from HEAD `4e8019d`:

- Whole-tree `cargo fmt` has 14 non-owned diffs (files outside this stack).
- `cargo clippy -D warnings -p node` fails on `scratch.rs` dead_code (not touched here).
- `cargo test -p node --lib` has 4 failures + 1 ignored (the four named failures; see atomic-verify-evidence).

None of these are introduced or worsened by this commit.