### PR TITLE
Let classify own Esplora namespace stripping

### DIFF
--- a/crates/rpc/README.md
+++ b/crates/rpc/README.md
@@ -18,7 +18,7 @@ no backend cargo feature (`g17_dependency_direction` proves both from
 ### 1. Protocol demuxing and authentication
 - **Transport Demuxing**: Private free function `classify` (`crates/rpc/src/server.rs`) is the listener directory table. `serve_connection` dispatches that table before authentication:
   - `GET /rest/*` → Core REST (`rest::route`).
-  - `GET` or `POST` under `/api` or `/esplora` → Esplora (`esplora::route` / `route_post`). Those directories are closed: unknown paths 404 and never become JSON-RPC. `/api` is public electrs; `/esplora` is the mempool-backend superset. Wallet broadcast is `POST /api/tx`.
+  - `GET` or `POST` under `/api` or `/esplora` → Esplora. `classify` strips the directory prefix and passes `Surface` plus the rest; `esplora::route` / `route_post` only dispatch inside that directory. Unknown paths 404 and never become JSON-RPC. `/api` is public electrs; `/esplora` is the mempool-backend superset. Wallet broadcast is `POST /api/tx`.
   - Other `POST` → JSON-RPC. `Auth::validate_header` (`crates/rpc/src/auth.rs`) guards this path only.
   - Any other method or GET outside `/rest/`, `/api`, and `/esplora` → 404 at the demux. Unprefixed electrs paths and `HEAD`/`PUT`/`DELETE` do not enter Esplora or JSON-RPC. The request parser accepts those methods so `classify` can 404 them instead of answering JSON-RPC 400.
 - **JSON-RPC Framing & Protocol Versioning**: `JsonRpcVersion` (`crates/rpc/src/server.rs`) governs wire framing:

--- a/crates/rpc/src/esplora.rs
+++ b/crates/rpc/src/esplora.rs
@@ -21,7 +21,6 @@ use crate::context::Context;
 use crate::handlers::Handler;
 use crate::rest::Response;
 
-use self::http::not_found;
 use self::projection::Projection;
 
 /// Which Esplora directory a request landed in.
@@ -33,15 +32,12 @@ pub enum Surface {
     Backend,
 }
 
-/// Routes a read-only Esplora request from the node HTTP listener.
+/// Routes a read-only Esplora request already classified onto a surface.
 ///
-/// `/api` is the public electrs directory. `/esplora` is the mempool-backend
-/// superset of that tree. Unprefixed paths 404 so JSON-RPC owns `/`.
+/// `path` is the rest after `/api` or `/esplora`. The listener demux owns
+/// prefix matching; this function only dispatches inside a directory.
 #[must_use]
-pub fn route(handler: &Handler, path: &str, query: &str) -> Response {
-    let Some((surface, path)) = namespace(path) else {
-        return not_found();
-    };
+pub fn route(handler: &Handler, surface: Surface, path: &str, query: &str) -> Response {
     let ctx = handler.context();
     let projection = Projection::new(&ctx);
     let chain_view = projection.capture_chain_view();
@@ -69,18 +65,16 @@ fn dispatch_get(
 
 /// Routes Esplora raw-transaction broadcast and mempool-backend POSTs.
 ///
-/// Returns `None` outside `/api` and `/esplora` so the HTTP demux can fall
-/// through to JSON-RPC. Inside either directory the namespace is closed:
-/// unknown paths 404.
+/// `path` is the rest after `/api` or `/esplora`. Unknown paths 404.
+/// The listener demux never calls this outside those directories.
 #[must_use]
-pub fn route_post(handler: &Handler, path: &str, body: &[u8]) -> Option<Response> {
-    let (surface, path) = namespace(path)?;
+pub fn route_post(handler: &Handler, surface: Surface, path: &str, body: &[u8]) -> Response {
     if surface == Surface::Backend {
         if let Some(response) = backend::post(handler, path, body) {
-            return Some(response);
+            return response;
         }
     }
-    Some(public::post(handler, path, body))
+    public::post(handler, path, body)
 }
 
 /// See `docs/contracts/wallet-facing.md` WF-02.
@@ -136,19 +130,29 @@ mod tests {
     /// Canonical public Esplora lives at `/api`. Tests that omit the prefix
     /// are naming that surface, not a second listener root.
     fn route(handler: &Handler, path: &str, query: &str) -> Response {
-        super::route(handler, &api(path), query)
+        dispatch(handler, &api(path), query)
     }
 
-    fn route_post(handler: &Handler, path: &str, body: &[u8]) -> Option<Response> {
-        super::route_post(handler, &api(path), body)
+    fn route_post(handler: &Handler, path: &str, body: &[u8]) -> Response {
+        dispatch_post(handler, &api(path), body)
     }
 
     fn backend_route(handler: &Handler, path: &str, query: &str) -> Response {
-        super::route(handler, &esplora(path), query)
+        dispatch(handler, &esplora(path), query)
     }
 
-    fn backend_route_post(handler: &Handler, path: &str, body: &[u8]) -> Option<Response> {
-        super::route_post(handler, &esplora(path), body)
+    fn backend_route_post(handler: &Handler, path: &str, body: &[u8]) -> Response {
+        dispatch_post(handler, &esplora(path), body)
+    }
+
+    fn dispatch(handler: &Handler, full: &str, query: &str) -> Response {
+        let (surface, path) = super::namespace(full).expect("test path is an Esplora directory");
+        super::route(handler, surface, path, query)
+    }
+
+    fn dispatch_post(handler: &Handler, full: &str, body: &[u8]) -> Response {
+        let (surface, path) = super::namespace(full).expect("test path is an Esplora directory");
+        super::route_post(handler, surface, path, body)
     }
 
     fn api(path: &str) -> String {
@@ -688,7 +692,7 @@ mod tests {
 
         let broadcast_transaction = transaction_with_funded_input(handler.context().as_ref());
         let raw = consensus_bytes(&broadcast_transaction).to_lower_hex_string();
-        let broadcast = route_post(&handler, "/tx", raw.as_bytes()).expect("POST /tx is routed");
+        let broadcast = route_post(&handler, "/tx", raw.as_bytes());
         assert_eq!(
             broadcast.status,
             200,
@@ -700,8 +704,7 @@ mod tests {
         // Package relay is conditional in API.md (Bitcoin Core 28+). This node
         // has no atomic package-admission capability, so it must not advertise
         // sequential sendrawtransaction calls as that endpoint.
-        let package = route_post(&handler, "/txs/package", b"[]")
-            .expect("package path must not fall through to JSON-RPC");
+        let package = route_post(&handler, "/txs/package", b"[]");
         assert_eq!(package.status, 404);
         Ok(())
     }
@@ -878,39 +881,35 @@ mod tests {
         let genesis = route(&handler, "/block-height/0", "");
         assert_eq!(genesis.status, 200);
         assert_eq!(
-            super::route(&handler, "/api/block-height/0", "").body,
+            dispatch(&handler, "/api/block-height/0", "").body,
             genesis.body
         );
-        assert_eq!(
-            super::route(&handler, "/block-height/0", "").status,
-            404,
+        assert!(
+            super::namespace("/block-height/0").is_none(),
             "unprefixed electrs paths are not Esplora on this listener"
         );
         assert_eq!(
-            super::route(&handler, "/api/v1/block-height/0", "").status,
+            dispatch(&handler, "/api/v1/block-height/0", "").status,
             404,
             "/api/v1 is Mempool's API, not an Esplora alias"
         );
-        assert_eq!(super::route(&handler, "/apitx", "").status, 404);
         assert!(
-            super::route_post(&handler, "/api/tx", b"00").is_some(),
-            "POST /api/tx must not fall through to JSON-RPC"
-        );
-        assert!(
-            super::route_post(&handler, "/api/v1/tx", b"00").is_some(),
-            "POST /api/v1/tx stays in the /api namespace (404), not JSON-RPC"
+            super::namespace("/apitx").is_none(),
+            "/apitx is not an Esplora directory"
         );
         assert_eq!(
-            super::route_post(&handler, "/api/v1/tx", b"00").map(|response| response.status),
-            Some(404)
+            dispatch_post(&handler, "/api/tx", b"00").status,
+            400,
+            "POST /api/tx stays Esplora"
+        );
+        assert_eq!(
+            dispatch_post(&handler, "/api/v1/tx", b"00").status,
+            404,
+            "POST /api/v1/tx stays in the /api namespace, not JSON-RPC"
         );
         assert!(
-            super::route_post(&handler, "/tx", b"00").is_none(),
+            super::namespace("/tx").is_none(),
             "unprefixed POST /tx falls through to JSON-RPC"
-        );
-        assert!(
-            super::route_post(&handler, "/apitx", b"00").is_none(),
-            "POST /apitx is not an Esplora path"
         );
         Ok(())
     }
@@ -928,24 +927,22 @@ mod tests {
             404,
             "/api/block-template is not a wallet-facing route"
         );
-        assert_eq!(
-            super::route(&handler, "/internal/mempool/txs", "").status,
-            404,
+        assert!(
+            super::namespace("/internal/mempool/txs").is_none(),
             "unprefixed /internal is not served"
         );
         assert_eq!(
-            super::route_post(&handler, "/api/internal/txs", b"[]").map(|response| response.status),
-            Some(404),
+            dispatch_post(&handler, "/api/internal/txs", b"[]").status,
+            404,
             "POST /api/internal/txs stays in the public directory (404)"
         );
         assert_eq!(
-            super::route_post(&handler, "/api/v1/not-esplora", b"{}")
-                .map(|response| response.status),
-            Some(404),
+            dispatch_post(&handler, "/api/v1/not-esplora", b"{}").status,
+            404,
             "unknown POST under /api must not fall through to JSON-RPC"
         );
         assert!(
-            super::route_post(&handler, "/not-esplora", b"{}").is_none(),
+            super::namespace("/not-esplora").is_none(),
             "unprefixed unknown POST still falls through to JSON-RPC"
         );
         Ok(())
@@ -970,19 +967,17 @@ mod tests {
             "/esplora is a superset: public electrs routes still answer"
         );
         assert_eq!(
-            super::route_post(&handler, "/esplora/internal/txs", b"[]")
-                .map(|response| response.status),
-            Some(200),
+            dispatch_post(&handler, "/esplora/internal/txs", b"[]").status,
+            200,
             "POST /esplora/internal/txs is the mempool-backend bulk path"
         );
         assert_eq!(
-            super::route_post(&handler, "/esplora/not-esplora", b"{}")
-                .map(|response| response.status),
-            Some(404),
+            dispatch_post(&handler, "/esplora/not-esplora", b"{}").status,
+            404,
             "unknown POST under /esplora must not fall through to JSON-RPC"
         );
         assert!(
-            super::route_post(&handler, "/esplorafoo", b"{}").is_none(),
+            super::namespace("/esplorafoo").is_none(),
             "POST /esplorafoo is not an Esplora path"
         );
         Ok(())
@@ -1032,8 +1027,7 @@ mod tests {
         let handler = Handler::new(Arc::clone(&ctx));
         let body = serde_json::to_vec(&vec![txid.to_string()]).expect("txids serialize");
 
-        let post = backend_route_post(&handler, "/internal/mempool/txs", &body)
-            .expect("internal route is handled");
+        let post = backend_route_post(&handler, "/internal/mempool/txs", &body);
         assert_eq!(post.status, 200);
         let paged = backend_route(&handler, "/internal/mempool/txs", "max_txs=1");
         assert_eq!(paged.status, 200);
@@ -1055,8 +1049,7 @@ mod tests {
             ("/internal/txs/outspends/by-txid", ids.as_slice()),
             ("/internal/txs/outspends/by-outpoint", outpoints.as_slice()),
         ] {
-            let response =
-                backend_route_post(&handler, path, body).expect("internal POST route exists");
+            let response = backend_route_post(&handler, path, body);
             assert_eq!(response.status, 200, "status for {path}");
             assert_eq!(response.content_type, "application/json");
         }
@@ -1075,10 +1068,7 @@ mod tests {
     #[test]
     fn package_broadcast_is_not_exposed_without_package_admission() {
         let handler = Handler::new(Arc::new(Context::new()));
-        assert_eq!(
-            route_post(&handler, "/txs/package", b"[]").map(|response| response.status),
-            Some(404)
-        );
+        assert_eq!(route_post(&handler, "/txs/package", b"[]").status, 404);
     }
 
     #[test]
@@ -1088,7 +1078,7 @@ mod tests {
         let txid = transaction.txid();
         let handler = Handler::new(ctx);
         let raw = consensus_bytes(&transaction).to_lower_hex_string();
-        let broadcast = route_post(&handler, "/tx", raw.as_bytes()).expect("broadcast route");
+        let broadcast = route_post(&handler, "/tx", raw.as_bytes());
         assert_eq!(broadcast.status, 200);
         let response = route(&handler, &format!("/tx/{txid}"), "");
         assert_eq!(response.status, 200);

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -157,19 +157,17 @@ fn serve_connection(
                 let response = crate::rest::route(handler.context(), path, query, rest_enabled);
                 write_response(reader.get_mut(), &response, keep_alive)?;
             }
-            HttpRoute::EsploraGet { path, query } => {
-                let response = crate::esplora::route(handler, path, query);
+            HttpRoute::EsploraGet {
+                surface,
+                path,
+                query,
+            } => {
+                let response = crate::esplora::route(handler, surface, path, query);
                 write_response(reader.get_mut(), &response, keep_alive)?;
             }
-            HttpRoute::EsploraPost { path } => {
-                match crate::esplora::route_post(handler, path, &request.body) {
-                    Some(response) => {
-                        write_response(reader.get_mut(), &response, keep_alive)?;
-                    }
-                    None => {
-                        write_not_found(reader.get_mut(), keep_alive)?;
-                    }
-                }
+            HttpRoute::EsploraPost { surface, path } => {
+                let response = crate::esplora::route_post(handler, surface, path, &request.body);
+                write_response(reader.get_mut(), &response, keep_alive)?;
             }
             HttpRoute::NotFound => {
                 write_not_found(reader.get_mut(), keep_alive)?;
@@ -525,21 +523,37 @@ fn split_path_query(path: &str) -> (&str, &str) {
 /// Directory table for this listener. `classify` is the owner.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum HttpRoute<'a> {
-    Rest { path: &'a str, query: &'a str },
-    EsploraGet { path: &'a str, query: &'a str },
-    EsploraPost { path: &'a str },
+    Rest {
+        path: &'a str,
+        query: &'a str,
+    },
+    EsploraGet {
+        surface: crate::esplora::Surface,
+        path: &'a str,
+        query: &'a str,
+    },
+    EsploraPost {
+        surface: crate::esplora::Surface,
+        path: &'a str,
+    },
     JsonRpc,
     NotFound,
 }
 
 fn classify<'a>(method: &str, raw_path: &'a str) -> HttpRoute<'a> {
     let (path, query) = split_path_query(raw_path);
-    let esplora = crate::esplora::namespace(path).is_some();
-    match method {
-        "GET" if path.starts_with("/rest/") => HttpRoute::Rest { path, query },
-        "GET" if esplora => HttpRoute::EsploraGet { path, query },
-        "POST" if esplora => HttpRoute::EsploraPost { path },
-        "POST" => HttpRoute::JsonRpc,
+    match (method, crate::esplora::namespace(path)) {
+        ("GET", _) if path.starts_with("/rest/") => HttpRoute::Rest { path, query },
+        ("GET", Some((surface, rest))) => HttpRoute::EsploraGet {
+            surface,
+            path: rest,
+            query,
+        },
+        ("POST", Some((surface, rest))) => HttpRoute::EsploraPost {
+            surface,
+            path: rest,
+        },
+        ("POST", None) => HttpRoute::JsonRpc,
         _ => HttpRoute::NotFound,
     }
 }
@@ -628,25 +642,31 @@ mod tests {
         assert_eq!(
             classify("GET", "/api/blocks/tip/height"),
             HttpRoute::EsploraGet {
-                path: "/api/blocks/tip/height",
+                surface: crate::esplora::Surface::Public,
+                path: "/blocks/tip/height",
                 query: ""
             }
         );
         assert_eq!(
             classify("GET", "/esplora/internal/mempool/txs?max_txs=1"),
             HttpRoute::EsploraGet {
-                path: "/esplora/internal/mempool/txs",
+                surface: crate::esplora::Surface::Backend,
+                path: "/internal/mempool/txs",
                 query: "max_txs=1"
             }
         );
         assert_eq!(
             classify("POST", "/api/tx"),
-            HttpRoute::EsploraPost { path: "/api/tx" }
+            HttpRoute::EsploraPost {
+                surface: crate::esplora::Surface::Public,
+                path: "/tx"
+            }
         );
         assert_eq!(
             classify("POST", "/esplora/internal/txs"),
             HttpRoute::EsploraPost {
-                path: "/esplora/internal/txs"
+                surface: crate::esplora::Surface::Backend,
+                path: "/internal/txs"
             }
         );
         assert_eq!(classify("POST", "/"), HttpRoute::JsonRpc);
@@ -669,7 +689,8 @@ mod tests {
         assert_eq!(
             classify("GET", "/api/v1/block-height/0"),
             HttpRoute::EsploraGet {
-                path: "/api/v1/block-height/0",
+                surface: crate::esplora::Surface::Public,
+                path: "/v1/block-height/0",
                 query: ""
             },
             "GET /api/v1 stays in the closed /api directory (404 inside Esplora)"
@@ -677,7 +698,8 @@ mod tests {
         assert_eq!(
             classify("POST", "/api/v1/tx"),
             HttpRoute::EsploraPost {
-                path: "/api/v1/tx"
+                surface: crate::esplora::Surface::Public,
+                path: "/v1/tx"
             }
         );
     }

--- a/crates/rpc/tests/manifest_coverage.rs
+++ b/crates/rpc/tests/manifest_coverage.rs
@@ -139,7 +139,9 @@ fn esplora_extension_row_resolves_to_the_router() {
         .find(|entry| entry.name == "esplora/*")
         .unwrap_or_else(|| panic!("esplora/* extension row missing from MANIFEST"));
     assert_eq!(row.status, Status::Extension);
-    let response = bitcoin_rs_rpc::esplora::route(&handler(), "/api/mempool", "");
+    let (surface, path) = bitcoin_rs_rpc::esplora::namespace("/api/mempool")
+        .unwrap_or_else(|| panic!("/api/mempool is the public Esplora directory"));
+    let response = bitcoin_rs_rpc::esplora::route(&handler(), surface, path, "");
     assert_eq!(
         response.status, 200,
         "esplora router must serve the row it declares"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #423.

`classify` is the only prefix matcher. It extracts `Surface` and the rest path; `esplora::route` / `route_post` dispatch inside that directory and always return a `Response`. There is no `Option` fallthrough to JSON-RPC.

## What broke

Callers that passed a full listener path into `esplora::route` must parse `namespace()` first. The HTTP server already does that. Unprefixed paths are `namespace() == None` and belong to the demux table, not Esplora.

Rebased onto #423 after #502 landed on `main`.

Relates to #116 / WF-02.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-269a3697-3a2b-407a-a8e5-5f642e2ce922?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-269a3697-3a2b-407a-a8e5-5f642e2ce922&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

