### PR TITLE
Drop references to the retired campaign runner

### DIFF
--- a/docs/benchmarks/p2p-loopback.md
+++ b/docs/benchmarks/p2p-loopback.md
@@ -215,9 +215,9 @@ python3 tools/benchmark-campaign/p2p_loopback.py --config <config.json> --output
 python3 -m unittest test_p2p_loopback   # from tools/benchmark-campaign/
 ```
 
-The tool depends on nothing in `runner.py`/`test_runner.py`; tests use real
-loopback sockets and deterministic fixture nodes (tiny Python scripts that
-connect, echo, read the exact corpus length, and write state files).
+The tool is standalone: tests use real loopback sockets and deterministic
+fixture nodes (tiny Python scripts that connect, echo, read the exact corpus
+length, and write state files).
 
 ## Limits
 

--- a/tools/benchmark-campaign/comp_lanes.py
+++ b/tools/benchmark-campaign/comp_lanes.py
@@ -213,11 +213,11 @@ def _find_bitcoind() -> str | None:
 
 
 def run_offline_lane(workspace: Path) -> dict[str, object]:
-    """Check whether the offline full-validation comparator (#34) can run.
+    """Report whether an offline full-validation run (#34) is reachable.
 
-    The comparator in ``runner.py`` requires a ``bitcoind`` binary and a
-    frozen corpus.  When ``bitcoind`` is absent the lane records the
-    blocking fact.
+    The strict comparator that consumed this signal was retired in commit
+    5487803, so this lane reports host readiness only: a ``bitcoind`` binary
+    on PATH, without which no offline comparison can start.
     """
     bitcoind = _find_bitcoind()
     if bitcoind is None:


### PR DESCRIPTION
## Why

Commit `5487803` ("refactor: retire remaining benchmark campaigns") deleted
`tools/benchmark-campaign/runner.py`, `native_offline.py`, and
`test_runner.py`. Two references to those files survive on `main`:

- `tools/benchmark-campaign/comp_lanes.py:218` — the `run_offline_lane`
  docstring says "The comparator in `runner.py` requires a `bitcoind` binary
  and a frozen corpus". There is no `runner.py`, so the function's stated
  purpose cannot be met, and a `reachable` verdict from that lane means only
  that `bitcoind` is on PATH.
- `docs/benchmarks/p2p-loopback.md:218` — tells readers "The tool depends on
  nothing in `runner.py`/`test_runner.py`", naming two deleted files to
  reassure the reader about a dependency that cannot exist.

## What changed

- `comp_lanes.py`: the docstring now states what the lane reports — host
  readiness, one `bitcoind` on PATH — and names the retiring commit so the
  next reader does not go looking for the comparator.
- `p2p-loopback.md`: the standalone claim stays; the deleted filenames go.

Docstring and prose only. No control flow, no return shape, no lane key or
status string changes.

## Verification

- `python3 -m unittest test_comp_lanes` from `tools/benchmark-campaign/`:
  14 tests, OK.
- `python3 -m py_compile tools/benchmark-campaign/comp_lanes.py`: clean.
- `ruff check tools/benchmark-campaign/comp_lanes.py`: 5 findings
  (`UP035`, `I001`, `F401`, `RUF100` x2), byte-identical before and after this
  change — all pre-existing at `bd22078` in the import block, none in the
  touched docstring.

Note for reviewers: `main` at `bd22078` is already red on `clippy`, `fmt`,
`deny`, and `test` (run 33707929426). Those failures predate this branch,
which touches one Markdown file and one Python docstring.
