### PR TITLE
Wire production P2P transaction ingress and relay

### DIFF
--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -1390,6 +1390,17 @@ pub(crate) fn disconnect_block_admitted(
     // publishes the rolled-back UTXO set and tip.
     if let Some(admission) = &handles.tx_admission {
         admission.invalidate_recent_rejects();
+        // Restored coins can make a previously-missing spend valid. Those
+        // children are indexed under the creating parent, which is already
+        // confirmed and will not publish another `Accepted` wake.
+        let restored_parents: HashSet<_> = undo
+            .restores()
+            .iter()
+            .map(|restored| restored.outpoint.txid)
+            .collect();
+        for parent in restored_parents {
+            admission.enqueue_orphans_waiting_on(parent);
+        }
     }
     Ok(parent_tip)
 }

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -901,6 +901,9 @@ pub struct ApplyHandles {
     /// Publishes checkpoints to settle rolled-back disconnect debt after a
     /// non-fatal reorg. `None` in unit-test handle sets that never reorg.
     pub(crate) checkpoint_publisher: Option<Arc<crate::checkpoint_worker::CheckpointPublisher>>,
+    /// P2P admission policy. Present in production so every chain movement
+    /// can clear recent-rejects and wake orphans; `None` in unit-test sets.
+    pub(crate) tx_admission: Option<Arc<crate::tx_admission::TxAdmission>>,
 }
 
 impl ApplyHandles {
@@ -984,6 +987,7 @@ impl ApplyHandles {
             assume_valid_gate: Arc::new(AssumeValidGate::with_anchor(None)),
             journal: None,
             checkpoint_publisher: None,
+            tx_admission: None,
         }
     }
 
@@ -1384,6 +1388,9 @@ pub(crate) fn disconnect_block_admitted(
     //
     // [`NodeState::write_clean_checkpoint`] clears the marker only after it
     // publishes the rolled-back UTXO set and tip.
+    if let Some(admission) = &handles.tx_admission {
+        admission.invalidate_recent_rejects();
+    }
     Ok(parent_tip)
 }
 
@@ -2724,6 +2731,14 @@ fn apply_block_admitted<'b>(
             block_txids,
             height,
         );
+        if let Some(admission) = &handles.tx_admission {
+            // Chain movement itself, not a non-empty pool mutation, owns
+            // reject invalidation: an empty sweep still advances the tip.
+            admission.invalidate_recent_rejects();
+            for txid in block_txids {
+                admission.enqueue_orphans_waiting_on(*txid);
+            }
+        }
     }
     let mempool_evict_dur = mempool_evict_started.elapsed();
     metrics::histogram!("node.apply_block.mempool_evict_seconds")

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -28,6 +28,8 @@ pub mod import;
 pub mod logging;
 /// Metrics instrumentation and optional exposition.
 pub mod metrics;
+/// P2P admission and local-relay mempool observer legs.
+mod mempool_observer;
 /// Node-owned mining candidate lifecycle coordinator.
 pub mod mining;
 /// Chain-event reconciliation seam for index consumers.

--- a/crates/node/src/mempool_observer.rs
+++ b/crates/node/src/mempool_observer.rs
@@ -1,0 +1,214 @@
+//! Node-owned mempool observers for P2P admission and local relay.
+//!
+//! Sequence ZMQ and mining-generation wakes stay with their owner crates
+//! ([`crate::zmq_publisher`] and [`crate::mining`]). This module holds only
+//! the two legs this wiring adds: recent-reject invalidation on chain
+//! movement, and `inv` announce for RPC/reorg accepts.
+
+use std::sync::Arc;
+
+use bitcoin_rs_mempool::{AdmissionOrigin, MempoolObserver, MutationEnvelope, MutationOutcome};
+use bitcoin_rs_primitives::{Txid, Wtxid};
+
+/// Clears the recent-rejects cache when the chain moves.
+///
+/// A transaction rejected against an old tip may become valid once its
+/// inputs confirm, so stale rejections must not suppress the next `inv`.
+pub(crate) struct RejectInvalidationObserver {
+    admission: Arc<crate::tx_admission::TxAdmission>,
+}
+
+impl RejectInvalidationObserver {
+    /// Observes chain-moving mutations on behalf of `admission`.
+    #[must_use]
+    pub(crate) fn new(admission: Arc<crate::tx_admission::TxAdmission>) -> Self {
+        Self { admission }
+    }
+}
+
+impl MempoolObserver for RejectInvalidationObserver {
+    fn on_mutation(&self, envelope: &MutationEnvelope) {
+        if matches!(
+            envelope.origin,
+            AdmissionOrigin::Block | AdmissionOrigin::Reorg
+        ) {
+            self.admission.invalidate_recent_rejects();
+        }
+    }
+}
+
+/// Announces locally-injected accepted transactions (`sendrawtransaction`,
+/// reorg re-admission) to every connected peer.
+///
+/// Peer-origin accepts are announced by the ingress consumer, which is the
+/// only place that still has the delivering connection id in scope at the
+/// moment of evaluation. This observer covers the origins that have no
+/// source peer to exclude.
+pub(crate) struct LocalTxRelayObserver {
+    relay: crate::tx_relay::TxRelayQueue,
+}
+
+impl LocalTxRelayObserver {
+    /// Relays accepted local mutations through `relay`.
+    #[must_use]
+    pub(crate) fn new(relay: crate::tx_relay::TxRelayQueue) -> Self {
+        Self { relay }
+    }
+}
+
+impl MempoolObserver for LocalTxRelayObserver {
+    fn on_mutation(&self, envelope: &MutationEnvelope) {
+        if !matches!(
+            envelope.origin,
+            AdmissionOrigin::Rpc | AdmissionOrigin::Reorg
+        ) {
+            return;
+        }
+        for change in &envelope.result.changes {
+            if !matches!(change.outcome, MutationOutcome::Accepted) {
+                continue;
+            }
+            let txid = Txid(change.txid);
+            // The mutation record carries txid only; the current `inv` path
+            // announces by txid, so the wtxid field is unused by the sink.
+            self.relay.announce(txid, Wtxid(change.txid), None);
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use bitcoin_rs_mempool::{
+        AdmissionOrigin, Mempool, MempoolGateway, MempoolLimits, MempoolObserver, MutationOutcome,
+    };
+    use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn tx(label: u8) -> Tx {
+        Tx {
+            version: 2,
+            lock_time: 0,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[label; 32])), 0),
+                script_sig: Vec::new(),
+                sequence: 0xffff_ffff,
+                witness: Vec::new(),
+            }],
+            outputs: vec![TxOut {
+                value: 1_000,
+                script_pubkey: vec![0x51, label],
+            }],
+        }
+    }
+
+    fn envelope(
+        origin: AdmissionOrigin,
+        txid: Hash256,
+        outcome: MutationOutcome,
+    ) -> bitcoin_rs_mempool::MutationEnvelope {
+        bitcoin_rs_mempool::MutationEnvelope {
+            origin,
+            result: bitcoin_rs_mempool::MutationResult {
+                changes: vec![bitcoin_rs_mempool::MutationChange { txid, outcome }],
+                sequence_base: 1,
+            },
+        }
+    }
+
+    #[test]
+    fn reject_invalidation_clears_cache_only_on_chain_movement() {
+        use bitcoin_rs_primitives::Wtxid;
+
+        let gateway = MempoolGateway::new(
+            Arc::new(RwLock::new(Mempool::new(MempoolLimits::default()))),
+            None,
+        );
+        let admission = Arc::new(crate::tx_admission::TxAdmission::new(Arc::new(gateway)));
+        let rejected = tx(8);
+        admission.record_reject(rejected.txid(), rejected.wtxid());
+        assert!(admission.is_rejected(Hash256::from(rejected.txid())));
+
+        let observer = super::RejectInvalidationObserver::new(Arc::clone(&admission));
+        observer.on_mutation(&envelope(
+            AdmissionOrigin::Rpc,
+            Hash256::from(rejected.txid()),
+            MutationOutcome::Accepted,
+        ));
+        assert!(
+            admission.is_rejected(Hash256::from(rejected.txid())),
+            "RPC admission must not drop recent-rejects"
+        );
+
+        observer.on_mutation(&envelope(
+            AdmissionOrigin::Block,
+            Hash256::from(rejected.txid()),
+            MutationOutcome::Removed(bitcoin_rs_mempool::RemovalReason::BlockInclusion),
+        ));
+        assert!(
+            !admission.is_rejected(Hash256::from(rejected.txid())),
+            "block-connect must drop recent-rejects"
+        );
+
+        admission.record_reject(rejected.txid(), Wtxid(rejected.txid().0));
+        observer.on_mutation(&envelope(
+            AdmissionOrigin::Reorg,
+            Hash256::from(rejected.txid()),
+            MutationOutcome::Accepted,
+        ));
+        assert!(
+            !admission.is_rejected(Hash256::from(rejected.txid())),
+            "reorg must drop recent-rejects"
+        );
+    }
+
+    #[test]
+    fn local_tx_relay_announces_rpc_and_reorg_accepts_only() {
+        use bitcoin_rs_mempool::PeerToken;
+        use bitcoin_rs_primitives::Wtxid;
+
+        let (queue, rx) = crate::tx_relay::TxRelayQueue::new(8);
+        let observer = super::LocalTxRelayObserver::new(queue);
+        let accepted = tx(9);
+        let txid_hash = Hash256::from(accepted.txid());
+
+        observer.on_mutation(&envelope(
+            AdmissionOrigin::Peer(PeerToken {
+                addr: std::net::SocketAddr::from(([127, 0, 0, 1], 8333)),
+                connection_id: 7,
+            }),
+            txid_hash,
+            MutationOutcome::Accepted,
+        ));
+        assert!(
+            rx.try_recv().is_err(),
+            "peer-origin accepts are announced by the ingress consumer"
+        );
+
+        observer.on_mutation(&envelope(
+            AdmissionOrigin::Rpc,
+            txid_hash,
+            MutationOutcome::Removed(bitcoin_rs_mempool::RemovalReason::PolicyEviction),
+        ));
+        assert!(rx.try_recv().is_err(), "removals must not announce");
+
+        observer.on_mutation(&envelope(
+            AdmissionOrigin::Rpc,
+            txid_hash,
+            MutationOutcome::Accepted,
+        ));
+        let announced = rx.try_recv().expect("RPC accept must announce");
+        assert_eq!(announced.txid, accepted.txid());
+        assert_eq!(announced.wtxid, Wtxid(txid_hash));
+        assert_eq!(announced.source, None);
+
+        observer.on_mutation(&envelope(
+            AdmissionOrigin::Reorg,
+            txid_hash,
+            MutationOutcome::Accepted,
+        ));
+        let announced = rx.try_recv().expect("reorg accept must announce");
+        assert_eq!(announced.source, None);
+    }
+}

--- a/crates/node/src/mempool_observer.rs
+++ b/crates/node/src/mempool_observer.rs
@@ -2,37 +2,39 @@
 //!
 //! Sequence ZMQ and mining-generation wakes stay with their owner crates
 //! ([`crate::zmq_publisher`] and [`crate::mining`]). This module holds only
-//! the two legs this wiring adds: recent-reject invalidation on chain
-//! movement, and `inv` announce for RPC/reorg accepts.
+//! the two legs this wiring adds: orphan wake on any-origin parent accept,
+//! and `inv` announce for RPC/reorg accepts. Chain movement clears
+//! recent-rejects in [`crate::apply`], not here.
 
 use std::sync::Arc;
 
 use bitcoin_rs_mempool::{AdmissionOrigin, MempoolObserver, MutationEnvelope, MutationOutcome};
 use bitcoin_rs_primitives::{Txid, Wtxid};
 
-/// Clears the recent-rejects cache when the chain moves.
+/// Re-queues orphans whose parent was just admitted, from any origin.
 ///
-/// A transaction rejected against an old tip may become valid once its
-/// inputs confirm, so stale rejections must not suppress the next `inv`.
-pub(crate) struct RejectInvalidationObserver {
+/// Peer, RPC, and reorg accepts all publish `Accepted` here, so waiting
+/// children share one wake path. Block confirmation of a parent that was
+/// never in the pool is handled by the apply path, which sees every
+/// connected txid.
+pub(crate) struct OrphanWakeObserver {
     admission: Arc<crate::tx_admission::TxAdmission>,
 }
 
-impl RejectInvalidationObserver {
-    /// Observes chain-moving mutations on behalf of `admission`.
+impl OrphanWakeObserver {
+    /// Wakes held children when `admission` sees a newly available parent.
     #[must_use]
     pub(crate) fn new(admission: Arc<crate::tx_admission::TxAdmission>) -> Self {
         Self { admission }
     }
 }
 
-impl MempoolObserver for RejectInvalidationObserver {
+impl MempoolObserver for OrphanWakeObserver {
     fn on_mutation(&self, envelope: &MutationEnvelope) {
-        if matches!(
-            envelope.origin,
-            AdmissionOrigin::Block | AdmissionOrigin::Reorg
-        ) {
-            self.admission.invalidate_recent_rejects();
+        for change in &envelope.result.changes {
+            if matches!(change.outcome, MutationOutcome::Accepted) {
+                self.admission.enqueue_orphans_waiting_on(Txid(change.txid));
+            }
         }
     }
 }
@@ -82,6 +84,7 @@ mod tests {
     use bitcoin_rs_mempool::{
         AdmissionOrigin, Mempool, MempoolGateway, MempoolLimits, MempoolObserver, MutationOutcome,
     };
+    use bitcoin_rs_p2p::InboundTx;
     use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
     use parking_lot::RwLock;
     use std::sync::Arc;
@@ -118,49 +121,35 @@ mod tests {
     }
 
     #[test]
-    fn reject_invalidation_clears_cache_only_on_chain_movement() {
-        use bitcoin_rs_primitives::Wtxid;
-
+    fn orphan_wake_requeues_children_on_parent_accept() {
         let gateway = MempoolGateway::new(
             Arc::new(RwLock::new(Mempool::new(MempoolLimits::default()))),
             None,
         );
         let admission = Arc::new(crate::tx_admission::TxAdmission::new(Arc::new(gateway)));
-        let rejected = tx(8);
-        admission.record_reject(rejected.txid(), rejected.wtxid());
-        assert!(admission.is_rejected(Hash256::from(rejected.txid())));
+        let (ingress_tx, ingress_rx) = crossbeam_channel::bounded::<InboundTx>(4);
+        admission.attach_ingress(ingress_tx);
 
-        let observer = super::RejectInvalidationObserver::new(Arc::clone(&admission));
+        let child = Arc::new(tx(8));
+        let parent = child.inputs[0].previous_output.txid;
+        let (lease_tx, _lease_rx) = crossbeam_channel::unbounded();
+        let source = bitcoin_rs_p2p::PeerLease::new(lease_tx)
+            .source(std::net::SocketAddr::from(([127, 0, 0, 1], 8333)));
+        admission.record_orphan(&child, source);
+
+        let observer = super::OrphanWakeObserver::new(Arc::clone(&admission));
         observer.on_mutation(&envelope(
             AdmissionOrigin::Rpc,
-            Hash256::from(rejected.txid()),
+            Hash256::from(parent),
             MutationOutcome::Accepted,
         ));
-        assert!(
-            admission.is_rejected(Hash256::from(rejected.txid())),
-            "RPC admission must not drop recent-rejects"
-        );
 
-        observer.on_mutation(&envelope(
-            AdmissionOrigin::Block,
-            Hash256::from(rejected.txid()),
-            MutationOutcome::Removed(bitcoin_rs_mempool::RemovalReason::BlockInclusion),
-        ));
-        assert!(
-            !admission.is_rejected(Hash256::from(rejected.txid())),
-            "block-connect must drop recent-rejects"
-        );
-
-        admission.record_reject(rejected.txid(), Wtxid(rejected.txid().0));
-        observer.on_mutation(&envelope(
-            AdmissionOrigin::Reorg,
-            Hash256::from(rejected.txid()),
-            MutationOutcome::Accepted,
-        ));
-        assert!(
-            !admission.is_rejected(Hash256::from(rejected.txid())),
-            "reorg must drop recent-rejects"
-        );
+        let inbound = ingress_rx
+            .try_recv()
+            .expect("accepted parent must re-queue the waiting child");
+        assert_eq!(inbound.tx.txid(), child.txid());
+        assert_eq!(inbound.source, source);
+        assert_eq!(admission.orphan_count(), 0);
     }
 
     #[test]

--- a/crates/node/src/reorg.rs
+++ b/crates/node/src/reorg.rs
@@ -647,12 +647,9 @@ fn reconsider_disconnected_transactions<F>(
         .reconsider_disconnected(AdmissionOrigin::Reorg, entries);
 }
 
-/// Core's `IsCoinBase`: a single input spending the null prevout (zero txid,
-/// `vout` `u32::MAX`). The derived all-zero outpoint (`vout` 0) is not null.
+/// Core's `IsCoinBase`: a single input spending the null prevout.
 fn is_coinbase(tx: &Tx) -> bool {
-    tx.inputs.len() == 1
-        && tx.inputs[0].previous_output.txid == Txid::default()
-        && tx.inputs[0].previous_output.vout == u32::MAX
+    tx.inputs.len() == 1 && tx.inputs[0].previous_output.is_null()
 }
 
 /// Prices `tx` for re-admission, or returns `None` when an input is neither a

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -834,7 +834,8 @@ pub(crate) fn start_node(
     // owned reference here would cycle through `apply_handles`.
     state.mining_generation_signal().attach(&mining_control);
     let tx_admission = state.tx_admission();
-    let tx_inventory: Arc<dyn bitcoin_rs_p2p::TxInventory> = Arc::clone(&tx_admission);
+    let cloned_admission = Arc::clone(&tx_admission);
+    let tx_inventory: Arc<dyn bitcoin_rs_p2p::TxInventory> = cloned_admission;
     let listener_extras = bitcoin_rs_p2p::ListenerExtras {
         tx_inventory: Some(tx_inventory),
         inbound_tx: Some(state.inbound_tx_sender()),

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -435,6 +435,10 @@ pub(crate) struct NodeServices {
     /// Periodic chainstate checkpoint worker; joined before the clean
     /// checkpoint publication so it does not race the final write.
     checkpoint_worker: Option<std::thread::JoinHandle<()>>,
+    /// P2P transaction ingress consumer; drains inbound `tx` into admission.
+    tx_ingress: Option<std::thread::JoinHandle<()>>,
+    /// Outbound transaction-inventory relay worker.
+    tx_relay: Option<std::thread::JoinHandle<()>>,
     /// Process-level SIGINT/SIGTERM forwarding handler, owned by the graph
     /// so the shared teardown — never a leak — closes and joins it.
     signal_handler: Option<crate::signal::ShutdownHandler>,
@@ -496,8 +500,9 @@ impl NodeServices {
 
     /// Joins the stages that run before the bounded subsystem drain: the
     /// event loop, the rpc listener, every p2p listener, the metrics
-    /// listener, and the outbound drain worker. Every stage still runs when
-    /// an earlier one fails; the first failure lands in `first_error`.
+    /// listener, the outbound drain worker, and the tx ingress/relay
+    /// workers. Every stage still runs when an earlier one fails; the first
+    /// failure lands in `first_error`.
     fn join_core_services(
         &mut self,
         state: Option<&NodeState>,
@@ -559,6 +564,22 @@ impl NodeServices {
         if let Some(state) = state {
             if let Err(error) = state.p2p().join_core_workers() {
                 set_first_error(first_error, anyhow::Error::new(error));
+            }
+        }
+        if let Some(handle) = self.tx_ingress.take() {
+            if matches!(handle.join(), Ok(())) {
+                tracing::info!("tx ingress consumer exited cleanly");
+            } else {
+                tracing::error!("tx ingress consumer panicked");
+                set_first_error(first_error, anyhow::anyhow!("tx ingress consumer panicked"));
+            }
+        }
+        if let Some(handle) = self.tx_relay.take() {
+            if matches!(handle.join(), Ok(())) {
+                tracing::info!("tx relay worker exited cleanly");
+            } else {
+                tracing::error!("tx relay worker panicked");
+                set_first_error(first_error, anyhow::anyhow!("tx relay worker panicked"));
             }
         }
     }
@@ -812,6 +833,30 @@ pub(crate) fn start_node(
     // coordinator's lifetime: the RPC context owns the coordinator, and an
     // owned reference here would cycle through `apply_handles`.
     state.mining_generation_signal().attach(&mining_control);
+    let tx_admission = state.tx_admission();
+    let tx_inventory: Arc<dyn bitcoin_rs_p2p::TxInventory> = Arc::clone(&tx_admission);
+    let listener_extras = bitcoin_rs_p2p::ListenerExtras {
+        tx_inventory: Some(tx_inventory),
+        inbound_tx: Some(state.inbound_tx_sender()),
+    };
+    let ingress = crate::tx_ingress::spawn_tx_ingress_consumer(
+        state,
+        state.mempool_gateway(),
+        Arc::clone(&mining_control),
+        Arc::clone(&shutdown),
+        state.inbound_tx_rx_handle(),
+        Arc::clone(&tx_admission),
+    )?;
+    if let Err(error) = state.mempool_gateway().attach_observer_leg(
+        "tx-relay",
+        Arc::new(crate::mempool_observer::LocalTxRelayObserver::new(
+            ingress.queue.clone(),
+        )),
+    ) {
+        tracing::error!(error, "failed to attach local tx-relay observer");
+    }
+    guard.services.tx_ingress = Some(ingress.ingress);
+    guard.services.tx_relay = Some(ingress.relay);
     let rpc_auth = Arc::new(build_rpc_auth(&state.config().rpc.auth)?);
     let mut rpc_context =
         bitcoin_rs_rpc::context::Context::from_handles(bitcoin_rs_rpc::context::ContextHandles {
@@ -876,15 +921,20 @@ pub(crate) fn start_node(
         .spawn(move || rpc_server.serve_with_shutdown(rpc_shutdown))?;
     guard.services.rpc_thread = Some(rpc_thread);
     // P2pService is the single owner of listener, outbound, bootstrap, and
-    // download-window workers. The node supplies only chain reads and sync
-    // wake delivery.
+    // download-window workers. The node supplies chain reads, sync wake,
+    // and the transaction inventory / ingress sinks.
     let peer_ready: Arc<dyn Fn(bitcoin_rs_p2p::PeerSource) + Send + Sync> =
         Arc::new(move |source: bitcoin_rs_p2p::PeerSource| {
             peer_ready_sync.on_peer_ready(source);
         });
     state
         .p2p()
-        .start(Some(&p2p_chain_query), Some(&sync_wake_tx), &peer_ready)
+        .start(
+            Some(&p2p_chain_query),
+            Some(&sync_wake_tx),
+            &peer_ready,
+            listener_extras,
+        )
         .map_err(anyhow::Error::from)?;
     // Periodic chainstate checkpoint worker: publishes a checkpoint every
     // CHECKPOINT_INTERVAL_BLOCKS or CHECKPOINT_INTERVAL_SECS so a node

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1839,7 +1839,9 @@ impl NodeState {
             } else if let Some(observer) = mempool_observer.cloned() {
                 composite.add_leg("test", observer);
             }
-            composite.add_leg("mining", Arc::clone(&mining_generation) as _);
+            let cloned_mining = Arc::clone(&mining_generation);
+            let mining_leg: Arc<dyn bitcoin_rs_mempool::MempoolObserver> = cloned_mining;
+            composite.add_leg("mining", mining_leg);
             bitcoin_rs_mempool::MempoolGateway::shared_with(
                 Arc::clone(&mempool),
                 Arc::new(composite),

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -62,6 +62,12 @@ pub(crate) const INBOUND_BLOCK_CHANNEL_LIMIT: usize = 256;
 // inbound-block bound so both channels share the same flood posture; a full
 // channel drops the hint and never blocks the commit path.
 pub(crate) const CHAIN_HINT_CHANNEL_LIMIT: usize = INBOUND_BLOCK_CHANNEL_LIMIT;
+// Bounds inbound peer transactions between the per-peer listener threads and
+// the single ingress consumer. A full channel applies TCP backpressure to
+// that peer's read loop; other peers keep their own threads. Sized to absorb
+// a burst of honest `tx` deliveries without stalling header/block traffic on
+// the same connection under normal load.
+pub(crate) const INBOUND_TX_CHANNEL_LIMIT: usize = 1_024;
 
 /// A coherent, non-torn view of the applied chain tip.
 ///
@@ -1479,6 +1485,10 @@ pub struct NodeState {
     inbound_headers_rx: Arc<Mutex<Receiver<bitcoin_rs_p2p::InboundHeaders>>>,
     inbound_blocks_tx: Sender<bitcoin_rs_p2p::InboundBlock>,
     inbound_blocks_rx: Arc<Mutex<Receiver<bitcoin_rs_p2p::InboundBlock>>>,
+    inbound_tx_tx: Sender<bitcoin_rs_p2p::InboundTx>,
+    inbound_tx_rx: Arc<Mutex<Receiver<bitcoin_rs_p2p::InboundTx>>>,
+    /// Process-wide P2P admission policy (orphan map + recent-rejects).
+    tx_admission: Arc<crate::tx_admission::TxAdmission>,
     chain_events: Arc<ChainEventPublisher>,
     chain_event_hints_rx: Arc<Mutex<Receiver<ChainEventHint>>>,
     apply_handles: crate::apply::ApplyHandles,
@@ -1802,6 +1812,9 @@ impl NodeState {
         let inbound_headers_rx = p2p.inbound_headers_receiver();
         let inbound_blocks_tx = p2p.inbound_blocks_sender();
         let inbound_blocks_rx = p2p.inbound_blocks_receiver();
+        let (inbound_tx_tx, inbound_tx_rx_raw) =
+            crossbeam_channel::bounded::<bitcoin_rs_p2p::InboundTx>(INBOUND_TX_CHANNEL_LIMIT);
+        let inbound_tx_rx = Arc::new(Mutex::new(inbound_tx_rx_raw));
         let chain_event_hints_rx = Arc::new(Mutex::new(chain_event_hints_rx_raw));
         // The template-coordinator wake exists from node birth so the apply
         // path and the gateway can fire it before `run` builds the
@@ -1832,6 +1845,21 @@ impl NodeState {
                 Arc::new(composite),
             )
         };
+        let tx_admission = Arc::new(crate::tx_admission::TxAdmission::new(Arc::clone(
+            &mempool_gateway,
+        )));
+        // Chain movement (block connect / reorg) must drop stale recent-rejects
+        // so a previously-invalid tx can be requested again once its inputs
+        // confirm. The apply path already publishes those mutations through
+        // this gateway; the observer is the one place that sees them all.
+        if let Err(error) = mempool_gateway.attach_observer_leg(
+            "tx-admission",
+            Arc::new(crate::mempool_observer::RejectInvalidationObserver::new(
+                Arc::clone(&tx_admission),
+            )),
+        ) {
+            tracing::error!(error, "failed to attach tx-admission observer");
+        }
         let mut apply_handles = crate::apply::ApplyHandles {
             network: config.network,
             chain_tip: Arc::clone(&chain_tip),
@@ -1952,6 +1980,9 @@ impl NodeState {
             inbound_headers_rx,
             inbound_blocks_tx,
             inbound_blocks_rx,
+            inbound_tx_tx,
+            inbound_tx_rx,
+            tx_admission,
             chain_events: Arc::clone(&chain_events),
             chain_event_hints_rx,
             apply_handles,
@@ -2345,6 +2376,25 @@ impl NodeState {
     #[must_use]
     pub fn inbound_blocks_rx_handle(&self) -> Arc<Mutex<Receiver<bitcoin_rs_p2p::InboundBlock>>> {
         Arc::clone(&self.inbound_blocks_rx)
+    }
+
+    /// Returns a cloned `Sender` that the P2P listener pushes inbound
+    /// transactions into for mempool admission.
+    pub fn inbound_tx_sender(&self) -> Sender<bitcoin_rs_p2p::InboundTx> {
+        self.inbound_tx_tx.clone()
+    }
+
+    /// Returns the shared receiver handle drained by the tx-ingress consumer.
+    #[must_use]
+    pub fn inbound_tx_rx_handle(&self) -> Arc<Mutex<Receiver<bitcoin_rs_p2p::InboundTx>>> {
+        Arc::clone(&self.inbound_tx_rx)
+    }
+
+    /// Returns the process-wide P2P admission policy (orphan map, recent-rejects,
+    /// and the [`bitcoin_rs_p2p::TxInventory`] implementation).
+    #[must_use]
+    pub fn tx_admission(&self) -> Arc<crate::tx_admission::TxAdmission> {
+        Arc::clone(&self.tx_admission)
     }
 
     /// Returns the current coherent chain snapshot: the applied tip stamped
@@ -3028,6 +3078,36 @@ mod tests {
         assert!(
             matches!(overflow, Err(crossbeam_channel::TrySendError::Full(_))),
             "channel must reject blocks past INBOUND_BLOCK_CHANNEL_LIMIT, got {overflow:?}",
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn inbound_tx_channel_is_bounded_against_flood() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut config = crate::NodeConfig::default_for_network(crate::Network::Regtest);
+        config.data_dir = dir.path().join("node");
+        config.p2p.listen.clear();
+        let state = NodeState::open(config, None)?;
+        let sender = state.inbound_tx_sender();
+        let (lease_tx, _lease_rx) = crossbeam_channel::unbounded();
+        let lease = bitcoin_rs_p2p::PeerLease::new(lease_tx);
+        let source = lease.source(std::net::SocketAddr::from(([127, 0, 0, 1], 8333)));
+        let tx = bitcoin_rs_primitives::Tx {
+            version: 1,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            lock_time: 0,
+        };
+        for _ in 0..super::INBOUND_TX_CHANNEL_LIMIT {
+            sender
+                .try_send(bitcoin_rs_p2p::InboundTx::new(tx.clone(), source))
+                .unwrap_or_else(|error| panic!("send within the bound must succeed: {error}"));
+        }
+        let overflow = sender.try_send(bitcoin_rs_p2p::InboundTx::new(tx, source));
+        assert!(
+            matches!(overflow, Err(crossbeam_channel::TrySendError::Full(_))),
+            "channel must reject txs past INBOUND_TX_CHANNEL_LIMIT, got {overflow:?}",
         );
         Ok(())
     }

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1848,17 +1848,14 @@ impl NodeState {
         let tx_admission = Arc::new(crate::tx_admission::TxAdmission::new(Arc::clone(
             &mempool_gateway,
         )));
-        // Chain movement (block connect / reorg) must drop stale recent-rejects
-        // so a previously-invalid tx can be requested again once its inputs
-        // confirm. The apply path already publishes those mutations through
-        // this gateway; the observer is the one place that sees them all.
+        tx_admission.attach_ingress(inbound_tx_tx.clone());
         if let Err(error) = mempool_gateway.attach_observer_leg(
-            "tx-admission",
-            Arc::new(crate::mempool_observer::RejectInvalidationObserver::new(
+            "tx-orphans",
+            Arc::new(crate::mempool_observer::OrphanWakeObserver::new(
                 Arc::clone(&tx_admission),
             )),
         ) {
-            tracing::error!(error, "failed to attach tx-admission observer");
+            tracing::error!(error, "failed to attach orphan-wake observer");
         }
         let mut apply_handles = crate::apply::ApplyHandles {
             network: config.network,
@@ -1888,6 +1885,7 @@ impl NodeState {
             )),
             journal,
             checkpoint_publisher: None,
+            tx_admission: Some(Arc::clone(&tx_admission)),
         };
         apply_handles.assume_valid_gate.evaluate(&block_tree.read());
         // A restored checkpoint is durable at its own height by definition, so

--- a/crates/node/src/tx_admission.rs
+++ b/crates/node/src/tx_admission.rs
@@ -51,6 +51,11 @@ pub struct TxAdmission {
     /// Optional ingress producer used to re-queue orphans when a parent
     /// becomes available from any origin (peer, RPC, reorg, or block).
     ingress: Mutex<Option<Sender<InboundTx>>>,
+    /// Children whose parent became available but could not be `try_send`'d
+    /// onto the bounded ingress channel. The ingress consumer drains this
+    /// directly so a parent that will not be accepted again cannot leave
+    /// them parked under `have_tx`.
+    pending_retries: Mutex<VecDeque<Txid>>,
 }
 
 /// An orphan body plus the peer that delivered it.
@@ -100,6 +105,7 @@ impl TxAdmission {
             quota,
             reject_cap: DEFAULT_REJECT_CAP,
             ingress: Mutex::new(None),
+            pending_retries: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -184,8 +190,11 @@ impl TxAdmission {
 
     /// Re-queues every orphan waiting on `parent` into the ingress channel.
     ///
-    /// Used when a parent is admitted (any origin) or confirmed in a block.
-    /// A full or missing channel puts the orphan back so it is not dropped.
+    /// Used when a parent is admitted (any origin), confirmed in a block, or
+    /// restored by a disconnect. A full or missing channel keeps the body in
+    /// the orphan map (so `have_tx` still suppresses re-requests) and records
+    /// it for [`Self::take_orphan_retries`], which the ingress consumer drains
+    /// without waiting for another parent-accept event.
     pub fn enqueue_orphans_waiting_on(&self, parent: Txid) {
         for (tx, source) in self.take_orphans_waiting_on(parent) {
             let inbound = InboundTx::new((*tx).clone(), source);
@@ -195,9 +204,26 @@ impl TxAdmission {
                 .as_ref()
                 .is_some_and(|sender| sender.try_send(inbound).is_ok());
             if !sent {
+                let txid = tx.txid();
                 self.record_orphan(&tx, source);
+                self.pending_retries.lock().push_back(txid);
             }
         }
+    }
+
+    /// Takes every orphan that failed to re-enter the ingress channel.
+    ///
+    /// The ingress consumer processes these directly so a saturated channel
+    /// cannot pin children under a parent that will not be accepted again.
+    pub fn take_orphan_retries(&self) -> Vec<(Arc<Tx>, PeerSource)> {
+        let txids: Vec<Txid> = {
+            let mut pending = self.pending_retries.lock();
+            pending.drain(..).collect()
+        };
+        txids
+            .into_iter()
+            .filter_map(|txid| self.take_orphan(&txid))
+            .collect()
     }
 
     /// Records a rejected transaction in the recent-rejects cache by both
@@ -531,6 +557,48 @@ mod tests {
             .get_tx(txid)
             .expect("getdata for a held orphan must serve its body");
         assert_eq!(served.txid(), txid);
+    }
+
+    #[test]
+    fn enqueue_parks_retries_when_the_ingress_channel_is_full() {
+        let gateway = empty_gateway();
+        let admission = TxAdmission::new(gateway);
+        let (ingress_tx, _ingress_rx) = crossbeam_channel::bounded::<InboundTx>(1);
+        admission.attach_ingress(ingress_tx.clone());
+
+        let filler = tx_with_marker(1);
+        ingress_tx
+            .try_send(InboundTx::new(filler, test_source()))
+            .expect("the single channel slot must fill");
+
+        let child = Arc::new(tx_with_marker(6));
+        let parent = Txid::from(Hash256::from_le_bytes(&[6; 32]));
+        let source = test_source();
+        admission.record_orphan(&child, source);
+        admission.enqueue_orphans_waiting_on(parent);
+
+        assert_eq!(
+            admission.orphan_count(),
+            1,
+            "a full channel must keep the child so have_tx still suppresses re-requests"
+        );
+        assert!(
+            admission.have_tx(Hash256::from(child.txid()), false),
+            "a parked retry must still count as have_tx"
+        );
+
+        let retries = admission.take_orphan_retries();
+        assert_eq!(
+            retries.len(),
+            1,
+            "the ingress consumer must be able to drain the parked child"
+        );
+        assert_eq!(retries[0].0.txid(), child.txid());
+        assert_eq!(
+            admission.orphan_count(),
+            0,
+            "take_orphan_retries must remove the child from the orphan map"
+        );
     }
 
     #[test]

--- a/crates/node/src/tx_admission.rs
+++ b/crates/node/src/tx_admission.rs
@@ -22,8 +22,9 @@ use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
 use bitcoin_rs_mempool::MempoolGateway;
-use bitcoin_rs_p2p::TxInventory;
+use bitcoin_rs_p2p::{InboundTx, PeerSource, TxInventory};
 use bitcoin_rs_primitives::{Hash256, Tx, Txid, Wtxid};
+use crossbeam_channel::Sender;
 use parking_lot::Mutex;
 
 /// Default maximum number of orphan transactions held for parent arrival.
@@ -47,13 +48,23 @@ pub struct TxAdmission {
     gateway: Arc<MempoolGateway>,
     quota: usize,
     reject_cap: usize,
+    /// Optional ingress producer used to re-queue orphans when a parent
+    /// becomes available from any origin (peer, RPC, reorg, or block).
+    ingress: Mutex<Option<Sender<InboundTx>>>,
+}
+
+/// An orphan body plus the peer that delivered it.
+#[derive(Clone, Debug)]
+struct HeldOrphan {
+    tx: Arc<Tx>,
+    source: PeerSource,
 }
 
 #[derive(Debug, Default)]
 struct AdmissionInner {
     /// Orphan transactions keyed by txid, stored in insertion order via
     /// [`orphan_order`] for FIFO eviction.
-    orphans: hashbrown::HashMap<Txid, Arc<Tx>>,
+    orphans: hashbrown::HashMap<Txid, HeldOrphan>,
     /// Secondary index: wtxid → txid, so BIP339 wtxid-typed inventory can
     /// be matched against held orphans without a linear scan.
     orphan_by_wtxid: hashbrown::HashMap<Wtxid, Txid>,
@@ -88,7 +99,14 @@ impl TxAdmission {
             gateway,
             quota,
             reject_cap: DEFAULT_REJECT_CAP,
+            ingress: Mutex::new(None),
         }
+    }
+
+    /// Installs the ingress producer used to re-queue orphans when a parent
+    /// becomes available. Called once from [`crate::state::NodeState::open`].
+    pub fn attach_ingress(&self, tx: Sender<InboundTx>) {
+        *self.ingress.lock() = Some(tx);
     }
 
     /// Records an orphan transaction (missing prevouts) for parent arrival.
@@ -97,19 +115,23 @@ impl TxAdmission {
     /// (FIFO), so after `quota + 1` inserts the map size is exactly
     /// `quota`. Re-inserting an already-held orphan (by txid) refreshes its
     /// body without growing the map.
-    pub fn record_orphan(&self, tx: &Arc<Tx>) {
+    pub fn record_orphan(&self, tx: &Arc<Tx>, source: PeerSource) {
         let txid = tx.txid();
         let wtxid = tx.wtxid();
         let mut inner = self.inner.lock();
-        if let Some(old) = inner.orphans.insert(txid, Arc::clone(tx)) {
+        let held = HeldOrphan {
+            tx: Arc::clone(tx),
+            source,
+        };
+        if let Some(old) = inner.orphans.insert(txid, held) {
             // Replace: refresh the body without growing the map or
             // reordering. Drop the previous body's wtxid index entry so a
             // changed witness does not leave a stale wtxid → txid mapping.
-            let old_wtxid = old.wtxid();
+            let old_wtxid = old.tx.wtxid();
             if old_wtxid != wtxid {
                 inner.orphan_by_wtxid.remove(&old_wtxid);
             }
-            unindex_orphan_parents(&mut inner, &txid, &old);
+            unindex_orphan_parents(&mut inner, &txid, &old.tx);
             index_orphan_parents(&mut inner, tx);
         } else {
             // New entry: append and evict the oldest over the quota.
@@ -120,8 +142,8 @@ impl TxAdmission {
                     break;
                 };
                 if let Some(evicted_tx) = inner.orphans.remove(&evicted) {
-                    inner.orphan_by_wtxid.remove(&evicted_tx.wtxid());
-                    unindex_orphan_parents(&mut inner, &evicted, &evicted_tx);
+                    inner.orphan_by_wtxid.remove(&evicted_tx.tx.wtxid());
+                    unindex_orphan_parents(&mut inner, &evicted, &evicted_tx.tx);
                 }
             }
         }
@@ -134,23 +156,22 @@ impl TxAdmission {
         }
     }
 
-    /// Removes an orphan by txid, returning its body if present. Used when a
-    /// parent arrives and the orphan is re-evaluated through the gateway.
-    pub fn take_orphan(&self, txid: &Txid) -> Option<Arc<Tx>> {
+    /// Removes an orphan by txid, returning its body and delivering peer.
+    pub fn take_orphan(&self, txid: &Txid) -> Option<(Arc<Tx>, PeerSource)> {
         let mut inner = self.inner.lock();
-        let tx = inner.orphans.remove(txid)?;
-        inner.orphan_by_wtxid.remove(&tx.wtxid());
+        let held = inner.orphans.remove(txid)?;
+        inner.orphan_by_wtxid.remove(&held.tx.wtxid());
         inner.orphan_order.retain(|id| id != txid);
-        unindex_orphan_parents(&mut inner, txid, &tx);
-        Some(tx)
+        unindex_orphan_parents(&mut inner, txid, &held.tx);
+        Some((held.tx, held.source))
     }
 
     /// Removes and returns every orphan that spends an output of `parent`.
     ///
-    /// Called when `parent` is admitted so the children can be re-evaluated
-    /// through the gateway. Missing children (already evicted or taken) are
-    /// skipped.
-    pub fn take_orphans_waiting_on(&self, parent: Txid) -> Vec<Arc<Tx>> {
+    /// Called when `parent` becomes available so the children can be
+    /// re-evaluated through the gateway. Missing children (already evicted
+    /// or taken) are skipped.
+    pub fn take_orphans_waiting_on(&self, parent: Txid) -> Vec<(Arc<Tx>, PeerSource)> {
         let waiting = {
             let mut inner = self.inner.lock();
             inner.orphans_waiting.remove(&parent).unwrap_or_default()
@@ -159,6 +180,24 @@ impl TxAdmission {
             .into_iter()
             .filter_map(|txid| self.take_orphan(&txid))
             .collect()
+    }
+
+    /// Re-queues every orphan waiting on `parent` into the ingress channel.
+    ///
+    /// Used when a parent is admitted (any origin) or confirmed in a block.
+    /// A full or missing channel puts the orphan back so it is not dropped.
+    pub fn enqueue_orphans_waiting_on(&self, parent: Txid) {
+        for (tx, source) in self.take_orphans_waiting_on(parent) {
+            let inbound = InboundTx::new((*tx).clone(), source);
+            let sent = self
+                .ingress
+                .lock()
+                .as_ref()
+                .is_some_and(|sender| sender.try_send(inbound).is_ok());
+            if !sent {
+                self.record_orphan(&tx, source);
+            }
+        }
     }
 
     /// Records a rejected transaction in the recent-rejects cache by both
@@ -237,7 +276,7 @@ impl TxAdmission {
             .lock()
             .orphans
             .get(txid)
-            .map(|arc| (**arc).clone())
+            .map(|held| (*held.tx).clone())
     }
 
     /// Looks up a transaction body by wtxid by scanning the mempool entries
@@ -251,7 +290,7 @@ impl TxAdmission {
         }
         let inner = self.inner.lock();
         let txid = inner.orphan_by_wtxid.get(wtxid)?;
-        inner.orphans.get(txid).map(|arc| (**arc).clone())
+        inner.orphans.get(txid).map(|held| (*held.tx).clone())
     }
 
     fn have_tx(&self, hash: Hash256, wtxid_relay: bool) -> bool {
@@ -295,7 +334,9 @@ impl TxAdmission {
 fn index_orphan_parents(inner: &mut AdmissionInner, tx: &Tx) {
     let txid = tx.txid();
     for input in &tx.inputs {
-        if input.previous_output == bitcoin_rs_primitives::OutPoint::default() {
+        if input.previous_output.is_null()
+            || input.previous_output == bitcoin_rs_primitives::OutPoint::default()
+        {
             continue;
         }
         inner
@@ -349,6 +390,12 @@ mod tests {
         MempoolGateway::shared(pool)
     }
 
+    fn test_source() -> PeerSource {
+        let (tx, _rx) = crossbeam_channel::unbounded();
+        bitcoin_rs_p2p::PeerLease::new(tx)
+            .source(std::net::SocketAddr::from(([127, 0, 0, 1], 8333)))
+    }
+
     fn tx_with_marker(byte: u8) -> Tx {
         Tx {
             version: 2,
@@ -377,7 +424,7 @@ mod tests {
         // Insert quota + 1 = 5 distinct orphans.
         for byte in 1..=5_u8 {
             let tx = Arc::new(tx_with_marker(byte));
-            admission.record_orphan(&tx);
+            admission.record_orphan(&tx, test_source());
         }
 
         assert_eq!(
@@ -393,9 +440,9 @@ mod tests {
         let admission = TxAdmission::with_quota(gateway, 4);
         let tx = Arc::new(tx_with_marker(1));
 
-        admission.record_orphan(&tx);
-        admission.record_orphan(&tx);
-        admission.record_orphan(&tx);
+        admission.record_orphan(&tx, test_source());
+        admission.record_orphan(&tx, test_source());
+        admission.record_orphan(&tx, test_source());
 
         assert_eq!(
             admission.orphan_count(),
@@ -459,7 +506,7 @@ mod tests {
         let tx = Arc::new(tx_with_marker(3));
         let wtxid = tx.wtxid();
 
-        admission.record_orphan(&tx);
+        admission.record_orphan(&tx, test_source());
 
         assert!(
             admission.have_tx(Hash256::from(wtxid), true),
@@ -478,7 +525,7 @@ mod tests {
         let tx = Arc::new(tx_with_marker(4));
         let txid = tx.txid();
 
-        admission.record_orphan(&tx);
+        admission.record_orphan(&tx, test_source());
 
         let served = admission
             .get_tx(txid)
@@ -492,11 +539,13 @@ mod tests {
         let admission = TxAdmission::new(gateway);
         let tx = Arc::new(tx_with_marker(6));
         let parent = Txid::from(Hash256::from_le_bytes(&[6; 32]));
-        admission.record_orphan(&tx);
+        let source = test_source();
+        admission.record_orphan(&tx, source);
 
         let waiting = admission.take_orphans_waiting_on(parent);
         assert_eq!(waiting.len(), 1, "the child must be waiting on its parent");
-        assert_eq!(waiting[0].txid(), tx.txid());
+        assert_eq!(waiting[0].0.txid(), tx.txid());
+        assert_eq!(waiting[0].1, source);
         assert_eq!(
             admission.orphan_count(),
             0,
@@ -511,7 +560,7 @@ mod tests {
         let tx = Arc::new(tx_with_marker(5));
         let txid = tx.txid();
 
-        admission.record_orphan(&tx);
+        admission.record_orphan(&tx, test_source());
         assert_eq!(admission.orphan_count(), 1);
 
         let taken = admission.take_orphan(&txid);

--- a/crates/node/src/tx_admission.rs
+++ b/crates/node/src/tx_admission.rs
@@ -59,6 +59,9 @@ struct AdmissionInner {
     orphan_by_wtxid: hashbrown::HashMap<Wtxid, Txid>,
     /// Insertion order for FIFO eviction; the front is the oldest orphan.
     orphan_order: VecDeque<Txid>,
+    /// Parent txid → orphan txids that spend an output of that parent.
+    /// Used to re-evaluate held children when a parent is admitted.
+    orphans_waiting: hashbrown::HashMap<Txid, hashbrown::HashSet<Txid>>,
     /// Recent-rejects cache: both wtxid and txid of each rejected
     /// transaction, stored as raw [`Hash256`] so a single lookup answers
     /// both BIP339 and legacy inventory vectors.
@@ -106,15 +109,19 @@ impl TxAdmission {
             if old_wtxid != wtxid {
                 inner.orphan_by_wtxid.remove(&old_wtxid);
             }
+            unindex_orphan_parents(&mut inner, &txid, &old);
+            index_orphan_parents(&mut inner, tx);
         } else {
             // New entry: append and evict the oldest over the quota.
             inner.orphan_order.push_back(txid);
+            index_orphan_parents(&mut inner, tx);
             while inner.orphan_order.len() > self.quota {
                 let Some(evicted) = inner.orphan_order.pop_front() else {
                     break;
                 };
                 if let Some(evicted_tx) = inner.orphans.remove(&evicted) {
                     inner.orphan_by_wtxid.remove(&evicted_tx.wtxid());
+                    unindex_orphan_parents(&mut inner, &evicted, &evicted_tx);
                 }
             }
         }
@@ -134,7 +141,24 @@ impl TxAdmission {
         let tx = inner.orphans.remove(txid)?;
         inner.orphan_by_wtxid.remove(&tx.wtxid());
         inner.orphan_order.retain(|id| id != txid);
+        unindex_orphan_parents(&mut inner, txid, &tx);
         Some(tx)
+    }
+
+    /// Removes and returns every orphan that spends an output of `parent`.
+    ///
+    /// Called when `parent` is admitted so the children can be re-evaluated
+    /// through the gateway. Missing children (already evicted or taken) are
+    /// skipped.
+    pub fn take_orphans_waiting_on(&self, parent: Txid) -> Vec<Arc<Tx>> {
+        let waiting = {
+            let mut inner = self.inner.lock();
+            inner.orphans_waiting.remove(&parent).unwrap_or_default()
+        };
+        waiting
+            .into_iter()
+            .filter_map(|txid| self.take_orphan(&txid))
+            .collect()
     }
 
     /// Records a rejected transaction in the recent-rejects cache by both
@@ -169,10 +193,9 @@ impl TxAdmission {
     /// tx_admission.invalidate_recent_rejects();
     /// ```
     ///
-    /// Wire it into `crates/node/src/apply.rs` immediately after a
-    /// successful block connect, before the next `inv` round trips. This
-    /// module deliberately does not edit `apply.rs` (it is outside the
-    /// admission leaf's ownership); the parent connects the call.
+    /// Wired through the node-owned gateway observer: block-connect and
+    /// reorg mutations already publish there, so apply.rs does not own
+    /// admission state.
     pub fn invalidate_recent_rejects(&self) {
         let mut inner = self.inner.lock();
         inner.recent_rejects.clear();
@@ -232,18 +255,19 @@ impl TxAdmission {
     }
 
     fn have_tx(&self, hash: Hash256, wtxid_relay: bool) -> bool {
-        let inner = self.inner.lock();
-        if inner.recent_rejects.contains(&hash) {
-            return true;
-        }
-        if wtxid_relay {
-            let wtxid = Wtxid::from(hash);
-            if inner.orphan_by_wtxid.contains_key(&wtxid) {
+        // Release the admission lock before touching the gateway. Observer
+        // legs (reject invalidation) take this lock after a commit, and
+        // holding it across `gateway.read()` inverts that order.
+        {
+            let inner = self.inner.lock();
+            if inner.recent_rejects.contains(&hash) {
                 return true;
             }
-        } else {
-            let txid = Txid::from(hash);
-            if inner.orphans.contains_key(&txid) {
+            if wtxid_relay {
+                if inner.orphan_by_wtxid.contains_key(&Wtxid::from(hash)) {
+                    return true;
+                }
+            } else if inner.orphans.contains_key(&Txid::from(hash)) {
                 return true;
             }
         }
@@ -255,8 +279,7 @@ impl TxAdmission {
             let pool = self.gateway.read();
             pool.contains_wtxid(&wtxid)
         } else {
-            let txid = Txid::from(hash);
-            self.gateway.read().contains_txid(&txid)
+            self.gateway.read().contains_txid(&Txid::from(hash))
         }
     }
 
@@ -266,6 +289,32 @@ impl TxAdmission {
 
     fn get_tx_by_wtxid(&self, wtxid: Wtxid) -> Option<Tx> {
         self.lookup_tx_by_wtxid(&wtxid)
+    }
+}
+
+fn index_orphan_parents(inner: &mut AdmissionInner, tx: &Tx) {
+    let txid = tx.txid();
+    for input in &tx.inputs {
+        if input.previous_output == bitcoin_rs_primitives::OutPoint::default() {
+            continue;
+        }
+        inner
+            .orphans_waiting
+            .entry(input.previous_output.txid)
+            .or_default()
+            .insert(txid);
+    }
+}
+
+fn unindex_orphan_parents(inner: &mut AdmissionInner, txid: &Txid, tx: &Tx) {
+    for input in &tx.inputs {
+        let parent = input.previous_output.txid;
+        if let Some(waiting) = inner.orphans_waiting.get_mut(&parent) {
+            waiting.remove(txid);
+            if waiting.is_empty() {
+                inner.orphans_waiting.remove(&parent);
+            }
+        }
     }
 }
 
@@ -438,6 +487,24 @@ mod tests {
     }
 
     #[test]
+    fn take_orphans_waiting_on_returns_children() {
+        let gateway = empty_gateway();
+        let admission = TxAdmission::new(gateway);
+        let tx = Arc::new(tx_with_marker(6));
+        let parent = Txid::from(Hash256::from_le_bytes(&[6; 32]));
+        admission.record_orphan(&tx);
+
+        let waiting = admission.take_orphans_waiting_on(parent);
+        assert_eq!(waiting.len(), 1, "the child must be waiting on its parent");
+        assert_eq!(waiting[0].txid(), tx.txid());
+        assert_eq!(
+            admission.orphan_count(),
+            0,
+            "take_orphans_waiting_on must remove the child"
+        );
+    }
+
+    #[test]
     fn take_orphan_removes_entry() {
         let gateway = empty_gateway();
         let admission = TxAdmission::new(gateway);
@@ -449,6 +516,12 @@ mod tests {
 
         let taken = admission.take_orphan(&txid);
         assert!(taken.is_some(), "take_orphan must return the body");
+        assert!(
+            admission
+                .take_orphans_waiting_on(Txid::from(Hash256::from_le_bytes(&[5; 32])))
+                .is_empty(),
+            "taking the orphan must drop its parent index"
+        );
         assert_eq!(
             admission.orphan_count(),
             0,

--- a/crates/node/src/tx_ingress.rs
+++ b/crates/node/src/tx_ingress.rs
@@ -1,8 +1,9 @@
 //! P2P transaction ingress consumer for the node.
 //!
-//! Each transaction is evaluated through the mempool's standardness +
-//! acceptance policy, and admitted through the one
-//! [`MempoolGateway`](bitcoin_rs_mempool::MempoolGateway).
+//! Each transaction is admitted through the one
+//! [`MempoolGateway::admit_transaction`](bitcoin_rs_mempool::MempoolGateway::admit_transaction)
+//! path RPC uses: policy, then consensus verification under
+//! [`VerifyFlags::STANDARD`](bitcoin_rs_script::VerifyFlags), then insert.
 //!
 //! # Ordering and side effects
 //!
@@ -17,15 +18,18 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use arc_swap::ArcSwapOption;
+use bitcoin_rs_chain::{BlockTree, TipSnapshot};
 use bitcoin_rs_mempool::{
-    AdmissionOrigin, MempoolGateway, PeerToken, ReplacementCandidate,
-    standardness::{PackageTxContext, evaluate_package_acceptance},
+    AdmissionOrigin, AdmissionRequest, AdmitError, AdmitOutcome, MempoolGateway, PeerToken,
+    standardness::{PackageTxContext, is_standard_tx},
 };
-use bitcoin_rs_primitives::{Hash256, Tx, Txid};
+use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxOut, Txid};
 use bitcoin_rs_rpc::context::MiningControl;
 use bitcoin_rs_utxo::UtxoSet;
 use crossbeam_channel::Receiver;
-use parking_lot::Mutex;
+use hashbrown::HashMap;
+use parking_lot::{Mutex, RwLock};
 
 use crate::state::NodeState;
 use crate::tx_admission::TxAdmission;
@@ -35,6 +39,8 @@ use crate::tx_relay::{PeerRelaySink, TxRelayQueue, spawn_tx_relay_worker};
 const TX_INGRESS_POLL: Duration = Duration::from_millis(100);
 /// Bounded capacity of the outbound tx-relay queue.
 const TX_RELAY_QUEUE_CAPACITY: usize = 1024;
+/// Same generation/sequence retry budget as RPC `sendrawtransaction`.
+const MAX_ADMISSION_RETRIES: usize = 4;
 
 /// Join handles and the shared relay queue returned by
 /// [`spawn_tx_ingress_consumer`].
@@ -52,9 +58,8 @@ pub struct TxIngressHandles {
 /// Spawns the single tx-ingress consumer thread.
 ///
 /// The thread drains [`bitcoin_rs_p2p::InboundTx`] items from the bounded
-/// channel, evaluates each through the mempool's acceptance policy, and
-/// admits accepted transactions through the [`MempoolGateway`]. Only
-/// accepted mutations trigger relay and mining wake.
+/// channel and admits each through [`MempoolGateway::admit_transaction`].
+/// Only accepted mutations trigger relay and mining wake.
 ///
 /// # Arguments
 ///
@@ -74,6 +79,8 @@ pub fn spawn_tx_ingress_consumer(
     let utxo = state.utxo();
     let transactions = state.transactions();
     let peer_table = state.peer_table();
+    let applied_tip = state.applied_tip();
+    let block_tree = state.block_tree();
     let (relay, relay_rx) = TxRelayQueue::new(TX_RELAY_QUEUE_CAPACITY);
     let relay_sink = PeerRelaySink::new(Arc::clone(&peer_table));
     let relay_handle = spawn_tx_relay_worker(relay_sink, relay_rx, Arc::clone(&shutdown))?;
@@ -89,8 +96,19 @@ pub fn spawn_tx_ingress_consumer(
                 mining_control,
                 relay,
                 tx_admission,
+                applied_tip,
+                block_tree,
             };
             while !shutdown.load(Ordering::Relaxed) {
+                loop {
+                    let retries = consumer.tx_admission.take_orphan_retries();
+                    if retries.is_empty() {
+                        break;
+                    }
+                    for (tx, source) in retries {
+                        consumer.process_one(bitcoin_rs_p2p::InboundTx::new((*tx).clone(), source));
+                    }
+                }
                 let recv = {
                     let guard = tx_rx.lock();
                     guard.recv_timeout(TX_INGRESS_POLL)
@@ -123,11 +141,14 @@ struct TxIngressConsumer {
     relay: TxRelayQueue,
     /// Orphan map and recent-rejects cache for inbound tx admission.
     tx_admission: Arc<TxAdmission>,
+    /// Applied chain tip; admission height and median-time-past follow this.
+    applied_tip: Arc<ArcSwapOption<TipSnapshot>>,
+    block_tree: Arc<RwLock<BlockTree>>,
 }
 
 impl TxIngressConsumer {
-    /// Processes one inbound transaction: evaluate acceptance, admit through
-    /// the gateway, and on accepted only — relay inv and wake mining.
+    /// Processes one inbound transaction: admit through the gateway, and on
+    /// accepted only — relay inv and wake mining.
     fn process_one(&self, inbound: bitcoin_rs_p2p::InboundTx) {
         let tx = inbound.tx;
         let source = inbound.source;
@@ -160,48 +181,7 @@ impl TxIngressConsumer {
             return;
         }
 
-        let (fact, policy) = self.evaluate_acceptance(&tx, txid);
-        if fact.allowed != Some(true) {
-            self.reject_or_hold_orphan(tx, source, txid, wtxid, fact.reject_reason);
-            return;
-        }
-        self.admit_and_relay(tx, source, txid, wtxid, &fact, &policy);
-    }
-
-    fn evaluate_acceptance(
-        &self,
-        tx: &Tx,
-        txid: Txid,
-    ) -> (
-        bitcoin_rs_mempool::standardness::TxAcceptanceFact,
-        bitcoin_rs_mempool::MempoolPolicySnapshot,
-    ) {
-        let pool = self.mempool_gateway.read();
-        let policy = pool.policy_snapshot();
-        let contexts = self.package_contexts(&pool, std::slice::from_ref(tx));
-        let facts = evaluate_package_acceptance(
-            &pool,
-            &policy.standardness,
-            std::slice::from_ref(tx),
-            &contexts,
-            None,
-            policy.incremental_relay_fee_sat_per_kvb,
-        );
-        let fact = facts.results.into_iter().next().unwrap_or_else(|| {
-            bitcoin_rs_mempool::standardness::TxAcceptanceFact {
-                txid,
-                wtxid: tx.wtxid(),
-                allowed: Some(false),
-                vsize: u32::try_from(tx.vsize()).unwrap_or(u32::MAX),
-                weight: tx.weight(),
-                sigop_cost: 0,
-                base_fee: None,
-                reject_reason: Some(
-                    bitcoin_rs_mempool::standardness::AcceptanceRejectReason::PackageTooLarge,
-                ),
-            }
-        });
-        (fact, policy)
+        self.admit_and_relay(tx, source, txid, wtxid);
     }
 
     fn reject_or_hold_orphan(
@@ -221,6 +201,16 @@ impl TxIngressConsumer {
                 self.tx_admission.record_reject(txid, wtxid);
                 return;
             }
+            let policy = self.mempool_gateway.read().policy_snapshot();
+            if let Err(error) = is_standard_tx(&tx, &policy.standardness) {
+                tracing::debug!(
+                    %txid,
+                    %error,
+                    "p2p missing-input tx failed standardness; not held as orphan"
+                );
+                self.tx_admission.record_reject(txid, wtxid);
+                return;
+            }
             let held = Arc::new(tx);
             self.tx_admission.record_orphan(&held, source);
             self.request_missing_parents(&held, source);
@@ -237,119 +227,141 @@ impl TxIngressConsumer {
         source: bitcoin_rs_p2p::PeerSource,
         txid: Txid,
         wtxid: bitcoin_rs_primitives::Wtxid,
-        fact: &bitcoin_rs_mempool::standardness::TxAcceptanceFact,
-        policy: &bitcoin_rs_mempool::MempoolPolicySnapshot,
     ) {
         let token = PeerToken {
             addr: source.addr,
             connection_id: source.connection_id().get(),
         };
-        let candidate = ReplacementCandidate::new(
-            Arc::new(tx),
-            fact.vsize,
-            fact.base_fee.unwrap_or(0),
-            policy.incremental_relay_fee_sat_per_kvb,
-        );
-        let result = self.mempool_gateway.replace_transaction(
-            AdmissionOrigin::Peer(token),
-            candidate,
-            unix_time_secs(),
-            self.applied_height(),
-            fact.sigop_cost,
-        );
-        match result {
-            Ok(outcome) if outcome.is_shed() => {
-                self.tx_admission.record_reject(txid, wtxid);
-            }
-            Ok(outcome) => {
-                let accepted = outcome.into_mutation().changes.iter().any(|change| {
-                    change.txid == Hash256::from(txid)
-                        && matches!(
-                            change.outcome,
-                            bitcoin_rs_mempool::MutationOutcome::Accepted
-                        )
-                });
-                if accepted {
-                    self.relay
-                        .announce(txid, wtxid, Some(source.connection_id().get()));
-                    self.mining_control.publish_generation();
-                    tracing::trace!(%txid, "p2p tx admitted and relayed");
-                    // Waiting children are re-queued by the gateway observer
-                    // so RPC, reorg, and peer accepts share one wake path.
+        let origin = AdmissionOrigin::Peer(token);
+        let tx = Arc::new(tx);
+        for _ in 0..MAX_ADMISSION_RETRIES {
+            let Some(generation) = self.mempool_gateway.stable_generation() else {
+                continue;
+            };
+            let (sequence, mempool_prevouts) = {
+                let pool = self.mempool_gateway.read();
+                if pool.contains_txid(&txid) {
+                    return;
                 }
+                (pool.sequence_number(), resolve_mempool_prevouts(&pool, &tx))
+            };
+            let (context, prevouts) = self.resolve_full_context(&tx, &mempool_prevouts);
+            if context.missing_inputs {
+                self.reject_or_hold_orphan(
+                    (*tx).clone(),
+                    source,
+                    txid,
+                    wtxid,
+                    Some(bitcoin_rs_mempool::standardness::AcceptanceRejectReason::MissingInputs),
+                );
+                return;
             }
-            Err(error) => {
-                tracing::debug!(%txid, %error, "p2p tx admission failed; not relaying");
-                self.tx_admission.record_reject(txid, wtxid);
+            let request = AdmissionRequest {
+                tx: Arc::clone(&tx),
+                context,
+                prevouts,
+                locktime_cutoff: self.locktime_cutoff(),
+                max_feerate_sat_per_kvb: None,
+                time: unix_time_secs(),
+                height: self.applied_height(),
+                origin,
+                expected_generation: generation,
+                expected_sequence: sequence,
+            };
+            match self.mempool_gateway.admit_transaction(request) {
+                Ok(AdmitOutcome::Committed(result)) => {
+                    let accepted = result.changes.iter().any(|change| {
+                        change.txid == Hash256::from(txid)
+                            && matches!(
+                                change.outcome,
+                                bitcoin_rs_mempool::MutationOutcome::Accepted
+                            )
+                    });
+                    if accepted {
+                        self.relay
+                            .announce(txid, wtxid, Some(source.connection_id().get()));
+                        self.mining_control.publish_generation();
+                        tracing::trace!(%txid, "p2p tx admitted and relayed");
+                    }
+                    return;
+                }
+                Ok(AdmitOutcome::AlreadyKnown) => return,
+                Err(AdmitError::GenerationChanged | AdmitError::MempoolChanged) => continue,
+                Err(AdmitError::Policy(
+                    bitcoin_rs_mempool::standardness::AcceptanceRejectReason::MissingInputs,
+                )) => {
+                    self.reject_or_hold_orphan(
+                        (*tx).clone(),
+                        source,
+                        txid,
+                        wtxid,
+                        Some(
+                            bitcoin_rs_mempool::standardness::AcceptanceRejectReason::MissingInputs,
+                        ),
+                    );
+                    return;
+                }
+                Err(AdmitError::Policy(reason)) => {
+                    tracing::debug!(%txid, %reason, "p2p tx rejected by mempool policy; not relaying");
+                    self.tx_admission.record_reject(txid, wtxid);
+                    return;
+                }
+                Err(AdmitError::Consensus) => {
+                    tracing::debug!(%txid, "p2p tx failed consensus verification; not relaying");
+                    self.tx_admission.record_reject(txid, wtxid);
+                    return;
+                }
             }
         }
+        tracing::debug!(%txid, "p2p tx admission retry exhausted; not relaying");
     }
 
-    /// Resolves prevout contexts for a package of transactions, using the
-    /// mempool and UTXO set — the same logic as the RPC
-    /// `sendrawtransaction` handler.
-    fn package_contexts(
+    /// Combines mempool-dependent prevouts (captured under a read guard) with
+    /// UTXO-set prevouts (resolved without a pool guard).
+    fn resolve_full_context(
         &self,
-        pool: &bitcoin_rs_mempool::Mempool,
-        txs: &[Tx],
-    ) -> Vec<PackageTxContext> {
-        use bitcoin_rs_primitives::OutPoint;
-        use hashbrown::HashMap;
+        tx: &Tx,
+        mempool_prevouts: &HashMap<OutPoint, TxOut>,
+    ) -> (PackageTxContext, Vec<(OutPoint, TxOut)>) {
+        let mut missing_inputs = false;
+        let mut input_value = 0_u64;
+        let mut prevouts: Vec<(OutPoint, TxOut)> = Vec::new();
 
-        let mut package_outputs: HashMap<(Txid, u32), u64> = HashMap::new();
-        let mut contexts = Vec::with_capacity(txs.len());
-
-        for tx in txs {
-            let mut missing_inputs = false;
-            let mut input_value = 0_u64;
-
-            for input in &tx.inputs {
-                if input.previous_output == OutPoint::default() {
-                    missing_inputs = true;
-                    continue;
-                }
-                let key = (input.previous_output.txid, input.previous_output.vout);
-                if let Some(value) = package_outputs.get(&key) {
-                    input_value = input_value.saturating_add(*value);
-                    continue;
-                }
-                if let Some(parent) = pool.transaction_by_txid(&input.previous_output.txid)
-                    && let Ok(vout) = usize::try_from(input.previous_output.vout)
-                    && let Some(output) = parent.outputs.get(vout)
-                {
-                    input_value = input_value.saturating_add(output.value);
-                    continue;
-                }
-                if let Some(live) = self.utxo.get_entry(&input.previous_output) {
-                    input_value = input_value.saturating_add(live.txout.value);
-                    continue;
-                }
+        for input in &tx.inputs {
+            if input.previous_output == OutPoint::default() || input.previous_output.is_null() {
                 missing_inputs = true;
+                continue;
             }
+            if let Some(output) = mempool_prevouts.get(&input.previous_output) {
+                input_value = input_value.saturating_add(output.value);
+                prevouts.push((input.previous_output, output.clone()));
+                continue;
+            }
+            if let Some(live) = self.utxo.get_entry(&input.previous_output) {
+                input_value = input_value.saturating_add(live.txout.value);
+                prevouts.push((input.previous_output, live.txout.clone()));
+                continue;
+            }
+            missing_inputs = true;
+        }
 
-            let output_value = tx
-                .outputs
-                .iter()
-                .fold(0_u64, |sum, output| sum.saturating_add(output.value));
-            let fee = input_value.saturating_sub(output_value);
-            let vsize = u32::try_from(tx.vsize()).unwrap_or(u32::MAX);
-            let sigop_cost = bitcoin_rs_script::count_tx_legacy(tx);
+        let output_value = tx
+            .outputs
+            .iter()
+            .fold(0_u64, |sum, output| sum.saturating_add(output.value));
+        let fee = input_value.saturating_sub(output_value);
+        let vsize = u32::try_from(tx.vsize()).unwrap_or(u32::MAX);
+        let sigop_cost = bitcoin_rs_script::count_tx_legacy(tx);
 
-            contexts.push(PackageTxContext {
+        (
+            PackageTxContext {
                 fee,
                 vsize,
                 sigop_cost,
                 missing_inputs,
-            });
-
-            let txid = tx.txid();
-            for (vout, output) in tx.outputs.iter().enumerate() {
-                let vout = u32::try_from(vout).unwrap_or(u32::MAX);
-                package_outputs.insert((txid, vout), output.value);
-            }
-        }
-
-        contexts
+            },
+            prevouts,
+        )
     }
 
     /// Asks the delivering peer for each missing parent via `getdata`.
@@ -358,7 +370,6 @@ impl TxIngressConsumer {
     /// txid-typed even when the peer negotiated BIP339.
     fn request_missing_parents(&self, tx: &Tx, source: bitcoin_rs_p2p::PeerSource) {
         use bitcoin::p2p::message_blockdata::Inventory;
-        use bitcoin_rs_primitives::OutPoint;
 
         let Some(lease) = self.peer_table.lease(source.addr) else {
             return;
@@ -400,11 +411,39 @@ impl TxIngressConsumer {
 
     /// Returns the current applied tip height.
     fn applied_height(&self) -> u32 {
-        let _ = self;
-        // The admission height is used for mempool entry ancestor
-        // accounting. The apply path corrects it on block connect.
-        0
+        self.applied_tip.load().as_ref().map_or(0, |tip| tip.height)
     }
+
+    /// Median-time-past of the applied tip for BIP113 finality, or zero
+    /// when no tip is published.
+    fn locktime_cutoff(&self) -> u32 {
+        let Some(tip) = self.applied_tip.load_full() else {
+            return 0;
+        };
+        self.block_tree
+            .read()
+            .median_time_past_at(tip.tip_id, 11)
+            .unwrap_or(0)
+    }
+}
+
+fn resolve_mempool_prevouts(
+    pool: &bitcoin_rs_mempool::Mempool,
+    tx: &Tx,
+) -> HashMap<OutPoint, TxOut> {
+    let mut prevouts = HashMap::new();
+    for input in &tx.inputs {
+        if input.previous_output == OutPoint::default() || input.previous_output.is_null() {
+            continue;
+        }
+        if let Some(parent) = pool.transaction_by_txid(&input.previous_output.txid)
+            && let Ok(vout) = usize::try_from(input.previous_output.vout)
+            && let Some(output) = parent.outputs.get(vout)
+        {
+            prevouts.insert(input.previous_output, output.clone());
+        }
+    }
+    prevouts
 }
 
 fn unix_time_secs() -> u64 {
@@ -503,7 +542,10 @@ mod tests {
         }
     }
 
-    /// Builds a tx that spends a known UTXO, passing standardness checks.
+    /// Builds a tx that spends a known UTXO, passing standardness and
+    /// script checks. Empty `scriptSig` plus an OP_TRUE prevout satisfy
+    /// `SCRIPT_VERIFY_CLEANSTACK`; the OP_RETURN payload pads the
+    /// non-witness size to the 65-byte standardness floor.
     fn spending_tx() -> Tx {
         let parent_txid = Txid::from(Hash256::from_le_bytes(&[0xAA; 32]));
         Tx {
@@ -513,13 +555,13 @@ mod tests {
                     txid: parent_txid,
                     vout: 0,
                 },
-                script_sig: vec![0x52, 0x02, 0xAA, 0xBB],
+                script_sig: Vec::new(),
                 sequence: 0xFFFF_FFFF,
                 witness: Vec::new(),
             }],
             outputs: vec![TxOut {
                 value: 49_000,
-                script_pubkey: vec![0x6A],
+                script_pubkey: vec![0x6A, 0x04, 0xAA, 0xBB, 0xCC, 0xDD],
             }],
             lock_time: 0,
         }
@@ -542,7 +584,7 @@ mod tests {
             },
             TxOut {
                 value: 50_000,
-                script_pubkey: Vec::new(),
+                script_pubkey: vec![0x51],
             },
             false,
             100,
@@ -559,6 +601,8 @@ mod tests {
             mining_control: mining,
             relay,
             tx_admission: Arc::new(TxAdmission::new(Arc::clone(gateway))),
+            applied_tip: Arc::new(ArcSwapOption::empty()),
+            block_tree: Arc::new(RwLock::new(BlockTree::new())),
         }
     }
 
@@ -587,6 +631,8 @@ mod tests {
             mining_control: mining,
             relay,
             tx_admission: Arc::new(TxAdmission::new(Arc::clone(gateway))),
+            applied_tip: Arc::new(ArcSwapOption::empty()),
+            block_tree: Arc::new(RwLock::new(BlockTree::new())),
         }
     }
 
@@ -764,6 +810,70 @@ mod tests {
         assert!(
             consumer.tx_admission.is_rejected(Hash256::from(txid)),
             "a peer coinbase must enter recent-rejects"
+        );
+    }
+
+    #[test]
+    fn non_final_tx_is_rejected_not_admitted() {
+        let pool = Arc::new(RwLock::new(Mempool::new(MempoolLimits {
+            min_relay_fee_sat_per_kvb: 0,
+            ..MempoolLimits::default()
+        })));
+        let gateway = MempoolGateway::shared(Arc::clone(&pool));
+        let mining = Arc::new(RecordingMining::new());
+        let consumer = make_consumer_with_utxo(&gateway, mining);
+        let mut tx = spending_tx();
+        tx.lock_time = 100;
+        tx.inputs[0].sequence = 0xFFFF_FFFE;
+        let txid = tx.txid();
+        consumer.process_one(bitcoin_rs_p2p::InboundTx::new(tx, test_source()));
+        assert!(
+            !gateway.read().contains_txid(&txid),
+            "a non-final peer tx must not enter the mempool"
+        );
+        assert!(
+            consumer.tx_admission.is_rejected(Hash256::from(txid)),
+            "a non-final peer tx must enter recent-rejects"
+        );
+    }
+
+    #[test]
+    fn oversized_missing_input_tx_is_rejected_not_orphaned() {
+        let pool = Arc::new(RwLock::new(Mempool::new(MempoolLimits::default())));
+        let gateway = MempoolGateway::shared(Arc::clone(&pool));
+        let mining = Arc::new(RecordingMining::new());
+        let consumer = make_consumer(&gateway, mining);
+        let parent = Txid::from(Hash256::from_le_bytes(&[0xCC; 32]));
+        // A 401_000-weight witness keeps the body over the 400k standard
+        // cap so MissingInputs cannot consume orphan quota.
+        let tx = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(parent, 0),
+                script_sig: Vec::new(),
+                sequence: 0xFFFF_FFFF,
+                witness: vec![vec![0; 100_250]],
+            }],
+            outputs: vec![TxOut {
+                value: 1_000,
+                script_pubkey: vec![0x6A, 0x04, 0xAA, 0xBB, 0xCC, 0xDD],
+            }],
+            lock_time: 0,
+        };
+        assert!(
+            tx.weight() > 400_000,
+            "the fixture must exceed MAX_STANDARD_TX_WEIGHT"
+        );
+        let txid = tx.txid();
+        consumer.process_one(bitcoin_rs_p2p::InboundTx::new(tx, test_source()));
+        assert_eq!(
+            consumer.tx_admission.orphan_count(),
+            0,
+            "a non-standard missing-input body must not consume orphan quota"
+        );
+        assert!(
+            consumer.tx_admission.is_rejected(Hash256::from(txid)),
+            "a non-standard missing-input body must enter recent-rejects"
         );
     }
 }

--- a/crates/node/src/tx_ingress.rs
+++ b/crates/node/src/tx_ingress.rs
@@ -240,7 +240,7 @@ impl TxIngressConsumer {
             connection_id: source.connection_id().get(),
         };
         let candidate = ReplacementCandidate::new(
-            Arc::new(tx.clone()),
+            Arc::new(tx),
             fact.vsize,
             fact.base_fee.unwrap_or(0),
             policy.incremental_relay_fee_sat_per_kvb,
@@ -266,7 +266,7 @@ impl TxIngressConsumer {
                 });
                 if accepted {
                     self.relay
-                        .announce(txid, tx.wtxid(), Some(source.connection_id().get()));
+                        .announce(txid, wtxid, Some(source.connection_id().get()));
                     self.mining_control.publish_generation();
                     tracing::trace!(%txid, "p2p tx admitted and relayed");
                     for orphan in self.tx_admission.take_orphans_waiting_on(txid) {

--- a/crates/node/src/tx_ingress.rs
+++ b/crates/node/src/tx_ingress.rs
@@ -844,15 +844,16 @@ mod tests {
         let mining = Arc::new(RecordingMining::new());
         let consumer = make_consumer(&gateway, mining);
         let parent = Txid::from(Hash256::from_le_bytes(&[0xCC; 32]));
-        // A 401_000-weight witness keeps the body over the 400k standard
-        // cap so MissingInputs cannot consume orphan quota.
+        // Witness counts 1× toward BIP141 weight. A 400_000-byte stack
+        // item puts the body over the 400k standard cap so MissingInputs
+        // cannot consume orphan quota.
         let tx = Tx {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(parent, 0),
                 script_sig: Vec::new(),
                 sequence: 0xFFFF_FFFF,
-                witness: vec![vec![0; 100_250]],
+                witness: vec![vec![0; 400_000]],
             }],
             outputs: vec![TxOut {
                 value: 1_000,

--- a/crates/node/src/tx_ingress.rs
+++ b/crates/node/src/tx_ingress.rs
@@ -543,8 +543,8 @@ mod tests {
     }
 
     /// Builds a tx that spends a known UTXO, passing standardness and
-    /// script checks. Empty `scriptSig` plus an OP_TRUE prevout satisfy
-    /// `SCRIPT_VERIFY_CLEANSTACK`; the OP_RETURN payload pads the
+    /// script checks. Empty `scriptSig` plus an `OP_TRUE` prevout satisfy
+    /// `SCRIPT_VERIFY_CLEANSTACK`; the `OP_RETURN` payload pads the
     /// non-witness size to the 65-byte standardness floor.
     fn spending_tx() -> Tx {
         let parent_txid = Txid::from(Hash256::from_le_bytes(&[0xAA; 32]));

--- a/crates/node/src/tx_ingress.rs
+++ b/crates/node/src/tx_ingress.rs
@@ -216,8 +216,13 @@ impl TxIngressConsumer {
             reason,
             Some(bitcoin_rs_mempool::standardness::AcceptanceRejectReason::MissingInputs)
         ) {
+            if is_coinbase(&tx) {
+                tracing::debug!(%txid, "p2p coinbase rejected; not held as orphan");
+                self.tx_admission.record_reject(txid, wtxid);
+                return;
+            }
             let held = Arc::new(tx);
-            self.tx_admission.record_orphan(&held);
+            self.tx_admission.record_orphan(&held, source);
             self.request_missing_parents(&held, source);
             tracing::debug!(%txid, "p2p tx missing inputs; held as orphan");
             return;
@@ -269,9 +274,8 @@ impl TxIngressConsumer {
                         .announce(txid, wtxid, Some(source.connection_id().get()));
                     self.mining_control.publish_generation();
                     tracing::trace!(%txid, "p2p tx admitted and relayed");
-                    for orphan in self.tx_admission.take_orphans_waiting_on(txid) {
-                        self.process_one(bitcoin_rs_p2p::InboundTx::new((*orphan).clone(), source));
-                    }
+                    // Waiting children are re-queued by the gateway observer
+                    // so RPC, reorg, and peer accepts share one wake path.
                 }
             }
             Err(error) => {
@@ -362,14 +366,24 @@ impl TxIngressConsumer {
         if !lease.is_current(source) {
             return;
         }
-        let items: Vec<Inventory> = tx
-            .inputs
-            .iter()
-            .filter(|input| input.previous_output != OutPoint::default())
-            .map(|input| {
-                Inventory::Transaction(bitcoin::hashes::Hash::from_byte_array(
-                    *input.previous_output.txid.as_bytes(),
-                ))
+        let mut parent_ids = hashbrown::HashSet::new();
+        {
+            let pool = self.mempool_gateway.read();
+            for input in &tx.inputs {
+                let prevout = input.previous_output;
+                if prevout.is_null() || prevout == OutPoint::default() {
+                    continue;
+                }
+                if pool.contains_txid(&prevout.txid) || self.utxo.get_entry(&prevout).is_some() {
+                    continue;
+                }
+                parent_ids.insert(prevout.txid);
+            }
+        }
+        let items: Vec<Inventory> = parent_ids
+            .into_iter()
+            .map(|txid| {
+                Inventory::Transaction(bitcoin::hashes::Hash::from_byte_array(*txid.as_bytes()))
             })
             .collect();
         if items.is_empty() {
@@ -397,6 +411,11 @@ fn unix_time_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| d.as_secs())
+}
+
+/// Core's `IsCoinBase`: one input spending the null prevout.
+fn is_coinbase(tx: &Tx) -> bool {
+    tx.inputs.len() == 1 && tx.inputs[0].previous_output.is_null()
 }
 
 #[cfg(test)]
@@ -712,6 +731,39 @@ mod tests {
             mining.publish_count(),
             1,
             "accepted tx must wake mining exactly once"
+        );
+    }
+
+    #[test]
+    fn coinbase_is_rejected_not_orphaned() {
+        let pool = Arc::new(RwLock::new(Mempool::new(MempoolLimits::default())));
+        let gateway = MempoolGateway::shared(Arc::clone(&pool));
+        let mining = Arc::new(RecordingMining::new());
+        let consumer = make_consumer(&gateway, mining);
+        let coinbase = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid::default(), u32::MAX),
+                script_sig: vec![0x00],
+                sequence: 0xFFFF_FFFF,
+                witness: Vec::new(),
+            }],
+            outputs: vec![TxOut {
+                value: 50_000,
+                script_pubkey: vec![0x6A],
+            }],
+            lock_time: 0,
+        };
+        let txid = coinbase.txid();
+        consumer.process_one(bitcoin_rs_p2p::InboundTx::new(coinbase, test_source()));
+        assert_eq!(
+            consumer.tx_admission.orphan_count(),
+            0,
+            "a peer coinbase must not consume orphan quota"
+        );
+        assert!(
+            consumer.tx_admission.is_rejected(Hash256::from(txid)),
+            "a peer coinbase must enter recent-rejects"
         );
     }
 }

--- a/crates/node/src/tx_ingress.rs
+++ b/crates/node/src/tx_ingress.rs
@@ -36,6 +36,19 @@ const TX_INGRESS_POLL: Duration = Duration::from_millis(100);
 /// Bounded capacity of the outbound tx-relay queue.
 const TX_RELAY_QUEUE_CAPACITY: usize = 1024;
 
+/// Join handles and the shared relay queue returned by
+/// [`spawn_tx_ingress_consumer`].
+pub struct TxIngressHandles {
+    /// The ingress consumer thread.
+    pub ingress: std::thread::JoinHandle<()>,
+    /// The outbound `inv` relay worker started by the same spawn.
+    pub relay: std::thread::JoinHandle<()>,
+    /// Cloneable producer side of the relay queue. Production startup
+    /// attaches this to the gateway observer so RPC-admitted transactions
+    /// announce through the same worker.
+    pub queue: TxRelayQueue,
+}
+
 /// Spawns the single tx-ingress consumer thread.
 ///
 /// The thread drains [`bitcoin_rs_p2p::InboundTx`] items from the bounded
@@ -57,19 +70,21 @@ pub fn spawn_tx_ingress_consumer(
     shutdown: Arc<AtomicBool>,
     tx_rx: Arc<Mutex<Receiver<bitcoin_rs_p2p::InboundTx>>>,
     tx_admission: Arc<TxAdmission>,
-) -> std::io::Result<std::thread::JoinHandle<()>> {
+) -> std::io::Result<TxIngressHandles> {
     let utxo = state.utxo();
     let transactions = state.transactions();
     let peer_table = state.peer_table();
     let (relay, relay_rx) = TxRelayQueue::new(TX_RELAY_QUEUE_CAPACITY);
-    let relay_sink = PeerRelaySink::new(peer_table);
-    spawn_tx_relay_worker(relay_sink, relay_rx, Arc::clone(&shutdown))?;
+    let relay_sink = PeerRelaySink::new(Arc::clone(&peer_table));
+    let relay_handle = spawn_tx_relay_worker(relay_sink, relay_rx, Arc::clone(&shutdown))?;
+    let queue = relay.clone();
     let handle = std::thread::Builder::new()
         .name("bitcoin-rs-tx-ingress".to_owned())
         .spawn(move || {
             let consumer = TxIngressConsumer {
                 utxo,
                 transactions,
+                peer_table,
                 mempool_gateway: gateway,
                 mining_control,
                 relay,
@@ -89,13 +104,18 @@ pub fn spawn_tx_ingress_consumer(
                 }
             }
         })?;
-    Ok(handle)
+    Ok(TxIngressHandles {
+        ingress: handle,
+        relay: relay_handle,
+        queue,
+    })
 }
 
 /// The single consumer that evaluates and admits peer transactions.
 struct TxIngressConsumer {
     utxo: Arc<UtxoSet>,
     transactions: Arc<parking_lot::RwLock<hashbrown::HashMap<Txid, Tx>>>,
+    peer_table: Arc<bitcoin_rs_p2p::PeerTable>,
     mempool_gateway: Arc<MempoolGateway>,
     mining_control: Arc<dyn MiningControl>,
     /// Outbound relay queue: enqueues `inv` announcements for the relay
@@ -140,54 +160,81 @@ impl TxIngressConsumer {
             return;
         }
 
-        // Evaluate acceptance policy (standardness, fee, missing inputs).
-        let (fact, policy) = {
-            let pool = self.mempool_gateway.read();
-            let policy = pool.policy_snapshot();
-            let contexts = self.package_contexts(&pool, std::slice::from_ref(&tx));
-            let facts = evaluate_package_acceptance(
-                &pool,
-                &policy.standardness,
-                std::slice::from_ref(&tx),
-                &contexts,
-                None,
-                policy.incremental_relay_fee_sat_per_kvb,
-            );
-            let fact = facts.results.into_iter().next().unwrap_or_else(|| {
-                let mut fact = bitcoin_rs_mempool::standardness::TxAcceptanceFact {
-                    txid,
-                    wtxid: tx.wtxid(),
-                    allowed: Some(false),
-                    vsize: u32::try_from(tx.vsize()).unwrap_or(u32::MAX),
-                    weight: tx.weight(),
-                    sigop_cost: 0,
-                    base_fee: None,
-                    reject_reason: None,
-                };
-                fact.reject_reason =
-                    Some(bitcoin_rs_mempool::standardness::AcceptanceRejectReason::PackageTooLarge);
-                fact
-            });
-            (fact, policy)
-        };
-
-        // Rejected: record in recent-rejects so the Inv filter suppresses
-        // future getdata for this tx. Missing-inputs rejections are not
-        // orphans here — the standardness evaluator reports them as
-        // rejected, and the tx is cached. A dedicated orphan path (parent
-        // arrival triggers re-evaluation) is handled by the orphan map in
-        // TxAdmission; this consumer records the reject and moves on.
+        let (fact, policy) = self.evaluate_acceptance(&tx, txid);
         if fact.allowed != Some(true) {
-            tracing::debug!(
-                %txid,
-                reason = ?fact.reject_reason,
-                "p2p tx rejected by mempool policy; not relaying"
-            );
-            self.tx_admission.record_reject(txid, wtxid);
+            self.reject_or_hold_orphan(tx, source, txid, wtxid, fact.reject_reason);
             return;
         }
+        self.admit_and_relay(tx, source, txid, wtxid, &fact, &policy);
+    }
 
-        // Admit through the one gateway.
+    fn evaluate_acceptance(
+        &self,
+        tx: &Tx,
+        txid: Txid,
+    ) -> (
+        bitcoin_rs_mempool::standardness::TxAcceptanceFact,
+        bitcoin_rs_mempool::MempoolPolicySnapshot,
+    ) {
+        let pool = self.mempool_gateway.read();
+        let policy = pool.policy_snapshot();
+        let contexts = self.package_contexts(&pool, std::slice::from_ref(tx));
+        let facts = evaluate_package_acceptance(
+            &pool,
+            &policy.standardness,
+            std::slice::from_ref(tx),
+            &contexts,
+            None,
+            policy.incremental_relay_fee_sat_per_kvb,
+        );
+        let fact = facts.results.into_iter().next().unwrap_or_else(|| {
+            bitcoin_rs_mempool::standardness::TxAcceptanceFact {
+                txid,
+                wtxid: tx.wtxid(),
+                allowed: Some(false),
+                vsize: u32::try_from(tx.vsize()).unwrap_or(u32::MAX),
+                weight: tx.weight(),
+                sigop_cost: 0,
+                base_fee: None,
+                reject_reason: Some(
+                    bitcoin_rs_mempool::standardness::AcceptanceRejectReason::PackageTooLarge,
+                ),
+            }
+        });
+        (fact, policy)
+    }
+
+    fn reject_or_hold_orphan(
+        &self,
+        tx: Tx,
+        source: bitcoin_rs_p2p::PeerSource,
+        txid: Txid,
+        wtxid: bitcoin_rs_primitives::Wtxid,
+        reason: Option<bitcoin_rs_mempool::standardness::AcceptanceRejectReason>,
+    ) {
+        if matches!(
+            reason,
+            Some(bitcoin_rs_mempool::standardness::AcceptanceRejectReason::MissingInputs)
+        ) {
+            let held = Arc::new(tx);
+            self.tx_admission.record_orphan(&held);
+            self.request_missing_parents(&held, source);
+            tracing::debug!(%txid, "p2p tx missing inputs; held as orphan");
+            return;
+        }
+        tracing::debug!(%txid, ?reason, "p2p tx rejected by mempool policy; not relaying");
+        self.tx_admission.record_reject(txid, wtxid);
+    }
+
+    fn admit_and_relay(
+        &self,
+        tx: Tx,
+        source: bitcoin_rs_p2p::PeerSource,
+        txid: Txid,
+        wtxid: bitcoin_rs_primitives::Wtxid,
+        fact: &bitcoin_rs_mempool::standardness::TxAcceptanceFact,
+        policy: &bitcoin_rs_mempool::MempoolPolicySnapshot,
+    ) {
         let token = PeerToken {
             addr: source.addr,
             connection_id: source.connection_id().get(),
@@ -198,34 +245,33 @@ impl TxIngressConsumer {
             fact.base_fee.unwrap_or(0),
             policy.incremental_relay_fee_sat_per_kvb,
         );
-        let time = unix_time_secs();
-        let height = self.applied_height();
         let result = self.mempool_gateway.replace_transaction(
             AdmissionOrigin::Peer(token),
             candidate,
-            time,
-            height,
+            unix_time_secs(),
+            self.applied_height(),
             fact.sigop_cost,
         );
-
         match result {
-            // A replacement the size-limit trim shed after commit is not in
-            // the pool: record the reject exactly like a refused admission.
             Ok(outcome) if outcome.is_shed() => {
                 self.tx_admission.record_reject(txid, wtxid);
             }
             Ok(outcome) => {
-                // Accepted-only relay: only relay if the mutation includes
-                // an Accepted outcome for this txid.
-                let accepted = outcome.into_mutation().changes.iter().any(|c| {
-                    c.txid == Hash256::from(txid)
-                        && matches!(c.outcome, bitcoin_rs_mempool::MutationOutcome::Accepted)
+                let accepted = outcome.into_mutation().changes.iter().any(|change| {
+                    change.txid == Hash256::from(txid)
+                        && matches!(
+                            change.outcome,
+                            bitcoin_rs_mempool::MutationOutcome::Accepted
+                        )
                 });
                 if accepted {
                     self.relay
                         .announce(txid, tx.wtxid(), Some(source.connection_id().get()));
                     self.mining_control.publish_generation();
                     tracing::trace!(%txid, "p2p tx admitted and relayed");
+                    for orphan in self.tx_admission.take_orphans_waiting_on(txid) {
+                        self.process_one(bitcoin_rs_p2p::InboundTx::new((*orphan).clone(), source));
+                    }
                 }
             }
             Err(error) => {
@@ -300,6 +346,42 @@ impl TxIngressConsumer {
         }
 
         contexts
+    }
+
+    /// Asks the delivering peer for each missing parent via `getdata`.
+    ///
+    /// Prevouts only carry the parent txid, so the request is always
+    /// txid-typed even when the peer negotiated BIP339.
+    fn request_missing_parents(&self, tx: &Tx, source: bitcoin_rs_p2p::PeerSource) {
+        use bitcoin::p2p::message_blockdata::Inventory;
+        use bitcoin_rs_primitives::OutPoint;
+
+        let Some(lease) = self.peer_table.lease(source.addr) else {
+            return;
+        };
+        if !lease.is_current(source) {
+            return;
+        }
+        let items: Vec<Inventory> = tx
+            .inputs
+            .iter()
+            .filter(|input| input.previous_output != OutPoint::default())
+            .map(|input| {
+                Inventory::Transaction(bitcoin::hashes::Hash::from_byte_array(
+                    *input.previous_output.txid.as_bytes(),
+                ))
+            })
+            .collect();
+        if items.is_empty() {
+            return;
+        }
+        if let Err(error) = lease.send(bitcoin_rs_p2p::Message::GetData(items)) {
+            tracing::debug!(
+                peer_addr = %source.addr,
+                %error,
+                "orphan parent getdata not sent"
+            );
+        }
     }
 
     /// Returns the current applied tip height.
@@ -453,6 +535,7 @@ mod tests {
         TxIngressConsumer {
             utxo,
             transactions,
+            peer_table: Arc::new(bitcoin_rs_p2p::PeerTable::new()),
             mempool_gateway: Arc::clone(gateway),
             mining_control: mining,
             relay,
@@ -480,6 +563,7 @@ mod tests {
         TxIngressConsumer {
             utxo,
             transactions,
+            peer_table: Arc::new(bitcoin_rs_p2p::PeerTable::new()),
             mempool_gateway: Arc::clone(gateway),
             mining_control: mining,
             relay,

--- a/crates/node/src/tx_relay.rs
+++ b/crates/node/src/tx_relay.rs
@@ -44,8 +44,9 @@
 //! self.relay.announce(txid, tx.wtxid(), Some(source.connection_id().get()));
 //! ```
 //!
-//! Wiring that line is out of scope for this file (it edits `tx_ingress.rs`);
-//! the worker and queue here are ready to receive it.
+//! The ingress consumer announces peer-origin accepts with the source
+//! excluded. RPC and reorg accepts announce through
+//! [`crate::mempool_observer::LocalTxRelayObserver`] on the same queue.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/crates/node/src/zmq_publisher.rs
+++ b/crates/node/src/zmq_publisher.rs
@@ -963,6 +963,7 @@ mod tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::as_conversions)]
 mod compat_manifest_tests {
     use super::*;
 

--- a/crates/node/tests/tx_ingress_e2e.rs
+++ b/crates/node/tests/tx_ingress_e2e.rs
@@ -13,13 +13,10 @@
 //! the sockets: the bystander peer receives the `inv`, the source peer does
 //! not.
 //!
-//! One seam is filled by the test's node-side thread: the production listener
-//! (`crates/p2p/src/listener.rs::run_message_loop`) does not yet carry a
-//! `Message::Tx` → `InboundTx` hand-off (`InboundSyncSinks` is
-//! headers/blocks/wake only), so the stand-in forwards the decoded body with
-//! the *real* lease-stamped [`PeerSource`]. Everything else — handshake FSM,
-//! inv filter, admission, relay queue, relay worker, peer leases, wire
-//! framing — is the production code under test.
+//! The production listener now forwards `Message::Tx` into the ingress
+//! channel and dispatches through `TxInventory`. This harness still drives
+//! its own loopback sockets so the assertions stay deterministic; it uses
+//! the same consumer, admission, and relay worker `start_node` spawns.
 //!
 //! Skip gate: when loopback TCP is unavailable (sandboxed environment) the
 //! tests return early with a `tracing::warn!` rather than failing.

--- a/crates/node/tests/tx_ingress_e2e.rs
+++ b/crates/node/tests/tx_ingress_e2e.rs
@@ -96,7 +96,7 @@ fn fund_utxo(state: &NodeState, parent: Txid, value: u64) -> anyhow::Result<()> 
         OutPoint::new(parent, 0),
         TxOut {
             value,
-            script_pubkey: Vec::new(),
+            script_pubkey: vec![0x51],
         },
         false,
         100,
@@ -114,13 +114,13 @@ fn spending_tx(parent: Txid, output_value: u64) -> Tx {
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(parent, 0),
-            script_sig: vec![0x52, 0x02, 0xAA, 0xBB],
+            script_sig: Vec::new(),
             sequence: 0xffff_ffff,
             witness: Vec::new(),
         }],
         outputs: vec![TxOut {
             value: output_value,
-            script_pubkey: vec![0x6A],
+            script_pubkey: vec![0x6A, 0x04, 0xAA, 0xBB, 0xCC, 0xDD],
         }],
         lock_time: 0,
     }

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -40,13 +40,14 @@ identity-checked removal go through `PeerTable`, used by the inbound TCP
 `listener` and connection-session paths. A connection is identified by a
 `ConnectionId`, cleaned up through a `PeerLease`, and opened outbound through
 `spawn_outbound_connection`, while the `listener` module accepts inbound TCP connections
-with graceful shutdown. A connection negotiates version/verack in `handshake`, then runs
-the peer finite-state machine in `fsm`; `wire` is the protocol codec, decoding `Message`
-values and reporting `PeerError`. Inbound traffic reaches the host through
-`dispatch_inbound_with_chain`, which streams getdata responses block by block behind the
-outbound budget's pre-load production headroom gate and reads the active chain through
-the `ChainQuery` trait, a read-only view for server-side responders; `inbound` hands
-over `InboundBlock` and `InboundHeaders` with their wire bytes preserved. Misbehaving peers
+with graceful shutdown. A connection negotiates version/verack in
+`handshake`, then runs the peer finite-state machine in `fsm`; `wire` is the protocol
+codec, decoding `Message` values and reporting `PeerError`. Inbound traffic reaches
+the host through `dispatch_inbound_full`, which streams getdata responses
+block by block behind the outbound budget's pre-load production headroom gate,
+filters transaction inventory through the `TxInventory` trait, and reads the
+active chain through the `ChainQuery` trait; `inbound` hands over `InboundBlock`,
+`InboundHeaders`, and `InboundTx` with their delivering peer stamped. Misbehaving peers
 are tracked via the file-persisted `BanList` of the `banlist` module, whole subnets are
 excluded as a `BannedSubnet` built from an `IpSubnet`, and BIP155 addrv2 and BIP339
 wtxid-relay state live in `addrv2` and `wtxid`.

--- a/crates/p2p/src/dispatch.rs
+++ b/crates/p2p/src/dispatch.rs
@@ -99,8 +99,9 @@ pub fn dispatch_inbound<S>(
 ///
 /// Equivalent to [`dispatch_inbound_full`] with `tx_inventory: None`: every
 /// announced tx is requested, and tx-typed `getdata` items are reported
-/// missing. Kept for call sites (the listener) that have not yet been wired
-/// with a [`TxInventory`] handle.
+/// missing. Production listeners pass a [`TxInventory`] through
+/// [`dispatch_inbound_full`]; this wrapper remains for call sites that only
+/// have a chain view.
 pub fn dispatch_inbound_with_chain<S>(
     peer: &mut Peer<S>,
     message: &Message,

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -45,7 +45,7 @@ pub use connection::{ConnectionId, PeerLease, PeerLifecycle, PeerSource, PeerSta
 pub use counters::{CountingStream, PeerCounters};
 pub use dispatch::{ChainQuery, InventoryServing, TxInventory};
 pub use inbound::{InboundBlock, InboundHeaders, InboundTx};
-pub use listener::spawn_outbound_connection;
+pub use listener::{ListenerExtras, spawn_outbound_connection};
 pub use peer::{
     AddNodeError, AddedNodeInfo, BanError, ConnectedPeer, ConnectionCounts, DnsResolver,
     MAX_BLOCK_SERIALIZED_SIZE, MAX_BLOCK_SERIALIZED_SIZE_USIZE, NetworkActivity, NetworkControls,

--- a/crates/p2p/src/listener.rs
+++ b/crates/p2p/src/listener.rs
@@ -21,8 +21,23 @@ const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_mins(1);
 const STREAM_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 type ChainQueryHandle = Option<Arc<dyn crate::dispatch::ChainQuery + 'static>>;
+type TxInventoryHandle = Option<Arc<dyn crate::dispatch::TxInventory + 'static>>;
 type SyncWakeHandle = Option<Sender<()>>;
 type PeerReadyHandle = Option<Arc<dyn Fn(crate::PeerSource) + Send + Sync>>;
+
+/// Optional node-owned handles layered onto a listener or outbound session.
+///
+/// Chain serving and sync wake stay positional on the P2P-owned entry points.
+/// Transaction inventory and inbound `tx` forwarding live here so those
+/// production paths do not grow another suffix each time a handle is added.
+#[derive(Clone, Default)]
+pub struct ListenerExtras {
+    /// Mempool / orphan / recent-rejects view for the `inv` filter and
+    /// transaction `getdata` serving.
+    pub tx_inventory: TxInventoryHandle,
+    /// Bounded ingress for decoded `tx` bodies from Ready peers.
+    pub inbound_tx: Option<Sender<crate::InboundTx>>,
+}
 
 /// State shared by the listener and every connection thread it spawns.
 ///
@@ -37,6 +52,7 @@ struct ConnectionShared {
     activity: Option<Arc<crate::NetworkActivity>>,
     totals: Option<Arc<crate::TrafficTotals>>,
     chain_query: ChainQueryHandle,
+    tx_inventory: TxInventoryHandle,
     session_cancel: Option<Arc<AtomicBool>>,
     peer_ready: PeerReadyHandle,
 }
@@ -53,6 +69,7 @@ impl ConnectionShared {
             activity: None,
             totals: None,
             chain_query,
+            tx_inventory: None,
             session_cancel: None,
             peer_ready: None,
         }
@@ -68,9 +85,15 @@ impl ConnectionShared {
             activity: Some(Arc::clone(controls.activity())),
             totals: Some(Arc::clone(controls.totals())),
             chain_query,
+            tx_inventory: None,
             session_cancel: None,
             peer_ready: None,
         }
+    }
+
+    fn with_tx_inventory(mut self, tx_inventory: TxInventoryHandle) -> Self {
+        self.tx_inventory = tx_inventory;
+        self
     }
 
     fn with_session_cancel(mut self, session_cancel: Arc<AtomicBool>) -> Self {
@@ -123,6 +146,7 @@ impl ConnectionShared {
 struct InboundSyncSinks {
     headers_tx: Sender<crate::InboundHeaders>,
     blocks_tx: Sender<crate::InboundBlock>,
+    tx_tx: Option<Sender<crate::InboundTx>>,
     wake_tx: SyncWakeHandle,
     session_cancel: Option<Arc<AtomicBool>>,
 }
@@ -136,9 +160,15 @@ impl InboundSyncSinks {
         Self {
             headers_tx,
             blocks_tx,
+            tx_tx: None,
             wake_tx,
             session_cancel: None,
         }
+    }
+
+    fn with_inbound_tx(mut self, tx_tx: Option<Sender<crate::InboundTx>>) -> Self {
+        self.tx_tx = tx_tx;
+        self
     }
 
     fn attach_session_cancel(&mut self, shared: &ConnectionShared) {
@@ -200,6 +230,35 @@ impl InboundSyncSinks {
                     );
                     return;
                 }
+            }
+        }
+    }
+
+    /// Forwards a decoded transaction into the node's ingress channel.
+    ///
+    /// The `tx` sink contract lives in `docs/policies/p2p-compatibility.md`.
+    /// A full channel drops this body so the read loop can still service
+    /// ping, headers, and blocks from this peer.
+    fn send_tx(&self, source: crate::PeerSource, tx: bitcoin_rs_primitives::Tx) {
+        let Some(tx_tx) = self.tx_tx.as_ref() else {
+            return;
+        };
+        if self.is_cancelled() {
+            return;
+        }
+        match tx_tx.try_send(crate::InboundTx::new(tx, source)) {
+            Ok(()) => {}
+            Err(crossbeam_channel::TrySendError::Full(_)) => {
+                tracing::debug!(
+                    peer_addr = %source.addr,
+                    "p2p inbound tx channel full; dropping body"
+                );
+            }
+            Err(crossbeam_channel::TrySendError::Disconnected(_)) => {
+                tracing::warn!(
+                    peer_addr = %source.addr,
+                    "p2p inbound tx channel disconnected"
+                );
             }
         }
     }
@@ -496,15 +555,18 @@ pub fn serve_bound_with_session_cancel(
     sync_wake_tx: Option<Sender<()>>,
     session_cancel: Arc<AtomicBool>,
     peer_ready: Arc<dyn Fn(crate::PeerSource) + Send + Sync>,
+    extras: ListenerExtras,
 ) -> Result<(), ListenerError> {
     let mut shared = ConnectionShared::from_parts(peer_table, banned, chain_query)
         .with_session_cancel(session_cancel)
-        .with_peer_ready(peer_ready);
+        .with_peer_ready(peer_ready)
+        .with_tx_inventory(extras.tx_inventory);
     shared.activity = Some(Arc::new(crate::NetworkActivity::from_shared(
         network_active,
     )));
     let inbound_sync_sinks =
-        InboundSyncSinks::new(inbound_headers_tx, inbound_blocks_tx, sync_wake_tx);
+        InboundSyncSinks::new(inbound_headers_tx, inbound_blocks_tx, sync_wake_tx)
+            .with_inbound_tx(extras.inbound_tx);
     accept_connections(
         addr,
         &listener,
@@ -530,10 +592,12 @@ pub fn spawn_outbound_connection_with_session_cancel(
     sync_wake_tx: Option<Sender<()>>,
     session_cancel: Arc<AtomicBool>,
     peer_ready: Arc<dyn Fn(crate::PeerSource) + Send + Sync>,
+    extras: ListenerExtras,
 ) -> std::thread::JoinHandle<Result<(), crate::wire::PeerError>> {
     let mut shared = ConnectionShared::from_parts(peer_table, banned, chain_query)
         .with_session_cancel(session_cancel)
-        .with_peer_ready(peer_ready);
+        .with_peer_ready(peer_ready)
+        .with_tx_inventory(extras.tx_inventory);
     shared.activity = Some(Arc::new(crate::NetworkActivity::from_shared(
         network_active,
     )));
@@ -541,7 +605,8 @@ pub fn spawn_outbound_connection_with_session_cancel(
         addr,
         magic,
         shared,
-        InboundSyncSinks::new(inbound_headers_tx, inbound_blocks_tx, sync_wake_tx),
+        InboundSyncSinks::new(inbound_headers_tx, inbound_blocks_tx, sync_wake_tx)
+            .with_inbound_tx(extras.inbound_tx),
     )
 }
 
@@ -921,6 +986,7 @@ fn run_connected_session(
             &lease,
             inbound_sync_sinks,
             shared.chain_query.as_deref(),
+            shared.tx_inventory.as_deref(),
             shared.totals.as_ref(),
         )
     })();
@@ -944,6 +1010,7 @@ fn run_message_loop<S: std::io::Read + std::io::Write>(
     lease: &crate::PeerLease,
     inbound_sync_sinks: &InboundSyncSinks,
     chain_query: Option<&dyn crate::dispatch::ChainQuery>,
+    tx_inventory: Option<&dyn crate::dispatch::TxInventory>,
     totals: Option<&Arc<crate::TrafficTotals>>,
 ) -> Result<(), crate::wire::PeerError> {
     use crate::peer::PeerState;
@@ -990,10 +1057,11 @@ fn run_message_loop<S: std::io::Read + std::io::Write>(
                     command = ?std::mem::discriminant(&message),
                     "p2p message received",
                 );
-                crate::dispatch::dispatch_inbound_with_chain(
+                crate::dispatch::dispatch_inbound_full(
                     peer,
                     &message,
                     chain_query,
+                    tx_inventory,
                     &|| budget.has_block_production_headroom(),
                     &mut |response| {
                         lease.send(response).map_err(|_| {
@@ -1007,6 +1075,9 @@ fn run_message_loop<S: std::io::Read + std::io::Write>(
                     }
                     crate::Message::Block(block) => {
                         inbound_sync_sinks.send_block(lease.source(peer_addr), block, raw);
+                    }
+                    crate::Message::Tx(tx) => {
+                        inbound_sync_sinks.send_tx(lease.source(peer_addr), tx);
                     }
                     crate::Message::Pong(nonce) => {
                         lease.stats().complete_ping(nonce, unix_micros());
@@ -1513,7 +1584,7 @@ mod writer_shutdown_tests {
             crossbeam_channel::unbounded().0,
             None,
         );
-        assert!(run_message_loop(&mut peer, addr, &lease, &sinks, None, None).is_ok());
+        assert!(run_message_loop(&mut peer, addr, &lease, &sinks, None, None, None).is_ok());
     }
 
     #[test]
@@ -1544,7 +1615,7 @@ mod writer_shutdown_tests {
         );
         peer.state = PeerState::Ready;
 
-        assert!(run_message_loop(&mut peer, addr, &old, &sinks, None, None).is_ok());
+        assert!(run_message_loop(&mut peer, addr, &old, &sinks, None, None, None).is_ok());
         assert!(headers_rx.try_recv().is_err());
         assert!(old.is_cancelled());
         assert!(table.is_current(replacement.source(addr)));
@@ -1586,7 +1657,7 @@ mod writer_shutdown_tests {
             None,
         );
 
-        assert!(run_message_loop(&mut peer, addr, &lease, &sinks, None, None).is_err());
+        assert!(run_message_loop(&mut peer, addr, &lease, &sinks, None, None, None).is_err());
         assert_eq!(reads.load(Ordering::Relaxed), 2);
     }
 
@@ -1979,7 +2050,7 @@ mod writer_shutdown_tests {
 
         // The Pong response cannot be admitted onto the zero budget, so the
         // saturation policy cancels the lease and ends the loop.
-        let result = run_message_loop(&mut peer, addr, &lease, &sinks, None, None);
+        let result = run_message_loop(&mut peer, addr, &lease, &sinks, None, None, None);
         assert!(result.is_err(), "saturation must end the message loop");
         assert!(lease.is_cancelled());
     }

--- a/crates/p2p/src/service.rs
+++ b/crates/p2p/src/service.rs
@@ -203,6 +203,7 @@ impl P2pService {
         chain_query: Option<&Arc<dyn crate::ChainQuery + 'static>>,
         sync_wake_tx: Option<&Sender<()>>,
         peer_ready: &Arc<dyn Fn(crate::PeerSource) + Send + Sync>,
+        extras: crate::listener::ListenerExtras,
     ) -> Result<(), P2pServiceError> {
         let chain_query = chain_query.cloned();
         let sync_wake_tx = sync_wake_tx.cloned();
@@ -241,6 +242,7 @@ impl P2pService {
             let sync_wake_tx = sync_wake_tx.clone();
             let session_cancel = Arc::clone(&session_cancel);
             let peer_ready = Arc::clone(&peer_ready);
+            let extras = extras.clone();
             let magic = self.config.magic;
             let handle = match thread::Builder::new()
                 .name(format!("bitcoin-rs-p2p-{listener_addr}"))
@@ -259,6 +261,7 @@ impl P2pService {
                         sync_wake_tx,
                         session_cancel,
                         peer_ready,
+                        extras,
                     )
                 }) {
                 Ok(handle) => handle,
@@ -275,6 +278,7 @@ impl P2pService {
             sync_wake_tx,
             Arc::clone(&session_cancel),
             Arc::clone(&peer_ready),
+            extras,
         ) {
             Ok(handle) => handle,
             Err(error) => {
@@ -321,6 +325,7 @@ impl P2pService {
         sync_wake_tx: Option<Sender<()>>,
         session_cancel: Arc<AtomicBool>,
         peer_ready: Arc<dyn Fn(crate::PeerSource) + Send + Sync>,
+        extras: crate::listener::ListenerExtras,
     ) -> Result<JoinHandle<()>, io::Error> {
         let outbound_rx = Arc::clone(&self.outbound_rx);
         let lifecycle = Arc::clone(&self.lifecycle);
@@ -371,6 +376,7 @@ impl P2pService {
                         sync_wake_tx.clone(),
                         Arc::clone(&session_cancel),
                         Arc::clone(&peer_ready),
+                        extras.clone(),
                     );
                     active.insert(addr);
                     handles.push((addr, handle));
@@ -1044,7 +1050,7 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
         );
         let error = service
-            .start(None, None, &idle_ready())
+            .start(None, None, &idle_ready(), crate::listener::ListenerExtras::default())
             .expect_err("occupied listen addr must fail start");
         assert!(
             matches!(error, P2pServiceError::Listener(ListenerError::Bind { .. })),
@@ -1064,7 +1070,7 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
         );
         service
-            .start(None, None, &idle_ready())
+            .start(None, None, &idle_ready(), crate::listener::ListenerExtras::default())
             .expect("empty listen set starts");
         service.shutdown();
         service.join().expect("clean join");

--- a/crates/p2p/src/service.rs
+++ b/crates/p2p/src/service.rs
@@ -1050,7 +1050,12 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
         );
         let error = service
-            .start(None, None, &idle_ready(), crate::listener::ListenerExtras::default())
+            .start(
+                None,
+                None,
+                &idle_ready(),
+                crate::listener::ListenerExtras::default(),
+            )
             .expect_err("occupied listen addr must fail start");
         assert!(
             matches!(error, P2pServiceError::Listener(ListenerError::Bind { .. })),
@@ -1070,7 +1075,12 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
         );
         service
-            .start(None, None, &idle_ready(), crate::listener::ListenerExtras::default())
+            .start(
+                None,
+                None,
+                &idle_ready(),
+                crate::listener::ListenerExtras::default(),
+            )
             .expect("empty listen set starts");
         service.shutdown();
         service.join().expect("clean join");

--- a/crates/primitives/src/outpoint.rs
+++ b/crates/primitives/src/outpoint.rs
@@ -40,6 +40,15 @@ impl OutPoint {
     pub const fn new(txid: Txid, vout: u32) -> Self {
         Self { txid, vout }
     }
+
+    /// Bitcoin's null / coinbase prevout: an all-zero txid with `vout == u32::MAX`.
+    ///
+    /// `OutPoint::default()` is the derived all-zero layout (`vout == 0`) and
+    /// is not null. Consensus coinbase detection uses this predicate.
+    #[must_use]
+    pub fn is_null(self) -> bool {
+        self.vout == u32::MAX && self.txid.as_bytes().iter().all(|&byte| byte == 0)
+    }
 }
 
 impl fmt::Display for OutPoint {
@@ -74,5 +83,13 @@ mod tests {
             outpoint.to_string(),
             Txid(Hash256::from_le_bytes(&txid)).to_string() + ":168496141"
         );
+    }
+
+    #[test]
+    fn null_outpoint_is_zero_txid_and_max_vout() {
+        let coinbase = OutPoint::new(Txid::default(), u32::MAX);
+        assert!(coinbase.is_null());
+        assert!(!OutPoint::default().is_null());
+        assert!(!OutPoint::new(Txid::default(), 0).is_null());
     }
 }

--- a/crates/rpc/src/esplora.rs
+++ b/crates/rpc/src/esplora.rs
@@ -530,9 +530,8 @@ fn internal_mempool_txs(ctx: &Context, last: Option<&str>, query: &str) -> Respo
     let transactions = {
         let pool = ctx.mempool.read();
         let mut ordered = pool
-            .entries
-            .iter()
-            .map(|(_, entry)| (entry.time, entry.txid, Arc::clone(&entry.tx)))
+            .iter_entries()
+            .map(|entry| (entry.time, entry.txid, Arc::clone(&entry.tx)))
             .collect::<Vec<_>>();
         drop(pool);
         ordered.sort_unstable_by(|left, right| {

--- a/docs/policies/p2p-compatibility.md
+++ b/docs/policies/p2p-compatibility.md
@@ -64,14 +64,14 @@ The decoder in `crates/p2p/src/wire.rs::decode_payload` dispatches exactly **36 
 | `sendheaders` | negotiated | BIP130. Sent in handshake; inbound tracked. |
 | `ping` | served | Answered with `pong` echoing the nonce, ready peers only; pongs feed peer RTT stats. |
 | `pong` | ignored | Completes outstanding ping RTT accounting. |
-| `inv` | served | Answered with `getdata` echoing the announced vectors verbatim (a wtxid-relay peer announcing `MSG_WTX` is asked for `MSG_WTX`). Bound: 50 000 vectors (`MAX_INV_PER_MSG`, Core `MAX_INV_SZ`). |
-| `getdata` | served | Served from the active chain: block inventory resolves to `block` messages; misses resolve to one `notfound`. Bound: 50 000 vectors. |
+| `inv` | served | Answered with `getdata` for announced vectors the node does not already hold. Transaction inventory is filtered through the node's admission view (mempool, orphan map, recent-rejects); a wtxid-relay peer announcing `MSG_WTX` is asked for `MSG_WTX`. Bound: 50 000 vectors (`MAX_INV_PER_MSG`, Core `MAX_INV_SZ`). |
+| `getdata` | served | Blocks stream from the active chain; transaction inventory is served from the mempool / orphan map. Misses resolve to one trailing `notfound`. Bound: 50 000 vectors. |
 | `notfound` | ignored | Decoded with the same inventory bound. |
 | `getheaders` | served | Answered with `headers` from the active chain: first locator hash on the active chain anchors the walk, total miss anchors after genesis, stop hash truncates inclusively, ≤ 2 000 headers per message (Core's per-message maximum). Locator bound: 101 hashes (Core `MAX_LOCATOR_SZ`). Empty locator + zero stop answers nothing (Core clients always send a locator; unreachable in practice). |
 | `getblocks` | ignored | Legacy locator request; Core answers with an `inv`, we stay silent. Documented deviation. Locator bound identical. |
 | `headers` | sink | Forwarded to the node's header-sync pipeline. Bound: ≤ 2 000 headers per message. |
 | `block` | sink | Forwarded to the node's block pipeline with the original wire bytes preserved. |
-| `tx` | sink (incomplete) | Decoded and FSM-accepted, but not yet delivered into the mempool — production transaction relay is incomplete (see `CONCEPTS.md` "Tx relaying"). No response, no disconnect. |
+| `tx` | sink | Forwarded from a Ready peer into the node's bounded ingress channel; the ingress consumer admits through the one mempool gateway and announces accepted transactions as `inv(tx)` to peers other than the source. A full channel applies backpressure to that peer's read loop. No protocol response, no disconnect. |
 | `mempool` | ignored | BIP35 mempool snapshot request; Core answers with an `inv` of relay-pool transactions. Deviation: silent. |
 | `getaddr` | ignored | No address gossip: Core answers with an `addr` burst. Deviation: silent. |
 | `addr` / `addrv2` | ignored | Decoded (bound: 1 000 entries, Core `MAX_ADDR_TO_SEND`); never gossiped onward. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Inbound peer `tx` messages were decoded and then dropped: the listener had no ingress sink, dispatch ran with `tx_inventory: None`, and `spawn_tx_ingress_consumer` had no production caller. The mempool therefore filled only through `sendrawtransaction`, and even those RPC-admitted transactions were never announced.

This PR is the missing production wiring. The admission, orphan, reject-cache, and relay machinery from #101 stay the owners; startup now constructs the bounded channel, hands `TxAdmission` to dispatch, and starts the ingress consumer (which starts the relay worker).

## What changed

- The listener forwards `Message::Tx` from Ready peers into a bounded `InboundTx` channel. A full channel **drops** the body (`try_send`) so one flooder cannot stall ping/headers/blocks on every other connection that later receives a `tx`. Optional `tx_inventory` and `inbound_tx` live on `ListenerExtras`; `P2pService` remains the sole listener/outbound owner after #218.
- `start_node` constructs `TxAdmission` over the process-wide gateway, calls `spawn_tx_ingress_consumer`, and joins both the ingress and relay workers on teardown.
- Dispatch uses `dispatch_inbound_full` with the real `TxInventory` handle: `inv(tx)` is filtered against mempool / orphans / recent-rejects, and `getdata` is served from the pool.
- P2P admission builds an `AdmissionRequest` (applied tip, median-time-past, resolved prevouts) and calls `MempoolGateway::admit_transaction`, so peer transactions run the same STANDARD script, locktime, and height checks as RPC.
- Missing-input peers are held as orphans (never coinbases, never non-standard / overweight bodies) with their delivering peer, and only actually-missing parents are requested via `getdata`. Admitting a parent from any origin — peer, RPC, reorg, block confirmation, or disconnect restore — re-queues waiting children.
- A full or missing ingress channel parks failed orphan wakes on a pending-retry list that the ingress consumer drains directly, so a parent that will not be accepted again cannot leave children stranded under `have_tx`.
- RPC and reorg accepts announce through `LocalTxRelayObserver` on the same relay queue. Peer-origin accepts still announce from the ingress consumer so the delivering connection is excluded.
- Chain movement itself (every block connect and disconnect, including empty mempool sweeps) clears recent-rejects through `ApplyHandles`, so `apply.rs` is the one caller and empty blocks do not leave stale suppressions.

## Review follow-up

Rebased onto current `main` after #218, #331, #344, #350, and #346.

- `mempool_observer.rs` is this PR's two legs only (`OrphanWakeObserver`, `LocalTxRelayObserver`); sequence ZMQ and mining wakes stay with their owner crates.
- Wtxid inventory uses the mempool's `contains_wtxid` index from #350.
- Esplora mempool paging uses `iter_entries` after #350 made `Mempool.entries` private.
- Did not restore `spawn_p2p_listeners`.

Validated remaining comments against this head:

- **Already fixed:** consensus admission, disconnect orphan wake, parked retries, standardness-before-orphan, drop-on-full `send_tx`, empty-block reject invalidation, coinbase orphan quota, orphan source, missing-parent `getdata`.
- **Not applied:** citing `P2P-01` for the `tx` sink — that clause owns wire/handshake; the policy `tx` row remains the owner.

Does **not** close #323: Core interop proof of announce-excluding-source and per-peer admission rate limits stay out of scope.

## Verification

- `cargo test -p bitcoin-rs-p2p --lib -- listener` — 22 passed
- `cargo test -p bitcoin-rs-node --no-default-features --features fjall --lib -- tx_admission tx_ingress mempool_observer inbound_tx_channel coinbase orphan_wake`
- `cargo test -p bitcoin-rs-node --no-default-features --features fjall --test tx_ingress_e2e`
- `cargo clippy` on p2p and node (`--no-default-features --features fjall`) with `-D warnings`

Out of scope (tracked separately): cluster-limit policy, block-inclusion refinement, `testmempoolaccept` residuals, Core interop proof of the live path, per-peer admission rate limits.

Relations: child of #113; fulfills the #116 mempool relay item and the unchecked relay item of #114; built on #101. See also #323 (residuals remain).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a452cce-c137-49c4-b2c7-f9f69e04796b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a452cce-c137-49c4-b2c7-f9f69e04796b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

