### PR TITLE
Drop the dual ScriptIndex format marker and Legacy dual-read

### DIFF
--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -199,6 +199,43 @@ fn is_predecessor_height_format(value: &[u8]) -> bool {
     value == FORMAT_VERSION_V3 || value == FORMAT_VERSION_V4
 }
 
+fn decode_format_version(value: &[u8]) -> u32 {
+    value
+        .get(..4)
+        .and_then(|bytes| <[u8; 4]>::try_from(bytes).ok())
+        .map_or(0, u32::from_le_bytes)
+}
+
+/// Decoded `[0x00, 'V']` marker. Callers apply policy: [`IndexWriter::open`]
+/// resets predecessors; [`Indexer::ensure_format_version`] refuses them.
+enum StoreFormat {
+    Current,
+    Predecessor { version: u32 },
+    Foreign { version: u32 },
+    Absent,
+}
+
+fn classify_store_format(value: Option<&[u8]>) -> StoreFormat {
+    match value {
+        Some(value) if value == FORMAT_VERSION_VALUE => StoreFormat::Current,
+        Some(value) if is_predecessor_height_format(value) => StoreFormat::Predecessor {
+            version: decode_format_version(value),
+        },
+        Some(value) => StoreFormat::Foreign {
+            version: decode_format_version(value),
+        },
+        None => StoreFormat::Absent,
+    }
+}
+
+fn stored_format<S: KvStore>(store: &S) -> Result<StoreFormat, IndexError> {
+    Ok(classify_store_format(
+        store
+            .get(ColumnFamily::UtxoMeta, FORMAT_VERSION_KEY)?
+            .as_deref(),
+    ))
+}
+
 /// Decoded durable capability-reset state.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum ResetState {
@@ -622,7 +659,8 @@ fn ensure_fence_live<S: KvStore>(
 }
 
 /// Publishes or adopts a reset claim. Same-mask adoption writes nothing; mask
-/// growth changes only byte zero of the exact observed claim.
+/// growth changes only byte zero of the exact observed claim. Leftover
+/// dual-format keys converge when the claim completes, not on adoption.
 fn acquire_capability_reset<S: KvStore>(
     store: &S,
     requested_mask: u8,
@@ -812,6 +850,14 @@ fn resume_capability_reset<S: KvStore>(
             ORDINARY_STATE_REVISION_KEY,
             &work.next_revision,
         );
+        // Same-mask adoption of an older claim never rewrites the claim
+        // batch, so leftover dual-format keys converge here (`IDX-05`).
+        completion.put(
+            ColumnFamily::UtxoMeta,
+            FORMAT_VERSION_KEY,
+            &FORMAT_VERSION_VALUE,
+        );
+        completion.delete(ColumnFamily::UtxoMeta, INDEX_FORMAT_VERSION_KEY);
         if store.write_durable_if(&conditions, completion)? {
             return Ok(());
         }
@@ -1728,19 +1774,15 @@ impl<S: KvStore> Indexer<S> {
     /// store unmarked; the next call retries. Storage errors belong to the
     /// caller.
     pub fn ensure_format_version(&self) -> Result<(), IndexError> {
-        match self.store.get(ColumnFamily::UtxoMeta, FORMAT_VERSION_KEY)? {
-            Some(value) if value.as_slice() == FORMAT_VERSION_VALUE => Ok(()),
-            Some(value) => {
-                let version = value
-                    .get(..4)
-                    .and_then(|bytes| <[u8; 4]>::try_from(bytes).ok())
-                    .map_or(0, u32::from_le_bytes);
+        match stored_format(self.store.as_ref())? {
+            StoreFormat::Current => Ok(()),
+            StoreFormat::Predecessor { version } | StoreFormat::Foreign { version } => {
                 Err(IndexError::UnsupportedTxIndexFormatVersion { version })
             }
-            None if has_any_index_row(self.store.as_ref())? => {
+            StoreFormat::Absent if has_any_index_row(self.store.as_ref())? => {
                 Err(IndexError::LegacyCursorlessIndex)
             }
-            None => {
+            StoreFormat::Absent => {
                 let mut batch = self.store.new_batch();
                 batch.put(
                     ColumnFamily::UtxoMeta,
@@ -3065,26 +3107,19 @@ impl<S: KvStore> IndexWriter<S> {
     /// [`IndexError::UnsupportedTxIndexFormatVersion`].
     pub fn open(store: std::sync::Arc<S>, generation: u64) -> Result<Self, IndexError> {
         let indexer = Indexer::new(store);
-        match indexer
-            .store
-            .get(ColumnFamily::UtxoMeta, FORMAT_VERSION_KEY)?
-        {
-            Some(value) if value.as_slice() == FORMAT_VERSION_VALUE => {}
-            Some(value) if is_predecessor_height_format(value.as_slice()) => {
+        match stored_format(indexer.store.as_ref())? {
+            StoreFormat::Current => {}
+            StoreFormat::Predecessor { .. } => {
                 resume_capability_reset(
                     indexer.store.as_ref(),
                     generation,
                     IndexCapabilities::HISTORICAL.to_mask(),
                 )?;
             }
-            Some(value) => {
-                let version = value
-                    .get(..4)
-                    .and_then(|bytes| <[u8; 4]>::try_from(bytes).ok())
-                    .map_or(0, u32::from_le_bytes);
+            StoreFormat::Foreign { version } => {
                 return Err(IndexError::UnsupportedTxIndexFormatVersion { version });
             }
-            None => {
+            StoreFormat::Absent => {
                 if has_any_index_row(&*indexer.store)? {
                     return Err(IndexError::LegacyCursorlessIndex);
                 }

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -162,6 +162,9 @@ const FORMAT_VERSION_KEY: &[u8] = &[0x00, b'V'];
 const FORMAT_VERSION_VALUE: [u8; 4] = 5_u32.to_le_bytes();
 const FORMAT_VERSION_V3: [u8; 4] = 3_u32.to_le_bytes();
 const FORMAT_VERSION_V4: [u8; 4] = 4_u32.to_le_bytes();
+/// Leftover ASCII row-value marker from formats 1–4. Written nowhere; deleted
+/// on reset so a store does not carry two version keys.
+const INDEX_FORMAT_VERSION_KEY: &[u8] = b"index:format_version";
 const TX_LOOKUP_WATERMARK_KEY: &[u8] = &[0x00, b'T'];
 const SCRIPT_HISTORY_WATERMARK_KEY: &[u8] = &[0x00, b'S'];
 const SCRIPT_LIVE_WATERMARK_KEY: &[u8] = &[0x00, b'L'];
@@ -706,20 +709,13 @@ fn acquire_capability_reset<S: KvStore>(
             FORMAT_VERSION_KEY,
             &FORMAT_VERSION_VALUE,
         );
+        batch.delete(ColumnFamily::UtxoMeta, INDEX_FORMAT_VERSION_KEY);
         let capabilities = IndexCapabilities::from_mask(mask)?;
         if capabilities.tx_lookup {
             batch.delete(ColumnFamily::UtxoMeta, TX_LOOKUP_WATERMARK_KEY);
         }
         if capabilities.script_history {
             batch.delete(ColumnFamily::UtxoMeta, SCRIPT_HISTORY_WATERMARK_KEY);
-            // Same durable batch as FORMAT_VERSION_VALUE so a predecessor
-            // height-format reset cannot publish version 5 while leaving the
-            // row-value marker behind.
-            batch.put(
-                ColumnFamily::UtxoMeta,
-                INDEX_FORMAT_VERSION_KEY,
-                &INDEX_FORMAT_VERSION.to_le_bytes(),
-            );
         }
         if capabilities.script_live {
             batch.delete(ColumnFamily::UtxoMeta, SCRIPT_LIVE_WATERMARK_KEY);
@@ -816,15 +812,6 @@ fn resume_capability_reset<S: KvStore>(
             ORDINARY_STATE_REVISION_KEY,
             &work.next_revision,
         );
-        if capabilities.script_history {
-            // Resume of a claim that predates the acquire-batch marker
-            // still publishes the current row-value format.
-            completion.put(
-                ColumnFamily::UtxoMeta,
-                INDEX_FORMAT_VERSION_KEY,
-                &INDEX_FORMAT_VERSION.to_le_bytes(),
-            );
-        }
         if store.write_durable_if(&conditions, completion)? {
             return Ok(());
         }
@@ -1724,61 +1711,34 @@ impl<S: KvStore> Indexer<S> {
         Ok(None)
     }
 
-    /// Reports whether this index's rows carry transaction positions, adopting
-    /// the current format when the index is empty.
+    /// Confirms this store carries the current layout, adopting it when empty.
     ///
-    /// Reading is always correct either way — a row without positions takes the
-    /// scan fallback — so this exists to tell an operator which path their node
-    /// is on, not to gate correctness. The difference is three orders of
-    /// magnitude on history resolution, which is worth a startup line.
-    ///
-    /// An index with rows but no version marker predates the format and is
-    /// reported as [`IndexFormat::Legacy`]. The marker is written only for an
-    /// empty index, because that is the only case where every row that will ever
-    /// exist is going to be written with positions. Writing it for a populated
-    /// legacy index would claim positions that are not there.
-    pub fn ensure_format_version(&self) -> Result<IndexFormat, IndexError> {
-        match self.read_format_version()? {
-            Some(FormatMarker::Version(found)) => {
-                return Ok(if found == INDEX_FORMAT_VERSION {
-                    IndexFormat::Current
-                } else {
-                    IndexFormat::Legacy { found: Some(found) }
-                });
+    /// A populated store with a missing or foreign marker is an error, not a
+    /// slower dual-read path. Empty-or-malformed *row values* still scan the
+    /// block: that is corruption safety, not an old-format decoder.
+    pub fn ensure_format_version(&self) -> Result<(), IndexError> {
+        match self.store.get(ColumnFamily::UtxoMeta, FORMAT_VERSION_KEY)? {
+            Some(value) if value.as_slice() == FORMAT_VERSION_VALUE => Ok(()),
+            Some(value) => {
+                let version = value
+                    .get(..4)
+                    .and_then(|bytes| <[u8; 4]>::try_from(bytes).ok())
+                    .map_or(0, u32::from_le_bytes);
+                Err(IndexError::UnsupportedTxIndexFormatVersion { version })
             }
-            Some(FormatMarker::Unreadable { len }) => {
-                return Ok(IndexFormat::UnreadableMarker { len });
+            None if self.has_any_header()? => Err(IndexError::LegacyCursorlessIndex),
+            None => {
+                let mut batch = self.store.new_batch();
+                batch.put(
+                    ColumnFamily::UtxoMeta,
+                    FORMAT_VERSION_KEY,
+                    &FORMAT_VERSION_VALUE,
+                );
+                batch.delete(ColumnFamily::UtxoMeta, INDEX_FORMAT_VERSION_KEY);
+                self.store.write(batch)?;
+                Ok(())
             }
-            None => {}
         }
-        if self.has_any_header()? {
-            return Ok(IndexFormat::Legacy { found: None });
-        }
-        let mut batch = self.store.new_batch();
-        batch.put(
-            ColumnFamily::UtxoMeta,
-            INDEX_FORMAT_VERSION_KEY,
-            &INDEX_FORMAT_VERSION.to_le_bytes(),
-        );
-        self.store.write(batch)?;
-        Ok(IndexFormat::Current)
-    }
-
-    fn read_format_version(&self) -> Result<Option<FormatMarker>, IndexError> {
-        let Some(bytes) = self
-            .store
-            .get(ColumnFamily::UtxoMeta, INDEX_FORMAT_VERSION_KEY)?
-        else {
-            return Ok(None);
-        };
-        let Ok(encoded) = <[u8; 4]>::try_from(bytes.as_slice()) else {
-            // Reported as its own outcome rather than folded into version 0: an
-            // operator told "your index is at version 0" deletes and re-syncs,
-            // which is the wrong response to bytes that should be a `u32` and
-            // are not.
-            return Ok(Some(FormatMarker::Unreadable { len: bytes.len() }));
-        };
-        Ok(Some(FormatMarker::Version(u32::from_le_bytes(encoded))))
     }
 
     /// True when the header column family holds at least one row.
@@ -3729,13 +3689,12 @@ pub trait IndexerLike: Send + Sync {
     /// Walks `block` once and writes index rows. See `Indexer::ingest_block`.
     fn ingest_block(&mut self, block: &[u8], height: u32) -> Result<IndexRowCounts, IndexError>;
 
-    /// Reports the row-value format. See [`Indexer::ensure_format_version`].
+    /// Confirms the store carries the current layout. See [`Indexer::ensure_format_version`].
     ///
-    /// Defaults to [`IndexFormat::Current`] for the in-memory and stub indexers
-    /// used in tests, which have no persisted rows and therefore no legacy ones.
-    /// A store-backed implementation must override this.
-    fn ensure_format_version(&self) -> Result<IndexFormat, IndexError> {
-        Ok(IndexFormat::Current)
+    /// Defaults to success for in-memory and stub indexers, which have no
+    /// persisted rows. A store-backed implementation must override this.
+    fn ensure_format_version(&self) -> Result<(), IndexError> {
+        Ok(())
     }
 
     /// Walks `block` once and writes index rows, reusing precomputed transaction IDs when supported.
@@ -3846,49 +3805,6 @@ pub trait IndexerLike: Send + Sync {
     ) -> Result<Option<u64>, IndexError>;
 }
 
-/// Metadata key marking which row-value format an index was written with.
-const INDEX_FORMAT_VERSION_KEY: &[u8] = b"index:format_version";
-
-/// Current row-value format. Version 1 added transaction byte positions to
-/// funding and txid row values; version 2 added positions to spending row
-/// values; version 0 (unmarked) has empty values.
-pub const INDEX_FORMAT_VERSION: u32 = 2;
-
-/// Which row-value format an opened index carries.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum IndexFormat {
-    /// Rows carry transaction positions; resolvers take the fast path.
-    Current,
-    /// Rows predate transaction positions; resolvers scan whole blocks.
-    ///
-    /// Correct but far slower. Clearing the index directory and re-syncing
-    /// rebuilds it in the current format.
-    Legacy {
-        /// The version marker found, or `None` when the index carries none.
-        found: Option<u32>,
-    },
-    /// A version marker exists but is not the 4 little-endian bytes of a `u32`.
-    ///
-    /// Resolvers scan, exactly as for [`Self::Legacy`], but the operator
-    /// response differs: this is damaged metadata, not an old index, and
-    /// deleting the directory would discard the evidence of whatever wrote it.
-    UnreadableMarker {
-        /// Byte length of the marker value that failed to decode.
-        len: usize,
-    },
-}
-
-/// What the format-version marker key holds, when it is present at all.
-enum FormatMarker {
-    /// Four little-endian bytes that decoded to this version.
-    Version(u32),
-    /// Present, but not a 4-byte little-endian `u32`.
-    Unreadable {
-        /// Byte length of the value found.
-        len: usize,
-    },
-}
-
 /// Provides block lookups for resolving lossy index prefixes to full identities.
 ///
 /// The index column families store 8-byte prefixes of txids/scripthashes/outpoints.
@@ -3920,7 +3836,7 @@ impl<S: KvStore + Send + Sync + 'static> IndexerLike for Indexer<S> {
         Self::ingest_block(self, block, height)
     }
 
-    fn ensure_format_version(&self) -> Result<IndexFormat, IndexError> {
+    fn ensure_format_version(&self) -> Result<(), IndexError> {
         Self::ensure_format_version(self)
     }
 

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -1716,6 +1716,17 @@ impl<S: KvStore> Indexer<S> {
     /// A populated store with a missing or foreign marker is an error, not a
     /// slower dual-read path. Empty-or-malformed *row values* still scan the
     /// block: that is corruption safety, not an old-format decoder.
+    ///
+    /// Emptiness matches [`IndexWriter::open`]: any row in `TxConfirmed`,
+    /// `Funding`, `Spending`, `BlockHeaders`, or `ScriptLive` is an index row.
+    /// A markerless store that already has one is
+    /// [`IndexError::LegacyCursorlessIndex`].
+    ///
+    /// Adopting an empty store writes format 5 and deletes the leftover ASCII
+    /// marker in one [`KvStore::write_durable`] batch (`IDX-05`). The commit
+    /// point is that durable batch. A crash before it is durable leaves the
+    /// store unmarked; the next call retries. Storage errors belong to the
+    /// caller.
     pub fn ensure_format_version(&self) -> Result<(), IndexError> {
         match self.store.get(ColumnFamily::UtxoMeta, FORMAT_VERSION_KEY)? {
             Some(value) if value.as_slice() == FORMAT_VERSION_VALUE => Ok(()),
@@ -1726,7 +1737,9 @@ impl<S: KvStore> Indexer<S> {
                     .map_or(0, u32::from_le_bytes);
                 Err(IndexError::UnsupportedTxIndexFormatVersion { version })
             }
-            None if self.has_any_header()? => Err(IndexError::LegacyCursorlessIndex),
+            None if has_any_index_row(self.store.as_ref())? => {
+                Err(IndexError::LegacyCursorlessIndex)
+            }
             None => {
                 let mut batch = self.store.new_batch();
                 batch.put(
@@ -1735,21 +1748,10 @@ impl<S: KvStore> Indexer<S> {
                     &FORMAT_VERSION_VALUE,
                 );
                 batch.delete(ColumnFamily::UtxoMeta, INDEX_FORMAT_VERSION_KEY);
-                self.store.write(batch)?;
+                self.store.write_durable(batch)?;
                 Ok(())
             }
         }
-    }
-
-    /// True when the header column family holds at least one row.
-    ///
-    /// Deliberately not `header_count`: a legacy index takes this branch on
-    /// every single start, and counting reads every row in the column family
-    /// and allocates an 80-byte array per row — roughly a million of each at
-    /// mainnet height — to answer a question that is only ever yes or no.
-    fn has_any_header(&self) -> Result<bool, IndexError> {
-        let mut rows = self.store.iter_prefix(ColumnFamily::BlockHeaders, &[])?;
-        Ok(rows.next().transpose()?.is_some())
     }
 
     const FLUSH_THRESHOLD_ROWS: usize = 500_000;

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -9,11 +9,11 @@ pub mod mempool;
 pub mod types;
 
 pub use index::{
-    BlockSource, ConsumerCursorUpdate, INDEX_FORMAT_VERSION, IndexCapabilities, IndexCapability,
-    IndexError, IndexFormat, IndexReader, IndexRowCounts, IndexWatermark, IndexWatermarks,
-    IndexWriteFence, IndexWriter, Indexer, IndexerLike, MAX_LIVE_SCRIPT_SIZE, NoSpentScripts,
-    PreparedBatch, PreparedBatchLimits, PreparedBlock, ScriptHistoryEntry, ScriptLiveScan,
-    SpentCoinScripts, TxIndexScan, TxIndexScanRow, TxIndexSnapshot,
+    BlockSource, ConsumerCursorUpdate, IndexCapabilities, IndexCapability, IndexError, IndexReader,
+    IndexRowCounts, IndexWatermark, IndexWatermarks, IndexWriteFence, IndexWriter, Indexer,
+    IndexerLike, MAX_LIVE_SCRIPT_SIZE, NoSpentScripts, PreparedBatch, PreparedBatchLimits,
+    PreparedBlock, ScriptHistoryEntry, ScriptLiveScan, SpentCoinScripts, TxIndexScan,
+    TxIndexScanRow, TxIndexSnapshot,
 };
 pub use mempool::{MempoolRowCounts, MempoolRowWriter};
 pub use types::{

--- a/crates/index/tests/index_roundtrip.rs
+++ b/crates/index/tests/index_roundtrip.rs
@@ -779,6 +779,30 @@ fn unversioned_rows_are_rejected() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// `IDX-05`: a markerless store with Funding rows and no headers is refused,
+/// not stamped format 5.
+#[test]
+fn ensure_format_version_rejects_markerless_funding_rows() -> Result<(), Box<dyn std::error::Error>>
+{
+    let store = Arc::new(MemoryStore::default());
+    store.put(
+        ColumnFamily::Funding,
+        &[0u8; bitcoin_rs_index::HASH_PREFIX_ROW_SIZE],
+        &[],
+    )?;
+
+    let indexer = Indexer::new(Arc::clone(&store));
+    assert!(matches!(
+        indexer.ensure_format_version(),
+        Err(IndexError::LegacyCursorlessIndex)
+    ));
+    assert!(
+        store.get(ColumnFamily::UtxoMeta, &[0x00, b'V'])?.is_none(),
+        "must not stamp format 5 onto a markerless populated store"
+    );
+    Ok(())
+}
+
 #[test]
 fn reset_index_replaces_an_incompatible_derived_format() -> Result<(), Box<dyn std::error::Error>> {
     let store = Arc::new(MemoryStore::default());
@@ -1935,6 +1959,8 @@ fn reset_index_adopts_a_foreign_fence_as_an_all_capability_reset()
     Ok(())
 }
 
+/// `IDX-05`: format 5 remains the only durable marker after historical reset
+/// and rebuild; the leftover ASCII dual-read key stays deleted.
 #[test]
 fn format_stays_current_after_reset_and_rebuild() -> Result<(), Box<dyn std::error::Error>> {
     let store = Arc::new(MemoryStore::default());

--- a/crates/index/tests/index_roundtrip.rs
+++ b/crates/index/tests/index_roundtrip.rs
@@ -1305,8 +1305,8 @@ fn reset_claim_carries_mask_epoch_and_base_version() -> Result<(), Box<dyn std::
         "completion CASes the exact claim to Idle(base_version + 1)"
     );
     assert_eq!(
-        marker_puts[1].deletes, 0,
-        "completion never deletes the state key"
+        marker_puts[1].deletes, 1,
+        "completion deletes the leftover ASCII format marker; the reset state key is CASed to Idle"
     );
     assert!(writer.consumer_cursor()?.is_none());
     Ok(())
@@ -3096,6 +3096,43 @@ fn same_mask_claim_is_adopted_cooperatively_without_rewrite()
     Ok(())
 }
 
+/// `IDX-05`: completing a same-mask claim from an older binary drops the leftover ASCII marker.
+#[test]
+fn completing_an_adopted_claim_deletes_the_leftover_ascii_marker()
+-> Result<(), Box<dyn std::error::Error>> {
+    let store = Arc::new(MemoryStore::default());
+    seed_populated_store(&store, 1)?;
+    store.put(
+        ColumnFamily::UtxoMeta,
+        b"index:format_version",
+        &2_u32.to_le_bytes(),
+    )?;
+    let mut crash = store.new_batch();
+    crash.put(
+        ColumnFamily::UtxoMeta,
+        RESET_KEY,
+        &claim_bytes(SCRIPT_HISTORY_MASK, 9, 0),
+    );
+    crash.delete(ColumnFamily::UtxoMeta, SCRIPT_WATERMARK_KEY);
+    crash.delete(ColumnFamily::UtxoMeta, CURSOR_KEY);
+    store.write_durable(crash)?;
+
+    IndexWriter::open(Arc::clone(&store), 7)?;
+
+    assert!(
+        store
+            .get(ColumnFamily::UtxoMeta, b"index:format_version")?
+            .is_none(),
+        "same-mask adoption must still drop the leftover ASCII marker on completion"
+    );
+    assert_eq!(
+        store.get(ColumnFamily::UtxoMeta, FORMAT_KEY)?.as_deref(),
+        Some(FORMAT_VALUE.as_slice()),
+        "completion stamps format 5 even when the adopted claim did not rewrite metadata"
+    );
+    Ok(())
+}
+
 #[test]
 fn union_growth_preserves_claim_identity_and_deletes_full_union_state()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -3144,7 +3181,10 @@ fn union_growth_preserves_claim_identity_and_deletes_full_union_state()
         markers[1].marker_put.as_deref(),
         Some(idle_bytes(4).as_slice())
     );
-    assert_eq!(markers[1].deletes, 0, "completion never deletes");
+    assert_eq!(
+        markers[1].deletes, 1,
+        "completion deletes the leftover ASCII format marker"
+    );
 
     assert_eq!(
         store.get(ColumnFamily::UtxoMeta, RESET_KEY)?,

--- a/crates/index/tests/index_roundtrip.rs
+++ b/crates/index/tests/index_roundtrip.rs
@@ -18,7 +18,7 @@ use parking_lot::{Mutex, RwLock};
 use bitcoin_rs_index::ScriptHash;
 use bitcoin_rs_index::types::{TxPosition, TxPositionValue};
 use bitcoin_rs_index::{
-    ConsumerCursorUpdate, IndexCapabilities, IndexError, IndexFormat, IndexReader, IndexRowCounts,
+    ConsumerCursorUpdate, IndexCapabilities, IndexError, IndexReader, IndexRowCounts,
     IndexWatermark, IndexWatermarks, IndexWriter, Indexer, PreparedBatch, PreparedBatchLimits,
 };
 use bitcoin_rs_storage::{
@@ -744,11 +744,11 @@ fn predecessor_height_format_resets_historical(
         store.get(ColumnFamily::UtxoMeta, &[0x00, b'V'])?.as_deref(),
         Some(5_u32.to_le_bytes().as_slice())
     );
-    assert_eq!(
+    assert!(
         store
             .get(ColumnFamily::UtxoMeta, b"index:format_version")?
-            .as_deref(),
-        Some(2_u32.to_le_bytes().as_slice())
+            .is_none(),
+        "the leftover ASCII row-value marker must not survive a format reset"
     );
     assert_eq!(
         writer.watermarks()?,
@@ -1271,8 +1271,9 @@ fn reset_claim_carries_mask_epoch_and_base_version() -> Result<(), Box<dyn std::
         "claim value is mask(1) || process_epoch(8 LE) || base_version(8 LE)"
     );
     assert_eq!(
-        marker_puts[0].deletes, 2,
-        "the claim atomically deletes the selected watermark and global cursor"
+        marker_puts[0].deletes, 3,
+        "the claim atomically deletes the selected watermark, global cursor, \
+         and leftover ASCII format marker"
     );
     assert_eq!(
         marker_puts[1].marker_put.as_deref(),
@@ -1943,21 +1944,25 @@ fn format_stays_current_after_reset_and_rebuild() -> Result<(), Box<dyn std::err
     writer.reset_capabilities(IndexCapabilities::HISTORICAL)?;
     drop(writer);
 
-    // The emptied index claims the current row format before rebuilding.
+    // The emptied index claims the current store format before rebuilding.
     let indexer = Indexer::new(Arc::clone(&store));
-    assert_eq!(indexer.ensure_format_version()?, IndexFormat::Current);
+    indexer.ensure_format_version()?;
     drop(indexer);
 
     seed_populated_store(&store, 1)?;
 
     let indexer = Indexer::new(Arc::clone(&store));
-    assert_eq!(indexer.ensure_format_version()?, IndexFormat::Current);
+    indexer.ensure_format_version()?;
     assert_eq!(
+        store.get(ColumnFamily::UtxoMeta, &[0x00, b'V'])?.as_deref(),
+        Some(5_u32.to_le_bytes().as_slice()),
+        "the store format marker survives reset and rebuild"
+    );
+    assert!(
         store
             .get(ColumnFamily::UtxoMeta, b"index:format_version")?
-            .as_deref(),
-        Some(2u32.to_le_bytes().as_slice()),
-        "the row-format marker survives reset and rebuild"
+            .is_none(),
+        "the leftover ASCII row-value marker must not return after rebuild"
     );
     assert!(
         store
@@ -3106,8 +3111,8 @@ fn union_growth_preserves_claim_identity_and_deletes_full_union_state()
         "growth changes byte zero only; width, process epoch, and base survive raw"
     );
     assert_eq!(
-        markers[0].deletes, 3,
-        "the claim deletes the union watermarks and the consumer cursor"
+        markers[0].deletes, 4,
+        "the claim deletes the union watermarks, the consumer cursor, and the leftover ASCII format marker"
     );
     assert_eq!(
         markers[1].marker_put.as_deref(),

--- a/docs/benchmarks/scriptindex-format.md
+++ b/docs/benchmarks/scriptindex-format.md
@@ -261,62 +261,44 @@ default until one is.
 
 ## Versioning: per-capability format and reset
 
-The index tracks two independently versioned capabilities via
+The index tracks three independently versioned capabilities via
 `IndexCapability`:
 
 | Capability | Column families | Watermark key |
 |---|---|---|
 | `TxLookup` | `TxConfirmed`, `BlockHeaders` | `TX_LOOKUP_WATERMARK_KEY` |
 | `ScriptHistory` | `Funding`, `Spending` | `SCRIPT_HISTORY_WATERMARK_KEY` |
+| `ScriptLive` | `ScriptLive` | `SCRIPT_LIVE_WATERMARK_KEY` |
 
-**Per-capability format version.** The row-value format version
-(`INDEX_FORMAT_VERSION`, currently 2) is a single marker in `UtxoMeta`. It
-governs whether Funding, Spending, and TxConfirmed values carry `TxPosition`
-arrays.
-A future format bump (e.g. changing `TxPosition` width) would increment this
-version. Readers already handle
-`IndexFormat::Legacy` by falling back to full block scans, so an old-format
-index remains correct, just slower.
+**One store format.** `[0x00, b'V']` in `UtxoMeta` is the only layout marker
+(currently 5: big-endian hash-prefix heights, positioned Spending values,
+full-outpoint Live locators). The leftover ASCII `index:format_version` key
+from formats 1–4 is deleted on reset and is not read.
 
 **Per-capability reset.** The `IndexCapabilities` mask allows resetting one
-capability without touching the other. `acquire_capability_reset` and
+capability without touching the others. `acquire_capability_reset` and
 `resume_capability_reset` delete only the column families belonging to the
 requested capability and clear only that capability's watermark. The reset
 state is tracked in `RESET_CAPABILITIES_KEY` with a monotonic version that
 prevents ABA across repeated resets.
 
-Opening a format-3 store (Spending keys without positions) is this kind of
-reset: `IndexWriter::open` rebuilds `ScriptHistory` only and leaves
-`TxLookup` ready. A foreign format version still refuses start.
+Opening a format-3 or format-4 store (little-endian heights) is this kind of
+reset: `IndexWriter::open` rebuilds `TxLookup` and `ScriptHistory` and leaves
+`ScriptLive` ready. A foreign format version still refuses start.
 
-**Adding ScriptLive later must not force a History reindex.** ScriptLive
-rows would occupy a new column family (not one of the existing four). The
-`IndexCapability` enum would gain a `ScriptLive` variant with its own
-watermark key. Because the reset mechanism is per-capability:
-
-- Adding `ScriptLive` does not touch `Funding`, `Spending`, `TxConfirmed`,
-  or `BlockHeaders` rows.
-- A `ScriptHistory` reset (clearing `Funding` + `Spending`) does not touch
-  `ScriptLive` rows.
-- A `ScriptLive` reset clears only the Live CF.
-- The `INDEX_FORMAT_VERSION` marker does not change: it governs the
-  row-value format of existing CFs, not the existence of a new CF.
+A `ScriptLive` locator change would reset only `ScriptLive`. A History or
+TxLookup key change resets those families and can leave Live in place when
+its locator did not change.
 
 The only shared state between capabilities is the `ORDINARY_STATE_REVISION`
 counter in `UtxoMeta`, which advances on every ordinary commit regardless of
 which capability wrote. This is by design: the revision fences derived
 writes against concurrent resets, and a new capability's writes must be
-fenced the same way. Adding a capability does not change the revision
-counter's semantics; it just means more writes advance it.
+fenced the same way.
 
-**No dual-read path.** The reader does not maintain a "read from old format,
-then read from new format" fallback for a capability that has not been
-reset. The `IndexFormat::Legacy` fallback is for the row-value format
-(positions vs no positions), not for the presence or absence of a column
-family. A new CF is either populated (after the first ingest) or empty
-(before it); the reader handles both without a format check.
+**No dual-read path.** A foreign or missing format marker refuses start or
+selects delete-and-rebuild. Empty or malformed *row values* still scan the
+block: that is corruption safety, not an old-format decoder.
 
-**No migration.** Adding a capability is additive: open the new keyspace,
-start ingesting, advance the new watermark. No existing row is rewritten.
-The only operator action is enabling the capability in the ingest
-configuration; the reset mechanism handles the rest.
+**No migration.** Format changes delete the affected capability rows and
+rebuild from authoritative chain or UTXO state. No existing row is rewritten.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #452. Second slice of #226: one store format marker, no legacy dual-read. Restacked onto the rebased #452 branch (current `main`, including #502).

## What this removes

The index previously carried two version keys:

- `[0x00, b'V']` — store format (5 after #452)
- `index:format_version` — row-value format (2), with `IndexFormat::Legacy` telling resolvers to scan

#226 forbids dual-read paths and leftover decoders for old index files. Empty or malformed *row values* still scan the block; that is corruption safety, not an old-format reader.

## What remains

`[0x00, b'V']` is the only layout marker. Reset deletes the leftover ASCII key. `ensure_format_version` writes the current marker on an empty store and returns `UnsupportedTxIndexFormatVersion` or `LegacyCursorlessIndex` otherwise.

Emptiness matches `IndexWriter::open`: any row in `TxConfirmed`, `Funding`, `Spending`, `BlockHeaders`, or `ScriptLive` is an index row. Empty adoption is one `write_durable` batch (`IDX-05`). Formats 3 and 4 still reset `TxLookup` + `ScriptHistory` and leave `ScriptLive` (from #452). Completing an adopted same-mask reset also stamps format 5 and deletes the leftover ASCII key, so a claim left by an older binary converges to one marker.

Format classification is one helper. `IndexWriter::open` still resets predecessors; `ensure_format_version` still refuses them.

## Proof

`format_3_open_resets_historical_keys_and_keeps_live`, `format_4_open_resets_historical_keys_and_keeps_live`, `format_stays_current_after_reset_and_rebuild`, `ensure_format_version_rejects_markerless_funding_rows`, `completing_an_adopted_claim_deletes_the_leftover_ascii_marker`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11b3d2bc-f76e-4951-bceb-0d1f84839f5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11b3d2bc-f76e-4951-bceb-0d1f84839f5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

