### PR TITLE
Simplify user-facing config surface

### DIFF
--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -39,9 +39,6 @@ const DEFAULT_LOG_LEVEL: &str = "info";
 const DEFAULT_RPC_USER: &str = "bitcoin-rs";
 const DEFAULT_RPC_PASSWORD: &str = "bitcoin-rs";
 const DEFAULT_DBCACHE_MB: u64 = 450;
-/// Fork depth (blocks) at which a stale txindex watermark stops the
-/// per-block rewind and routes to a selective reset + rebuild instead.
-const DEFAULT_INDEX_ROLLBACK_REBUILD_CUTOVER: u32 = 100_000;
 const DEFAULT_ZMQ_HWM: u32 = 1_000;
 const DRYNET4_CONNECT: &str = "drynet4.drivechain.dev:8533";
 const DRYNET4_P2P_MAGIC: [u8; 4] = [0xec, 0xa5, 0xd4, 0x04];
@@ -166,29 +163,19 @@ pub struct ZmqPublication {
 /// How much of the derived `ScriptIndex` a node maintains.
 ///
 /// `ScriptIndex` is rebuildable derived state, so the mode is a capability
-/// selection rather than a storage compatibility question: `utxo` maintains
-/// only the compact live-output view, `full` adds historical funding/spending
-/// rows.
+/// selection rather than a storage compatibility question: `full` adds
+/// historical funding/spending rows while still maintaining the live-output
+/// view.
 ///
 /// The boolean spellings remain behaviorally compatible: `--scriptindex`,
 /// `--scriptindex=true`, and `BITCOIN_RS_SCRIPTINDEX=true` all mean
 /// [`Self::Full`], and `false` means [`Self::Disabled`].
-///
-/// [`Self::Utxo`] is parsed and named but not yet accepted by
-/// [`NodeConfig::validate`]: the durable live-output store it describes does
-/// not exist. See [`ScriptIndexMode::has_live_store`].
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ScriptIndexMode {
     /// No `ScriptIndex` capability is maintained.
     #[default]
     Disabled,
-    /// Maintain only the compact live-output view.
-    ///
-    /// Named and parsed, but **not accepted** by [`NodeConfig::validate`] until
-    /// the durable live-output store exists. See
-    /// [`ScriptIndexMode::has_live_store`].
-    Utxo,
     /// Maintain both the live-output view and historical script activity.
     Full,
 }
@@ -201,31 +188,9 @@ impl ScriptIndexMode {
     }
 
     /// Whether historical funding/spending rows are maintained.
-    ///
-    /// Only `full` keeps history; `utxo` deliberately avoids paying the
-    /// storage cost of full historical script indexing.
     #[must_use]
     pub const fn keeps_history(self) -> bool {
         matches!(self, Self::Full)
-    }
-
-    /// Whether this mode has a durable store backing every view it claims.
-    ///
-    /// `utxo` is the one mode that does not, yet. Its whole purpose is the
-    /// compact live-output view, and that view has no on-disk representation:
-    /// #225 defers the `ScriptLive` row format to #226 Q5, which is still
-    /// choosing the locator. Until a live store exists, a node configured
-    /// `utxo` would build no `Funding`/`Spending` rows (those families are
-    /// claimed only under `script_history`), publish no `ScriptHistory`
-    /// watermark, and then have every `ScriptIndexQuery` method —
-    /// `unspent_outputs` included — gate on
-    /// `IndexCapabilities::SCRIPT_HISTORY` and report `Retry` forever. That is
-    /// an advertised capability with nothing behind it.
-    ///
-    /// `Disabled` trivially has every store it claims, which is none.
-    #[must_use]
-    pub const fn has_live_store(self) -> bool {
-        !matches!(self, Self::Utxo)
     }
 
     /// Parses a mode from a configuration value.
@@ -234,7 +199,6 @@ impl ScriptIndexMode {
     /// means `full` and `false` means disabled. Parsing is case-insensitive.
     pub fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "utxo" => Some(Self::Utxo),
             // `true` is the historical boolean spelling and must keep meaning
             // `full`; it is a separate pattern for that readability, not a
             // distinct outcome.
@@ -298,15 +262,6 @@ pub struct NodeConfig {
     /// down so share arithmetic stays exact. Effective per-namespace
     /// capacities are logged at startup (`opened storage backend`).
     pub dbcache_mb: u64,
-    /// Fork depth at which a stale txindex watermark routes to a selective
-    /// reset and rebuild instead of a per-block rewind.
-    ///
-    /// Grounded in three measured runs of per-block forward-ingest versus
-    /// rollback cost (see `docs/benchmarks/index-rollback-rebuild-cutover.md`):
-    /// the default routes the 834k-block stale-branch incident shape to a
-    /// rebuild while organic reorgs (tens of blocks) keep rewinding block by
-    /// block.
-    pub index_rollback_rebuild_cutover: u32,
     /// Tracing filter level used when `RUST_LOG` is unset.
     pub log_level: String,
     /// Optional Prometheus metrics bind address. `None` disables metrics.
@@ -361,10 +316,6 @@ impl fmt::Debug for NodeConfig {
             .field("prune_target_mb", &self.prune_target_mb)
             .field("txindex", &self.txindex)
             .field("dbcache_mb", &self.dbcache_mb)
-            .field(
-                "index_rollback_rebuild_cutover",
-                &self.index_rollback_rebuild_cutover,
-            )
             .field("log_level", &self.log_level)
             .field("metrics_bind", &self.metrics_bind)
             .field("zmqpubhashblock", &self.zmqpubhashblock)
@@ -415,7 +366,6 @@ impl NodeConfig {
             prune_target_mb: 0,
             txindex: false,
             dbcache_mb: DEFAULT_DBCACHE_MB,
-            index_rollback_rebuild_cutover: DEFAULT_INDEX_ROLLBACK_REBUILD_CUTOVER,
             log_level: DEFAULT_LOG_LEVEL.to_owned(),
             metrics_bind: None,
             zmqpubhashblock: Vec::new(),
@@ -510,12 +460,6 @@ impl NodeConfig {
             "rocksdb" | "fjall" | "redb" | "mdbx" => {}
             other => bail!("unsupported storage backend {other}"),
         }
-        ensure!(
-            self.script_index.has_live_store(),
-            "scriptindex=utxo is not yet usable: the compact live-output store it \
-             requires does not exist (#225). Only `full` and `disabled` are accepted. \
-             Blocked on #226 Q5, which selects the ScriptLive locator format."
-        );
         for (name, hwm) in [
             ("zmqpubhashblockhwm", self.zmqpubhashblockhwm),
             ("zmqpubhashtxhwm", self.zmqpubhashtxhwm),
@@ -633,7 +577,7 @@ impl NodeConfig {
         if let Some(script_index) = &layer.script_index {
             self.script_index = ScriptIndexMode::parse(script_index).ok_or_else(|| {
                 anyhow::anyhow!(
-                    "invalid scriptindex value `{script_index}`: expected `utxo`, `full`, or a boolean"
+                    "invalid scriptindex value `{script_index}`: expected `full` or a boolean"
                 )
             })?;
         }
@@ -655,17 +599,11 @@ impl NodeConfig {
         if let Some(dbcache_mb) = layer.dbcache_mb {
             self.dbcache_mb = dbcache_mb;
         }
-        if let Some(cutover) = layer.index_rollback_rebuild_cutover {
-            self.index_rollback_rebuild_cutover = cutover;
-        }
         if let Some(log_level) = &layer.log_level {
             self.log_level.clone_from(log_level);
         }
         if let Some(metrics_bind) = layer.metrics_bind {
             self.metrics_bind = Some(metrics_bind);
-        }
-        if layer.clear_metrics_bind {
-            self.metrics_bind = None;
         }
         if let Some(endpoints) = &layer.zmqpubhashblock {
             self.zmqpubhashblock.clone_from(endpoints);
@@ -816,14 +754,10 @@ pub struct UserConfig {
     pub(crate) txindex: Option<bool>,
     #[arg(long = "dbcache-mb")]
     pub(crate) dbcache_mb: Option<u64>,
-    #[arg(long = "index-rollback-rebuild-cutover")]
-    pub(crate) index_rollback_rebuild_cutover: Option<u32>,
     #[arg(long = "log-level")]
     pub(crate) log_level: Option<String>,
     #[arg(long = "metrics-bind")]
     pub(crate) metrics_bind: Option<SocketAddr>,
-    #[arg(skip)]
-    pub(crate) clear_metrics_bind: bool,
     #[arg(long = "zmqpubhashblock", value_delimiter = ',')]
     pub(crate) zmqpubhashblock: Option<Vec<String>>,
     #[arg(long = "zmqpubhashtx", value_delimiter = ',')]
@@ -882,9 +816,6 @@ impl UserConfig {
                 "BITCOIN_RS_PRUNE_TARGET_MB" => layer.prune_target_mb = Some(value.parse()?),
                 "BITCOIN_RS_TXINDEX" => layer.txindex = Some(parse_bool(value)?),
                 "BITCOIN_RS_DBCACHE_MB" => layer.dbcache_mb = Some(value.parse()?),
-                "BITCOIN_RS_INDEX_ROLLBACK_REBUILD_CUTOVER" => {
-                    layer.index_rollback_rebuild_cutover = Some(value.parse()?);
-                }
                 "BITCOIN_RS_LOG_LEVEL" => layer.log_level = Some(value.to_owned()),
                 "BITCOIN_RS_METRICS_BIND" => layer.metrics_bind = Some(value.parse()?),
                 "BITCOIN_RS_ZMQPUBHASHBLOCK" => {

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1046,7 +1046,7 @@ fn build_tx_index_open_spec(
         batch_limits,
         epoch,
         enabled,
-        rollback_rebuild_cutover: config.index_rollback_rebuild_cutover,
+        rollback_rebuild_cutover: crate::txindex_worker::DEFAULT_ROLLBACK_REBUILD_CUTOVER,
         canonical_data_root,
     }))
 }
@@ -2229,17 +2229,11 @@ mod tests {
         Ok(())
     }
 
-    /// Opens a node in each `scriptindex` mode and asserts the concrete answer
-    /// for `unspent_outputs`, rather than only the `full` path.
+    /// Opens a node in each accepted `scriptindex` mode and asserts the
+    /// concrete answer for `unspent_outputs`, rather than only the `full` path.
     ///
-    /// This is the guard that would have caught advertising `utxo` before a
-    /// live store exists. Under `utxo` the node currently builds no
-    /// `Funding`/`Spending` rows and publishes no `ScriptHistory` watermark,
-    /// so every `ScriptIndexQuery` method gates on
-    /// `IndexCapabilities::SCRIPT_HISTORY` and reports `Retry` forever. The
-    /// mode is therefore rejected at config time; this test pins that the
-    /// rejection happens at `open`, and that the two accepted modes give
-    /// distinct, concrete answers instead of both degrading to `Retry`.
+    /// This is the guard that the two accepted modes give distinct, concrete
+    /// answers instead of both degrading to `Retry`.
     #[test]
     fn script_index_modes_give_concrete_unspent_outputs_answers() -> anyhow::Result<()> {
         use bitcoin_rs_index::ScriptHash;
@@ -2248,7 +2242,7 @@ mod tests {
         // Genesis is applied in each case so the index worker has at least one
         // block to index. Without it the worker never publishes a
         // `ScriptHistory` watermark and every mode retries forever, which would
-        // make all three cases indistinguishable.
+        // make both cases indistinguishable.
         let scripthash = ScriptHash::from_script_bytes(&[0x51, 0x01]);
 
         // `disabled`: no script index at all, so no query adapter is handed
@@ -2266,26 +2260,6 @@ mod tests {
             "disabled must not hand out a script-index query adapter"
         );
         drop(state);
-
-        // `utxo`: the mode is named and parsed but has no durable live-output
-        // store, so opening must fail loudly rather than start a node that
-        // would advertise a live view nothing backs.
-        let dir = tempfile::tempdir()?;
-        let mut config = crate::NodeConfig::default_for_network(crate::Network::Regtest);
-        config.data_dir = dir.path().join("node");
-        config.p2p_listen.clear();
-        config.txindex = false;
-        config.script_index = crate::config::ScriptIndexMode::Utxo;
-        let error = match NodeState::open(config, None) {
-            Ok(_) => panic!("utxo must be rejected while no live store backs it"),
-            Err(error) => error,
-        };
-        assert!(
-            error
-                .to_string()
-                .contains("scriptindex=utxo is not yet usable"),
-            "rejection must name what is missing, got: {error}"
-        );
 
         // `full`: the accepted mode. It converges on a concrete answer — an
         // empty set for an unfunded script — rather than retrying forever.

--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -77,6 +77,15 @@ pub(crate) const REDB_BATCH_LIMITS: PreparedBatchLimits = PreparedBatchLimits {
     max_bytes: BATCH_BYTE_LIMIT,
 };
 
+/// Default fork depth at which a stale txindex watermark routes to a
+/// selective reset + rebuild instead of a per-block rewind.
+///
+/// Grounded in three measured runs of per-block forward-ingest versus rollback
+/// cost (see `docs/benchmarks/index-rollback-rebuild-cutover.md`): the default
+/// routes the 834k-block stale-branch incident shape to a rebuild while organic
+/// reorgs (tens of blocks) keep rewinding block by block.
+pub(crate) const DEFAULT_ROLLBACK_REBUILD_CUTOVER: u32 = 100_000;
+
 const IDENTITY_CHUNK_BLOCKS: u32 = 65_536;
 const POSITION_PREFETCH_BLOCKS: usize = 65_536;
 /// Maximum number of blocks whose bodies are held in memory and whose

--- a/docs/benchmarks/index-rollback-rebuild-cutover.md
+++ b/docs/benchmarks/index-rollback-rebuild-cutover.md
@@ -2,8 +2,8 @@
 
 ## Knob
 
-`Config::index_rollback_rebuild_cutover` (`crates/node/src/config.rs`), default
-`DEFAULT_INDEX_ROLLBACK_REBUILD_CUTOVER: u32 = 100_000`.
+`txindex_worker::DEFAULT_ROLLBACK_REBUILD_CUTOVER` (`crates/node/src/txindex_worker.rs`), default
+`100_000`.
 
 Decision rule implemented by the txindex worker (`reconcile_once`): for each
 stale-watermark selection, `depth = reconcile::rollback_depth(...)` (watermark
@@ -59,7 +59,7 @@ cutover = clamp(100_000 × t_fw / t_rb, 1_000, 100_000)
         → one significant figure = 100_000
 ```
 
-`DEFAULT_INDEX_ROLLBACK_REBUILD_CUTOVER = 100_000`. The benchmark proves the
+The default is `100_000`. The benchmark proves the
 default rounds to 100,000 and routes the #208 834k-gap incident to rebuild
 while ≤ ~100-block organic reorgs continue to rewind. The per-block ratio does
 not prove rebuild always scales better because total costs depend on tip height
@@ -71,6 +71,5 @@ Status: COMPLETED — three runs, medians of medians, spread recorded.
 
 - No bitcoin_conf_compat alias: this is not a Core knob and that file is
   outside this leaf.
-- `cutover = 0` means every resolvable stale watermark rebuilds (legal
-  operator choice, documented in `Config` rustdoc); `u32::MAX` restores the
-  pre-cutover rewind-at-any-depth behavior.
+- `cutover = 0` means every resolvable stale watermark rebuilds (used in
+  tests); `u32::MAX` restores the pre-cutover rewind-at-any-depth behavior.


### PR DESCRIPTION
## Summary

Removes three internal/dead items from the node operator surface to shrink the public config contract and give each semantic fact one owner:

- `--index-rollback-rebuild-cutover` / `BITCOIN_RS_INDEX_ROLLBACK_REBUILD_CUTOVER` / `NodeConfig.index_rollback_rebuild_cutover` are gone. The `100_000` default moves into `txindex_worker::DEFAULT_ROLLBACK_REBUILD_CUTOVER`, which `NodeState::open` uses directly.
- The unused `clear_metrics_bind` `#[arg(skip)]` flag is gone.
- `ScriptIndexMode::Utxo` is gone; it was parsed but always rejected by `NodeConfig::validate`. The accepted surface is `disabled`/`full` (and the historical booleans `true`/`false`/`1`/`0`/`yes`/`no`).

The benchmark grounding doc is updated to point at the internal constant, and the `state.rs` test that asserted the `Utxo` rejection now checks only the two accepted modes.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p bitcoin-rs-node --no-default-features --features fjall --all-targets -- -D warnings`
- `cargo build --bin bitcoin-rs --no-default-features --features fjall`
- `cargo test -p bitcoin-rs-node --no-default-features --features fjall` (503 passed)

Refs #254.

Link to Devin session: https://app.devin.ai/sessions/201889046862450d9b491b67f17e8ef4
Open in Devin Desktop: https://app.devin.ai/desktop/session/201889046862450d9b491b67f17e8ef4?variant=devin
Requested by: @metaphorics