### PR TITLE
fix: clear CI clippy and stale getchaintxstats schema claim after #269

### DIFF
--- a/bin/bitcoin-rs/src/main.rs
+++ b/bin/bitcoin-rs/src/main.rs
@@ -269,11 +269,11 @@ hwm = 5000
         let path = dir.path().join("node.toml");
         std::fs::write(
             &path,
-            r#"
+            r"
 [chainstate_journal]
 enabled = true
 blocks = 100
-"#,
+",
         )
         .unwrap_or_else(|error| panic!("write toml: {error}"));
 
@@ -283,8 +283,7 @@ blocks = 100
                 "--config",
                 path.to_str().unwrap_or_else(|| panic!("utf-8 path")),
             ],
-            [("BITCOIN_RS_CHAINSTATE_JOURNAL_BLOCKS", "200")]
-                .into_iter()
+            std::iter::once(("BITCOIN_RS_CHAINSTATE_JOURNAL_BLOCKS", "200"))
                 .map(|(key, value)| (OsString::from(key), OsString::from(value))),
         )
         .unwrap_or_else(|error| panic!("valid journal configuration: {error}"));

--- a/docs/api/core-compat.toml
+++ b/docs/api/core-compat.toml
@@ -119,13 +119,7 @@ status = "implemented_unverified"
 [[rpc]]
 method = "getchaintxstats"
 group = "blockchain"
-status = "deviation"
-deviation = "Optional window statistics (`txrate`, `window_interval`, `window_tx_count`) are serialized as JSON null; Core omits them when unknown. Tracked in #160."
-schema_mismatched = [
-    "txrate: Null vs NUM",
-    "window_interval: Null vs NUM",
-    "window_tx_count: Null vs NUM",
-]
+status = "implemented_unverified"
 
 [[rpc]]
 method = "getblockcount"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#269 landed on `main` while its last CI run was still failing. This follows up with the two red checks from that run.

**Clippy (`bitcoin-rs` test target).** The journal TOML fixture added in #269 used `r#"..."#` and a one-item `.into_iter()`, which `-D warnings` rejects (`needless_raw_string_hashes`, `iter_on_single_items`).

**`compared_methods_differ_from_core_exactly_as_declared`.** After #106, `getchaintxstats` omits unknown window statistics the way Core does. The schema oracle now finds no mismatches, but `docs/api/core-compat.toml` still declared the old `Null vs NUM` deviation. The manifest is the owner of that claim; this updates it to `implemented_unverified`.

Greptile’s latest pass on #269 (`6ae183bc`) posted no new findings. The earlier cutover restore request remains declined (#273).

## Test plan

- [x] `cargo clippy -p bitcoin-rs --no-default-features --features fjall --all-targets -- -D warnings`
- [x] `cargo test -p bitcoin-rs-rpc --lib compared_methods_differ_from_core_exactly_as_declared`
- [x] `cargo test -p bitcoin-rs --no-default-features --features fjall --bin bitcoin-rs`
- [x] `cargo fmt --all -- --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-715d7e1a-2add-4fb2-8132-6af584b2970e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-715d7e1a-2add-4fb2-8132-6af584b2970e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

