### PR TITLE
Build strict offline full-validation comparator

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -326,6 +326,14 @@ The modern product corpus: mainnet genesis through height 709,635, the first hei
 ### Matched-harness comparison
 A cross-node benchmark matches every input that is not the thing under test — block source, validation posture, allocator, CPU pinning, time of measurement — before any ratio is quoted. Interleave both nodes back-to-back on an idle host and quote paired medians. See `docs/solutions/performance/allocator-parity-changes-wall-not-cpu.md`.
 
+### Offline full-validation comparator
+The processing-bound cross-node oracle: Bitcoin Core 31.1 and bitcoin-rs both
+build chainstate from one hash-pinned Core-framed archive under full
+validation, matched index posture, and production durability. Wall time is
+process start through durable clean exit. The harness lives in
+`tools/benchmark-campaign/offline_full_validation.py`; see
+`docs/benchmarks/offline-full-validation.md`.
+
 ### CPU-seconds as a first-class metric
 A throughput change is measured against CPU time as well as wall time, because an idle many-core host lets wall-clock tuning spend cores for free. Sampling `utime+stime` from `/proc/<pid>/stat` while polling height is enough; per-thread attribution comes from `/proc/<pid>/task/*/stat`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,9 @@ precedence rule and the index of contract pages live in
   [db-migration.md](policies/db-migration.md) covers on-disk schema changes.
 - [benchmarks/](benchmarks/) holds the retained benchmark notes:
   [end-to-end-sync.md](benchmarks/end-to-end-sync.md),
+  [offline-full-validation.md](benchmarks/offline-full-validation.md),
+  [p2p-loopback.md](benchmarks/p2p-loopback.md),
+  [muhash-rpc.md](benchmarks/muhash-rpc.md),
   [index-read-path.md](benchmarks/index-read-path.md),
   [utxo-memory.md](benchmarks/utxo-memory.md), the product hot-path
   [ledger](benchmarks/hot-path-ledger.toml) owned by

--- a/docs/benchmarks/offline-full-validation.md
+++ b/docs/benchmarks/offline-full-validation.md
@@ -14,25 +14,27 @@ proves the harness with fixture nodes.
 
 One `offline-full-validation-config-v1` document binds every arm:
 
-- **Archive**: Bitcoin Core block-file framing only — 4-byte network magic,
+- **Archive**: Bitcoin Core `blk*.dat` framing only — 4-byte message start,
   4-byte little-endian payload length, consensus-serialized block. No
   padding, stale-chain records, or backend-specific bytes. The comparator
   opens the file `O_NOFOLLOW`, hashes it, and walks every record against the
   manifest. Trailing bytes, a magic mismatch, a length mismatch, or a header
   hash that does not match the manifest refuse the run before any child
-  starts. Block hash is double-SHA256 of the 80-byte header, displayed
-  little-endian, matching Bitcoin. The hash helper is checked against the
-  published 80-byte mainnet genesis header
-  (`000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`),
-  not only against synthetic fixture bytes hashed with the same algorithm.
+  starts. Block hash is Bitcoin Core `CBlockHeader::GetHash`: double-SHA256
+  of the 80-byte header, displayed little-endian. The helper is checked
+  against the published mainnet genesis header
+  (`000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
+  from Core `CMainParams`), not only against synthetic fixture bytes hashed
+  with the same algorithm.
 - **Manifest**: `core-framed-archive-manifest-v1` names network, magic,
   inclusive height range, archive digest and size, and one packed entry per
   height (`hash`, `offset`, `payload_length`). Heights are contiguous. The
   packed records must consume the archive exactly.
 - **Pinned corpus**: after config load, the campaign copies archive and
   manifest into a private campaign directory, re-hashes both, and
-  chmod's them `0o400`. Every arm reads those pins. A same-size rewrite
-  of the operator path after load cannot change what the children see.
+  chmod's them `0o400`. Every arm reads those pins. Before and after every
+  child, the controller re-hashes both pins and checks device, inode, size,
+  and mtime. A same-user child that chmod's and rewrites a pin fails closed.
 - **Posture**: `assume_valid` must be false. `txindex`, `blockfilterindex`,
   and `coinstatsindex` must be off. Cache policy is the closed set
   `process-cold/page-cache-unspecified`. The sibling MuHash comparator

--- a/docs/benchmarks/offline-full-validation.md
+++ b/docs/benchmarks/offline-full-validation.md
@@ -21,17 +21,24 @@ One `offline-full-validation-config-v1` document binds every arm:
   manifest. Trailing bytes, a magic mismatch, a length mismatch, or a header
   hash that does not match the manifest refuse the run before any child
   starts. Block hash is double-SHA256 of the 80-byte header, displayed
-  little-endian, matching Bitcoin.
+  little-endian, matching Bitcoin. The hash helper is checked against the
+  published 80-byte mainnet genesis header
+  (`000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`),
+  not only against synthetic fixture bytes hashed with the same algorithm.
 - **Manifest**: `core-framed-archive-manifest-v1` names network, magic,
   inclusive height range, archive digest and size, and one packed entry per
   height (`hash`, `offset`, `payload_length`). Heights are contiguous. The
   packed records must consume the archive exactly.
+- **Pinned corpus**: after config load, the campaign copies archive and
+  manifest into a private campaign directory, re-hashes both, and
+  chmod's them `0o400`. Every arm reads those pins. A same-size rewrite
+  of the operator path after load cannot change what the children see.
 - **Posture**: `assume_valid` must be false. `txindex`, `blockfilterindex`,
-  and `coinstatsindex` must be off. Cache policy is a closed set
-  (`process-cold/page-cache-unspecified` or
-  `process-cold/page-cache-evicted`). A configured cache number that
-  production code does not consume cannot appear here as if it established
-  parity.
+  and `coinstatsindex` must be off. Cache policy is the closed set
+  `process-cold/page-cache-unspecified`. The sibling MuHash comparator
+  requires hash-bound evidence before it will claim page-cache eviction;
+  this harness does not enact eviction, so that policy string is refused
+  rather than published as a posture the run did not take.
 - **Certified state**: height, best block, UTXO count, total amount in
   satoshis, MuHash, `hash_serialized_3`, body availability, and one-block
   disconnect readiness. Height and best block must equal the manifest tip.
@@ -43,7 +50,13 @@ One `offline-full-validation-config-v1` document binds every arm:
   The controller copies the pinned program into a private arm directory,
   verifies the copy, strips owner-write (`0o500`), and re-hashes immediately
   before every spawn. Placeholders are `{binary}`, `{data_dir}`,
-  `{corpus_path}`, `{manifest_path}`, `{state_path}`.
+  `{corpus_path}`, `{manifest_path}`, `{state_path}`. The timed command
+  must carry a known assume-valid-off token (`-assumevalid=0`,
+  `--assume-valid-height=0`, or the two-token form with `0`) and must not
+  carry a known index-on token (`-txindex`, `-txindex=1`, `--txindex=true`,
+  `-blockfilterindex`, `-coinstatsindex`, and the same spellings with
+  `--` and `=1`/`=true`). Reopen commands are not re-checked. The
+  comparator does not parse the rest of either product's flag dialect.
 
 ## Timed boundary
 
@@ -58,9 +71,10 @@ must not daemonize (`-daemon=0`) and should stop after import
 (`-stopafterblockimport=1`, `-assumevalid=0`, `-stopatheight=H`). bitcoin-rs
 commands must apply the same archive through height `H` with
 `--assume-valid-height 0`, persist bodies and undo, publish the production
-clean checkpoint, and exit nonzero if publication fails. The comparator
-does not parse product-specific flags; the pinned command and the certified
-state are the proof.
+clean checkpoint, and exit nonzero if publication fails. After wait, the
+process group must be empty and the comparator, running as a Linux child
+subreaper, must own no leftover descendants. A fixture that forks a
+sleeper and then exits 0 is refused; no result JSON is published.
 
 ## Correctness gates, in order
 
@@ -68,15 +82,18 @@ state are the proof.
 
 1. Exactly 14 arms, two per pair, one Core and one bitcoin-rs.
 2. Alternation: even pairs Core-first, odd pairs bitcoin-rs-first.
-3. Archive and binary identities unchanged from config load.
+3. Archive and binary identities unchanged from the campaign pin.
 4. Each arm exited 0 (durable clean exit). Reopen arms additionally exited 0.
 5. Certified state equals the config expectation on both arms and the two
    arms agree with each other.
 
 Any refusal raises `ContractError`, the process exits 2, and **no result
 JSON is emitted**. Publication is atomic: bytes are written to an unnamed
-`O_TMPFILE` inode, fsynced, and linked with `linkat(AT_EMPTY_PATH)`. An
-existing destination survives.
+`O_TMPFILE` inode, fsynced, and linked with `linkat(AT_EMPTY_PATH)`. The
+commit point is a successful link. Crash before the link leaves the
+destination unchanged and is retriable; crash after the link (or a retry
+against an existing name) is `EEXIST` and must not overwrite. Directory
+fsync follows the link. This function does not retry.
 
 ## Result contract
 
@@ -106,6 +123,10 @@ hash-pinned `bitcoind` and bitcoin-rs binaries plus a frozen corpus from
 issue #42.
 
 ## Limits
+
+Campaign ceilings: archive 1 TiB, manifest 512 MiB, 2 000 000 blocks.
+Those bounds admit a Cmodern prefix; they are not a promise to ingest the
+live full-tip chain (~760 GiB) until issue #42 freezes that corpus.
 
 This is the processing-bound regime in CONCEPTS.md: blocks are local, wall
 is validation plus durable commit. It is not download-bound IBD. Historical

--- a/docs/benchmarks/offline-full-validation.md
+++ b/docs/benchmarks/offline-full-validation.md
@@ -1,0 +1,113 @@
+# Offline full-validation comparator
+
+Harness: `tools/benchmark-campaign/offline_full_validation.py`. Tests:
+`tools/benchmark-campaign/test_offline_full_validation.py`. Addresses issue #34
+and implements the frozen parity contract from issue #46.
+
+Both Bitcoin Core 31.1 and bitcoin-rs construct chainstate from the **same**
+hash-pinned Core-framed archive. The comparator never reaches inside either
+node. A ratio is computed only after every custody and correctness gate
+passes. This repository does not claim a live C150 or Cmodern campaign: CI
+proves the harness with fixture nodes.
+
+## What is held identical
+
+One `offline-full-validation-config-v1` document binds every arm:
+
+- **Archive**: Bitcoin Core block-file framing only — 4-byte network magic,
+  4-byte little-endian payload length, consensus-serialized block. No
+  padding, stale-chain records, or backend-specific bytes. The comparator
+  opens the file `O_NOFOLLOW`, hashes it, and walks every record against the
+  manifest. Trailing bytes, a magic mismatch, a length mismatch, or a header
+  hash that does not match the manifest refuse the run before any child
+  starts. Block hash is double-SHA256 of the 80-byte header, displayed
+  little-endian, matching Bitcoin.
+- **Manifest**: `core-framed-archive-manifest-v1` names network, magic,
+  inclusive height range, archive digest and size, and one packed entry per
+  height (`hash`, `offset`, `payload_length`). Heights are contiguous. The
+  packed records must consume the archive exactly.
+- **Posture**: `assume_valid` must be false. `txindex`, `blockfilterindex`,
+  and `coinstatsindex` must be off. Cache policy is a closed set
+  (`process-cold/page-cache-unspecified` or
+  `process-cold/page-cache-evicted`). A configured cache number that
+  production code does not consume cannot appear here as if it established
+  parity.
+- **Certified state**: height, best block, UTXO count, total amount in
+  satoshis, MuHash, `hash_serialized_3`, body availability, and one-block
+  disconnect readiness. Height and best block must equal the manifest tip.
+  Body availability and disconnect readiness must be true.
+- **Lifecycle**: `fresh` times one process from spawn through durable clean
+  exit. `reopen` then runs an untimed reopen command against the same data
+  directory and requires the same certified state.
+- **Binaries**: SHA-256 pinned. `command[0]` is the `{binary}` placeholder.
+  The controller copies the pinned program into a private arm directory,
+  verifies the copy, strips owner-write (`0o500`), and re-hashes immediately
+  before every spawn. Placeholders are `{binary}`, `{data_dir}`,
+  `{corpus_path}`, `{manifest_path}`, `{state_path}`.
+
+## Timed boundary
+
+Wall time is `time.monotonic_ns` from child creation through wait-for-exit.
+It includes archive read, framing parse, validation, chainstate mutation,
+persistence, flush, and shutdown. No stage is subtracted. CPU (`utime+stime`)
+and peak RSS are sampled from `/proc` and reported separately; they are not
+an alternate definition of speed.
+
+The child must remain in the foreground and exit. Bitcoin Core commands
+must not daemonize (`-daemon=0`) and should stop after import
+(`-stopafterblockimport=1`, `-assumevalid=0`, `-stopatheight=H`). bitcoin-rs
+commands must apply the same archive through height `H` with
+`--assume-valid-height 0`, persist bodies and undo, publish the production
+clean checkpoint, and exit nonzero if publication fails. The comparator
+does not parse product-specific flags; the pinned command and the certified
+state are the proof.
+
+## Correctness gates, in order
+
+`_require_comparable` runs before any statistics:
+
+1. Exactly 14 arms, two per pair, one Core and one bitcoin-rs.
+2. Alternation: even pairs Core-first, odd pairs bitcoin-rs-first.
+3. Archive and binary identities unchanged from config load.
+4. Each arm exited 0 (durable clean exit). Reopen arms additionally exited 0.
+5. Certified state equals the config expectation on both arms and the two
+   arms agree with each other.
+
+Any refusal raises `ContractError`, the process exits 2, and **no result
+JSON is emitted**. Publication is atomic: bytes are written to an unnamed
+`O_TMPFILE` inode, fsynced, and linked with `linkat(AT_EMPTY_PATH)`. An
+existing destination survives.
+
+## Result contract
+
+`offline-full-validation-result-v1` binds the config canonical hash, the
+custody block (magic, network, height range, archive/manifest/binary
+digests, posture, lifecycle), a `correctness` block (every gate `true` —
+the document cannot exist otherwise), every arm's wall/CPU/RSS, exit code,
+and certified state, per-role percentile summaries, and
+`candidate_over_core_p50_ratio`. `result_sha256` is the canonical hash of
+the document without that field.
+
+Raw argv is never published. Public command digests use the same
+category-only projection as the P2P loopback comparator.
+
+## Standalone usage
+
+```
+python3 tools/benchmark-campaign/offline_full_validation.py \
+  --config <config.json> --output <result.json>
+python3 -m unittest test_offline_full_validation   # from tools/benchmark-campaign/
+```
+
+Tests use a two-block Core-framed archive and deterministic fixture nodes
+that read the archive and write the certified state file. They prove the
+harness, not live node performance. A live seven-pair campaign still needs
+hash-pinned `bitcoind` and bitcoin-rs binaries plus a frozen corpus from
+issue #42.
+
+## Limits
+
+This is the processing-bound regime in CONCEPTS.md: blocks are local, wall
+is validation plus durable commit. It is not download-bound IBD. Historical
+1.654× C150 numbers are not carried forward; a new ratio exists only after
+a gated result file is published against a frozen corpus.

--- a/tools/benchmark-campaign/comp_lanes.py
+++ b/tools/benchmark-campaign/comp_lanes.py
@@ -235,6 +235,7 @@ parser.add_argument('--data-dir', required=True)
 parser.add_argument('--corpus', required=True)
 parser.add_argument('--manifest', required=True)
 parser.add_argument('--state', required=True)
+parser.add_argument('--assume-valid-height', default='0')
 args = parser.parse_args()
 corpus = Path(args.corpus).read_bytes()
 if not corpus:
@@ -304,6 +305,7 @@ def _build_offline_fixture(workspace: Path) -> Path:
         "{manifest_path}",
         "--state",
         "{state_path}",
+        "--assume-valid-height=0",
     ]
 
     def _program() -> dict[str, object]:

--- a/tools/benchmark-campaign/comp_lanes.py
+++ b/tools/benchmark-campaign/comp_lanes.py
@@ -3,9 +3,9 @@
 """Campaign lane runner for comparator issues #34, #35, #41.
 
 Runs each comparator in its offline-reachable mode and produces a combined
-lane report.  The P2P loopback lane (#35) is fully reachable offline using
-deterministic fixture nodes.  The offline full-validation lane (#34) and
-the MuHash RPC lane (#41) require a ``bitcoind`` binary; when it is absent
+lane report.  The P2P loopback lane (#35) and the offline full-validation lane (#34)
+are fully reachable offline using deterministic fixture nodes.  The
+MuHash RPC lane (#41) requires a ``bitcoind`` binary; when it is absent
 the lane records the blocking fact and the exact command that failed.
 
 This is a thin orchestrator over the existing comparators — it does not
@@ -26,7 +26,17 @@ from typing import Sequence
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
+import offline_full_validation  # noqa: E402
 import p2p_loopback  # noqa: E402
+from offline_full_validation import (  # noqa: E402
+    CONFIG_SCHEMA as OFFLINE_CONFIG_SCHEMA,
+    MANIFEST_SCHEMA as OFFLINE_MANIFEST_SCHEMA,
+    CertifiedState as OfflineState,
+    canonical_bytes as offline_canonical_bytes,
+    header_hash as offline_header_hash,
+    main as offline_main,
+    state_json as offline_state_json,
+)
 from p2p_loopback import (  # noqa: E402
     CONFIG_SCHEMA as P2P_CONFIG_SCHEMA,
     canonical_bytes as p2p_canonical_bytes,
@@ -207,35 +217,181 @@ def run_p2p_lane(workspace: Path) -> dict[str, object]:
     }
 
 
-def _find_bitcoind() -> str | None:
-    """Return the path to bitcoind if found on PATH, else None."""
-    return shutil.which("bitcoind")
+def _offline_payload(marker: int) -> bytes:
+    return bytes([marker]) * 80 + bytes([marker])
+
+
+def _offline_record(payload: bytes) -> bytes:
+    return bytes.fromhex(MAGIC) + len(payload).to_bytes(4, "little") + payload
+
+
+def _offline_node_source(expected: OfflineState) -> str:
+    payload = json.dumps(offline_state_json(expected), sort_keys=True)
+    return f"""#!{sys.executable}
+import argparse
+from pathlib import Path
+parser = argparse.ArgumentParser()
+parser.add_argument('--data-dir', required=True)
+parser.add_argument('--corpus', required=True)
+parser.add_argument('--manifest', required=True)
+parser.add_argument('--state', required=True)
+args = parser.parse_args()
+corpus = Path(args.corpus).read_bytes()
+if not corpus:
+    raise SystemExit(3)
+Path(args.data_dir, 'imported').write_bytes(corpus)
+Path(args.state).write_text({payload!r} + '\\n', encoding='utf-8')
+raise SystemExit(0)
+"""
+
+
+def _build_offline_fixture(workspace: Path) -> Path:
+    """Create a two-block Core-framed archive and fixture importer nodes."""
+    payloads = (_offline_payload(1), _offline_payload(2))
+    records = [_offline_record(payload) for payload in payloads]
+    archive_bytes = b"".join(records)
+    archive_path = workspace / "blocks.dat"
+    archive_path.write_bytes(archive_bytes)
+    hashes = [offline_header_hash(payload) for payload in payloads]
+    offset = 0
+    entries: list[dict[str, object]] = []
+    for height, (payload, digest, record) in enumerate(
+        zip(payloads, hashes, records, strict=True)
+    ):
+        entries.append(
+            {
+                "height": height,
+                "hash": digest,
+                "offset": offset,
+                "payload_length": len(payload),
+            }
+        )
+        offset += len(record)
+    manifest = {
+        "schema": OFFLINE_MANIFEST_SCHEMA,
+        "network": "mainnet",
+        "network_magic": MAGIC,
+        "start_height": 0,
+        "stop_height": 1,
+        "archive_sha256": hashlib.sha256(archive_bytes).hexdigest(),
+        "archive_bytes": len(archive_bytes),
+        "blocks": entries,
+    }
+    manifest_path = workspace / "offline-manifest.json"
+    manifest_bytes = offline_canonical_bytes(manifest) + b"\n"
+    manifest_path.write_bytes(manifest_bytes)
+    expected = OfflineState(
+        1,
+        hashes[-1],
+        2,
+        5_000_000_000,
+        "cd" * 32,
+        "ef" * 32,
+        True,
+        True,
+    )
+    node = _write_executable(
+        workspace / "offline-node.py", _offline_node_source(expected)
+    )
+    digest = _sha256_file(node)
+    command = [
+        "{binary}",
+        "--data-dir",
+        "{data_dir}",
+        "--corpus",
+        "{corpus_path}",
+        "--manifest",
+        "{manifest_path}",
+        "--state",
+        "{state_path}",
+    ]
+
+    def _program() -> dict[str, object]:
+        return {
+            "binary": str(node),
+            "binary_sha256": digest,
+            "command": command,
+            "reopen_command": None,
+        }
+
+    config = {
+        "schema": OFFLINE_CONFIG_SCHEMA,
+        "network_magic": MAGIC,
+        "arm_timeout_ns": 10_000_000_000,
+        "posture": {
+            "assume_valid": False,
+            "txindex": False,
+            "blockfilterindex": False,
+            "coinstatsindex": False,
+            "cache_policy": "process-cold/page-cache-unspecified",
+        },
+        "corpus": {
+            "archive": {
+                "path": str(archive_path),
+                "sha256": hashlib.sha256(archive_bytes).hexdigest(),
+                "bytes": len(archive_bytes),
+            },
+            "manifest": {
+                "path": str(manifest_path),
+                "sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+                "bytes": len(manifest_bytes),
+            },
+        },
+        "expected_state": offline_state_json(expected),
+        "core": _program(),
+        "candidate": _program(),
+        "lifecycle": {"mode": "fresh", "expected_reopen_state": None},
+    }
+    config_path = workspace / "offline-config.json"
+    config_path.write_bytes(offline_canonical_bytes(config) + b"\n")
+    return config_path
 
 
 def run_offline_lane(workspace: Path) -> dict[str, object]:
-    """Report whether an offline full-validation run (#34) is reachable.
-
-    The strict comparator that consumed this signal was retired in commit
-    5487803, so this lane reports host readiness only: a ``bitcoind`` binary
-    on PATH, without which no offline comparison can start.
-    """
-    bitcoind = _find_bitcoind()
-    if bitcoind is None:
+    """Run the offline full-validation comparator (#34) with fixture nodes."""
+    config_path = _build_offline_fixture(workspace)
+    output_path = workspace / "offline-result.json"
+    started = time.monotonic_ns()
+    try:
+        code = offline_main(["--config", str(config_path), "--output", str(output_path)])
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 2
+    except offline_full_validation.ContractError as exc:
         return {
             "issue": "#34",
             "lane": "offline-full-validation",
             "status": "blocked",
-            "reason": "bitcoind binary not found on PATH",
-            "command_run": "shutil.which('bitcoind')",
-            "command_result": None,
+            "reason": str(exc),
+            "elapsed_ns": time.monotonic_ns() - started,
         }
+    elapsed_ns = time.monotonic_ns() - started
+    if code != 0 or not output_path.is_file():
+        return {
+            "issue": "#34",
+            "lane": "offline-full-validation",
+            "status": "blocked",
+            "reason": f"offline_full_validation exited with code {code}",
+            "elapsed_ns": elapsed_ns,
+        }
+    result = json.loads(output_path.read_bytes())
     return {
         "issue": "#34",
         "lane": "offline-full-validation",
-        "status": "reachable",
-        "reason": None,
-        "bitcoind_path": bitcoind,
+        "status": "passed",
+        "result_path": str(output_path),
+        "result_schema": result.get("schema"),
+        "pair_count": result.get("pair_count"),
+        "arm_count": len(result.get("arms", [])),
+        "correctness": result.get("correctness"),
+        "ratio": result.get("candidate_over_core_p50_ratio"),
+        "result_sha256": result.get("result_sha256"),
+        "elapsed_ns": elapsed_ns,
     }
+
+
+def _find_bitcoind() -> str | None:
+    """Return the path to bitcoind if found on PATH, else None."""
+    return shutil.which("bitcoind")
 
 
 def run_rpc_lane(workspace: Path) -> dict[str, object]:

--- a/tools/benchmark-campaign/offline_full_validation.py
+++ b/tools/benchmark-campaign/offline_full_validation.py
@@ -447,7 +447,14 @@ def _identity_from_stat(info: os.stat_result, digest: str) -> FileIdentity:
 
 
 def header_hash(payload: bytes) -> str:
-    """Display-hex of double-SHA256(header), matching Bitcoin block hashes."""
+    """Display-hex of double-SHA256 of the 80-byte header.
+
+    This is Bitcoin Core ``CBlockHeader::GetHash`` (``HashWriter`` over the
+    header, then byte-reversed hex). Independent vector: the published
+    mainnet genesis header hashes to
+    ``000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f``
+    (Bitcoin Core ``CMainParams``, bitcoin-rs ``MAINNET_GENESIS``).
+    """
     if len(payload) < HEADER_BYTES:
         raise ContractError("block payload is shorter than a header")
     digest = hashlib.sha256(hashlib.sha256(payload[:HEADER_BYTES]).digest()).digest()
@@ -517,6 +524,7 @@ def _parse_manifest(value: object, archive: FileRef, magic: bytes) -> Manifest:
 
 
 def _verify_archive(archive: FileRef, manifest: Manifest, magic: bytes) -> FileIdentity:
+    """Walk a Core ``blk*.dat`` stream: 4-byte message start, 4-byte LE size, block."""
     descriptor = _open_regular(archive.path, "archive")
     digest = hashlib.sha256()
     try:
@@ -554,22 +562,39 @@ def _verify_archive(archive: FileRef, manifest: Manifest, magic: bytes) -> FileI
         os.close(descriptor)
 
 
-def _require_unchanged(path: Path, expected: FileIdentity, field: str) -> None:
+def _hash_regular(path: Path, field: str) -> tuple[os.stat_result, str]:
     descriptor = _open_regular(path, field)
+    digest = hashlib.sha256()
     try:
         info = os.fstat(descriptor)
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
     except OSError as error:
+        raise ContractError(f"cannot hash {field}: {error}") from error
+    finally:
         os.close(descriptor)
-        raise ContractError(f"cannot restat {field}: {error}") from error
-    os.close(descriptor)
-    current = _identity_from_stat(info, expected.sha256)
+    return info, digest.hexdigest()
+
+
+def _require_pin(path: Path, expected: FileIdentity, field: str) -> None:
+    info, digest = _hash_regular(path, field)
+    current = _identity_from_stat(info, digest)
     if (
         current.dev != expected.dev
         or current.ino != expected.ino
         or current.size != expected.size
         or current.mtime_ns != expected.mtime_ns
+        or digest != expected.sha256
     ):
         raise ContractError(f"{field} changed after custody verification")
+
+
+def _assert_pins(pinned: PinnedCorpus) -> None:
+    _require_pin(pinned.archive.path, pinned.archive_identity, "archive")
+    _require_pin(pinned.manifest.path, pinned.manifest_identity, "manifest")
 
 
 def _certified_state(value: object, field: str) -> CertifiedState:
@@ -1129,8 +1154,7 @@ def _run_arm(
     data_dir = arm_dir / "data"
     data_dir.mkdir()
     binary_path = _verified_copy(program, arm_dir)
-    _require_unchanged(pinned.archive.path, pinned.archive_identity, "archive")
-    _require_unchanged(pinned.manifest.path, pinned.manifest_identity, "manifest")
+    _assert_pins(pinned)
     _verify_copy_digest(binary_path, program.binary_sha256)
     state_path = arm_dir / "state.json"
     argv = _expand_command(
@@ -1143,6 +1167,7 @@ def _run_arm(
     )
     deadline = time.monotonic_ns() + config.arm_timeout_ns
     code, wall_ns, cpu_ns, peak_rss = _run_phase(argv, arm_dir, deadline)
+    _assert_pins(pinned)
     final = _state(state_path, f"{program.role} final state")
     expected_json = state_json(config.expected_state)
     durability_ok = code == 0
@@ -1155,6 +1180,7 @@ def _run_arm(
         if program.reopen_command is None:
             raise ContractError(f"{program.role} has no reopen command")
         reopen_path = arm_dir / "reopen-state.json"
+        _assert_pins(pinned)
         _verify_copy_digest(binary_path, program.binary_sha256)
         reopen_argv = _expand_command(
             program.reopen_command,
@@ -1166,6 +1192,7 @@ def _run_arm(
         )
         reopen_deadline = time.monotonic_ns() + config.arm_timeout_ns
         reopen_exit, _, _, _ = _run_phase(reopen_argv, arm_dir, reopen_deadline)
+        _assert_pins(pinned)
         reopened = _state(reopen_path, f"{program.role} reopen state")
         reopen_state = state_json(reopened)
         reopen_hash = canonical_sha256(reopen_state)

--- a/tools/benchmark-campaign/offline_full_validation.py
+++ b/tools/benchmark-campaign/offline_full_validation.py
@@ -24,11 +24,17 @@ import os
 import signal
 import stat
 import subprocess
+import shutil
+#
+# The archive and manifest are copied into a private custody directory before
+# any arm starts.  Children only receive those copies; the configured paths are
+# never used as a check-then-use input after custody is established.
+#
 import sys
 import tempfile
 import time
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import NoReturn, TypedDict, TypeIs
 
@@ -875,6 +881,17 @@ def _kill_tree(process: subprocess.Popen[bytes]) -> None:
     raise ContractError("child process group did not terminate")
 
 
+def _evict_page_cache() -> None:
+    """Fail closed unless Linux can perform the declared cache eviction."""
+    try:
+        os.sync()
+        with open("/proc/sys/vm/drop_caches", "w", encoding="ascii") as stream:
+            stream.write("3\n")
+            stream.flush()
+    except OSError as error:
+        raise ContractError(f"cannot evict page cache: {error}") from error
+
+
 def _child_env(arm_dir: Path) -> dict[str, str]:
     tmp = arm_dir / "tmp"
     tmp.mkdir(exist_ok=True)
@@ -921,6 +938,8 @@ def _run_arm(
 ) -> ArmObservation:
     arm_dir = root / f"{order_index:02d}-{program.role}"
     arm_dir.mkdir(parents=True)
+    if config.posture.cache_policy == "process-cold/page-cache-evicted":
+        _evict_page_cache()
     data_dir = arm_dir / "data"
     data_dir.mkdir()
     binary_path = _verified_copy(program, arm_dir)
@@ -1066,6 +1085,26 @@ def run_campaign(config: Config, output_root: Path) -> JsonObject:
     if sys.platform != "linux":
         raise ContractError("offline full-validation comparator requires Linux")
     output_root.mkdir(parents=True, exist_ok=True)
+    custody_dir = output_root / "custody"
+    custody_dir.mkdir()
+    frozen_archive = custody_dir / "archive.dat"
+    frozen_manifest = custody_dir / "manifest.json"
+    try:
+        shutil.copyfile(config.archive.path, frozen_archive)
+        shutil.copyfile(config.manifest.path, frozen_manifest)
+    except OSError as error:
+        raise ContractError(f"cannot create immutable corpus custody copy: {error}") from error
+    with frozen_archive.open("rb") as stream:
+        archive_digest = hashlib.file_digest(stream, "sha256").hexdigest()
+    with frozen_manifest.open("rb") as stream:
+        manifest_digest = hashlib.file_digest(stream, "sha256").hexdigest()
+    if archive_digest != config.archive.sha256:
+        raise ContractError("archive changed while creating custody copy")
+    if manifest_digest != config.manifest.sha256:
+        raise ContractError("manifest changed while creating custody copy")
+    frozen_archive_ref = replace(config.archive, path=frozen_archive)
+    frozen_manifest_ref = replace(config.manifest, path=frozen_manifest)
+    config = replace(config, archive=frozen_archive_ref, manifest=frozen_manifest_ref)
     arms: list[ArmObservation] = []
     order_index = 0
     for pair_index in range(PAIR_COUNT):
@@ -1124,6 +1163,16 @@ def run_campaign(config: Config, output_root: Path) -> JsonObject:
 
 
 def _publish_result(result: JsonObject, output: Path) -> None:
+    """Publish atomically; commitment is the successful directory fsync.
+
+    The unnamed inode is fsynced before linking, then the containing directory
+    is fsynced.  Thus a successful return means the result name and bytes are
+    durable.  Failures before the directory fsync are non-committed and may be
+    retried (the destination must still be absent); an EEXIST or ambiguous
+    post-fsync failure is non-retriable and callers must inspect the destination.
+    This function owns no retries or compensation, and crash recovery consists
+    of retaining the already-linked result or rerunning when the name is absent.
+    """
     if sys.platform != "linux":
         raise ContractError("publication requires Linux O_TMPFILE support")
     at_empty_path = getattr(os, "AT_EMPTY_PATH", 0x1000)

--- a/tools/benchmark-campaign/offline_full_validation.py
+++ b/tools/benchmark-campaign/offline_full_validation.py
@@ -24,19 +24,16 @@ import os
 import signal
 import stat
 import subprocess
-import shutil
-#
-# The archive and manifest are copied into a private custody directory before
-# any arm starts.  Children only receive those copies; the configured paths are
-# never used as a check-then-use input after custody is established.
-#
 import sys
 import tempfile
 import time
 from collections.abc import Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn, TypedDict, TypeIs
+
+from p2p_loopback import ContractError as _P2PContractError
+from p2p_loopback import _ChildSubreaperScope, _direct_children_pids
 
 CONFIG_SCHEMA = "offline-full-validation-config-v1"
 MANIFEST_SCHEMA = "core-framed-archive-manifest-v1"
@@ -44,23 +41,60 @@ RESULT_SCHEMA = "offline-full-validation-result-v1"
 PAIR_COUNT = 7
 HEADER_BYTES = 80
 MAX_PAYLOAD_BYTES = 4_000_000
-MAX_ARCHIVE_BYTES = 8 * 1024 * 1024 * 1024
-MAX_MANIFEST_BYTES = 32 * 1024 * 1024
+MAX_ARCHIVE_BYTES = 1 * 1024 * 1024 * 1024 * 1024
+MAX_MANIFEST_BYTES = 512 * 1024 * 1024
 MAX_CONFIG_BYTES = 1 * 1024 * 1024
 MAX_STATE_BYTES = 1024 * 1024
 MAX_BINARY_BYTES = 1024 * 1024 * 1024
 MAX_JSON_DEPTH = 32
 MAX_COMMAND_ARGS = 256
-MAX_BLOCKS = 1_000_000
+MAX_BLOCKS = 2_000_000
 MAX_ARM_TIMEOUT_NS = 4 * 60 * 60 * 1_000_000_000
 MIN_ARM_TIMEOUT_NS = 1_000_000_000
 CHILD_TERMINATE_GRACE_NS = 1_000_000_000
 CHILD_KILL_REAP_NS = 1_000_000_000
 _HASH_LENGTH = 64
-CACHE_POLICIES = frozenset(
+CACHE_POLICIES = frozenset({"process-cold/page-cache-unspecified"})
+_ASSUME_VALID_OFF_EQUAL = frozenset(
     {
-        "process-cold/page-cache-unspecified",
-        "process-cold/page-cache-evicted",
+        "-assumevalid=0",
+        "--assumevalid=0",
+        "-assume-valid=0",
+        "--assume-valid=0",
+        "-assume-valid-height=0",
+        "--assume-valid-height=0",
+    }
+)
+_ASSUME_VALID_OFF_FLAGS = frozenset(
+    {
+        "-assumevalid",
+        "--assumevalid",
+        "-assume-valid",
+        "--assume-valid",
+        "-assume-valid-height",
+        "--assume-valid-height",
+    }
+)
+_INDEX_ON_TOKENS = frozenset(
+    {
+        "-txindex",
+        "-txindex=1",
+        "-txindex=true",
+        "--txindex",
+        "--txindex=1",
+        "--txindex=true",
+        "-blockfilterindex",
+        "-blockfilterindex=1",
+        "-blockfilterindex=true",
+        "--blockfilterindex",
+        "--blockfilterindex=1",
+        "--blockfilterindex=true",
+        "-coinstatsindex",
+        "-coinstatsindex=1",
+        "-coinstatsindex=true",
+        "--coinstatsindex",
+        "--coinstatsindex=1",
+        "--coinstatsindex=true",
     }
 )
 ALLOWED_PLACEHOLDERS = frozenset(
@@ -163,6 +197,14 @@ class FileIdentity:
     size: int
     mtime_ns: int
     sha256: str
+
+
+@dataclass(frozen=True)
+class PinnedCorpus:
+    archive: FileRef
+    archive_identity: FileIdentity
+    manifest: FileRef
+    manifest_identity: FileIdentity
 
 
 @dataclass(frozen=True)
@@ -578,7 +620,29 @@ def _posture(value: object) -> Posture:
     return posture
 
 
-def _command(raw: object, field: str) -> tuple[str, ...]:
+def _assume_valid_is_off(parts: Sequence[str]) -> bool:
+    if any(part in _ASSUME_VALID_OFF_EQUAL for part in parts):
+        return True
+    for index, part in enumerate(parts[:-1]):
+        if part in _ASSUME_VALID_OFF_FLAGS and parts[index + 1] == "0":
+            return True
+    return False
+
+
+def _require_timed_command_tokens(parts: Sequence[str], field: str) -> None:
+    if not _assume_valid_is_off(parts):
+        raise ContractError(
+            f"{field} must disable assume-valid "
+            "(-assumevalid=0 or --assume-valid-height=0)"
+        )
+    for part in parts:
+        if part in _INDEX_ON_TOKENS:
+            raise ContractError(f"{field} enables an auxiliary index ({part})")
+
+
+def _command(
+    raw: object, field: str, *, require_validation_tokens: bool
+) -> tuple[str, ...]:
     parts = tuple(_text(part, field) for part in _array(raw, field))
     if not parts or len(parts) > MAX_COMMAND_ARGS:
         raise ContractError(f"{field} must contain 1 to {MAX_COMMAND_ARGS} arguments")
@@ -594,16 +658,22 @@ def _command(raw: object, field: str) -> tuple[str, ...]:
                 end = part.find("}", start)
                 if end < 0 or part[start : end + 1] not in ALLOWED_PLACEHOLDERS:
                     raise ContractError(f"{field} contains an unsupported placeholder")
+    if require_validation_tokens:
+        _require_timed_command_tokens(parts, field)
     return parts
 
 
 def _program(raw: object, role: str, reopen_required: bool) -> Program:
     item = _object(raw, role, _PROGRAM_KEYS)
-    command = _command(item["command"], f"{role}.command")
+    command = _command(
+        item["command"], f"{role}.command", require_validation_tokens=True
+    )
     reopen_raw = item["reopen_command"]
     reopen: tuple[str, ...] | None = None
     if reopen_raw is not None:
-        reopen = _command(reopen_raw, f"{role}.reopen_command")
+        reopen = _command(
+            reopen_raw, f"{role}.reopen_command", require_validation_tokens=False
+        )
     elif reopen_required:
         raise ContractError(f"{role}.reopen_command is required for reopen lifecycle")
     return Program(
@@ -798,6 +868,82 @@ def _verify_copy_digest(binary_path: Path, expected: str) -> None:
         raise ContractError("arm binary changed after its verified copy")
 
 
+def _copy_readonly(
+    source: Path,
+    dest: Path,
+    expected_sha256: str,
+    expected_size: int,
+    field: str,
+) -> FileIdentity:
+    descriptor = _open_regular(source, field)
+    digest = hashlib.sha256()
+    copied = 0
+    try:
+        dest_fd = os.open(
+            dest, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC, 0o400
+        )
+        try:
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                copied += len(chunk)
+                digest.update(chunk)
+                written = 0
+                while written < len(chunk):
+                    written += os.write(dest_fd, chunk[written:])
+            os.fsync(dest_fd)
+            info = os.fstat(dest_fd)
+        finally:
+            os.close(dest_fd)
+    except OSError as error:
+        dest.unlink(missing_ok=True)
+        raise ContractError(f"cannot pin {field}: {error}") from error
+    finally:
+        os.close(descriptor)
+    observed = digest.hexdigest()
+    if copied != expected_size or observed != expected_sha256:
+        dest.unlink(missing_ok=True)
+        raise ContractError(f"{field} changed before the campaign pin")
+    dest.chmod(0o400)
+    return _identity_from_stat(info, observed)
+
+
+def _pin_corpus(config: Config, root: Path) -> PinnedCorpus:
+    custody = root / "custody"
+    custody.mkdir()
+    archive_path = custody / "archive"
+    manifest_path = custody / "manifest"
+    archive_identity = _copy_readonly(
+        config.archive.path,
+        archive_path,
+        config.archive.sha256,
+        config.archive.size,
+        "archive",
+    )
+    manifest_identity = _copy_readonly(
+        config.manifest.path,
+        manifest_path,
+        config.manifest.sha256,
+        config.manifest.size,
+        "manifest",
+    )
+    try:
+        dirfd = os.open(custody, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    except OSError as error:
+        raise ContractError(f"cannot dirsync custody pin: {error}") from error
+    try:
+        os.fsync(dirfd)
+    finally:
+        os.close(dirfd)
+    return PinnedCorpus(
+        FileRef(archive_path, config.archive.sha256, config.archive.size),
+        archive_identity,
+        FileRef(manifest_path, config.manifest.sha256, config.manifest.size),
+        manifest_identity,
+    )
+
+
 def _state(path: Path, field: str) -> CertifiedState:
     return _certified_state(_load_json(path, field, MAX_STATE_BYTES), field)
 
@@ -881,15 +1027,50 @@ def _kill_tree(process: subprocess.Popen[bytes]) -> None:
     raise ContractError("child process group did not terminate")
 
 
-def _evict_page_cache() -> None:
-    """Fail closed unless Linux can perform the declared cache eviction."""
+def _kill_pids(pids: Sequence[int]) -> None:
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    deadline = time.monotonic_ns() + CHILD_KILL_REAP_NS
+    remaining = set(pids)
+    while remaining and time.monotonic_ns() < deadline:
+        for pid in tuple(remaining):
+            try:
+                waited, _status = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                remaining.discard(pid)
+                continue
+            if waited == pid:
+                remaining.discard(pid)
+        if remaining:
+            time.sleep(0.01)
+
+
+def _reap_owned_descendants() -> list[int]:
+    leftover = _direct_children_pids()
+    if leftover:
+        _kill_pids(leftover)
+    return leftover
+
+
+def _settle_after_wait(process: subprocess.Popen[bytes]) -> None:
+    group_left = False
     try:
-        os.sync()
-        with open("/proc/sys/vm/drop_caches", "w", encoding="ascii") as stream:
-            stream.write("3\n")
-            stream.flush()
-    except OSError as error:
-        raise ContractError(f"cannot evict page cache: {error}") from error
+        os.killpg(process.pid, 0)
+        group_left = True
+    except ProcessLookupError:
+        pass
+    if group_left:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            group_left = False
+    leftover = _reap_owned_descendants()
+    if group_left or leftover:
+        listed = ",".join(str(pid) for pid in leftover) or str(process.pid)
+        raise ContractError(f"arm left descendant processes after exit: {listed}")
 
 
 def _child_env(arm_dir: Path) -> dict[str, str]:
@@ -923,9 +1104,11 @@ def _run_phase(
         raise ContractError(f"cannot spawn arm process: {error}") from error
     try:
         code, cpu_ns, peak_rss = _wait_child(process, deadline_ns)
+        _settle_after_wait(process)
     except BaseException:
         if process.poll() is None:
             _kill_tree(process)
+        _reap_owned_descendants()
         raise
     wall_ns = time.monotonic_ns() - started
     if wall_ns <= 0:
@@ -934,24 +1117,28 @@ def _run_phase(
 
 
 def _run_arm(
-    config: Config, program: Program, pair_index: int, order_index: int, root: Path
+    config: Config,
+    program: Program,
+    pair_index: int,
+    order_index: int,
+    root: Path,
+    pinned: PinnedCorpus,
 ) -> ArmObservation:
     arm_dir = root / f"{order_index:02d}-{program.role}"
     arm_dir.mkdir(parents=True)
-    if config.posture.cache_policy == "process-cold/page-cache-evicted":
-        _evict_page_cache()
     data_dir = arm_dir / "data"
     data_dir.mkdir()
     binary_path = _verified_copy(program, arm_dir)
-    _require_unchanged(config.archive.path, config.archive_identity, "archive")
+    _require_unchanged(pinned.archive.path, pinned.archive_identity, "archive")
+    _require_unchanged(pinned.manifest.path, pinned.manifest_identity, "manifest")
     _verify_copy_digest(binary_path, program.binary_sha256)
     state_path = arm_dir / "state.json"
     argv = _expand_command(
         program.command,
         binary_path=binary_path,
         data_dir=data_dir,
-        corpus_path=config.archive.path,
-        manifest_path=config.manifest.path,
+        corpus_path=pinned.archive.path,
+        manifest_path=pinned.manifest.path,
         state_path=state_path,
     )
     deadline = time.monotonic_ns() + config.arm_timeout_ns
@@ -973,8 +1160,8 @@ def _run_arm(
             program.reopen_command,
             binary_path=binary_path,
             data_dir=data_dir,
-            corpus_path=config.archive.path,
-            manifest_path=config.manifest.path,
+            corpus_path=pinned.archive.path,
+            manifest_path=pinned.manifest.path,
             state_path=reopen_path,
         )
         reopen_deadline = time.monotonic_ns() + config.arm_timeout_ns
@@ -1085,35 +1272,28 @@ def run_campaign(config: Config, output_root: Path) -> JsonObject:
     if sys.platform != "linux":
         raise ContractError("offline full-validation comparator requires Linux")
     output_root.mkdir(parents=True, exist_ok=True)
-    custody_dir = output_root / "custody"
-    custody_dir.mkdir()
-    frozen_archive = custody_dir / "archive.dat"
-    frozen_manifest = custody_dir / "manifest.json"
-    try:
-        shutil.copyfile(config.archive.path, frozen_archive)
-        shutil.copyfile(config.manifest.path, frozen_manifest)
-    except OSError as error:
-        raise ContractError(f"cannot create immutable corpus custody copy: {error}") from error
-    with frozen_archive.open("rb") as stream:
-        archive_digest = hashlib.file_digest(stream, "sha256").hexdigest()
-    with frozen_manifest.open("rb") as stream:
-        manifest_digest = hashlib.file_digest(stream, "sha256").hexdigest()
-    if archive_digest != config.archive.sha256:
-        raise ContractError("archive changed while creating custody copy")
-    if manifest_digest != config.manifest.sha256:
-        raise ContractError("manifest changed while creating custody copy")
-    frozen_archive_ref = replace(config.archive, path=frozen_archive)
-    frozen_manifest_ref = replace(config.manifest, path=frozen_manifest)
-    config = replace(config, archive=frozen_archive_ref, manifest=frozen_manifest_ref)
+    pinned = _pin_corpus(config, output_root)
     arms: list[ArmObservation] = []
     order_index = 0
-    for pair_index in range(PAIR_COUNT):
-        first = config.core if pair_index % 2 == 0 else config.candidate
-        second = config.candidate if first is config.core else config.core
-        arms.append(_run_arm(config, first, pair_index, order_index, output_root))
-        order_index += 1
-        arms.append(_run_arm(config, second, pair_index, order_index, output_root))
-        order_index += 1
+    try:
+        with _ChildSubreaperScope():
+            for pair_index in range(PAIR_COUNT):
+                first = config.core if pair_index % 2 == 0 else config.candidate
+                second = config.candidate if first is config.core else config.core
+                arms.append(
+                    _run_arm(
+                        config, first, pair_index, order_index, output_root, pinned
+                    )
+                )
+                order_index += 1
+                arms.append(
+                    _run_arm(
+                        config, second, pair_index, order_index, output_root, pinned
+                    )
+                )
+                order_index += 1
+    except _P2PContractError as error:
+        raise ContractError(str(error)) from error
     _require_comparable(config, arms)
     core_walls = [arm.wall_ns for arm in arms if arm.role == "core"]
     candidate_walls = [arm.wall_ns for arm in arms if arm.role == "candidate"]
@@ -1163,15 +1343,19 @@ def run_campaign(config: Config, output_root: Path) -> JsonObject:
 
 
 def _publish_result(result: JsonObject, output: Path) -> None:
-    """Publish atomically; commitment is the successful directory fsync.
+    """Atomically publish one result document.
 
-    The unnamed inode is fsynced before linking, then the containing directory
-    is fsynced.  Thus a successful return means the result name and bytes are
-    durable.  Failures before the directory fsync are non-committed and may be
-    retried (the destination must still be absent); an EEXIST or ambiguous
-    post-fsync failure is non-retriable and callers must inspect the destination.
-    This function owns no retries or compensation, and crash recovery consists
-    of retaining the already-linked result or rerunning when the name is absent.
+    Commit point is successful ``linkat(AT_EMPTY_PATH)``. Bytes are written
+    to an unnamed ``O_TMPFILE`` inode, flushed, and fsynced; only then is
+    the inode named in the output directory. ``os.fsync`` of that directory
+    follows a successful link so the directory entry is durable.
+
+    Crash before the link leaves the destination unchanged. The unnamed
+    inode vanishes with the descriptor; the run is retriable against the
+    same output path. Crash after the link (or a retry against an existing
+    name) surfaces ``EEXIST``: the published bytes are the committed
+    document and must not be overwritten. This function does not retry;
+    the caller owns retry policy and must choose a new output path.
     """
     if sys.platform != "linux":
         raise ContractError("publication requires Linux O_TMPFILE support")

--- a/tools/benchmark-campaign/offline_full_validation.py
+++ b/tools/benchmark-campaign/offline_full_validation.py
@@ -1,0 +1,1208 @@
+#!/usr/bin/env python3.14
+# pyright: strict
+"""Strict offline full-validation comparator for Bitcoin Core and bitcoin-rs.
+
+Both arms consume one hash-pinned Core-framed archive and one manifest,
+start from a fresh native store, run full validation, persist bodies and
+undo under the production durability contract, and exit only after a
+clean durable shutdown. Wall time is an external monotonic interval from
+process creation through that exit. A ratio is published only after every
+custody and correctness gate passes.
+
+Addresses issue #34. Implements the #46 parity contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import hashlib
+import json
+import math
+import os
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn, TypedDict, TypeIs
+
+CONFIG_SCHEMA = "offline-full-validation-config-v1"
+MANIFEST_SCHEMA = "core-framed-archive-manifest-v1"
+RESULT_SCHEMA = "offline-full-validation-result-v1"
+PAIR_COUNT = 7
+HEADER_BYTES = 80
+MAX_PAYLOAD_BYTES = 4_000_000
+MAX_ARCHIVE_BYTES = 8 * 1024 * 1024 * 1024
+MAX_MANIFEST_BYTES = 32 * 1024 * 1024
+MAX_CONFIG_BYTES = 1 * 1024 * 1024
+MAX_STATE_BYTES = 1024 * 1024
+MAX_BINARY_BYTES = 1024 * 1024 * 1024
+MAX_JSON_DEPTH = 32
+MAX_COMMAND_ARGS = 256
+MAX_BLOCKS = 1_000_000
+MAX_ARM_TIMEOUT_NS = 4 * 60 * 60 * 1_000_000_000
+MIN_ARM_TIMEOUT_NS = 1_000_000_000
+CHILD_TERMINATE_GRACE_NS = 1_000_000_000
+CHILD_KILL_REAP_NS = 1_000_000_000
+_HASH_LENGTH = 64
+CACHE_POLICIES = frozenset(
+    {
+        "process-cold/page-cache-unspecified",
+        "process-cold/page-cache-evicted",
+    }
+)
+ALLOWED_PLACEHOLDERS = frozenset(
+    {
+        "{binary}",
+        "{data_dir}",
+        "{corpus_path}",
+        "{manifest_path}",
+        "{state_path}",
+    }
+)
+_PUBLIC_PLACEHOLDERS = {
+    "{binary}": "<binary>",
+    "{data_dir}": "<data-dir>",
+    "{corpus_path}": "<corpus-path>",
+    "{manifest_path}": "<manifest-path>",
+    "{state_path}": "<state-path>",
+}
+_ARGUMENT_MARKER = "<argument>"
+_STATE_KEYS = frozenset(
+    {
+        "height",
+        "bestblock",
+        "txouts",
+        "total_amount_sat",
+        "muhash",
+        "utxo_hash_serialized_3",
+        "bodies_available",
+        "disconnect_ready",
+    }
+)
+_POSTURE_KEYS = frozenset(
+    {
+        "assume_valid",
+        "txindex",
+        "blockfilterindex",
+        "coinstatsindex",
+        "cache_policy",
+    }
+)
+_PROGRAM_KEYS = frozenset(
+    {"binary", "binary_sha256", "command", "reopen_command"}
+)
+_CORPUS_KEYS = frozenset({"archive", "manifest"})
+_FILE_REF_KEYS = frozenset({"path", "sha256", "bytes"})
+_MANIFEST_KEYS = frozenset(
+    {
+        "schema",
+        "network",
+        "network_magic",
+        "start_height",
+        "stop_height",
+        "archive_sha256",
+        "archive_bytes",
+        "blocks",
+    }
+)
+_BLOCK_ENTRY_KEYS = frozenset({"height", "hash", "offset", "payload_length"})
+_CONFIG_KEYS = frozenset(
+    {
+        "schema",
+        "network_magic",
+        "arm_timeout_ns",
+        "posture",
+        "corpus",
+        "expected_state",
+        "core",
+        "candidate",
+        "lifecycle",
+    }
+)
+_LIFECYCLE_KEYS = frozenset({"mode", "expected_reopen_state"})
+
+JsonObject = dict[str, object]
+
+
+class ContractError(ValueError):
+    """The comparator cannot make a controlled comparison."""
+
+
+class Summary(TypedDict):
+    samples: int
+    p50_ns: int
+    p95_ns: int
+    p99_ns: int
+    max_ns: int
+
+
+@dataclass(frozen=True)
+class FileRef:
+    path: Path
+    sha256: str
+    size: int
+
+
+@dataclass(frozen=True)
+class FileIdentity:
+    dev: int
+    ino: int
+    size: int
+    mtime_ns: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class BlockEntry:
+    height: int
+    block_hash: str
+    offset: int
+    payload_length: int
+
+
+@dataclass(frozen=True)
+class Manifest:
+    network: str
+    network_magic: bytes
+    start_height: int
+    stop_height: int
+    archive_sha256: str
+    archive_bytes: int
+    blocks: tuple[BlockEntry, ...]
+
+
+@dataclass(frozen=True)
+class CertifiedState:
+    height: int
+    bestblock: str
+    txouts: int
+    total_amount_sat: int
+    muhash: str
+    utxo_hash_serialized_3: str
+    bodies_available: bool
+    disconnect_ready: bool
+
+
+@dataclass(frozen=True)
+class Posture:
+    assume_valid: bool
+    txindex: bool
+    blockfilterindex: bool
+    coinstatsindex: bool
+    cache_policy: str
+
+
+@dataclass(frozen=True)
+class Program:
+    role: str
+    binary: Path
+    binary_sha256: str
+    command: tuple[str, ...]
+    reopen_command: tuple[str, ...] | None
+
+
+@dataclass(frozen=True)
+class Config:
+    network_magic: bytes
+    arm_timeout_ns: int
+    posture: Posture
+    archive: FileRef
+    archive_identity: FileIdentity
+    manifest: FileRef
+    manifest_document: Manifest
+    expected_state: CertifiedState
+    core: Program
+    candidate: Program
+    lifecycle_mode: str
+    expected_reopen_state: CertifiedState | None
+    canonical_sha256: str
+
+
+@dataclass(frozen=True)
+class ArmObservation:
+    pair_index: int
+    order_index: int
+    role: str
+    binary_sha256: str
+    command_sha256: str
+    command_arg_count: int
+    reopen_command_sha256: str | None
+    wall_ns: int
+    cpu_ns: int
+    peak_rss_bytes: int
+    exit_code: int
+    final_state: JsonObject
+    final_state_sha256: str
+    reopen_exit_code: int | None
+    reopen_state: JsonObject | None
+    reopen_state_sha256: str | None
+    durability_ok: bool
+    state_ok: bool
+    error: str | None
+
+
+def _is_object(value: object) -> TypeIs[JsonObject]:
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+
+
+def _object(value: object, field: str, keys: frozenset[str]) -> JsonObject:
+    if not _is_object(value):
+        raise ContractError(f"{field} must be a JSON object")
+    actual = frozenset(value)
+    if actual != keys:
+        raise ContractError(
+            f"{field} has wrong keys; missing_count={len(keys - actual)}, "
+            f"unknown_count={len(actual - keys)}"
+        )
+    return value
+
+
+def _array(value: object, field: str) -> list[object]:
+    if not isinstance(value, list):
+        raise ContractError(f"{field} must be an array")
+    return value
+
+
+def _text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise ContractError(f"{field} must be a nonempty NUL-free string")
+    return value
+
+
+def _uint(value: object, field: str, maximum: int = (1 << 63) - 1) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= maximum
+    ):
+        raise ContractError(f"{field} must be an integer in [0, {maximum}]")
+    return value
+
+
+def _boolean(value: object, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise ContractError(f"{field} must be a boolean")
+    return value
+
+
+def _hash(value: object, field: str) -> str:
+    text = _text(value, field)
+    if len(text) != _HASH_LENGTH or any(ch not in "0123456789abcdef" for ch in text):
+        raise ContractError(f"{field} must be a lowercase SHA-256")
+    return text
+
+
+def _magic(value: object, field: str) -> bytes:
+    text = _text(value, field)
+    try:
+        magic = bytes.fromhex(text)
+    except ValueError as error:
+        raise ContractError(f"{field} must be hexadecimal") from error
+    if len(magic) != 4:
+        raise ContractError(f"{field} must contain exactly four bytes")
+    return magic
+
+
+def canonical_bytes(value: object) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("ascii")
+    except (TypeError, ValueError, RecursionError) as error:
+        raise ContractError("value is not canonical JSON") from error
+
+
+def canonical_sha256(value: object) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def _validate_json_depth(value: object, field: str) -> None:
+    stack: list[tuple[object, int]] = [(value, 1)]
+    while stack:
+        current, depth = stack.pop()
+        if depth > MAX_JSON_DEPTH:
+            raise ContractError(f"{field} exceeds JSON depth limit {MAX_JSON_DEPTH}")
+        if isinstance(current, dict):
+            stack.extend((child, depth + 1) for child in current.values())
+        elif isinstance(current, list):
+            stack.extend((child, depth + 1) for child in current)
+
+
+def _open_regular(path: Path, field: str) -> int:
+    try:
+        descriptor = os.open(
+            path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | os.O_CLOEXEC
+        )
+    except OSError as error:
+        raise ContractError(f"cannot open {field} {path}: {error}") from error
+    try:
+        info = os.fstat(descriptor)
+    except OSError as error:
+        os.close(descriptor)
+        raise ContractError(f"cannot stat {field} {path}: {error}") from error
+    if not stat.S_ISREG(info.st_mode):
+        os.close(descriptor)
+        raise ContractError(f"{field} is not a regular file")
+    return descriptor
+
+
+def _load_json(path: Path, field: str, maximum_bytes: int) -> object:
+    descriptor = _open_regular(path, field)
+    owned = False
+    try:
+        info = os.fstat(descriptor)
+        if info.st_size > maximum_bytes:
+            raise ContractError(f"{field} exceeds byte limit {maximum_bytes}")
+        with os.fdopen(descriptor, "rb") as stream:
+            owned = True
+            raw = stream.read(maximum_bytes + 1)
+    except OSError as error:
+        raise ContractError(f"cannot read {field} {path}") from error
+    finally:
+        if not owned:
+            os.close(descriptor)
+    if len(raw) > maximum_bytes:
+        raise ContractError(f"{field} exceeds byte limit {maximum_bytes}")
+    try:
+        value: object = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
+        raise ContractError(f"{field} is not bounded valid JSON") from error
+    _validate_json_depth(value, field)
+    return value
+
+
+def _file_ref(raw: object, field: str, maximum_bytes: int) -> FileRef:
+    item = _object(raw, field, _FILE_REF_KEYS)
+    path = Path(_text(item["path"], f"{field}.path")).absolute()
+    digest = _hash(item["sha256"], f"{field}.sha256")
+    size = _uint(item["bytes"], f"{field}.bytes", maximum_bytes)
+    if size == 0:
+        raise ContractError(f"{field}.bytes must be positive")
+    return FileRef(path, digest, size)
+
+
+def _identity_from_stat(info: os.stat_result, digest: str) -> FileIdentity:
+    return FileIdentity(
+        info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns, digest
+    )
+
+
+def header_hash(payload: bytes) -> str:
+    """Display-hex of double-SHA256(header), matching Bitcoin block hashes."""
+    if len(payload) < HEADER_BYTES:
+        raise ContractError("block payload is shorter than a header")
+    digest = hashlib.sha256(hashlib.sha256(payload[:HEADER_BYTES]).digest()).digest()
+    return digest[::-1].hex()
+
+
+def _parse_manifest(value: object, archive: FileRef, magic: bytes) -> Manifest:
+    root = _object(value, "manifest", _MANIFEST_KEYS)
+    if root["schema"] != MANIFEST_SCHEMA:
+        raise ContractError(f"manifest.schema must be {MANIFEST_SCHEMA}")
+    network = _text(root["network"], "manifest.network")
+    documented_magic = _magic(root["network_magic"], "manifest.network_magic")
+    if documented_magic != magic:
+        raise ContractError("manifest network magic does not match the config")
+    start = _uint(root["start_height"], "manifest.start_height")
+    stop = _uint(root["stop_height"], "manifest.stop_height")
+    if stop < start:
+        raise ContractError("manifest stop_height is before start_height")
+    archive_digest = _hash(root["archive_sha256"], "manifest.archive_sha256")
+    archive_bytes = _uint(root["archive_bytes"], "manifest.archive_bytes", MAX_ARCHIVE_BYTES)
+    if archive_digest != archive.sha256 or archive_bytes != archive.size:
+        raise ContractError("manifest archive identity does not match the corpus FileRef")
+    raw_blocks = _array(root["blocks"], "manifest.blocks")
+    expected = stop - start + 1
+    if not raw_blocks or len(raw_blocks) != expected or len(raw_blocks) > MAX_BLOCKS:
+        raise ContractError("manifest.blocks must list every height exactly once")
+    blocks: list[BlockEntry] = []
+    cursor = 0
+    for index, raw in enumerate(raw_blocks):
+        item = _object(raw, f"manifest.blocks[{index}]", _BLOCK_ENTRY_KEYS)
+        height = _uint(item["height"], f"manifest.blocks[{index}].height")
+        if height != start + index:
+            raise ContractError("manifest heights must be contiguous from start_height")
+        offset = _uint(item["offset"], f"manifest.blocks[{index}].offset", MAX_ARCHIVE_BYTES)
+        payload_length = _uint(
+            item["payload_length"],
+            f"manifest.blocks[{index}].payload_length",
+            MAX_PAYLOAD_BYTES,
+        )
+        if payload_length < HEADER_BYTES:
+            raise ContractError(f"manifest.blocks[{index}] payload is shorter than a header")
+        if offset != cursor:
+            raise ContractError(f"manifest.blocks[{index}] offset is not packed")
+        record_length = 8 + payload_length
+        if offset + record_length > archive.size:
+            raise ContractError(f"manifest.blocks[{index}] overruns the archive")
+        blocks.append(
+            BlockEntry(
+                height,
+                _hash(item["hash"], f"manifest.blocks[{index}].hash"),
+                offset,
+                payload_length,
+            )
+        )
+        cursor += record_length
+    if cursor != archive.size:
+        raise ContractError("manifest does not consume the archive exactly")
+    return Manifest(
+        network,
+        documented_magic,
+        start,
+        stop,
+        archive_digest,
+        archive_bytes,
+        tuple(blocks),
+    )
+
+
+def _verify_archive(archive: FileRef, manifest: Manifest, magic: bytes) -> FileIdentity:
+    descriptor = _open_regular(archive.path, "archive")
+    digest = hashlib.sha256()
+    try:
+        info = os.fstat(descriptor)
+        if info.st_size != archive.size:
+            raise ContractError("archive size does not match the FileRef")
+        if info.st_size > MAX_ARCHIVE_BYTES:
+            raise ContractError("archive exceeds MAX_ARCHIVE_BYTES")
+        for index, entry in enumerate(manifest.blocks):
+            header = os.read(descriptor, 8)
+            if len(header) != 8:
+                raise ContractError("archive ended inside a record header")
+            digest.update(header)
+            if header[:4] != magic:
+                raise ContractError(f"archive record {index} has the wrong network magic")
+            payload_length = int.from_bytes(header[4:], "little")
+            if payload_length != entry.payload_length:
+                raise ContractError(f"archive record {index} length does not match the manifest")
+            payload = os.read(descriptor, payload_length)
+            if len(payload) != payload_length:
+                raise ContractError("archive ended inside a block payload")
+            digest.update(payload)
+            if header_hash(payload) != entry.block_hash:
+                raise ContractError(f"archive record {index} header hash does not match the manifest")
+        trailing = os.read(descriptor, 1)
+        if trailing:
+            raise ContractError("archive contains trailing bytes after the last record")
+        observed = digest.hexdigest()
+        if observed != archive.sha256:
+            raise ContractError("archive digest does not match the FileRef")
+        return _identity_from_stat(info, observed)
+    except OSError as error:
+        raise ContractError(f"cannot read archive: {error}") from error
+    finally:
+        os.close(descriptor)
+
+
+def _require_unchanged(path: Path, expected: FileIdentity, field: str) -> None:
+    descriptor = _open_regular(path, field)
+    try:
+        info = os.fstat(descriptor)
+    except OSError as error:
+        os.close(descriptor)
+        raise ContractError(f"cannot restat {field}: {error}") from error
+    os.close(descriptor)
+    current = _identity_from_stat(info, expected.sha256)
+    if (
+        current.dev != expected.dev
+        or current.ino != expected.ino
+        or current.size != expected.size
+        or current.mtime_ns != expected.mtime_ns
+    ):
+        raise ContractError(f"{field} changed after custody verification")
+
+
+def _certified_state(value: object, field: str) -> CertifiedState:
+    item = _object(value, field, _STATE_KEYS)
+    state = CertifiedState(
+        _uint(item["height"], f"{field}.height"),
+        _hash(item["bestblock"], f"{field}.bestblock"),
+        _uint(item["txouts"], f"{field}.txouts"),
+        _uint(item["total_amount_sat"], f"{field}.total_amount_sat"),
+        _hash(item["muhash"], f"{field}.muhash"),
+        _hash(item["utxo_hash_serialized_3"], f"{field}.utxo_hash_serialized_3"),
+        _boolean(item["bodies_available"], f"{field}.bodies_available"),
+        _boolean(item["disconnect_ready"], f"{field}.disconnect_ready"),
+    )
+    if not state.bodies_available or not state.disconnect_ready:
+        raise ContractError(f"{field} must prove body availability and disconnect readiness")
+    return state
+
+
+def state_json(state: CertifiedState) -> JsonObject:
+    return {
+        "height": state.height,
+        "bestblock": state.bestblock,
+        "txouts": state.txouts,
+        "total_amount_sat": state.total_amount_sat,
+        "muhash": state.muhash,
+        "utxo_hash_serialized_3": state.utxo_hash_serialized_3,
+        "bodies_available": state.bodies_available,
+        "disconnect_ready": state.disconnect_ready,
+    }
+
+
+def _posture(value: object) -> Posture:
+    item = _object(value, "posture", _POSTURE_KEYS)
+    posture = Posture(
+        _boolean(item["assume_valid"], "posture.assume_valid"),
+        _boolean(item["txindex"], "posture.txindex"),
+        _boolean(item["blockfilterindex"], "posture.blockfilterindex"),
+        _boolean(item["coinstatsindex"], "posture.coinstatsindex"),
+        _text(item["cache_policy"], "posture.cache_policy"),
+    )
+    if posture.assume_valid:
+        raise ContractError("full validation is mandatory; assume_valid must be false")
+    if posture.txindex or posture.blockfilterindex or posture.coinstatsindex:
+        raise ContractError("auxiliary indexes must be off")
+    if posture.cache_policy not in CACHE_POLICIES:
+        raise ContractError("posture.cache_policy is not a declared cache policy")
+    return posture
+
+
+def _command(raw: object, field: str) -> tuple[str, ...]:
+    parts = tuple(_text(part, field) for part in _array(raw, field))
+    if not parts or len(parts) > MAX_COMMAND_ARGS:
+        raise ContractError(f"{field} must contain 1 to {MAX_COMMAND_ARGS} arguments")
+    if parts[0] != "{binary}":
+        raise ContractError(f"{field}[0] must be {{binary}}")
+    required = {"{data_dir}", "{corpus_path}", "{state_path}"}
+    present = set(parts)
+    if not required <= present:
+        raise ContractError(f"{field} must name data_dir, corpus_path, and state_path")
+    for part in parts:
+        for start in range(len(part)):
+            if part[start] == "{":
+                end = part.find("}", start)
+                if end < 0 or part[start : end + 1] not in ALLOWED_PLACEHOLDERS:
+                    raise ContractError(f"{field} contains an unsupported placeholder")
+    return parts
+
+
+def _program(raw: object, role: str, reopen_required: bool) -> Program:
+    item = _object(raw, role, _PROGRAM_KEYS)
+    command = _command(item["command"], f"{role}.command")
+    reopen_raw = item["reopen_command"]
+    reopen: tuple[str, ...] | None = None
+    if reopen_raw is not None:
+        reopen = _command(reopen_raw, f"{role}.reopen_command")
+    elif reopen_required:
+        raise ContractError(f"{role}.reopen_command is required for reopen lifecycle")
+    return Program(
+        role,
+        Path(_text(item["binary"], f"{role}.binary")).absolute(),
+        _hash(item["binary_sha256"], f"{role}.binary_sha256"),
+        command,
+        reopen,
+    )
+
+
+def parse_config(value: object) -> Config:
+    root = _object(value, "config", _CONFIG_KEYS)
+    if root["schema"] != CONFIG_SCHEMA:
+        raise ContractError(f"config.schema must be {CONFIG_SCHEMA}")
+    magic = _magic(root["network_magic"], "network_magic")
+    timeout = _uint(root["arm_timeout_ns"], "arm_timeout_ns", MAX_ARM_TIMEOUT_NS)
+    if timeout < MIN_ARM_TIMEOUT_NS:
+        raise ContractError("arm_timeout_ns is below the one-second floor")
+    posture = _posture(root["posture"])
+    corpus_raw = _object(root["corpus"], "corpus", _CORPUS_KEYS)
+    archive = _file_ref(corpus_raw["archive"], "corpus.archive", MAX_ARCHIVE_BYTES)
+    manifest_ref = _file_ref(
+        corpus_raw["manifest"], "corpus.manifest", MAX_MANIFEST_BYTES
+    )
+    manifest = _parse_manifest(
+        _load_json(manifest_ref.path, "manifest", MAX_MANIFEST_BYTES),
+        archive,
+        magic,
+    )
+    descriptor = _open_regular(manifest_ref.path, "manifest")
+    try:
+        manifest_info = os.fstat(descriptor)
+        hasher = hashlib.sha256()
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            hasher.update(chunk)
+        if hasher.hexdigest() != manifest_ref.sha256:
+            raise ContractError("manifest digest does not match the FileRef")
+        if manifest_info.st_size != manifest_ref.size:
+            raise ContractError("manifest size does not match the FileRef")
+    except OSError as error:
+        raise ContractError(f"cannot hash manifest: {error}") from error
+    finally:
+        os.close(descriptor)
+    archive_identity = _verify_archive(archive, manifest, magic)
+    expected = _certified_state(root["expected_state"], "expected_state")
+    if expected.height != manifest.stop_height:
+        raise ContractError("expected_state.height must equal the manifest stop height")
+    if expected.bestblock != manifest.blocks[-1].block_hash:
+        raise ContractError("expected_state.bestblock must equal the final archive block hash")
+    lifecycle_raw = _object(root["lifecycle"], "lifecycle", _LIFECYCLE_KEYS)
+    mode = _text(lifecycle_raw["mode"], "lifecycle.mode")
+    if mode not in {"fresh", "reopen"}:
+        raise ContractError("lifecycle.mode must be fresh or reopen")
+    reopen_state_raw = lifecycle_raw["expected_reopen_state"]
+    reopen_state: CertifiedState | None = None
+    if mode == "reopen":
+        reopen_state = _certified_state(reopen_state_raw, "lifecycle.expected_reopen_state")
+        if reopen_state != expected:
+            raise ContractError("reopen state must equal the timed-trial certified state")
+    elif reopen_state_raw is not None:
+        raise ContractError("fresh lifecycle forbids expected_reopen_state")
+    core = _program(root["core"], "core", mode == "reopen")
+    candidate = _program(root["candidate"], "candidate", mode == "reopen")
+    public_root = dict(root)
+    for role, program in (("core", core), ("candidate", candidate)):
+        raw_value = root[role]
+        if not _is_object(raw_value):
+            raise ContractError(f"{role} must be a JSON object")
+        projected = dict(raw_value)
+        projected["command"] = _public_argv(program.command)
+        projected["reopen_command"] = (
+            None if program.reopen_command is None else _public_argv(program.reopen_command)
+        )
+        public_root[role] = projected
+    return Config(
+        magic,
+        timeout,
+        posture,
+        archive,
+        archive_identity,
+        manifest_ref,
+        manifest,
+        expected,
+        core,
+        candidate,
+        mode,
+        reopen_state,
+        canonical_sha256(public_root),
+    )
+
+
+def load_config(path: Path) -> Config:
+    return parse_config(_load_json(path, "config", MAX_CONFIG_BYTES))
+
+
+def _public_argv(argv: Sequence[str]) -> list[str]:
+    if not argv:
+        return []
+    projected = ["<executable>"]
+    after_options = False
+    for part in argv[1:]:
+        if after_options:
+            projected.append(_ARGUMENT_MARKER)
+        elif part == "--":
+            projected.append("<end-options>")
+            after_options = True
+        elif part in _PUBLIC_PLACEHOLDERS:
+            projected.append(_PUBLIC_PLACEHOLDERS[part])
+        elif part.startswith("--"):
+            projected.append("<long-option=value>" if "=" in part else "<long-option>")
+        elif part.startswith("-"):
+            projected.append("<short-option>")
+        else:
+            projected.append(_ARGUMENT_MARKER)
+    return projected
+
+
+def _argv_digest(argv: Sequence[str]) -> str:
+    return hashlib.sha256(canonical_bytes(_public_argv(argv))).hexdigest()
+
+
+def _expand_command(
+    template: tuple[str, ...],
+    *,
+    binary_path: Path,
+    data_dir: Path,
+    corpus_path: Path,
+    manifest_path: Path,
+    state_path: Path,
+) -> tuple[str, ...]:
+    replacements = {
+        "{binary}": str(binary_path),
+        "{data_dir}": str(data_dir),
+        "{corpus_path}": str(corpus_path),
+        "{manifest_path}": str(manifest_path),
+        "{state_path}": str(state_path),
+    }
+    return tuple(replacements.get(part, part) for part in template)
+
+
+def _verified_copy(program: Program, arm_dir: Path) -> Path:
+    descriptor = _open_regular(program.binary, f"{program.role} binary")
+    digest = hashlib.sha256()
+    target = arm_dir / "node-under-test"
+    try:
+        info = os.fstat(descriptor)
+        if info.st_size > MAX_BINARY_BYTES:
+            raise ContractError(f"{program.role}.binary exceeds MAX_BINARY_BYTES")
+        target_fd = os.open(
+            target, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC, 0o500
+        )
+        try:
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+                written = 0
+                while written < len(chunk):
+                    written += os.write(target_fd, chunk[written:])
+            os.fsync(target_fd)
+        finally:
+            os.close(target_fd)
+    except OSError as error:
+        raise ContractError(f"cannot copy {program.role} binary: {error}") from error
+    finally:
+        os.close(descriptor)
+    if digest.hexdigest() != program.binary_sha256:
+        target.unlink(missing_ok=True)
+        raise ContractError(f"{program.role} copied binary digest mismatch")
+    target.chmod(0o500)
+    return target
+
+
+def _verify_copy_digest(binary_path: Path, expected: str) -> None:
+    descriptor = _open_regular(binary_path, "arm binary")
+    owned = False
+    try:
+        with os.fdopen(descriptor, "rb") as stream:
+            owned = True
+            digest = hashlib.file_digest(stream, "sha256").hexdigest()
+    except OSError as error:
+        raise ContractError(f"cannot verify arm binary bytes: {error}") from error
+    finally:
+        if not owned:
+            os.close(descriptor)
+    if digest != expected:
+        raise ContractError("arm binary changed after its verified copy")
+
+
+def _state(path: Path, field: str) -> CertifiedState:
+    return _certified_state(_load_json(path, field, MAX_STATE_BYTES), field)
+
+
+def _clk_tck() -> int:
+    ticks = os.sysconf("SC_CLK_TCK")
+    if ticks <= 0:
+        raise ContractError("cannot read SC_CLK_TCK")
+    return ticks
+
+
+def _page_size() -> int:
+    size = os.sysconf("SC_PAGESIZE")
+    if size <= 0:
+        raise ContractError("cannot read SC_PAGESIZE")
+    return size
+
+
+def _sample_child(pid: int) -> tuple[int, int] | None:
+    try:
+        stat_text = Path(f"/proc/{pid}/stat").read_text()
+    except OSError:
+        return None
+    fields = stat_text.rpartition(")")[2].split()
+    if len(fields) < 22:
+        return None
+    try:
+        utime = int(fields[11])
+        stime = int(fields[12])
+        rss_pages = int(fields[21])
+    except ValueError:
+        return None
+    cpu_ns = (utime + stime) * 1_000_000_000 // _clk_tck()
+    rss_bytes = rss_pages * _page_size()
+    return cpu_ns, rss_bytes
+
+
+def _wait_child(
+    process: subprocess.Popen[bytes], deadline_ns: int
+) -> tuple[int, int, int]:
+    peak_rss = 0
+    cpu_ns = 0
+    while True:
+        sample = _sample_child(process.pid)
+        if sample is not None:
+            cpu_ns, rss = sample
+            if rss > peak_rss:
+                peak_rss = rss
+        remaining = deadline_ns - time.monotonic_ns()
+        if remaining <= 0:
+            _kill_tree(process)
+            raise ContractError("arm exceeded its monotonic deadline")
+        try:
+            code = process.wait(timeout=min(0.05, remaining / 1_000_000_000))
+        except subprocess.TimeoutExpired:
+            continue
+        if code is None:
+            raise ContractError("child wait returned without an exit code")
+        return code, cpu_ns, peak_rss
+
+
+def _kill_tree(process: subprocess.Popen[bytes]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    grace = time.monotonic_ns() + CHILD_TERMINATE_GRACE_NS
+    while time.monotonic_ns() < grace:
+        if process.poll() is not None:
+            return
+        time.sleep(0.01)
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    kill_deadline = time.monotonic_ns() + CHILD_KILL_REAP_NS
+    while time.monotonic_ns() < kill_deadline:
+        if process.poll() is not None:
+            return
+        time.sleep(0.01)
+    raise ContractError("child process group did not terminate")
+
+
+def _child_env(arm_dir: Path) -> dict[str, str]:
+    tmp = arm_dir / "tmp"
+    tmp.mkdir(exist_ok=True)
+    return {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": str(arm_dir),
+        "TMPDIR": str(tmp),
+        "LC_ALL": "C",
+    }
+
+
+def _run_phase(
+    argv: tuple[str, ...],
+    arm_dir: Path,
+    deadline_ns: int,
+) -> tuple[int, int, int, int]:
+    env = _child_env(arm_dir)
+    started = time.monotonic_ns()
+    try:
+        process = subprocess.Popen(
+            argv,
+            shell=False,
+            close_fds=True,
+            start_new_session=True,
+            env=env,
+            cwd=arm_dir,
+        )
+    except OSError as error:
+        raise ContractError(f"cannot spawn arm process: {error}") from error
+    try:
+        code, cpu_ns, peak_rss = _wait_child(process, deadline_ns)
+    except BaseException:
+        if process.poll() is None:
+            _kill_tree(process)
+        raise
+    wall_ns = time.monotonic_ns() - started
+    if wall_ns <= 0:
+        raise ContractError("arm wall time was not positive")
+    return code, wall_ns, cpu_ns, peak_rss
+
+
+def _run_arm(
+    config: Config, program: Program, pair_index: int, order_index: int, root: Path
+) -> ArmObservation:
+    arm_dir = root / f"{order_index:02d}-{program.role}"
+    arm_dir.mkdir(parents=True)
+    data_dir = arm_dir / "data"
+    data_dir.mkdir()
+    binary_path = _verified_copy(program, arm_dir)
+    _require_unchanged(config.archive.path, config.archive_identity, "archive")
+    _verify_copy_digest(binary_path, program.binary_sha256)
+    state_path = arm_dir / "state.json"
+    argv = _expand_command(
+        program.command,
+        binary_path=binary_path,
+        data_dir=data_dir,
+        corpus_path=config.archive.path,
+        manifest_path=config.manifest.path,
+        state_path=state_path,
+    )
+    deadline = time.monotonic_ns() + config.arm_timeout_ns
+    code, wall_ns, cpu_ns, peak_rss = _run_phase(argv, arm_dir, deadline)
+    final = _state(state_path, f"{program.role} final state")
+    expected_json = state_json(config.expected_state)
+    durability_ok = code == 0
+    state_ok = state_json(final) == expected_json
+    reopen_exit: int | None = None
+    reopen_state: JsonObject | None = None
+    reopen_hash: str | None = None
+    reopen_digest: str | None = None
+    if config.lifecycle_mode == "reopen":
+        if program.reopen_command is None:
+            raise ContractError(f"{program.role} has no reopen command")
+        reopen_path = arm_dir / "reopen-state.json"
+        _verify_copy_digest(binary_path, program.binary_sha256)
+        reopen_argv = _expand_command(
+            program.reopen_command,
+            binary_path=binary_path,
+            data_dir=data_dir,
+            corpus_path=config.archive.path,
+            manifest_path=config.manifest.path,
+            state_path=reopen_path,
+        )
+        reopen_deadline = time.monotonic_ns() + config.arm_timeout_ns
+        reopen_exit, _, _, _ = _run_phase(reopen_argv, arm_dir, reopen_deadline)
+        reopened = _state(reopen_path, f"{program.role} reopen state")
+        reopen_state = state_json(reopened)
+        reopen_hash = canonical_sha256(reopen_state)
+        reopen_digest = _argv_digest(program.reopen_command)
+        durability_ok = durability_ok and reopen_exit == 0
+        state_ok = state_ok and reopen_state == expected_json
+    errors: list[str] = []
+    if not durability_ok:
+        errors.append("durable clean exit failed")
+    if not state_ok:
+        errors.append("certified state contract failed")
+    return ArmObservation(
+        pair_index,
+        order_index,
+        program.role,
+        program.binary_sha256,
+        _argv_digest(program.command),
+        len(program.command),
+        reopen_digest,
+        wall_ns,
+        cpu_ns,
+        peak_rss,
+        code,
+        state_json(final),
+        canonical_sha256(state_json(final)),
+        reopen_exit,
+        reopen_state,
+        reopen_hash,
+        durability_ok,
+        state_ok,
+        "; ".join(errors) or None,
+    )
+
+
+def _percentile(values: Sequence[int], percentile: float) -> int:
+    if not values:
+        raise ContractError("cannot summarize an empty sample")
+    ordered = sorted(values)
+    rank = math.ceil(percentile * len(ordered)) - 1
+    return ordered[max(0, rank)]
+
+
+def summarize(values: Sequence[int]) -> Summary:
+    return {
+        "samples": len(values),
+        "p50_ns": _percentile(values, 0.50),
+        "p95_ns": _percentile(values, 0.95),
+        "p99_ns": _percentile(values, 0.99),
+        "max_ns": max(values),
+    }
+
+
+def _arm_json(arm: ArmObservation) -> JsonObject:
+    return {
+        "pair_index": arm.pair_index,
+        "order_index": arm.order_index,
+        "role": arm.role,
+        "binary_sha256": arm.binary_sha256,
+        "command_sha256": arm.command_sha256,
+        "command_arg_count": arm.command_arg_count,
+        "reopen_command_sha256": arm.reopen_command_sha256,
+        "wall_ns": arm.wall_ns,
+        "cpu_ns": arm.cpu_ns,
+        "peak_rss_bytes": arm.peak_rss_bytes,
+        "exit_code": arm.exit_code,
+        "final_state": arm.final_state,
+        "final_state_sha256": arm.final_state_sha256,
+        "reopen_exit_code": arm.reopen_exit_code,
+        "reopen_state": arm.reopen_state,
+        "reopen_state_sha256": arm.reopen_state_sha256,
+        "durability_ok": arm.durability_ok,
+        "state_ok": arm.state_ok,
+        "error": arm.error,
+    }
+
+
+def _require_comparable(config: Config, arms: Sequence[ArmObservation]) -> None:
+    if len(arms) != 2 * PAIR_COUNT:
+        raise ContractError("campaign must contain exactly fourteen arms")
+    for pair_index in range(PAIR_COUNT):
+        first, second = arms[2 * pair_index], arms[2 * pair_index + 1]
+        expected_first = "core" if pair_index % 2 == 0 else "candidate"
+        expected_second = "candidate" if expected_first == "core" else "core"
+        if first.role != expected_first or second.role != expected_second:
+            raise ContractError("pair order must alternate Core-first then candidate-first")
+        if first.pair_index != pair_index or second.pair_index != pair_index:
+            raise ContractError("pair index is inconsistent")
+        for arm in (first, second):
+            if not arm.durability_ok or not arm.state_ok or arm.error is not None:
+                raise ContractError(f"{arm.role} arm {arm.order_index} failed its gates")
+            if arm.binary_sha256 != (
+                config.core.binary_sha256
+                if arm.role == "core"
+                else config.candidate.binary_sha256
+            ):
+                raise ContractError("arm binary identity drifted")
+            if arm.final_state != state_json(config.expected_state):
+                raise ContractError("arm certified state diverged")
+        if first.final_state != second.final_state:
+            raise ContractError("paired arms did not certify the same state")
+
+
+def run_campaign(config: Config, output_root: Path) -> JsonObject:
+    if sys.platform != "linux":
+        raise ContractError("offline full-validation comparator requires Linux")
+    output_root.mkdir(parents=True, exist_ok=True)
+    arms: list[ArmObservation] = []
+    order_index = 0
+    for pair_index in range(PAIR_COUNT):
+        first = config.core if pair_index % 2 == 0 else config.candidate
+        second = config.candidate if first is config.core else config.core
+        arms.append(_run_arm(config, first, pair_index, order_index, output_root))
+        order_index += 1
+        arms.append(_run_arm(config, second, pair_index, order_index, output_root))
+        order_index += 1
+    _require_comparable(config, arms)
+    core_walls = [arm.wall_ns for arm in arms if arm.role == "core"]
+    candidate_walls = [arm.wall_ns for arm in arms if arm.role == "candidate"]
+    core_summary = summarize(core_walls)
+    candidate_summary = summarize(candidate_walls)
+    ratio = candidate_summary["p50_ns"] / core_summary["p50_ns"]
+    result: JsonObject = {
+        "schema": RESULT_SCHEMA,
+        "config_sha256": config.canonical_sha256,
+        "pair_count": PAIR_COUNT,
+        "arm_count": len(arms),
+        "custody": {
+            "network_magic": config.network_magic.hex(),
+            "network": config.manifest_document.network,
+            "start_height": config.manifest_document.start_height,
+            "stop_height": config.manifest_document.stop_height,
+            "archive_sha256": config.archive.sha256,
+            "archive_bytes": config.archive.size,
+            "manifest_sha256": config.manifest.sha256,
+            "manifest_bytes": config.manifest.size,
+            "core_binary_sha256": config.core.binary_sha256,
+            "candidate_binary_sha256": config.candidate.binary_sha256,
+            "assume_valid": config.posture.assume_valid,
+            "txindex": config.posture.txindex,
+            "blockfilterindex": config.posture.blockfilterindex,
+            "coinstatsindex": config.posture.coinstatsindex,
+            "cache_policy": config.posture.cache_policy,
+            "lifecycle_mode": config.lifecycle_mode,
+        },
+        "correctness": {
+            "arm_count_ok": True,
+            "alternation_ok": True,
+            "archive_ok": True,
+            "full_validation_ok": True,
+            "indexes_off_ok": True,
+            "durability_ok": True,
+            "state_equal": True,
+            "reopen_ok": True,
+        },
+        "arms": [_arm_json(arm) for arm in arms],
+        "core": core_summary,
+        "candidate": candidate_summary,
+        "candidate_over_core_p50_ratio": ratio,
+    }
+    result["result_sha256"] = canonical_sha256(result)
+    return result
+
+
+def _publish_result(result: JsonObject, output: Path) -> None:
+    if sys.platform != "linux":
+        raise ContractError("publication requires Linux O_TMPFILE support")
+    at_empty_path = getattr(os, "AT_EMPTY_PATH", 0x1000)
+    payload = canonical_bytes(result) + b"\n"
+    try:
+        directory = os.open(output.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    except OSError as error:
+        raise ContractError(f"cannot open output directory {output.parent}: {error}") from error
+    try:
+        try:
+            descriptor = os.open(
+                output.parent, os.O_WRONLY | os.O_TMPFILE | os.O_CLOEXEC, 0o600
+            )
+        except OSError as error:
+            raise ContractError(
+                f"cannot create unnamed temp file in {output.parent}: {error}"
+            ) from error
+        try:
+            with os.fdopen(descriptor, "wb", closefd=False) as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(descriptor)
+            libc = ctypes.CDLL(None, use_errno=True)
+            linkat = libc.linkat
+            linkat.argtypes = (
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+            )
+            linked = linkat(
+                descriptor,
+                b"",
+                directory,
+                os.fsencode(output.name),
+                at_empty_path,
+            )
+            if linked != 0:
+                failure = ctypes.get_errno()
+                if failure == errno.EEXIST:
+                    raise ContractError(f"output already exists: {output}")
+                raise ContractError(f"cannot link published result: {os.strerror(failure)}")
+        finally:
+            os.close(descriptor)
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    config = load_config(args.config)
+    output = args.output
+    if output.exists():
+        raise ContractError(f"output already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix="offline-full-validation-", dir=output.parent
+    ) as temporary:
+        result = run_campaign(config, Path(temporary) / "arms")
+        _publish_result(result, output)
+    return 0
+
+
+def _fatal(error: Exception) -> NoReturn:
+    print(f"offline-full-validation: {error}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ContractError as error:
+        _fatal(error)

--- a/tools/benchmark-campaign/test_comp_lanes.py
+++ b/tools/benchmark-campaign/test_comp_lanes.py
@@ -86,25 +86,25 @@ class P2PLaneTests(unittest.TestCase):
 class OfflineLaneTests(unittest.TestCase):
     """Tests for the offline full-validation lane (#34)."""
 
-    def test_offline_lane_blocked_without_bitcoind(self) -> None:
-        workspace = Path(tempfile.mkdtemp(prefix="offline-lane-test-"))
-        try:
-            report = run_all_lanes(workspace)
-            lanes = report["lanes"]
-            assert isinstance(lanes, list)
-            offline = lanes[0]
-            assert isinstance(offline, dict)
-            self.assertEqual(offline["issue"], "#34")
-            if shutil.which("bitcoind") is None:
-                self.assertEqual(offline["status"], "blocked")
-                self.assertEqual(
-                    offline["reason"], "bitcoind binary not found on PATH"
-                )
-                self.assertEqual(offline["command_run"], "shutil.which('bitcoind')")
-            else:
-                self.assertEqual(offline["status"], "reachable")
-        finally:
-            shutil.rmtree(workspace, ignore_errors=True)
+    def setUp(self) -> None:
+        self.workspace = Path(tempfile.mkdtemp(prefix="offline-lane-test-"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.workspace, ignore_errors=True)
+
+    def test_offline_lane_produces_valid_result(self) -> None:
+        result = comp_lanes.run_offline_lane(self.workspace)
+        self.assertEqual(result["status"], "passed")
+        self.assertEqual(
+            result["result_schema"], "offline-full-validation-result-v1"
+        )
+        self.assertEqual(result["pair_count"], 7)
+        self.assertEqual(result["arm_count"], 14)
+        correctness = result["correctness"]
+        assert isinstance(correctness, dict)
+        self.assertTrue(all(correctness.values()))
+        self.assertIsNotNone(result["result_sha256"])
+        self.assertIsNotNone(result["ratio"])
 
 
 class RPCLaneTests(unittest.TestCase):
@@ -153,6 +153,18 @@ class CombinedReportTests(unittest.TestCase):
             )
             expected = hashlib.sha256(canonical).hexdigest()
             self.assertEqual(report["report_sha256"], expected)
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
+
+    def test_offline_lane_in_report_has_passed_status(self) -> None:
+        workspace, report = _run_in_workspace()
+        try:
+            lanes = report["lanes"]
+            assert isinstance(lanes, list)
+            offline = lanes[0]
+            assert isinstance(offline, dict)
+            self.assertEqual(offline["lane"], "offline-full-validation")
+            self.assertEqual(offline["status"], "passed")
         finally:
             shutil.rmtree(workspace, ignore_errors=True)
 

--- a/tools/benchmark-campaign/test_offline_full_validation.py
+++ b/tools/benchmark-campaign/test_offline_full_validation.py
@@ -513,6 +513,29 @@ class CampaignTests(unittest.TestCase):
             main(["--config", str(config_path), "--output", str(output)])
         self.assertFalse(output.exists())
 
+    def test_child_manifest_mutation_is_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-manifest-mut-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, expected = _build_workspace(root)
+        mutator = _write_executable(
+            root / "mutate.py",
+            _node_source(expected).replace(
+                "raise SystemExit(0)\n",
+                "manifest = __import__('pathlib').Path(args.manifest)\n"
+                "__import__('os').chmod(manifest, 0o600)\n"
+                "manifest.write_bytes(manifest.read_bytes()[::-1])\n"
+                "raise SystemExit(0)\n",
+            ),
+        )
+        config = json.loads(config_path.read_text())
+        config["candidate"]["binary"] = str(mutator)
+        config["candidate"]["binary_sha256"] = _sha256_file(mutator)
+        config_path.write_bytes(canonical_bytes(config) + b"\n")
+        output = root / OUTPUT_NAME
+        with self.assertRaises(ContractError):
+            main(["--config", str(config_path), "--output", str(output)])
+        self.assertFalse(output.exists())
+
     def test_summarize_uses_nearest_rank(self) -> None:
         summary = summarize([10, 20, 30, 40, 50, 60, 70])
         self.assertEqual(summary["samples"], 7)

--- a/tools/benchmark-campaign/test_offline_full_validation.py
+++ b/tools/benchmark-campaign/test_offline_full_validation.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3.14
+# pyright: strict
+"""Behavioral tests for the offline full-validation comparator."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import TypeIs
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import offline_full_validation as offline
+from offline_full_validation import (
+    CONFIG_SCHEMA,
+    MANIFEST_SCHEMA,
+    PAIR_COUNT,
+    RESULT_SCHEMA,
+    CertifiedState,
+    ContractError,
+    canonical_bytes,
+    canonical_sha256,
+    header_hash,
+    load_config,
+    main,
+    parse_config,
+    run_campaign,
+    state_json,
+    summarize,
+)
+
+JsonObject = dict[str, object]
+MAGIC = "f9beb4d9"
+HASH64 = "ab" * 32
+OUTPUT_NAME = Path("out") / "result.json"
+
+
+def _is_object(value: object) -> TypeIs[JsonObject]:
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+
+
+def _object(value: object) -> JsonObject:
+    if not _is_object(value):
+        raise TypeError("expected JSON object")
+    return value
+
+
+def _write_executable(path: Path, source: str) -> Path:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _record(payload: bytes, magic: bytes = bytes.fromhex(MAGIC)) -> bytes:
+    return magic + len(payload).to_bytes(4, "little") + payload
+
+
+def _payload(marker: int) -> bytes:
+    return bytes([marker]) * 80 + bytes([marker])
+
+
+def _state(
+    *,
+    height: int = 1,
+    bestblock: str | None = None,
+    txouts: int = 2,
+) -> CertifiedState:
+    return CertifiedState(
+        height,
+        bestblock or HASH64,
+        txouts,
+        5_000_000_000,
+        "cd" * 32,
+        "ef" * 32,
+        True,
+        True,
+    )
+
+
+def _node_source(expected: CertifiedState, *, reopen: bool = False) -> str:
+    payload = json.dumps(state_json(expected), sort_keys=True)
+    reopen_flag = "True" if reopen else "False"
+    return f"""#!{sys.executable}
+import argparse, json, sys
+from pathlib import Path
+parser = argparse.ArgumentParser()
+parser.add_argument('--data-dir', required=True)
+parser.add_argument('--corpus', required=True)
+parser.add_argument('--manifest', required=True)
+parser.add_argument('--state', required=True)
+parser.add_argument('--reopen', action='store_true')
+args = parser.parse_args()
+corpus = Path(args.corpus).read_bytes()
+if not corpus:
+    raise SystemExit(3)
+data = Path(args.data_dir)
+if {reopen_flag} and args.reopen:
+    marker = data / 'imported'
+    if not marker.is_file():
+        raise SystemExit(4)
+else:
+    (data / 'imported').write_bytes(corpus)
+Path(args.state).write_text({payload!r} + '\\n', encoding='utf-8')
+raise SystemExit(0)
+"""
+
+
+def _command(*, reopen: bool = False) -> list[str]:
+    command = [
+        "{binary}",
+        "--data-dir",
+        "{data_dir}",
+        "--corpus",
+        "{corpus_path}",
+        "--manifest",
+        "{manifest_path}",
+        "--state",
+        "{state_path}",
+    ]
+    if reopen:
+        command.append("--reopen")
+    return command
+
+
+def _build_workspace(root: Path, *, reopen: bool = False) -> tuple[Path, CertifiedState]:
+    payloads = (_payload(1), _payload(2))
+    records = [_record(payload) for payload in payloads]
+    archive_bytes = b"".join(records)
+    archive_path = root / "blocks.dat"
+    archive_path.write_bytes(archive_bytes)
+    hashes = [header_hash(payload) for payload in payloads]
+    offset = 0
+    entries: list[JsonObject] = []
+    for height, (payload, digest, record) in enumerate(
+        zip(payloads, hashes, records, strict=True)
+    ):
+        entries.append(
+            {
+                "height": height,
+                "hash": digest,
+                "offset": offset,
+                "payload_length": len(payload),
+            }
+        )
+        offset += len(record)
+    manifest = {
+        "schema": MANIFEST_SCHEMA,
+        "network": "mainnet",
+        "network_magic": MAGIC,
+        "start_height": 0,
+        "stop_height": 1,
+        "archive_sha256": hashlib.sha256(archive_bytes).hexdigest(),
+        "archive_bytes": len(archive_bytes),
+        "blocks": entries,
+    }
+    manifest_path = root / "manifest.json"
+    manifest_path.write_bytes(canonical_bytes(manifest) + b"\n")
+    expected = _state(height=1, bestblock=hashes[-1])
+    node = _write_executable(root / "node.py", _node_source(expected, reopen=reopen))
+    digest = _sha256_file(node)
+
+    def program() -> JsonObject:
+        return {
+            "binary": str(node),
+            "binary_sha256": digest,
+            "command": _command(),
+            "reopen_command": _command(reopen=True) if reopen else None,
+        }
+
+    config = {
+        "schema": CONFIG_SCHEMA,
+        "network_magic": MAGIC,
+        "arm_timeout_ns": 10_000_000_000,
+        "posture": {
+            "assume_valid": False,
+            "txindex": False,
+            "blockfilterindex": False,
+            "coinstatsindex": False,
+            "cache_policy": "process-cold/page-cache-unspecified",
+        },
+        "corpus": {
+            "archive": {
+                "path": str(archive_path),
+                "sha256": hashlib.sha256(archive_bytes).hexdigest(),
+                "bytes": len(archive_bytes),
+            },
+            "manifest": {
+                "path": str(manifest_path),
+                "sha256": _sha256_file(manifest_path),
+                "bytes": manifest_path.stat().st_size,
+            },
+        },
+        "expected_state": state_json(expected),
+        "core": program(),
+        "candidate": program(),
+        "lifecycle": {
+            "mode": "reopen" if reopen else "fresh",
+            "expected_reopen_state": state_json(expected) if reopen else None,
+        },
+    }
+    config_path = root / "config.json"
+    config_path.write_bytes(canonical_bytes(config) + b"\n")
+    return config_path, expected
+
+
+class ArchiveContractTests(unittest.TestCase):
+    def test_header_hash_is_reversed_double_sha256(self) -> None:
+        payload = _payload(9)
+        digest = hashlib.sha256(hashlib.sha256(payload[:80]).digest()).digest()
+        self.assertEqual(header_hash(payload), digest[::-1].hex())
+
+    def test_trailing_bytes_are_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-trailing-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        archive = root / "blocks.dat"
+        archive.write_bytes(archive.read_bytes() + b"\x00")
+        with self.assertRaises(ContractError):
+            load_config(config_path)
+
+    def test_magic_mismatch_is_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-magic-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        archive = root / "blocks.dat"
+        raw = bytearray(archive.read_bytes())
+        raw[0:4] = b"\x00\x00\x00\x00"
+        archive.write_bytes(raw)
+        with self.assertRaises(ContractError):
+            load_config(config_path)
+
+    def test_header_hash_mismatch_is_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-hash-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        manifest_path = root / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["blocks"][0]["hash"] = HASH64
+        manifest_path.write_bytes(canonical_bytes(manifest) + b"\n")
+        config = json.loads(config_path.read_text())
+        config["corpus"]["manifest"]["sha256"] = _sha256_file(manifest_path)
+        config["corpus"]["manifest"]["bytes"] = manifest_path.stat().st_size
+        config_path.write_bytes(canonical_bytes(config) + b"\n")
+        with self.assertRaises(ContractError):
+            load_config(config_path)
+
+
+class ConfigContractTests(unittest.TestCase):
+    def test_assume_valid_is_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-assume-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        config = json.loads(config_path.read_text())
+        config["posture"]["assume_valid"] = True
+        with self.assertRaises(ContractError):
+            parse_config(config)
+
+    def test_txindex_on_is_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-txindex-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        config = json.loads(config_path.read_text())
+        config["posture"]["txindex"] = True
+        with self.assertRaises(ContractError):
+            parse_config(config)
+
+    def test_expected_height_must_match_manifest_tip(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-height-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        config = json.loads(config_path.read_text())
+        config["expected_state"]["height"] = 99
+        with self.assertRaises(ContractError):
+            parse_config(config)
+
+    def test_command_must_use_binary_placeholder(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-argv0-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        config = json.loads(config_path.read_text())
+        config["core"]["command"][0] = "/usr/bin/bitcoind"
+        with self.assertRaises(ContractError):
+            parse_config(config)
+
+    def test_public_argv_strips_secret_text(self) -> None:
+        projected = offline._public_argv(
+            (
+                "{binary}",
+                "-datadir=/secret",
+                "{data_dir}",
+                "--rpcpassword=hunter2",
+                "{corpus_path}",
+            )
+        )
+        self.assertEqual(
+            projected,
+            [
+                "<executable>",
+                "<short-option>",
+                "<data-dir>",
+                "<long-option=value>",
+                "<corpus-path>",
+            ],
+        )
+
+
+class CampaignTests(unittest.TestCase):
+    def test_seven_pairs_publish_a_gated_result(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-campaign-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, expected = _build_workspace(root)
+        output = root / OUTPUT_NAME
+        self.assertEqual(main(["--config", str(config_path), "--output", str(output)]), 0)
+        result = json.loads(output.read_bytes())
+        self.assertEqual(result["schema"], RESULT_SCHEMA)
+        self.assertEqual(result["pair_count"], PAIR_COUNT)
+        self.assertEqual(result["arm_count"], 14)
+        correctness = _object(result["correctness"])
+        self.assertTrue(all(correctness.values()))
+        arms = result["arms"]
+        assert isinstance(arms, list)
+        self.assertEqual(len(arms), 14)
+        roles = [ _object(arm)["role"] for arm in arms ]
+        self.assertEqual(
+            roles,
+            ["core", "candidate", "candidate", "core"] * 3 + ["core", "candidate"],
+        )
+        for arm in arms:
+            record = _object(arm)
+            self.assertEqual(record["exit_code"], 0)
+            self.assertGreater(record["wall_ns"], 0)
+            self.assertEqual(record["final_state"], state_json(expected))
+        body = {key: value for key, value in result.items() if key != "result_sha256"}
+        self.assertEqual(result["result_sha256"], canonical_sha256(body))
+        leftovers = [path.name for path in output.parent.glob(".*result.json*")]
+        self.assertEqual(leftovers, [])
+
+    def test_reopen_lifecycle_is_untimed_and_gated(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-reopen-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, expected = _build_workspace(root, reopen=True)
+        output = root / OUTPUT_NAME
+        self.assertEqual(main(["--config", str(config_path), "--output", str(output)]), 0)
+        result = json.loads(output.read_bytes())
+        for arm in result["arms"]:
+            record = _object(arm)
+            self.assertEqual(record["reopen_exit_code"], 0)
+            self.assertEqual(record["reopen_state"], state_json(expected))
+            self.assertTrue(record["durability_ok"])
+
+    def test_state_mismatch_refuses_publication(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-mismatch-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, expected = _build_workspace(root)
+        liar = _write_executable(
+            root / "liar.py",
+            _node_source(_state(height=expected.height, bestblock=HASH64)),
+        )
+        config = json.loads(config_path.read_text())
+        config["candidate"]["binary"] = str(liar)
+        config["candidate"]["binary_sha256"] = _sha256_file(liar)
+        config_path.write_bytes(canonical_bytes(config) + b"\n")
+        output = root / OUTPUT_NAME
+        with self.assertRaises(ContractError):
+            main(["--config", str(config_path), "--output", str(output)])
+        self.assertFalse(output.exists())
+
+    def test_nonzero_exit_refuses_publication(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-exit-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, expected = _build_workspace(root)
+        failing = _write_executable(
+            root / "fail.py",
+            _node_source(expected).replace("raise SystemExit(0)", "raise SystemExit(9)"),
+        )
+        config = json.loads(config_path.read_text())
+        config["core"]["binary"] = str(failing)
+        config["core"]["binary_sha256"] = _sha256_file(failing)
+        config_path.write_bytes(canonical_bytes(config) + b"\n")
+        output = root / OUTPUT_NAME
+        with self.assertRaises(ContractError):
+            main(["--config", str(config_path), "--output", str(output)])
+        self.assertFalse(output.exists())
+
+    def test_existing_output_is_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-exists-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        output = root / OUTPUT_NAME
+        output.parent.mkdir(parents=True)
+        output.write_text("keep\n", encoding="utf-8")
+        with self.assertRaises(ContractError):
+            main(["--config", str(config_path), "--output", str(output)])
+        self.assertEqual(output.read_text(encoding="utf-8"), "keep\n")
+
+    def test_archive_mutation_after_load_is_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-mutate-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        config = load_config(config_path)
+        (root / "blocks.dat").write_bytes((root / "blocks.dat").read_bytes() + b"")
+        os.utime(root / "blocks.dat", (0, 0))
+        with self.assertRaises(ContractError):
+            run_campaign(config, root / "arms")
+
+    def test_summarize_uses_nearest_rank(self) -> None:
+        summary = summarize([10, 20, 30, 40, 50, 60, 70])
+        self.assertEqual(summary["samples"], 7)
+        self.assertEqual(summary["p50_ns"], 40)
+        self.assertEqual(summary["max_ns"], 70)
+
+
+class NonVacuityProofs(unittest.TestCase):
+    def test_RED_wrong_schema_is_caught(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-red-schema-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        output = root / OUTPUT_NAME
+        main(["--config", str(config_path), "--output", str(output)])
+        result = json.loads(output.read_bytes())
+        with self.assertRaises(AssertionError):
+            self.assertEqual(result["schema"], "offline-full-validation-result-v0")
+
+    def test_RED_wrong_arm_count_is_caught(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-red-arms-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        output = root / OUTPUT_NAME
+        main(["--config", str(config_path), "--output", str(output)])
+        result = json.loads(output.read_bytes())
+        with self.assertRaises(AssertionError):
+            self.assertEqual(result["arm_count"], 12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/benchmark-campaign/test_offline_full_validation.py
+++ b/tools/benchmark-campaign/test_offline_full_validation.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import shutil
 import stat
 import sys
@@ -99,6 +98,7 @@ parser.add_argument('--data-dir', required=True)
 parser.add_argument('--corpus', required=True)
 parser.add_argument('--manifest', required=True)
 parser.add_argument('--state', required=True)
+parser.add_argument('--assume-valid-height', default='0')
 parser.add_argument('--reopen', action='store_true')
 args = parser.parse_args()
 corpus = Path(args.corpus).read_bytes()
@@ -127,6 +127,7 @@ def _command(*, reopen: bool = False) -> list[str]:
         "{manifest_path}",
         "--state",
         "{state_path}",
+        "--assume-valid-height=0",
     ]
     if reopen:
         command.append("--reopen")
@@ -220,6 +221,22 @@ class ArchiveContractTests(unittest.TestCase):
         digest = hashlib.sha256(hashlib.sha256(payload[:80]).digest()).digest()
         self.assertEqual(header_hash(payload), digest[::-1].hex())
 
+    def test_header_hash_matches_published_mainnet_genesis(self) -> None:
+        # 80-byte header from Bitcoin Core CMainParams / bitcoin-rs MAINNET_GENESIS.
+        header = bytes.fromhex(
+            "01000000"
+            "0000000000000000000000000000000000000000000000000000000000000000"
+            "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
+            "29ab5f49"
+            "ffff001d"
+            "1dac2b7c"
+        )
+        self.assertEqual(len(header), 80)
+        self.assertEqual(
+            header_hash(header),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        )
+
     def test_trailing_bytes_are_refused(self) -> None:
         root = Path(tempfile.mkdtemp(prefix="offline-trailing-"))
         self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
@@ -274,6 +291,63 @@ class ConfigContractTests(unittest.TestCase):
         config["posture"]["txindex"] = True
         with self.assertRaises(ContractError):
             parse_config(config)
+
+    def test_evicted_cache_policy_is_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-evict-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        config = json.loads(config_path.read_text())
+        config["posture"]["cache_policy"] = "process-cold/page-cache-evicted"
+        with self.assertRaises(ContractError):
+            parse_config(config)
+
+    def test_timed_command_must_disable_assume_valid(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-assume-token-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        config = json.loads(config_path.read_text())
+        config["core"]["command"] = [
+            part
+            for part in config["core"]["command"]
+            if part != "--assume-valid-height=0"
+        ]
+        with self.assertRaises(ContractError):
+            parse_config(config)
+
+    def test_timed_command_index_on_token_is_refused(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-index-token-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        config = json.loads(config_path.read_text())
+        config["candidate"]["command"].append("-txindex=1")
+        with self.assertRaises(ContractError):
+            parse_config(config)
+
+    def test_assume_valid_height_two_token_form_is_accepted(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-assume-two-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root)
+        config = json.loads(config_path.read_text())
+        command = [
+            part
+            for part in config["core"]["command"]
+            if part != "--assume-valid-height=0"
+        ]
+        command.extend(["--assume-valid-height", "0"])
+        config["core"]["command"] = command
+        parse_config(config)
+
+    def test_reopen_command_need_not_repeat_assume_valid(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-reopen-token-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, _ = _build_workspace(root, reopen=True)
+        config = json.loads(config_path.read_text())
+        config["core"]["reopen_command"] = [
+            part
+            for part in config["core"]["reopen_command"]
+            if part != "--assume-valid-height=0"
+        ]
+        parse_config(config)
 
     def test_expected_height_must_match_manifest_tip(self) -> None:
         root = Path(tempfile.mkdtemp(prefix="offline-height-"))
@@ -409,10 +483,35 @@ class CampaignTests(unittest.TestCase):
         self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
         config_path, _ = _build_workspace(root)
         config = load_config(config_path)
-        (root / "blocks.dat").write_bytes((root / "blocks.dat").read_bytes() + b"")
-        os.utime(root / "blocks.dat", (0, 0))
+        raw = bytearray((root / "blocks.dat").read_bytes())
+        raw[-1] ^= 0xFF
+        (root / "blocks.dat").write_bytes(raw)
         with self.assertRaises(ContractError):
             run_campaign(config, root / "arms")
+
+    def test_leftover_descendant_refuses_publication(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="offline-daemon-"))
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        config_path, expected = _build_workspace(root)
+        daemon = _write_executable(
+            root / "daemon.py",
+            _node_source(expected).replace(
+                "raise SystemExit(0)\n",
+                "child = __import__('os').fork()\n"
+                "if child == 0:\n"
+                "    __import__('time').sleep(30)\n"
+                "    raise SystemExit(0)\n"
+                "raise SystemExit(0)\n",
+            ),
+        )
+        config = json.loads(config_path.read_text())
+        config["candidate"]["binary"] = str(daemon)
+        config["candidate"]["binary_sha256"] = _sha256_file(daemon)
+        config_path.write_bytes(canonical_bytes(config) + b"\n")
+        output = root / OUTPUT_NAME
+        with self.assertRaises(ContractError):
+            main(["--config", str(config_path), "--output", str(output)])
+        self.assertFalse(output.exists())
 
     def test_summarize_uses_nearest_rank(self) -> None:
         summary = summarize([10, 20, 30, 40, 50, 60, 70])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Question

How should both nodes perform symmetric offline full-validation chainstate construction with matched body, durability, cache, index, and correctness work?

## Answer

One hash-pinned Core-framed archive, two opaque binaries, external wall time, and a fail-closed certified-state gate.

Bitcoin Core 31.1 and bitcoin-rs both start from a fresh native store and consume the **same** archive bytes (`magic | u32le length | consensus block`, no padding). Assume-valid is forbidden. Auxiliary indexes are off. Cache policy is `process-cold/page-cache-unspecified`; the uneacted evicted-cache string is refused rather than published. Timing is process creation through durable clean exit; nothing is subtracted. After that exit, both arms must certify the same tip, UTXO count, amount, MuHash, serialized-state hash, body availability, and disconnect readiness. Reopen is an untimed second spawn against the same data directory.

The harness is `tools/benchmark-campaign/offline_full_validation.py`. It follows the P2P and MuHash comparators: seven alternating pairs, pinned binaries, `O_NOFOLLOW` inputs, atomic `O_TMPFILE` publication, and no result file unless every gate passes. It does **not** restore the retired 36-cell campaign runner.

CI proves the controller with a two-block fixture archive. A live C150/Cmodern ratio still needs hash-pinned binaries and the frozen corpus from #42; historical 1.654× numbers are not carried forward.

## Review follow-up

Rebased onto current `main` (CONCEPTS.md / docs/README.md merge). Qodo findings, applied fail-closed:

- Campaign ceilings raised (1 TiB archive, 512 MiB manifest, 2M blocks) so a Cmodern prefix fits; full-tip ingest still waits on #42.
- `process-cold/page-cache-evicted` removed until eviction has hash-bound evidence (a raw `drop_caches` write is not that).
- `header_hash` is `CBlockHeader::GetHash`, checked against the published mainnet genesis header from Core `CMainParams`.
- Archive and manifest copied to private `0o400` pins. Device/inode/size/mtime **and SHA-256** are re-checked before and after every child, including reopen. A same-user child that chmod's and rewrites the manifest fails closed.
- Timed commands must carry a known assume-valid-off token and must not carry known index-on tokens.
- After wait, the process group and child-subreaper descendants must be empty; a forked sleeper cannot score.
- Publication docstring names `linkat` as the commit point, crash-before-link as retriable, `EEXIST` as non-retriable.

## Proof

- `python3.13 tools/benchmark-campaign/test_offline_full_validation.py` — 26 tests
- Full `test_*.py` suite in `tools/benchmark-campaign/` green (199 tests)

Closes #34

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22651318-82e6-458b-89f8-d2b1b5ae084e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22651318-82e6-458b-89f8-d2b1b5ae084e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

