### PR TITLE
Bind MuHash campaign custody to the spawned child

### DIFF
--- a/crates/rpc/src/handlers/chain.rs
+++ b/crates/rpc/src/handlers/chain.rs
@@ -2074,6 +2074,14 @@ mod tests {
         }
     }
 
+    #[test]
+    fn gettxoutsetinfo_rejects_trailing_parameters() {
+        let ctx = Arc::new(Context::new());
+        let error = gettxoutsetinfo(&ctx, &json!(["muhash", null, false, true]))
+            .expect_err("trailing parameters must be refused");
+        assert_eq!(error.code(), RpcError::INVALID_PARAMS, "{error}");
+    }
+
     /// A genesis, an applied child at height 1, and a competing branch off the
     /// same genesis whose *header* chain reaches height 2.
     ///

--- a/crates/rpc/tests/handler_smoke.rs
+++ b/crates/rpc/tests/handler_smoke.rs
@@ -351,6 +351,17 @@ fn gettxoutsetinfo_production_triplet_matches_core_digest() -> Result<(), Box<dy
 }
 
 #[test]
+fn gettxoutsetinfo_rejects_trailing_parameters() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = Arc::new(Context::new());
+    let handler = Handler::new(Arc::clone(&ctx));
+    let error = handler
+        .dispatch("gettxoutsetinfo", &json!(["muhash", null, false, true]))
+        .expect_err("trailing parameters must be refused");
+    assert_eq!(error.code(), RpcError::INVALID_PARAMS, "{error}");
+    Ok(())
+}
+
+#[test]
 fn gettxoutsetinfo_hash_type_modes_match_core_shapes() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = Arc::new(Context::new());
     let handler = Handler::new(Arc::clone(&ctx));

--- a/docs/benchmarks/muhash-rpc.md
+++ b/docs/benchmarks/muhash-rpc.md
@@ -209,9 +209,11 @@ controller pre-receipt reference. The campaign config is a strict
 always `coinsdb`) to one bitcoin-rs arm (`backend` is exactly one of
 `fjall`, `rocksdb`, or `redb`), the single cache policy, the corpus, and the
 pinned binaries and commands. `{binary}` is copied and re-hashed before every
-spawn; `{rpc_bind}`, `{rpc_port}`, `{data_dir}`, and `{cookie}` are the only
-other placeholders. The controller owns process lifecycle and `/proc` fault
-and I/O snapshots, writes each pre-receipt/trial/observation/post-receipt
+spawn; `{config}` is required so the receipt's pinned config is the file the
+daemon received; `{rpc_bind}`, `{rpc_port}`, `{data_dir}`, and `{cookie}` are
+the only other placeholders. Readiness requires the listening socket inode to
+belong to the spawned child. The controller owns process lifecycle and `/proc`
+fault and I/O snapshots, writes each pre-receipt/trial/observation/post-receipt
 triple, and then hands the same 14 triples to `aggregate`. A second backend
 is a second campaign and a second result file.
 

--- a/tools/benchmark-campaign/muhash_rpc.py
+++ b/tools/benchmark-campaign/muhash_rpc.py
@@ -47,17 +47,6 @@ MAX_COMMAND_ARGS = 64
 ARM_READY_TIMEOUT_NS = 10_000_000_000
 CHILD_TERMINATE_GRACE_NS = 1_000_000_000
 CHILD_KILL_REAP_NS = 1_000_000_000
-_CAMPAIGN_PLACEHOLDERS = frozenset(
-    {"{binary}", "{data_dir}", "{rpc_port}", "{rpc_bind}", "{cookie}", "{config}"}
-)
-def _cache_action(policy: str) -> str:
-    return {
-        "warm": "warm-untimed-query-done",
-        "process-cold/page-cache-unspecified": "fresh-process-before-observation",
-        "process-cold/page-cache-evicted": "page-cache-evicted",
-    }[policy]
-
-
 CACHE_POLICIES = frozenset(
     {
         "warm",
@@ -65,6 +54,16 @@ CACHE_POLICIES = frozenset(
         "process-cold/page-cache-evicted",
     }
 )
+CACHE_POLICY_ACTIONS = {
+    "warm": "warm-untimed-query-done",
+    "process-cold/page-cache-unspecified": "fresh-process-before-observation",
+    "process-cold/page-cache-evicted": "page-cache-evicted",
+}
+_CAMPAIGN_PLACEHOLDERS = frozenset(
+    {"{binary}", "{config}", "{data_dir}", "{rpc_port}", "{rpc_bind}", "{cookie}"}
+)
+_TCP_LISTEN = 0x0A
+_LOOPBACK_V4 = "0100007F"
 OPERATOR_TRUST_BOUNDARY = (
     "operator-controlled observation; not remote binary authentication"
 )
@@ -491,8 +490,7 @@ def _parse_pre(value: object, field: str = "pre_receipt") -> JsonObject:
     corpus = _parse_corpus(item["corpus"], f"{field}.corpus")
     endpoint = _validate_endpoint(item["endpoint"], f"{field}.endpoint")
     action = _text(item["cache_policy_action"], f"{field}.cache_policy_action")
-    expected_action = _cache_action(policy)
-    if action != expected_action:
+    if action != CACHE_POLICY_ACTIONS[policy]:
         raise ContractError(f"{field}.cache_policy_action is wrong for {policy}")
     eviction_value = item["eviction_procedure"]
     eviction = (
@@ -1572,7 +1570,7 @@ def _command(value: object, field: str) -> tuple[str, ...]:
     if command[0] != "{binary}":
         raise ContractError(f"{field}[0] must be {{binary}}")
     if "{config}" not in command:
-        raise ContractError(f"{field} must contain the {{config}} placeholder")
+        raise ContractError(f"{field} must include {{config}}")
     for part in command:
         if "{" in part and part not in _CAMPAIGN_PLACEHOLDERS:
             raise ContractError(f"{field} contains an unsupported placeholder")
@@ -1704,26 +1702,81 @@ def _write_json(
     return _file_ref_from_path(path, cap, str(path))
 
 
-def _allocate_loopback_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        port = sock.getsockname()[1]
-        if not isinstance(port, int) or port <= 0:
-            raise ContractError("could not allocate a loopback RPC port")
-        return port
+def _allocate_distinct_loopback_ports(count: int) -> tuple[int, ...]:
+    held: list[socket.socket] = []
+    try:
+        for _ in range(count):
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.bind(("127.0.0.1", 0))
+            held.append(sock)
+        ports = tuple(int(sock.getsockname()[1]) for sock in held)
+        if len(set(ports)) != count or any(port <= 0 for port in ports):
+            raise ContractError("could not allocate distinct loopback RPC ports")
+        return ports
+    finally:
+        for sock in held:
+            sock.close()
 
 
-def _wait_tcp(host: str, port: int, deadline_ns: int, process: subprocess.Popen[bytes] | None = None) -> None:
+def _listen_inodes(port: int) -> set[int]:
+    needle = f"{_LOOPBACK_V4}:{port:04X}"
+    inodes: set[int] = set()
+    try:
+        text = Path("/proc/net/tcp").read_text()
+    except OSError as error:
+        raise ContractError("cannot read /proc/net/tcp") from error
+    for line in text.splitlines()[1:]:
+        fields = line.split()
+        if len(fields) < 10:
+            continue
+        if fields[1].upper() != needle:
+            continue
+        try:
+            if int(fields[3], 16) != _TCP_LISTEN:
+                continue
+            inodes.add(int(fields[9]))
+        except ValueError as error:
+            raise ContractError("/proc/net/tcp is unparsable") from error
+    return inodes
+
+
+def _pid_owns_inode(pid: int, inode: int) -> bool:
+    want = f"socket:[{inode}]"
+    try:
+        names = os.listdir(f"/proc/{pid}/fd")
+    except OSError:
+        return False
+    for name in names:
+        try:
+            if os.readlink(f"/proc/{pid}/fd/{name}") == want:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _endpoint_owned_by(pid: int, port: int) -> None:
+    inodes = _listen_inodes(port)
+    if len(inodes) != 1:
+        raise ContractError("RPC port does not have exactly one loopback listener")
+    if not _pid_owns_inode(pid, next(iter(inodes))):
+        raise ContractError("RPC endpoint is not owned by the arm process")
+
+
+def _wait_owned_endpoint(
+    process: subprocess.Popen[bytes], port: int, deadline_ns: int
+) -> None:
     while True:
-        if process is not None and process.poll() is not None:
-            raise ContractError("arm process exited before RPC readiness")
+        if process.poll() is not None:
+            raise ContractError("arm process exited before RPC was ready")
         remaining = deadline_ns - time.perf_counter_ns()
         if remaining <= 0:
             raise ContractError("arm RPC endpoint never became ready")
         try:
             with socket.create_connection(
-                (host, port), timeout=min(0.05, remaining / 1_000_000_000)
+                ("127.0.0.1", port), timeout=min(0.05, remaining / 1_000_000_000)
             ):
+                _endpoint_owned_by(process.pid, port)
                 return
         except OSError:
             time.sleep(0.01)
@@ -1831,18 +1884,18 @@ def _expand_command(
     template: tuple[str, ...],
     *,
     binary: Path,
+    config: Path,
     data_dir: Path,
     port: int,
     cookie: Path,
-    config: Path,
 ) -> list[str]:
     replacements = {
         "{binary}": str(binary),
+        "{config}": str(config),
         "{data_dir}": str(data_dir),
         "{rpc_port}": str(port),
         "{rpc_bind}": "127.0.0.1",
         "{cookie}": str(cookie),
-        "{config}": str(config),
     }
     return [replacements.get(part, part) for part in template]
 
@@ -1885,10 +1938,10 @@ class _ArmProcess:
         argv = _expand_command(
             self.spec.command,
             binary=self.binary,
+            config=self.spec.config.path,
             data_dir=self.spec.datadir,
             port=self.port,
             cookie=self.cookie,
-            config=self.spec.config.path,
         )
         try:
             self._process = subprocess.Popen(
@@ -1901,9 +1954,19 @@ class _ArmProcess:
         except OSError as error:
             raise ContractError(f"cannot spawn {self.spec.kind} process") from error
         self._pid = self._process.pid
-        _wait_tcp("127.0.0.1", self.port, time.perf_counter_ns() + ARM_READY_TIMEOUT_NS, self._process)
+        _wait_owned_endpoint(
+            self._process, self.port, time.perf_counter_ns() + ARM_READY_TIMEOUT_NS
+        )
         self._starttime = _read_starttime(self._pid)
         self._warmed = False
+
+    def require_endpoint(self) -> None:
+        if self._process is None or self._pid is None:
+            raise ContractError(f"{self.spec.kind} process is not running")
+        if self._process.poll() is not None:
+            raise ContractError(f"{self.spec.kind} process exited")
+        self.identity()
+        _endpoint_owned_by(self._pid, self.port)
 
     def ensure(self, policy: str) -> None:
         if policy == "warm":
@@ -1917,6 +1980,7 @@ class _ArmProcess:
     def warm(self) -> None:
         if self._warmed:
             return
+        self.require_endpoint()
         _rpc_once(
             self.endpoint,
             self._credentials,
@@ -2030,16 +2094,13 @@ def run_campaign(config_path: Path, workspace: Path) -> JsonObject:
     )
     expected_height = _uint(config.expected["height"], "campaign expected.height")
     expected_hash = _hash(config.expected["bestblock"], "campaign expected.bestblock")
-    core_port = _allocate_loopback_port()
-    candidate_port = _allocate_loopback_port()
-    if candidate_port == core_port:
-        raise ContractError("arm RPC ports collided")
+    core_port, candidate_port = _allocate_distinct_loopback_ports(2)
     arms = {
         "core": _ArmProcess(
             config.core,
             core_bin,
             config.credential_file.path,
-            _allocate_loopback_port(),
+            core_port,
             credentials,
             config.timeout_seconds,
             config.max_response_bytes,
@@ -2050,7 +2111,7 @@ def run_campaign(config_path: Path, workspace: Path) -> JsonObject:
             config.candidate,
             candidate_bin,
             config.credential_file.path,
-            _allocate_loopback_port(),
+            candidate_port,
             credentials,
             config.timeout_seconds,
             config.max_response_bytes,
@@ -2081,6 +2142,7 @@ def run_campaign(config_path: Path, workspace: Path) -> JsonObject:
                     raise ContractError("eviction policy is missing its procedure")
                 eviction_execution = _run_eviction(config.eviction_procedure)
             arm.ensure(config.policy)
+            arm.require_endpoint()
             pid, starttime = arm.identity()
             proc_stat_before, proc_io_before = arm.snapshot()
             prefix = f"{index:02d}-{kind}"
@@ -2109,7 +2171,7 @@ def run_campaign(config_path: Path, workspace: Path) -> JsonObject:
                 "attested_pid": pid,
                 "attested_starttime": starttime,
                 "affinity": config.affinity,
-                "cache_policy_action": _cache_action(config.policy),
+                "cache_policy_action": CACHE_POLICY_ACTIONS[config.policy],
                 "eviction_procedure": (
                     None
                     if config.eviction_procedure is None

--- a/tools/benchmark-campaign/test_muhash_rpc.py
+++ b/tools/benchmark-campaign/test_muhash_rpc.py
@@ -11,6 +11,9 @@ import io
 import json
 import os
 import shutil
+import socket
+import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -2062,6 +2065,8 @@ class CampaignControllerTests(unittest.TestCase):
             "{rpc_port}",
             "--cookie",
             "{cookie}",
+            "--config",
+            "{config}",
             "--data-dir",
             "{data_dir}",
         ]
@@ -2086,7 +2091,7 @@ class CampaignControllerTests(unittest.TestCase):
                 "arm_id": arm_id,
                 "binary": daemon["path"],
                 "binary_sha256": daemon["sha256"],
-                "command": command + ["--config", str(config["path"])],
+                "command": command,
                 "backend": kind_backend,
                 "config": config,
                 "datadir": str(datadir),
@@ -2230,6 +2235,42 @@ class CampaignControllerTests(unittest.TestCase):
         core["backend"] = "fjall"
         with self.assertRaises(module.ContractError):
             module._parse_campaign_config(parsed)
+
+    def test_command_must_include_config_placeholder(self) -> None:
+        _root, config_path, _output = self._campaign_files()
+        parsed, _ = module._load_json_path(
+            config_path, module.MAX_INPUT_BYTES, "campaign config"
+        )
+        assert isinstance(parsed, dict)
+        candidate = parsed["candidate"]
+        assert isinstance(candidate, dict)
+        command = list(candidate["command"])  # type: ignore[arg-type]
+        command[command.index("{config}")] = str(_root / "other.json")
+        candidate["command"] = command
+        with self.assertRaises(module.ContractError):
+            module._parse_campaign_config(parsed)
+
+    def test_readiness_rejects_a_listener_the_child_does_not_own(self) -> None:
+        decoy = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        decoy.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        decoy.bind(("127.0.0.1", 0))
+        decoy.listen()
+        port = int(decoy.getsockname()[1])
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            with self.assertRaises(module.ContractError) as raised:
+                module._wait_owned_endpoint(
+                    child, port, time.perf_counter_ns() + 2_000_000_000
+                )
+            self.assertIn("not owned", str(raised.exception))
+        finally:
+            child.kill()
+            child.wait(timeout=2)
+            decoy.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #353 / Qodo review: the campaign must prove the spawned child owns the RPC endpoint, and the pinned arm config must be the file that is actually exec'd.

## Endpoint ownership

The controller used to bind an ephemeral port, close it, then treat any successful TCP connect as readiness. That left a window where another local listener could take the port, receive cookie credentials, and supply measurements attributed to the intended arm.

This change:

- allocates both arm ports while the sockets are still held, then uses those ports (main currently allocated a second pair and discarded the first)
- waits until the unique `127.0.0.1` LISTEN inode in `/proc/net/tcp` is in the child's `/proc/<pid>/fd`
- refuses early child exit
- re-checks ownership before the untimed warm query and before each timed trial

## Config binding

`{config}` remains a required command placeholder so the verified FileRef is substituted into argv. One `CACHE_POLICY_ACTIONS` map feeds both receipt generation and aggregate validation.

## RPC contract coverage

Trailing `gettxoutsetinfo` arguments were already rejected. Unit and smoke tests now cover that refusal.

## Verification

- `cargo test -p bitcoin-rs-rpc --lib gettxoutsetinfo`: 5 passed
- `cargo test -p bitcoin-rs-rpc --test handler_smoke gettxoutsetinfo`: 5 passed
- `python3.13 tools/benchmark-campaign/test_muhash_rpc.py`: 103 passed
- `python3.13 tools/benchmark-campaign/test_comp_lanes.py`: 14 passed

## Test plan

- [x] `cargo test -p bitcoin-rs-rpc --lib gettxoutsetinfo`
- [x] `cargo test -p bitcoin-rs-rpc --test handler_smoke gettxoutsetinfo`
- [x] `python3.13 tools/benchmark-campaign/test_muhash_rpc.py`
- [x] `python3.13 tools/benchmark-campaign/test_comp_lanes.py`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-775d0277-5162-4f55-a52c-c2df56ff0731?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-775d0277-5162-4f55-a52c-c2df56ff0731&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

