### PR TITLE
Keep kernel as the library default until signed-spend wins

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -89,7 +89,7 @@ Skipping script-signature verification for blocks at or below a trusted height w
 The mainnet checkpoint (height 938343, block `00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac`). Script verification is skipped at or below it only after the active header chain is shown to contain this exact hash; sub-anchor header tips and diverged chains verify fully.
 
 ### Optimized default posture
-The default mainnet configuration: `fjall` backend, multi-peer download (outbound target 8, pending block budget 128, 16 in-flight per peer), hash-pinned assume-valid, 450 MiB `dbcache`, `txindex` and pruning off. The checked-in Compose specialization compiles only `fjall` + `bitcoinkernel`, runs unprivileged, and namespaces node and enforcer data by `BITCOIN_RS_NETWORK`.
+The default mainnet configuration: `fjall` backend, multi-peer download (outbound target 8, pending block budget 128, 16 in-flight per peer), hash-pinned assume-valid, 450 MiB `dbcache`, `txindex` and pruning off. The checked-in Compose specialization compiles `fjall` + `bitcoinkernel`, runs unprivileged, and namespaces node and enforcer data by `BITCOIN_RS_NETWORK`.
 
 ### Node network selection
 `BITCOIN_RS_NETWORK`/`--network` atomically selects consensus rules and P2P bootstrap identity while preserving later low-level overrides. The internal consensus `Network` remains the consensus selector: `drynet4` keeps mainnet consensus with message start `eca5d404`, no Bitcoin DNS seeds, and `drynet4.drivechain.dev:8533`. See `docs/solutions/architecture-patterns/network-selection-keeps-p2p-identity-atomic.md`.
@@ -107,9 +107,10 @@ retained Criterion benchmark targets are compiled in the `bench-smoke` CI lane
 ## Consensus validation
 
 ### bitcoinkernel
-Bitcoin Core's C++ consensus engine (`libbitcoinkernel`), the production consensus default. It is both the input-script verifier for every script class and the block **parser** on the apply path (*One-shot kernel block parse*). Rust performs the surrounding non-script transaction and block checks. Default builds need `cmake` and `libboost-dev`.
-### Rust interpreter (portable posture)
-The pure-Rust script path under `--no-default-features`. It fully verifies the Taproot key path; its non-Taproot path is a stub accepting only a bare `OP_TRUE` spend, and it has no Taproot script-path support. Retained for differential testing and lightweight non-production environments; a mainnet sync stops at the first real spend.
+Bitcoin Core's C++ consensus engine (`libbitcoinkernel`). With the `kernel` feature it is both the input-script verifier for every script class and the block **parser** on the apply path (*One-shot kernel block parse*). Rust performs the surrounding non-script transaction and block checks. `kernel` is the production default in `bitcoin-rs-consensus` and `bitcoin-rs-node`, and in the Compose image; the `bin/bitcoin-rs` binary leaves it off so `cargo build -p bitcoin-rs` uses the native interpreter. Builds with `kernel` need `cmake` and `libboost-dev`. Whether the native path also becomes the library and image default is the #213 measurement gate.
+
+### Native Rust interpreter
+The pure-Rust script path used when `kernel` is off (`crates/script`). It executes legacy, P2SH, SegWit v0, and Taproot key-path and script-path spends through the opcode evaluator. Core's `script_tests`, `tx_valid`, and `tx_invalid` vectors currently pin zero native mismatches. Signature checks reuse the process-wide `secp256k1::SECP256K1` context.
 
 ### One-shot kernel block parse
 Parsing each block exactly once with `bitcoinkernel::Block::new` (`KernelBlock`, `crates/consensus/src/kernel.rs`) and reusing that parse downstream for txids and the transaction objects script preparation borrows via `TransactionRef`. Price a replacement by everything it subsumes, not by the line item that motivated it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,11 @@ Core & domain: crates/consensus, crates/script, crates/utxo, crates/chain, crate
 Key rules:
 - No reverse dependencies: lower layers never depend on higher layers.
 - Storage isolation: storage backends remain behind `crates/storage`. `crates/rpc` consumes node-level capabilities, never storage engines directly.
-- Consensus authority: the native Rust validation engine in `crates/consensus` is the production default. `libbitcoinkernel` serves as an opt-in differential verification oracle.
+- Consensus authority: the native Rust interpreter in `crates/script` verifies
+  every consensus spend class. `libbitcoinkernel` is an opt-in differential
+  oracle behind `--features kernel`. The `kernel` feature remains the default
+  in `bitcoin-rs-consensus` and `bitcoin-rs-node` until the #213 measurement
+  gate flips those crates.
 
 ## Commit and PR conventions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ mimalloc = { version = ">=0.1.50, <0.2", default-features = false }
 # --- Bitcoin ecosystem --------------------------------------------------------
 # bitcoin 0.32 line; 0.33 is still beta. `default = [std, secp-recovery]`.
 # Keep `bitcoinconsensus-std` out of the workspace-wide dependency: the
-# `bitcoinconsensus` opt-in was removed and bitcoinkernel is the production
-# consensus engine, gated by the consensus crate's `kernel` feature. The
+# `bitcoinconsensus` opt-in was removed and bitcoinkernel is the optional
+# consensus oracle, gated by the consensus crate's `kernel` feature. The
 # `kernel` feature defaults ON in `crates/consensus` and `crates/node` but
-# OFF in `bin/bitcoin-rs`; the #166 flip to opt-in-everywhere is blocked
-# until the portable interpreter can validate ordinary spends.
+# OFF in `bin/bitcoin-rs`; issue #213 is the measurement gate for flipping
+# the library defaults to native.
 bitcoin = { version = ">=0.32.9, <0.33", default-features = false, features = [
     "std", "secp-recovery", "serde", "rand-std",
 ] }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # bitcoin-rs
 
 A Bitcoin full node in Rust 2024. The default binary build is pure Rust (no
-C++ toolchain required) and uses `libbitcoinkernel` as the production consensus
-engine when the `kernel` feature is enabled; the portable Rust script path
-verifies Taproot key-path spends only and is not yet a complete consensus
-validator (see #166).
+C++ toolchain required) and runs the native script interpreter for every
+consensus spend class. Enable `--features kernel` to route the same checks
+through `libbitcoinkernel` as an independent oracle. The `kernel` feature
+remains the default in the `bitcoin-rs-consensus` and `bitcoin-rs-node`
+library crates, and in the Compose image, until the #213 measurement gate
+flips them.
 
 [![CI](https://github.com/gosuda/bitcoin-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/gosuda/bitcoin-rs/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
@@ -79,19 +81,17 @@ risk of correlated implementation failures.
 
 ## Features
 
-- Consensus validation: `libbitcoinkernel` (Bitcoin Core's C++ engine) verifies
-  all script classes — Legacy, SegWit v0, and Taproot key-path and script-path
-  spends — when the `kernel` feature is enabled. The portable Rust interpreter
-  covers Taproot key-path only; other script classes are stubbed pending a full
-  opcode interpreter (see #166). Script checks run in parallel across rayon
-  workers with sighash midstate reuse per transaction.
-- Kernel feature: `--features kernel` enables `libbitcoinkernel` as the
-  consensus engine. The `crates/consensus` and `crates/node` library crates
-  default to `kernel`; the `bin/bitcoin-rs` binary defaults to `["fjall",
-  "redb", "zmq"]` (no kernel) for a pure-Rust quickstart. A default binary
-  build therefore excludes `bitcoinkernel` from its dependency graph and
-  cannot validate ordinary mainnet spends — pass `--features kernel` for
-  production consensus validation.
+- Consensus validation: the native Rust interpreter verifies Legacy, SegWit v0,
+  and Taproot key-path and script-path spends. Core's committed `script_tests`,
+  `tx_valid`, and `tx_invalid` vectors pin zero native mismatches. Script checks
+  run in parallel across rayon workers with sighash midstate reuse per
+  transaction. `--features kernel` routes the same checks through
+  `libbitcoinkernel` (Bitcoin Core's C++ engine) as an independent oracle.
+- Kernel feature: `--features kernel` enables `libbitcoinkernel`. The
+  `crates/consensus` and `crates/node` library crates still default to `kernel`;
+  the `bin/bitcoin-rs` binary defaults to `["fjall", "redb", "zmq"]` (no kernel)
+  so a default binary build is pure Rust. Issue #213 is the measurement gate
+  for making the native path the library default as well.
 - Pure-Rust storage defaults: LSM-tree storage backed by `fjall` by default,
   with `redb` compiled in, and `rocksdb`/`mdbx` available through optional Cargo
   features.
@@ -136,11 +136,11 @@ curl -s --user bitcoin-rs:bitcoin-rs \
   http://127.0.0.1:8332/
 ```
 
-### Kernel consensus build
+### Kernel oracle build
 
-To build with `libbitcoinkernel` as the consensus engine, install C++
-dependencies (`cmake` and `libboost-dev` on Debian/Ubuntu), then pass
-`--features kernel`:
+To route script verification through `libbitcoinkernel` instead of the native
+interpreter, install C++ dependencies (`cmake` and `libboost-dev` on
+Debian/Ubuntu), then pass `--features kernel`:
 
 ```sh
 cargo build --release -p bitcoin-rs --features kernel
@@ -176,9 +176,9 @@ Core & domain: crates/consensus, crates/script, crates/utxo, crates/chain, crate
 ```
 
 - Validation: script execution runs in parallel across rayon workers, with
-  sighash midstate reuse per transaction. Under the `kernel` feature,
-  `libbitcoinkernel` verifies all script classes; without it, the portable
-  Rust interpreter handles Taproot key-path only.
+  sighash midstate reuse per transaction. The native interpreter covers every
+  consensus spend class. Under the `kernel` feature, `libbitcoinkernel` is the
+  verifier instead.
 - Kernel boundary: `crates/consensus/src/kernel.rs` contains all
   `libbitcoinkernel` types behind `#[cfg(feature = "kernel")]`. Kernel types
   never leak into node state or apply logic.
@@ -192,7 +192,7 @@ Core & domain: crates/consensus, crates/script, crates/utxo, crates/chain, crate
 | Setting | Default |
 |---|---|
 | Storage backend | `fjall` |
-| Validation engine | `libbitcoinkernel` (with `--features kernel`); portable Rust (default binary, Taproot key-path only) |
+| Validation engine | Native Rust interpreter (default binary); `libbitcoinkernel` with `--features kernel` |
 | Kernel feature | Off in default binary build; on in `crates/consensus` and `crates/node` library defaults |
 | Database cache | 450 MiB (`--dbcache-mb`, split 80/20 when txindex is enabled) |
 | Multi-peer download | On (8 outbound peers, 128-block window) |

--- a/crates/consensus/README.md
+++ b/crates/consensus/README.md
@@ -1,9 +1,12 @@
 # bitcoin-rs-consensus
 
-Owns consensus validation: transaction and block rule checks for every active soft fork,
-with the `kernel` feature (the production default) routing script verification through
-bitcoinkernel — Bitcoin Core's native consensus engine — and a portable Rust path
-retained for differential tests and builds without a native backend.
+Owns consensus validation: transaction and block rule checks for every active soft fork.
+Script verification has two backends. The native Rust interpreter executes every
+consensus spend class. The `kernel` feature (the production default in this crate
+and in `bitcoin-rs-node`) routes the same checks through bitcoinkernel — Bitcoin
+Core's C++ consensus engine. The `bin/bitcoin-rs` binary does not enable `kernel`
+by default, so `cargo build -p bitcoin-rs` uses the native interpreter. Issue #213
+is the measurement gate for making that native path the library default as well.
 
 Rule checks live in small per-subject modules (`bip9`, `bip30`, `bip34`, `bip65`,
 `bip66`, `bip68`, `bip112`, `bip113`, `bip141`, `bip143`, `bip341`, `bip342`), surfaced

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Script verification has two backends. The native Rust interpreter in
 //! `bitcoin-rs-script` executes every consensus spend class: legacy, P2SH,
-//! SegWit v0, and Taproot key-path and script-path. The `kernel` feature
+//! `SegWit` v0, and Taproot key-path and script-path. The `kernel` feature
 //! routes the same checks through bitcoinkernel (Bitcoin Core's C++ engine)
 //! and is the production default in this crate and in `bitcoin-rs-node`.
 //! The `bin/bitcoin-rs` binary defaults to `["fjall", "redb", "zmq"]` (no

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -1,16 +1,14 @@
 //! Consensus validation surfaces for bitcoin-rs.
 //!
-//! The `kernel` feature is the production default in this crate and in
-//! `bitcoin-rs-node`: it routes every script class through bitcoinkernel
-//! (Bitcoin Core's native consensus engine). The `bin/bitcoin-rs` binary
-//! defaults to `["fjall", "redb", "zmq"]` (no `kernel`), so `cargo build
-//! -p bitcoin-rs` uses the portable path. With the feature off, the crate
-//! builds a portable Rust validation path that delegates taproot key-path
-//! script execution to `bitcoin-rs-script` and keeps consensus-facing rule
-//! checks in small, testable modules. The portable path's non-Taproot arm
-//! is a stub that accepts only bare `OP_TRUE` spends; it cannot validate
-//! ordinary mainnet spends (see #166). It is retained for differential
-//! tests and builds without a native backend.
+//! Script verification has two backends. The native Rust interpreter in
+//! `bitcoin-rs-script` executes every consensus spend class: legacy, P2SH,
+//! SegWit v0, and Taproot key-path and script-path. The `kernel` feature
+//! routes the same checks through bitcoinkernel (Bitcoin Core's C++ engine)
+//! and is the production default in this crate and in `bitcoin-rs-node`.
+//! The `bin/bitcoin-rs` binary defaults to `["fjall", "redb", "zmq"]` (no
+//! `kernel`), so `cargo build -p bitcoin-rs` uses the native interpreter.
+//! Whether that native path also becomes the library default is the
+//! measurement gate in issue #213.
 
 #![forbid(unsafe_op_in_unsafe_fn)]
 

--- a/crates/consensus/src/verify_tx.rs
+++ b/crates/consensus/src/verify_tx.rs
@@ -301,8 +301,9 @@ fn finalize_tx_value_and_sigops(tx: &Tx, prep: &TxPrep) -> Result<(), ConsensusE
     Ok(())
 }
 
-/// Portable per-input script verdict: the Rust interpreter handles taproot
-/// key-path; non-taproot spends require the kernel production path.
+/// Portable per-input script verdict: the native interpreter covers every
+/// consensus spend class (legacy, P2SH, segwit v0, taproot key-path and
+/// script-path).
 #[cfg(not(feature = "kernel"))]
 fn verify_input_script_portable(
     input_index: usize,

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -28,7 +28,8 @@ runtime crate.
 - `default` (enables `fjall`, `kernel`, and `zmq`): the performance-oriented fjall
   storage backend plus the bitcoinkernel consensus verifier and ZMQ notifications,
   so per-crate `cargo check` works out of the box. The `bitcoin-rs` binary's own
-  defaults are the pure-Rust `fjall,redb,zmq`; `kernel` stays opt-in there.
+  defaults are the pure-Rust `fjall,redb,zmq`; `kernel` stays opt-in there. Issue
+  #213 is the measurement gate for dropping `kernel` from this crate's defaults.
 - `rocksdb`, `fjall`, `redb`: forward the named storage backend to every subsystem
   crate.
 - `mdbx`: forward the mdbx backend to the crates that provide one.

--- a/crates/script/README.md
+++ b/crates/script/README.md
@@ -1,17 +1,17 @@
 # bitcoin-rs-script
 
-Script verification for the portable posture, plus the sigop counters and
-signature-hash caching that surround script execution.
+Native script verification for every consensus spend class, plus the sigop
+counters that surround execution.
 
 `Interpreter::execute` and `Interpreter::execute_with_prevouts` run one script
 spend under a `VerifyFlags` set (parseable from Core test-vector flag strings
-via `VerifyFlags::from_core_names`): the local BIP341 path verifies Taproot
-key-path spends in full — multi-input spends require the complete ordered
-prevout set — while the portable non-taproot path accepts only bare `OP_TRUE`
-spends; every other script class requires the kernel production path. Around
-the interpreter sit `sigops` (signature-operation counting), `sighash_cache`
-(the signature-hash cache wrapper), and `opcodes` (opcode re-exports and a
-local opcode newtype). Failures surface as `ScriptError`.
+via `VerifyFlags::from_core_names`). The opcode evaluator covers legacy and
+P2SH, SegWit v0 uses BIP143 sighashes, and Taproot key-path and script-path
+spends go through local BIP341/BIP342 verification. Multi-input Taproot
+spends require the complete ordered prevout set. Around the interpreter sit
+`sigops` (signature-operation counting) and the signature checker. Failures
+surface as `ScriptError`. Core's `script_tests`, `tx_valid`, and `tx_invalid`
+vectors pin zero native mismatches in `tests/core_vectors.rs`.
 
 ## Features
 

--- a/crates/script/src/checker.rs
+++ b/crates/script/src/checker.rs
@@ -10,7 +10,7 @@
 //! `CheckLockTime`, `CheckSequence`).
 
 use bitcoin_rs_primitives::{Hash256, Sighash, SighashCache, SighashError, Tx, TxOut};
-use secp256k1::{Message, PublicKey, Secp256k1, XOnlyPublicKey, ecdsa::Signature as EcdsaSig};
+use secp256k1::{Message, PublicKey, XOnlyPublicKey, ecdsa::Signature as EcdsaSig};
 
 use crate::interpreter::{ScriptErrCode, ScriptError, VerifyFlags};
 
@@ -218,9 +218,9 @@ impl<'a> TxSignatureChecker<'a> {
         };
 
         let message = Message::from_digest(*sighash.as_byte_array());
-        let secp = Secp256k1::verification_only();
-
-        let verified = secp
+        // One process-wide context: constructing `verification_only()` per
+        // signature rebuilds secp256k1's verification tables on every CHECKSIG.
+        let verified = secp256k1::SECP256K1
             .verify_ecdsa(&message, &ecdsa_sig, &secp_pubkey)
             .is_ok();
 
@@ -325,9 +325,8 @@ impl<'a> TxSignatureChecker<'a> {
             .map_err(|e| sighash_to_script_error(&e))?;
 
         let message = Message::from_digest(*sighash.as_byte_array());
-        let secp = Secp256k1::verification_only();
-
-        secp.verify_schnorr(&schnorr_sig, &message, &xonly_pubkey)
+        secp256k1::SECP256K1
+            .verify_schnorr(&schnorr_sig, &message, &xonly_pubkey)
             .map(|()| true)
             .map_err(|_| ScriptError::Invalid {
                 code: ScriptErrCode::SchnorrSig,

--- a/crates/script/src/interpreter.rs
+++ b/crates/script/src/interpreter.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::fmt;
 
 use bitcoin_rs_primitives::{Sighash, SighashCache, Tx, TxOut};
-use secp256k1::{Message, Secp256k1, XOnlyPublicKey, schnorr::Signature};
+use secp256k1::{Message, XOnlyPublicKey, schnorr::Signature};
 use thiserror::Error;
 
 use crate::checker::{SigVersion, TxSignatureChecker};
@@ -877,10 +877,13 @@ fn verify_taproot_keypath(
         .taproot_signature_hash(input_idx, prevouts, annex_bytes, None, sighash_type)
         .map_err(|error| ScriptError::Verification(error.to_string()))?;
     let message = Message::from_digest(*sighash.as_byte_array());
-    let secp = Secp256k1::verification_only();
-    secp.verify_schnorr(&signature, &message, &public_key)
-        .map(|()| true)
-        .map_err(|error| ScriptError::Verification(error.to_string()))
+    if taproot::verify_taproot_keypath(&signature, &message, &public_key) {
+        Ok(true)
+    } else {
+        Err(ScriptError::Verification(
+            "taproot key-path Schnorr verification failed".to_owned(),
+        ))
+    }
 }
 
 /// Verifies a taproot script-path spend (BIP341/BIP342).

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -19,7 +19,7 @@ pub mod interpreter;
 pub mod script;
 /// Signature operation counters.
 pub mod sigops;
-/// Bounded stack infrastructure for the future hand-rolled interpreter.
+/// Bounded script stack with Core's 1000-item maximum depth.
 pub mod stack;
 /// Taproot verification helpers.
 pub mod taproot;

--- a/crates/script/src/stack.rs
+++ b/crates/script/src/stack.rs
@@ -2,7 +2,7 @@ use smallvec::SmallVec;
 use thiserror::Error;
 use tinyvec::ArrayVec;
 
-/// One stack item in the future hand-rolled interpreter.
+/// One stack item.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ScriptItem {
     /// A minimally encoded script integer.

--- a/crates/script/src/taproot.rs
+++ b/crates/script/src/taproot.rs
@@ -1,5 +1,5 @@
 use bitcoin_rs_primitives::Hash256;
-use secp256k1::{Message, Parity, Scalar, Secp256k1, XOnlyPublicKey, schnorr::Signature};
+use secp256k1::{Message, Parity, Scalar, XOnlyPublicKey, schnorr::Signature};
 use sha2::{Digest, Sha256};
 
 /// BIP341 annex tag prefix (Core `ANNEX_TAG`).
@@ -124,8 +124,7 @@ pub fn verify_taproot_commitment(control: &[u8], program: &[u8], tapleaf_hash: &
     } else {
         Parity::Odd
     };
-    let secp = Secp256k1::verification_only();
-    internal.tweak_add_check(&secp, &output, parity, tweak)
+    internal.tweak_add_check(secp256k1::SECP256K1, &output, parity, tweak)
 }
 
 #[cfg(test)]

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ precedence rule and the index of contract pages live in
   [db-migration.md](policies/db-migration.md) covers on-disk schema changes.
 - [benchmarks/](benchmarks/) holds the retained benchmark notes:
   [end-to-end-sync.md](benchmarks/end-to-end-sync.md),
+  [native-validation-default.md](benchmarks/native-validation-default.md),
   [index-read-path.md](benchmarks/index-read-path.md),
   [utxo-memory.md](benchmarks/utxo-memory.md), and the product hot-path
   [ledger](benchmarks/hot-path-ledger.toml) owned by

--- a/docs/benchmarks/data/overhaul-signed-spend-20260904.md
+++ b/docs/benchmarks/data/overhaul-signed-spend-20260904.md
@@ -1,0 +1,82 @@
+# Signed-spend proxy measurement (PERF-V7)
+
+This measurement controls the signed-spend performance gate for issue #213
+after the process-wide `secp256k1::SECP256K1` reuse in the native checker.
+
+It uses the same harness as
+[`overhaul-signed-spend-20260902.md`](overhaul-signed-spend-20260902.md).
+Those earlier numbers were taken on a different host and are not a paired
+control for this run.
+
+## Configuration
+
+- Git commit: `0299e6770b5a79e8a7af594ab5ef380a2807228e`
+- rustc: 1.95.0 (`59807616e1fa2540724bfbac14d7976d7e4a3860`)
+- Host: Intel Xeon, 4 CPUs, Linux 6.12.94+, x86-64
+- Command (native): `cargo bench -p bitcoin-rs-node --bench sync_pipeline --no-default-features --features fjall -- signed_spend --sample-size 30 --warm-up-time 1 --measurement-time 8`
+- Command (kernel): same with `--features fjall,kernel`; `CC=gcc CXX=g++` and `LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu/13`
+- Env: `env -u RUSTC_WRAPPER -u CARGO_BUILD_BUILD_DIR TMPDIR=$PWD/target/tmp`
+- Storage backend: fjall
+- Transaction index: disabled
+- Independent runs: 3 per arm
+- Native bench SHA-256: `aecc038303049d1ca47660bfeb538c911de12dc67e83b7a664e89fcba30938e2`
+- Kernel bench SHA-256: `a3d13c5ceead948f61b2e4b1411891b0d958be06cb5a3de6d88ecf5f5cfbec97`
+
+## Corpus
+
+`signed_spend_proxy_blocks()` in `crates/node/benches/sync_pipeline.rs`.
+117-block skeleton: heights 1..100 fan out 64 coinbase outputs each;
+heights 101..116 spend those outputs. Spend classes: P2PKH, P2WPKH, and
+P2WSH 2-of-3.
+
+Criterion times include `open_regtest_state()` inside `iter_custom`. The
+manual percentile table times only the apply sweep. The gate uses the
+apply-only p50.
+
+## Results
+
+### Native arm (`--features fjall`)
+
+| Run | Criterion median (ms) | Apply p50 (ms) | p95 (ms) | p99 (ms) | max (ms) | samples |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 251.88 | 49.753 | 52.788 | 56.283 | 56.608 | 67 |
+| 2 | 245.07 | 50.306 | 52.393 | 54.106 | 55.870 | 67 |
+| 3 | 245.60 | 50.014 | 51.840 | 54.628 | 56.412 | 67 |
+
+Median of apply p50s: **50.014 ms**. Largest run-median deviation from that
+value: 0.58%.
+
+### Kernel arm (`--features fjall,kernel`)
+
+| Run | Criterion median (ms) | Apply p50 (ms) | p95 (ms) | p99 (ms) | max (ms) | samples |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 237.09 | 46.618 | 48.121 | 48.487 | 48.590 | 37 |
+| 2 | 239.86 | 45.588 | 47.452 | 48.641 | 49.182 | 67 |
+| 3 | 227.69 | 45.784 | 51.138 | 52.723 | 54.980 | 67 |
+
+Median of apply p50s: **45.784 ms**. Largest run-median deviation from that
+value: 1.82%.
+
+### Peak RSS
+
+`resource.getrusage(RUSAGE_CHILDREN)` over `--profile-time 2` on each
+binary: native 14 684 KiB, kernel 15 968 KiB. Allocation count is not
+reported by this harness.
+
+## Comparison
+
+| Metric | Native | Kernel | Native / kernel |
+|---|---:|---:|---:|
+| Median of apply p50s | 50.014 ms | 45.784 ms | 1.092 |
+| Median of Criterion medians | 245.60 ms | 237.09 ms | 1.036 |
+
+Both arms stay within five percent of their own independent-run median.
+Native apply p50 is higher than kernel apply p50.
+
+## Verdict
+
+**Gate fails.** The native path is stable and much closer than the
+2026-09-02 signed-spend run, after sharing `secp256k1::SECP256K1` across
+signature checks. It is still slower than libbitcoinkernel on this
+corpus, so `kernel` stays the default in `bitcoin-rs-consensus` and
+`bitcoin-rs-node`.

--- a/docs/benchmarks/native-validation-default.md
+++ b/docs/benchmarks/native-validation-default.md
@@ -54,50 +54,44 @@ The native interpreter executes legacy, P2SH, SegWit v0, and Taproot
 key-path and script-path spends. The earlier stub that accepted only
 `OP_TRUE` is gone.
 
-### Performance, signed-spend proxy (pre-change baseline, 2026-09-02)
+### Performance, signed-spend proxy (2026-09-04)
 
-Artifact: [`data/overhaul-signed-spend-20260902.md`](data/overhaul-signed-spend-20260902.md).
-This is the two-run pre-change baseline only; it is not the required post-change
-three-run decision measurement. Host: Intel Xeon Gold 6138. Corpus: 117-block
-regtest skeleton, 16 spend blocks, P2PKH / P2WPKH / P2WSH 2-of-3.
+Artifact: [`data/overhaul-signed-spend-20260904.md`](data/overhaul-signed-spend-20260904.md).
+Commit `0299e677`, rustc 1.95.0, 4-CPU Xeon, Linux 6.12.94+. Corpus: same
+117-block signed-spend proxy as the 2026-09-02 pre-change baseline. Three
+independent runs per arm after the `secp256k1::SECP256K1` reuse.
 
-| Arm | Run 1 Criterion median | Run 2 Criterion median |
+| Arm | Median of apply p50s | Run-median spread |
 |---|---:|---:|
-| Native (`fjall`) | 588.24 ms | 819.31 ms |
-| Kernel (`fjall,kernel`) | 532.21 ms | 616.60 ms |
+| Native (`fjall`) | 50.014 ms | 0.58% |
+| Kernel (`fjall,kernel`) | 45.784 ms | 1.82% |
 
-Native was slower on both runs. Neither arm stayed within five percent of
-its own independent-run median, so the comparison did not count under the
-#213 stability rule.
+Both arms stay within five percent of their own median. Native / kernel =
+1.092. Native does not win.
+
+The 2026-09-02 artifact was a different host (80-core Xeon Gold 6138) and
+is not a paired control for these numbers. On that host native apply p50
+was 486–639 ms; the context reuse is why this host sits near 50 ms, not a
+claim that the two hosts are comparable.
 
 ### Attributed lever
 
-Production CHECKSIG / Schnorr / Taproot tweak checks constructed
+Production CHECKSIG, Schnorr, and Taproot tweak checks constructed
 `Secp256k1::verification_only()` per signature. That rebuilds secp256k1's
-verification tables on every input. `crates/script/src/batch.rs` and
-`taproot::verify_taproot_keypath` already used the process-wide
-`secp256k1::SECP256K1` context. This change makes the remaining production
-paths use that same context.
+verification tables on every input. Those paths now share
+`secp256k1::SECP256K1`, which `batch.rs` and `taproot::verify_taproot_keypath`
+already used.
+
+### Peak RSS
+
+Profile-time child rusage: native 14.3 MiB, kernel 15.6 MiB. Allocation
+count is not reported by this harness.
 
 ## Disposition
 
 | Gate | Status |
 |---|---|
 | Core vector parity (available corpus) | Pass (zero pinned native mismatches) |
-| Signed-spend native faster, stable medians | Insufficient evidence: the 2026-09-02 artifact is a two-run pre-change baseline; three post-change runs per arm are pending |
+| Signed-spend native faster, stable medians | Fail (stable; native 9.2% slower on apply p50) |
 | Full-mainnet replay | Blocked on #34 / #42 |
-| Library / image default | Keep `kernel` until signed-spend passes |
-
-Do not flip `crates/consensus` or `crates/node` defaults on this page's
-current evidence. Re-run:
-
-```sh
-cargo bench -p bitcoin-rs-node --bench sync_pipeline \
-  --no-default-features --features fjall -- signed_spend
-cargo bench -p bitcoin-rs-node --bench sync_pipeline \
-  --no-default-features --features fjall,kernel -- signed_spend
-```
-
-Three independent runs per arm. Record p50 / p95 / p99 / max under
-`docs/benchmarks/data/` and update the disposition table here. Flip the
-library defaults only when that artifact shows a stable native win.
+| Library / image default | Keep `kernel` |

--- a/docs/benchmarks/native-validation-default.md
+++ b/docs/benchmarks/native-validation-default.md
@@ -1,0 +1,102 @@
+# Native validation default
+
+This page owns the #213 decision: whether the native Rust interpreter becomes
+the default script engine in `bitcoin-rs-consensus` and `bitcoin-rs-node`.
+Numbers from a named run live in `docs/benchmarks/data/`; this page records
+the disposition those numbers license.
+
+A **measured observation** copies a field or result from a cited artifact or
+from an in-tree test pin. An **inference** interprets those observations.
+
+## Decision rule (issue #213)
+
+The native path becomes the library default only after:
+
+1. Identities for both arms are pinned (source, compiler, features, corpus,
+   machine, binary).
+2. Every verdict on the available consensus corpus matches Bitcoin Core.
+3. The signed-spend harness reports p50 / p95 / p99 / max, with at least
+   three independent-run medians, and both arms stay within five percent of
+   their own median.
+4. The native median is faster than the pinned kernel median.
+5. Changed validation boundaries pass the in-tree test and clippy gates.
+
+Full-mainnet replay remains blocked on #34 and #42 (no frozen C150/Cmodern
+corpus and no in-tree `bitcoind` comparator run). A missing replay does not
+weaken the signed-spend or vector gates. A failed signed-spend measurement
+does not flip the default.
+
+## Current ownership of the default
+
+| Surface | Script engine |
+|---|---|
+| `bin/bitcoin-rs` default features (`fjall,redb,zmq`) | Native interpreter |
+| `bitcoin-rs-consensus` / `bitcoin-rs-node` crate defaults | `kernel` (`libbitcoinkernel`) |
+| Compose image (`Dockerfile --features fjall,kernel`) | `kernel` |
+
+One owner is the point of #213. Until the gates pass, the library crates and
+the image keep `kernel`. The binary already builds native so a default
+`cargo build -p bitcoin-rs` needs no C++ toolchain.
+
+## Measured observations
+
+### Correctness (in-tree Core vectors)
+
+`crates/script/tests/core_vectors.rs` pins:
+
+| Corpus | Native mismatch pin |
+|---|---:|
+| `script_tests.json` | 0 |
+| `tx_valid.json` | 0 |
+| `tx_invalid.json` | 0 |
+
+The native interpreter executes legacy, P2SH, SegWit v0, and Taproot
+key-path and script-path spends. The earlier stub that accepted only
+`OP_TRUE` is gone.
+
+### Performance, signed-spend proxy (2026-09-02)
+
+Artifact: [`data/overhaul-signed-spend-20260902.md`](data/overhaul-signed-spend-20260902.md).
+Host: Intel Xeon Gold 6138. Corpus: 117-block regtest skeleton, 16 spend
+blocks, P2PKH / P2WPKH / P2WSH 2-of-3.
+
+| Arm | Run 1 Criterion median | Run 2 Criterion median |
+|---|---:|---:|
+| Native (`fjall`) | 588.24 ms | 819.31 ms |
+| Kernel (`fjall,kernel`) | 532.21 ms | 616.60 ms |
+
+Native was slower on both runs. Neither arm stayed within five percent of
+its own independent-run median, so the comparison did not count under the
+#213 stability rule.
+
+### Attributed lever
+
+Production CHECKSIG / Schnorr / Taproot tweak checks constructed
+`Secp256k1::verification_only()` per signature. That rebuilds secp256k1's
+verification tables on every input. `crates/script/src/batch.rs` and
+`taproot::verify_taproot_keypath` already used the process-wide
+`secp256k1::SECP256K1` context. This change makes the remaining production
+paths use that same context.
+
+## Disposition
+
+| Gate | Status |
+|---|---|
+| Core vector parity (available corpus) | Pass (zero pinned native mismatches) |
+| Signed-spend native faster, stable medians | Fail on 2026-09-02; re-measure after the secp context lever |
+| Full-mainnet replay | Blocked on #34 / #42 |
+| Library / image default | Keep `kernel` until signed-spend passes |
+
+Do not flip `crates/consensus` or `crates/node` defaults on this page's
+current evidence. Re-run:
+
+```sh
+cargo bench -p bitcoin-rs-node --bench sync_pipeline \
+  --no-default-features --features fjall -- signed_spend
+cargo bench -p bitcoin-rs-node --bench sync_pipeline \
+  --no-default-features --features fjall,kernel -- signed_spend
+```
+
+Three independent runs per arm. Record p50 / p95 / p99 / max under
+`docs/benchmarks/data/` and update the disposition table here. Flip the
+library defaults only when that artifact shows a stable native win.

--- a/docs/benchmarks/native-validation-default.md
+++ b/docs/benchmarks/native-validation-default.md
@@ -54,11 +54,12 @@ The native interpreter executes legacy, P2SH, SegWit v0, and Taproot
 key-path and script-path spends. The earlier stub that accepted only
 `OP_TRUE` is gone.
 
-### Performance, signed-spend proxy (2026-09-02)
+### Performance, signed-spend proxy (pre-change baseline, 2026-09-02)
 
 Artifact: [`data/overhaul-signed-spend-20260902.md`](data/overhaul-signed-spend-20260902.md).
-Host: Intel Xeon Gold 6138. Corpus: 117-block regtest skeleton, 16 spend
-blocks, P2PKH / P2WPKH / P2WSH 2-of-3.
+This is the two-run pre-change baseline only; it is not the required post-change
+three-run decision measurement. Host: Intel Xeon Gold 6138. Corpus: 117-block
+regtest skeleton, 16 spend blocks, P2PKH / P2WPKH / P2WSH 2-of-3.
 
 | Arm | Run 1 Criterion median | Run 2 Criterion median |
 |---|---:|---:|
@@ -83,7 +84,7 @@ paths use that same context.
 | Gate | Status |
 |---|---|
 | Core vector parity (available corpus) | Pass (zero pinned native mismatches) |
-| Signed-spend native faster, stable medians | Fail on 2026-09-02; re-measure after the secp context lever |
+| Signed-spend native faster, stable medians | Insufficient evidence: the 2026-09-02 artifact is a two-run pre-change baseline; three post-change runs per arm are pending |
 | Full-mainnet replay | Blocked on #34 / #42 |
 | Library / image default | Keep `kernel` until signed-spend passes |
 

--- a/docs/benchmarks/native-validation-default.md
+++ b/docs/benchmarks/native-validation-default.md
@@ -21,10 +21,10 @@ The native path becomes the library default only after:
 4. The native median is faster than the pinned kernel median.
 5. Changed validation boundaries pass the in-tree test and clippy gates.
 
-Full-mainnet replay remains blocked on #34 and #42 (no frozen C150/Cmodern
-corpus and no in-tree `bitcoind` comparator run). A missing replay does not
-weaken the signed-spend or vector gates. A failed signed-spend measurement
-does not flip the default.
+Full-mainnet replay remains blocked on #34 (no in-tree `bitcoind` comparator
+run). #42 froze the C150/Cmodern corpus contracts; that freeze does not run
+the comparator. A missing replay does not weaken the signed-spend or vector
+gates. A failed signed-spend measurement does not flip the default.
 
 ## Current ownership of the default
 
@@ -93,5 +93,5 @@ count is not reported by this harness.
 |---|---|
 | Core vector parity (available corpus) | Pass (zero pinned native mismatches) |
 | Signed-spend native faster, stable medians | Fail (stable; native 9.2% slower on apply p50) |
-| Full-mainnet replay | Blocked on #34 / #42 |
+| Full-mainnet replay | Blocked on #34 (#42 corpus freeze is done) |
 | Library / image default | Keep `kernel` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,15 +7,15 @@ verify progress before moving on.
 
 - A Rust toolchain for edition 2024 (MSRV 1.95.0 or newer).
 - The default binary build is pure Rust and requires no C++ compiler or system
-  libraries. It uses the portable Rust script interpreter, which verifies
-  Taproot key-path spends only and cannot validate ordinary mainnet spends
-  (see #166). For production consensus validation, enable the `kernel` feature.
+  libraries. It uses the native Rust script interpreter, which verifies Legacy,
+  SegWit v0, and Taproot key-path and script-path spends. Core's committed
+  script and transaction vectors currently pin zero native mismatches.
 
-If you plan to compile with the `kernel` feature for production consensus
-validation via `libbitcoinkernel`, install `cmake` and `libboost-dev`:
+If you plan to compile with the `kernel` feature to run `libbitcoinkernel` as
+an independent verification oracle, install `cmake` and `libboost-dev`:
 
 ```sh
-# Required for the kernel consensus engine feature
+# Required for the kernel verification-oracle feature
 sudo apt-get install -y cmake libboost-dev
 ```
 
@@ -29,13 +29,10 @@ cargo build --release -p bitcoin-rs
 
 This produces `./target/release/bitcoin-rs`. The default configuration includes
 the `fjall` storage backend, `redb`, and `zmq` sequence publishing. The default
-binary build uses the portable Rust script interpreter, which verifies Taproot
-key-path spends only; other script classes (Legacy, SegWit v0, Taproot
-script-path) are stubbed pending a full opcode interpreter (see #166). A
-mainnet sync with this build stops at the first real spend.
+binary build uses the native Rust script interpreter for every consensus spend
+class.
 
-To compile with `libbitcoinkernel` as the consensus engine for full script
-validation across all script classes:
+To compile with `libbitcoinkernel` as an independent verification oracle:
 
 ```sh
 cargo build --release -p bitcoin-rs --features kernel
@@ -85,7 +82,7 @@ Configuration defaults:
 | `--prune-target-mb` | 0 (no pruning) |
 | `--txindex` | off |
 | `--scriptindex` | off (accepts `full`, `utxo`, or boolean; defaults to `full` when passed without a value) |
-| `--features kernel` (build-time) | off in default binary; enables `libbitcoinkernel` consensus engine |
+| `--features kernel` (build-time) | off in default binary; enables `libbitcoinkernel` as a verification oracle |
 
 The node logs its startup banner, effective cache allocation, and the address
 the JSON-RPC listener bound to.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Question

Does the native Rust validation path match Bitcoin Core on the required corpus and beat the pinned libbitcoinkernel baseline strongly enough to become the default?

## Decision

No. Keep `kernel` as the default in `bitcoin-rs-consensus`, `bitcoin-rs-node`, and the Compose image.

The native interpreter already matches Core's committed `script_tests`, `tx_valid`, and `tx_invalid` vectors at zero pinned mismatches. The default `bitcoin-rs` binary already uses it. The signed-spend gate does not pass.

## Evidence

Owner: [`docs/benchmarks/native-validation-default.md`](docs/benchmarks/native-validation-default.md)
Run: [`docs/benchmarks/data/overhaul-signed-spend-20260904.md`](docs/benchmarks/data/overhaul-signed-spend-20260904.md)

| Gate | Result |
|---|---|
| Core vector parity | Pass (0 native mismatches) |
| Signed-spend, 3 runs/arm | Native apply p50 **50.014 ms**, kernel **45.784 ms** (native 9.2% slower). Both arms within 2% of their own median. |
| Full-mainnet replay | Blocked on #34. #42 froze the C150/Cmodern corpus contracts; that freeze does not run the comparator. |

The previous native loss was inflated by constructing `Secp256k1::verification_only()` per signature. Production CHECKSIG / Schnorr / Taproot tweak checks now share `secp256k1::SECP256K1`. That is one measured lever. It is not a default flip.

A failed measurement does not close #213.

## Review follow-up

- Rebased onto `main`. Conflicts in `docs/README.md` (keep the hot-path ledger index plus `native-validation-default.md`) and `docs/getting-started.md` (keep `--scriptindex=utxo` plus the kernel-oracle wording).
- Qodo's signed-spend evidence request is recorded in the 2026-09-04 artifact: three independent runs per arm, p50/p95/p99/max, stability, commands, revision, workload, and environment. Gate still fails, so library defaults stay `kernel`.

## Changes

- Reuse the process-wide secp256k1 context in the script checker, interpreter, and Taproot commitment path.
- Stop describing the native interpreter as an `OP_TRUE` stub.
- Record the #213 disposition and the 2026-09-04 signed-spend artifact.

Refs #213

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a6766ed-c648-4107-90df-41ac014d6da0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a6766ed-c648-4107-90df-41ac014d6da0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

