### PR TITLE
Buffer inbound P2P reads on the counting stream

### DIFF
--- a/crates/p2p/src/counters.rs
+++ b/crates/p2p/src/counters.rs
@@ -327,14 +327,6 @@ mod tests {
         assert_ne!(counters.last_recv(), 0, "a read must stamp the time");
     }
 
-    /// Unauthenticated inbound sessions allocate this cache on the first
-    /// small read. Keep it at the `BufReader` default so a flood of
-    /// half-open handshakes cannot pin 256 KiB each.
-    #[test]
-    fn inbound_read_cache_matches_bufreader_default() {
-        assert_eq!(INBOUND_READ_BUFFER, 8 * 1024);
-    }
-
     /// One kernel delivery can contain the next message. The wrapper must
     /// keep those leftover bytes instead of asking the socket again.
     ///

--- a/crates/p2p/src/counters.rs
+++ b/crates/p2p/src/counters.rs
@@ -94,17 +94,35 @@ fn now_seconds() -> u64 {
 /// loop, and the writer thread that owns a cloned socket -- so a counter added
 /// at any one of them would report a fraction of the traffic as though it were
 /// all of it.
+///
+/// Reads are buffered so a kernel delivery that holds more than one message
+/// does not cost a syscall per `read_exact` of the 24-byte header. Large
+/// caller buffers (block payloads) bypass the cache and read into the
+/// destination. The writer-side `try_clone` starts with an empty read cache.
 #[derive(Debug)]
 pub struct CountingStream<S> {
     inner: S,
     counters: Arc<PeerCounters>,
+    read_buf: Vec<u8>,
+    read_pos: usize,
+    read_end: usize,
 }
+
+/// Sized to hold a max `headers` payload (~162 KiB) plus the next command
+/// header so IBD header sync does not round-trip to the socket per message.
+const INBOUND_READ_BUFFER: usize = 256 * 1024;
 
 impl<S> CountingStream<S> {
     /// Wraps `inner`, counting into `counters`.
     #[must_use]
     pub const fn new(inner: S, counters: Arc<PeerCounters>) -> Self {
-        Self { inner, counters }
+        Self {
+            inner,
+            counters,
+            read_buf: Vec::new(),
+            read_pos: 0,
+            read_end: 0,
+        }
     }
 
     /// The counters this stream feeds.
@@ -153,6 +171,9 @@ impl CountingStream<std::net::TcpStream> {
         Ok(Self {
             inner: self.inner.try_clone()?,
             counters: Arc::clone(&self.counters),
+            read_buf: Vec::new(),
+            read_pos: 0,
+            read_end: 0,
         })
     }
 
@@ -184,9 +205,44 @@ impl CountingStream<std::net::TcpStream> {
     }
 }
 
+impl<S: Read> CountingStream<S> {
+    fn take_leftover(&mut self, buffer: &mut [u8]) -> Option<usize> {
+        if self.read_pos >= self.read_end {
+            return None;
+        }
+        let take = (self.read_end - self.read_pos).min(buffer.len());
+        buffer[..take].copy_from_slice(&self.read_buf[self.read_pos..self.read_pos + take]);
+        self.read_pos += take;
+        Some(take)
+    }
+
+    fn fill_read_buf(&mut self) -> IoResult<()> {
+        if self.read_buf.len() < INBOUND_READ_BUFFER {
+            self.read_buf.resize(INBOUND_READ_BUFFER, 0);
+        }
+        self.read_pos = 0;
+        self.read_end = self.inner.read(&mut self.read_buf)?;
+        Ok(())
+    }
+
+    fn read_buffered(&mut self, buffer: &mut [u8]) -> IoResult<usize> {
+        if let Some(take) = self.take_leftover(buffer) {
+            return Ok(take);
+        }
+        if buffer.len() >= INBOUND_READ_BUFFER {
+            return self.inner.read(buffer);
+        }
+        self.fill_read_buf()?;
+        Ok(self.take_leftover(buffer).unwrap_or(0))
+    }
+}
+
 impl<S: Read> Read for CountingStream<S> {
     fn read(&mut self, buffer: &mut [u8]) -> IoResult<usize> {
-        let read = self.inner.read(buffer)?;
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+        let read = self.read_buffered(buffer)?;
         self.counters.record_recv(read);
         Ok(read)
     }
@@ -266,6 +322,101 @@ mod tests {
             assert_eq!(counters.bytes_recv(), expected);
         }
         assert_ne!(counters.last_recv(), 0, "a read must stamp the time");
+    }
+
+    /// One kernel delivery can contain the next message. The wrapper must
+    /// keep those leftover bytes instead of asking the socket again.
+    #[test]
+    fn leftover_bytes_do_not_revisit_the_socket() {
+        struct OneShot {
+            remaining: Vec<u8>,
+            reads: u8,
+        }
+        impl Read for OneShot {
+            fn read(&mut self, buffer: &mut [u8]) -> IoResult<usize> {
+                self.reads = self.reads.saturating_add(1);
+                if self.reads > 1 {
+                    return Err(std::io::Error::other("socket read more than once"));
+                }
+                let take = self.remaining.len().min(buffer.len());
+                buffer[..take].copy_from_slice(&self.remaining[..take]);
+                self.remaining.drain(..take);
+                Ok(take)
+            }
+        }
+
+        let counters = Arc::new(PeerCounters::default());
+        let mut stream = CountingStream::new(
+            OneShot {
+                remaining: vec![1, 2, 3, 4, 5],
+                reads: 0,
+            },
+            Arc::clone(&counters),
+        );
+        let mut first = [0_u8; 2];
+        let read = stream
+            .read(&mut first)
+            .unwrap_or_else(|error| panic!("first read failed: {error}"));
+        assert_eq!(read, 2);
+        assert_eq!(first, [1, 2]);
+        let mut second = [0_u8; 3];
+        let read = stream
+            .read(&mut second)
+            .unwrap_or_else(|error| panic!("leftover read failed: {error}"));
+        assert_eq!(read, 3);
+        assert_eq!(second, [3, 4, 5]);
+        assert_eq!(counters.bytes_recv(), 5);
+    }
+
+    /// Two framed pings delivered in one inner read must both decode without
+    /// a second socket read — the IBD headers path between small messages.
+    #[test]
+    fn two_wire_messages_decode_from_one_socket_read() {
+        struct OneShot {
+            remaining: Vec<u8>,
+            reads: u8,
+        }
+        impl Read for OneShot {
+            fn read(&mut self, buffer: &mut [u8]) -> IoResult<usize> {
+                self.reads = self.reads.saturating_add(1);
+                if self.reads > 1 {
+                    return Err(std::io::Error::other("socket read more than once"));
+                }
+                let take = self.remaining.len().min(buffer.len());
+                buffer[..take].copy_from_slice(&self.remaining[..take]);
+                self.remaining.drain(..take);
+                Ok(take)
+            }
+        }
+
+        let mut frames = Vec::new();
+        crate::wire::write_message(
+            &mut frames,
+            bitcoin::p2p::Magic::BITCOIN,
+            &crate::wire::Message::Ping(1),
+        )
+        .unwrap_or_else(|error| panic!("encode ping 1: {error}"));
+        crate::wire::write_message(
+            &mut frames,
+            bitcoin::p2p::Magic::BITCOIN,
+            &crate::wire::Message::Ping(2),
+        )
+        .unwrap_or_else(|error| panic!("encode ping 2: {error}"));
+
+        let counters = Arc::new(PeerCounters::default());
+        let mut stream = CountingStream::new(
+            OneShot {
+                remaining: frames,
+                reads: 0,
+            },
+            counters,
+        );
+        let (first, _) = crate::wire::read_message(&mut stream, bitcoin::p2p::Magic::BITCOIN)
+            .unwrap_or_else(|error| panic!("decode ping 1: {error}"));
+        let (second, _) = crate::wire::read_message(&mut stream, bitcoin::p2p::Magic::BITCOIN)
+            .unwrap_or_else(|error| panic!("decode ping 2: {error}"));
+        assert_eq!(first, crate::wire::Message::Ping(1));
+        assert_eq!(second, crate::wire::Message::Ping(2));
     }
 
     /// A read that moves nothing is not activity.

--- a/crates/p2p/src/counters.rs
+++ b/crates/p2p/src/counters.rs
@@ -170,13 +170,10 @@ impl CountingStream<std::net::TcpStream> {
     ///
     /// Returns the error `TcpStream::try_clone` returned.
     pub fn try_clone(&self) -> IoResult<Self> {
-        Ok(Self {
-            inner: self.inner.try_clone()?,
-            counters: Arc::clone(&self.counters),
-            read_buf: Vec::new(),
-            read_pos: 0,
-            read_end: 0,
-        })
+        Ok(Self::new(
+            self.inner.try_clone()?,
+            Arc::clone(&self.counters),
+        ))
     }
 
     /// Applies a read timeout to the wrapped socket.
@@ -222,8 +219,12 @@ impl<S: Read> CountingStream<S> {
         if self.read_buf.len() < INBOUND_READ_BUFFER {
             self.read_buf.resize(INBOUND_READ_BUFFER, 0);
         }
+        // Indices move only after a successful read. Resetting `read_pos`
+        // first would make a timeout revive already-consumed leftover bytes;
+        // the handshake and message loops retry TimedOut/WouldBlock.
+        let filled = self.inner.read(&mut self.read_buf)?;
         self.read_pos = 0;
-        self.read_end = self.inner.read(&mut self.read_buf)?;
+        self.read_end = filled;
         Ok(())
     }
 
@@ -378,6 +379,58 @@ mod tests {
         assert_eq!(read, 3);
         assert_eq!(second, [3, 4, 5]);
         assert_eq!(counters.bytes_recv(), 5);
+    }
+
+    /// Handshake and message loops retry `TimedOut`. A refill that fails
+    /// after leftover bytes were consumed must not revive those bytes.
+    ///
+    /// Contract: `docs/contracts/p2p-wire.md` `P2P-01`.
+    #[test]
+    fn a_timed_out_refill_does_not_replay_consumed_bytes() {
+        struct TimeoutAfterFirst {
+            remaining: Vec<u8>,
+            reads: u8,
+        }
+        impl Read for TimeoutAfterFirst {
+            fn read(&mut self, buffer: &mut [u8]) -> IoResult<usize> {
+                self.reads = self.reads.saturating_add(1);
+                if self.reads > 1 {
+                    return Err(std::io::Error::from(std::io::ErrorKind::TimedOut));
+                }
+                let take = self.remaining.len().min(buffer.len());
+                buffer[..take].copy_from_slice(&self.remaining[..take]);
+                self.remaining.drain(..take);
+                Ok(take)
+            }
+        }
+
+        let counters = Arc::new(PeerCounters::default());
+        let mut stream = CountingStream::new(
+            TimeoutAfterFirst {
+                remaining: vec![1, 2, 3],
+                reads: 0,
+            },
+            Arc::clone(&counters),
+        );
+        let mut first = [0_u8; 3];
+        let read = stream
+            .read(&mut first)
+            .unwrap_or_else(|error| panic!("first read failed: {error}"));
+        assert_eq!(read, 3);
+        assert_eq!(first, [1, 2, 3]);
+
+        let mut retry = [0_u8; 3];
+        let error = match stream.read(&mut retry) {
+            Ok(n) => panic!("refill must time out, got {n} bytes"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        let error = match stream.read(&mut retry) {
+            Ok(n) => panic!("retry after timeout must not replay, got {n} bytes"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        assert_eq!(counters.bytes_recv(), 3);
     }
 
     /// Two framed pings delivered in one inner read must both decode without

--- a/crates/p2p/src/counters.rs
+++ b/crates/p2p/src/counters.rs
@@ -108,9 +108,11 @@ pub struct CountingStream<S> {
     read_end: usize,
 }
 
-/// Sized to hold a max `headers` payload (~162 KiB) plus the next command
-/// header so IBD header sync does not round-trip to the socket per message.
-const INBOUND_READ_BUFFER: usize = 256 * 1024;
+/// Matches `std::io::BufReader`'s default. Unauthenticated inbound
+/// connections allocate this on the first small read; a 256 KiB cache would
+/// let a flood of half-open handshakes pin large RSS. Payloads whose caller
+/// buffer is already this size or larger bypass the cache.
+const INBOUND_READ_BUFFER: usize = 8 * 1024;
 
 impl<S> CountingStream<S> {
     /// Wraps `inner`, counting into `counters`.
@@ -324,8 +326,18 @@ mod tests {
         assert_ne!(counters.last_recv(), 0, "a read must stamp the time");
     }
 
+    /// Unauthenticated inbound sessions allocate this cache on the first
+    /// small read. Keep it at the `BufReader` default so a flood of
+    /// half-open handshakes cannot pin 256 KiB each.
+    #[test]
+    fn inbound_read_cache_matches_bufreader_default() {
+        assert_eq!(INBOUND_READ_BUFFER, 8 * 1024);
+    }
+
     /// One kernel delivery can contain the next message. The wrapper must
     /// keep those leftover bytes instead of asking the socket again.
+    ///
+    /// Contract: `docs/contracts/p2p-wire.md` `P2P-01`.
     #[test]
     fn leftover_bytes_do_not_revisit_the_socket() {
         struct OneShot {
@@ -370,6 +382,8 @@ mod tests {
 
     /// Two framed pings delivered in one inner read must both decode without
     /// a second socket read — the IBD headers path between small messages.
+    ///
+    /// Contract: `docs/contracts/p2p-wire.md` `P2P-01`.
     #[test]
     fn two_wire_messages_decode_from_one_socket_read() {
         struct OneShot {

--- a/docs/contracts/p2p-wire.md
+++ b/docs/contracts/p2p-wire.md
@@ -116,6 +116,8 @@ This page assigns ownership and cites proof under the
   `inbound_handshake_reaches_ready_after_remote_version_and_verack`: inbound
   handshake writes framed version, feature, and verack bytes once and reaches
   Ready (`P2P-01`).
-- `crates/p2p/src/counters.rs` tests `leftover_bytes_do_not_revisit_the_socket`
-  and `two_wire_messages_decode_from_one_socket_read`: one kernel delivery of
-  two v1 frames decodes both without a second socket read (`P2P-01`).
+- `crates/p2p/src/counters.rs` tests `leftover_bytes_do_not_revisit_the_socket`,
+  `two_wire_messages_decode_from_one_socket_read`, and
+  `a_timed_out_refill_does_not_replay_consumed_bytes`: one kernel delivery of
+  two v1 frames decodes both without a second socket read, and a timed-out
+  refill does not replay consumed bytes (`P2P-01`).

--- a/docs/contracts/p2p-wire.md
+++ b/docs/contracts/p2p-wire.md
@@ -116,3 +116,6 @@ This page assigns ownership and cites proof under the
   `inbound_handshake_reaches_ready_after_remote_version_and_verack`: inbound
   handshake writes framed version, feature, and verack bytes once and reaches
   Ready (`P2P-01`).
+- `crates/p2p/src/counters.rs` tests `leftover_bytes_do_not_revisit_the_socket`
+  and `two_wire_messages_decode_from_one_socket_read`: one kernel delivery of
+  two v1 frames decodes both without a second socket read (`P2P-01`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

#439 stacked PR 4/5. Stop paying a syscall per 24-byte header when the kernel already delivered the next frame.

`read_message` issues a 24-byte header `read_exact` then a payload read. Without a read cache, every small message is a syscall, and a kernel delivery that already holds the next frame is thrown away.

`BufReader` around `peer.stream` cannot live across dispatch: dispatch needs `&mut Peer` while the reader would hold `&mut peer.stream`. The buffer therefore lives on `CountingStream`, which already owns the read half for handshake and the message loop.

## What changed

`CountingStream` keeps an 8 KiB read cache (`std::io::BufReader`'s default) and counts only the bytes delivered to the caller. A 256 KiB cache would let unauthenticated inbound connections pin large RSS: accept is unbounded and handshake can live for a minute. Block-sized `read_exact` buffers still bypass the cache. The writer clone starts empty via `CountingStream::new` so it cannot steal leftover inbound bytes. The 8 KiB bound is owned by `INBOUND_READ_BUFFER`; it is not a `P2P-01` clause.

Cache indices move only after a successful inner read. Resetting `read_pos` first would let a `TimedOut` refill revive already-consumed leftover bytes; handshake and message loops retry that error.

Leftover-frame tests cite `P2P-01` (`docs/contracts/p2p-wire.md`).

## Acceptance

- Two v1 frames in one kernel delivery both decode (`P2P-01`).
- A timed-out refill does not replay consumed bytes (`P2P-01`).
- Evidence: `leftover_bytes_do_not_revisit_the_socket`, `two_wire_messages_decode_from_one_socket_read`, `a_timed_out_refill_does_not_replay_consumed_bytes`.

## Stack

1. #473 — honor writev on `CountingStream`
2. #477 — disable Nagle
3. #474 — write handshake bytes once
4. **This PR** — buffer inbound reads
5. #476 — drop the unused `P2pService` download window

## Related

- #439

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc46cc2b-2067-406a-b817-2e721677e8eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc46cc2b-2067-406a-b817-2e721677e8eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

