### PR TITLE
fix: restore the clippy gate on main

### DIFF
--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -1641,7 +1641,7 @@ fn transaction_heap_usage(tx: &Tx) -> u64 {
     for input in &tx.inputs {
         total = total.saturating_add(u64::try_from(input.script_sig.len()).unwrap_or(u64::MAX));
         total = total.saturating_add(
-            u64::try_from(input.witness.iter().map(|item| item.len()).sum::<usize>())
+            u64::try_from(input.witness.iter().map(std::vec::Vec::len).sum::<usize>())
                 .unwrap_or(u64::MAX),
         );
     }

--- a/crates/p2p/benches/write_message.rs
+++ b/crates/p2p/benches/write_message.rs
@@ -1,8 +1,8 @@
-//! Benchmark for `wire::write_message` over a loopback TcpStream.
+//! Benchmark for `wire::write_message` over a loopback `TcpStream`.
 //!
 //! Measures the end-to-end cost of emitting one p2p message onto a real
 //! socket (small `ping` vs a genesis-sized `block` payload) so transport
-//! changes such as write coalescing and TCP_NODELAY can be compared.
+//! changes such as write coalescing and `TCP_NODELAY` can be compared.
 //!
 //! Note: loopback has ~0 RTT, so Nagle/delayed-ACK latency effects from
 //! wide-area links are not visible here; this bench primarily captures
@@ -22,6 +22,9 @@ use bitcoin_rs_p2p::wire::{Message, write_message};
 
 /// Open a connected loopback pair and drain the read side on a thread so the
 /// writer never blocks on a full socket buffer.
+// A fixture that fails to build has no degraded mode: an I/O error would be
+// timed as a fast early return and reported as a win.
+#[expect(clippy::expect_used, reason = "fixture setup must fail loudly")]
 fn connected_pair() -> (TcpStream, JoinHandle<()>) {
     let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).expect("bind loopback");
     let addr = listener.local_addr().expect("listener addr");
@@ -29,12 +32,15 @@ fn connected_pair() -> (TcpStream, JoinHandle<()>) {
     writer.set_nodelay(true).expect("set nodelay");
     let (mut reader, _) = listener.accept().expect("accept loopback");
     let drain = std::thread::spawn(move || {
-        let mut buf = [0u8; 64 * 1024];
+        let mut buf = vec![0u8; 64 * 1024];
         while reader.read(&mut buf).is_ok_and(|n| n > 0) {}
     });
     (writer, drain)
 }
 
+// A fixture that fails to build has no degraded mode: a decode or write
+// error would be timed as a fast early return and reported as a win.
+#[expect(clippy::expect_used, reason = "timed fixture calls must fail loudly")]
 fn bench_write_message(c: &mut Criterion) {
     let mut group = c.benchmark_group("write_message");
 


### PR DESCRIPTION
Main's clippy lane has been red since the 07:13-07:15 merge wave
(runs 33847777435, 33847865658, 33847936262): `-D warnings` aborts on
the first offending crate, so debt hidden behind it never surfaced.

- `crates/mempool/src/pool.rs`: closure only calling `Vec::len` while
  summing witness bytes; replaced with clippy's own suggestion.
- `crates/p2p/benches/write_message.rs` (from #200): bare `expect()`
  calls now carry `#[expect(clippy::expect_used, reason = ...)]` on the
  two fixture functions, the 64 KiB drain buffer is heap-allocated, and
  `TcpStream` / `TCP_NODELAY` are backticked in the module docs.

All three CI clippy invocations verified locally at 0 errors on this
tree; mempool (185) and p2p (132) lib suites green; `cargo fmt --check`
clean. Every PR now open against main has its checks running on a red
base, so this should land first.

## Summary by Sourcery

Restore a clean Clippy gate on main by addressing newly exposed lint violations across mempool and p2p benchmark code.

Bug Fixes:
- Restore the main branch Clippy gate by resolving lint failures in the mempool and p2p benchmark code.

Enhancements:
- Clarify intentional fixture panics for Clippy and improve the p2p benchmark's buffer handling and documentation.