### PR TITLE
Serve getdata blocks from stored wire bytes

### DIFF
--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -14,8 +14,9 @@ negotiates version/verack in `handshake`, then runs the peer finite-state machin
 in `fsm`; `wire` is the protocol codec. Inbound traffic reaches the host through
 `dispatch_inbound_with_chain`, which streams getdata responses behind the outbound
 budget's pre-load production headroom gate and reads the active chain through the
-`ChainQuery` trait; `inbound` hands over `InboundBlock` and `InboundHeaders` with
-their wire bytes preserved. Misbehaving peers accumulate score on the file-persisted
+`ChainQuery` trait. Served block bodies are the stored consensus bytes
+(`Message::BlockPayload`); they are not decoded and re-encoded. `inbound` hands over
+`InboundBlock` and `InboundHeaders` with their wire bytes preserved. Misbehaving peers accumulate score on the file-persisted
 `BanList`; whole subnets are excluded as a `BannedSubnet` built from an `IpSubnet`,
 and BIP155 addrv2 and BIP339 wtxid-relay state live in `addrv2` and `wtxid`.
 

--- a/crates/p2p/src/chain_query.rs
+++ b/crates/p2p/src/chain_query.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use bitcoin::hashes::Hash as _;
 use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin_rs_chain::{BlockBodySource, BlockTree};
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header};
+use bitcoin_rs_primitives::{BlockHash, Hash256, Header};
 use parking_lot::RwLock;
 
 use crate::dispatch::{ChainQuery, InventoryServing};
@@ -39,18 +39,24 @@ impl ActiveChainQuery {
         self
     }
 
-    fn load_active_block_at_height(&self, current_height: u32, hash: BlockHash) -> Option<Block> {
+    fn load_active_block_bytes(
+        &self,
+        current_height: u32,
+        hash: BlockHash,
+    ) -> Option<bytes::Bytes> {
         let bytes = self
             .block_body_source
             .as_ref()?
             .block_body(current_height, hash)?;
-        let block = Block::consensus_decode(&bytes).ok()?;
-        if block.block_hash() != hash {
+        let header = bytes
+            .get(..80)
+            .and_then(|header| Header::consensus_decode(header).ok())?;
+        if header.compute_hash() != hash {
             return None;
         }
         let tree = self.block_tree.read();
         (tree.active_height_of(tree.tip()?.tip_id, hash.into()) == Some(current_height))
-            .then_some(block)
+            .then(|| bytes::Bytes::from(bytes))
     }
 }
 
@@ -114,7 +120,7 @@ impl ChainQuery for ActiveChainQuery {
         &self,
         items: &[Inventory],
         headroom: &dyn Fn() -> bool,
-        serve: &mut dyn FnMut(Block) -> Result<(), PeerError>,
+        serve: &mut dyn FnMut(bytes::Bytes) -> Result<(), PeerError>,
     ) -> Result<InventoryServing, PeerError> {
         let mut outcome = InventoryServing::default();
         for item in items {
@@ -135,8 +141,8 @@ impl ChainQuery for ActiveChainQuery {
                 outcome.halted = true;
                 return Ok(outcome);
             }
-            if let Some(block) = self.load_active_block_at_height(current_height, hash) {
-                serve(block)?;
+            if let Some(payload) = self.load_active_block_bytes(current_height, hash) {
+                serve(payload)?;
             } else {
                 outcome.not_found.push(*item);
             }
@@ -177,6 +183,7 @@ mod tests {
     use super::*;
     use bitcoin::{BlockHash as WireBlockHash, Txid as WireTxid};
     use bitcoin_rs_chain::NodeStatus;
+    use bitcoin_rs_primitives::Block;
     use bitcoin_rs_primitives::consensus_bytes;
     use std::cell::RefCell;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -222,8 +229,8 @@ mod tests {
         items: &[Inventory],
     ) -> Result<(InventoryServing, Vec<Block>), PeerError> {
         let blocks = RefCell::new(Vec::new());
-        let outcome = query.serve_inventory_blocks(items, &|| true, &mut |block| {
-            blocks.borrow_mut().push(block);
+        let outcome = query.serve_inventory_blocks(items, &|| true, &mut |payload| {
+            blocks.borrow_mut().push(Block::consensus_decode(&payload)?);
             Ok(())
         })?;
         Ok((outcome, blocks.into_inner()))

--- a/crates/p2p/src/dispatch.rs
+++ b/crates/p2p/src/dispatch.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use bitcoin::hashes::Hash as _;
 use bitcoin::p2p::message_blockdata::{GetHeadersMessage, Inventory};
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, Tx, Txid, Wtxid};
+use bitcoin_rs_primitives::{BlockHash, Hash256, Header, Tx, Txid, Wtxid};
 
 use crate::fsm::step;
 use crate::handshake::feature_messages;
@@ -43,14 +43,15 @@ pub trait ChainQuery: Send + Sync {
     /// Serves block inventory one body at a time, in `items` order. For each
     /// block-typed item `headroom` is consulted EXACTLY ONCE, immediately
     /// BEFORE its body load; `false` halts production and sets `halted`
-    /// (I7, I9). Each loaded body is delivered through `serve`; a `serve`
+    /// (I7, I9). Each loaded body is the stored consensus payload, delivered
+    /// through `serve` without a decode/re-encode round trip. A `serve`
     /// error aborts production and propagates. Non-block / unservable items
     /// are collected into `not_found` and never loaded.
     fn serve_inventory_blocks(
         &self,
         items: &[Inventory],
         headroom: &dyn Fn() -> bool,
-        serve: &mut dyn FnMut(Block) -> Result<(), PeerError>,
+        serve: &mut dyn FnMut(bytes::Bytes) -> Result<(), PeerError>,
     ) -> Result<InventoryServing, PeerError>;
 }
 
@@ -267,7 +268,7 @@ fn serve_getdata(
                     let outcome = chain.serve_inventory_blocks(
                         std::slice::from_ref(block_item),
                         headroom,
-                        &mut |block| send(Message::Block(block)),
+                        &mut |payload| send(Message::BlockPayload(payload)),
                     )?;
                     if outcome.halted {
                         return Err(PeerError::Protocol(
@@ -298,8 +299,8 @@ fn serve_getdata_blocks(
     match chain {
         None => send(Message::NotFound(items.to_vec()))?,
         Some(chain) => {
-            let outcome = chain.serve_inventory_blocks(items, headroom, &mut |block| {
-                send(Message::Block(block))
+            let outcome = chain.serve_inventory_blocks(items, headroom, &mut |payload| {
+                send(Message::BlockPayload(payload))
             })?;
             if outcome.halted {
                 return Err(PeerError::Protocol(
@@ -351,6 +352,14 @@ mod tests {
     use crate::peer::{Peer, PeerState};
     use crate::wire::{Message, PeerError};
 
+    fn block_payload_bytes(block: &Block) -> bytes::Bytes {
+        bytes::Bytes::from(bitcoin_rs_primitives::consensus_bytes(block))
+    }
+
+    fn block_payload(block: &Block) -> Message {
+        Message::BlockPayload(block_payload_bytes(block))
+    }
+
     #[derive(Default)]
     struct FakeChain {
         headers: Vec<Header>,
@@ -392,7 +401,7 @@ mod tests {
             &self,
             items: &[Inventory],
             headroom: &dyn Fn() -> bool,
-            serve: &mut dyn FnMut(Block) -> Result<(), PeerError>,
+            serve: &mut dyn FnMut(bytes::Bytes) -> Result<(), PeerError>,
         ) -> Result<InventoryServing, PeerError> {
             let mut outcome = InventoryServing::default();
             for item in items {
@@ -408,7 +417,7 @@ mod tests {
                     outcome.halted = true;
                     return Ok(outcome);
                 }
-                serve(found.clone())?;
+                serve(block_payload_bytes(found))?;
             }
             Ok(outcome)
         }
@@ -446,7 +455,7 @@ mod tests {
             &self,
             _items: &[Inventory],
             _headroom: &dyn Fn() -> bool,
-            _serve: &mut dyn FnMut(Block) -> Result<(), PeerError>,
+            _serve: &mut dyn FnMut(bytes::Bytes) -> Result<(), PeerError>,
         ) -> Result<InventoryServing, PeerError> {
             Ok(InventoryServing::default())
         }
@@ -579,9 +588,12 @@ mod tests {
 
         let responses = dispatch_collect(&mut peer, &message, Some(&chain))?;
 
-        let [Message::Block(found), Message::NotFound(not_found)] = responses.as_slice() else {
-            panic!("expected block plus notfound, got {responses:?}");
+        let [Message::BlockPayload(found), Message::NotFound(not_found)] = responses.as_slice()
+        else {
+            panic!("expected block payload plus notfound, got {responses:?}");
         };
+        let found = Block::consensus_decode(found)
+            .unwrap_or_else(|error| panic!("served payload must decode: {error}"));
         assert_eq!(found.block_hash(), chain.headers[0].compute_hash());
         assert_eq!(not_found, &vec![missing]);
         Ok(())
@@ -628,7 +640,7 @@ mod tests {
             &self,
             items: &[Inventory],
             headroom: &dyn Fn() -> bool,
-            serve: &mut dyn FnMut(Block) -> Result<(), PeerError>,
+            serve: &mut dyn FnMut(bytes::Bytes) -> Result<(), PeerError>,
         ) -> Result<InventoryServing, PeerError> {
             let mut outcome = InventoryServing::default();
             for item in items {
@@ -652,7 +664,7 @@ mod tests {
                     );
                 }
                 self.loads.fetch_add(1, Ordering::Relaxed);
-                serve(found.clone())?;
+                serve(block_payload_bytes(found))?;
             }
             Ok(outcome)
         }
@@ -694,8 +706,8 @@ mod tests {
         assert_eq!(
             emitted,
             vec![
-                Message::Block(block_a),
-                Message::Block(block_b),
+                block_payload(&block_a),
+                block_payload(&block_b),
                 Message::NotFound(vec![tx_inv, unknown]),
             ],
             "streamed emission must equal the pre-change batch shape (I8)"

--- a/crates/p2p/src/wire.rs
+++ b/crates/p2p/src/wire.rs
@@ -61,6 +61,9 @@ pub enum Message {
     Tx(Tx),
     /// `block`
     Block(Block),
+    /// Already-serialized `block` payload. Written as a `block` command
+    /// without re-encoding; the decoder never produces this variant.
+    BlockPayload(bytes::Bytes),
     /// `headers`
     Headers(Vec<Header>),
     /// `sendheaders`
@@ -134,7 +137,7 @@ impl Message {
             Self::GetHeaders(_) => "getheaders",
             Self::MemPool => "mempool",
             Self::Tx(_) => "tx",
-            Self::Block(_) => "block",
+            Self::Block(_) | Self::BlockPayload(_) => "block",
             Self::Headers(_) => "headers",
             Self::SendHeaders => "sendheaders",
             Self::GetAddr => "getaddr",
@@ -179,7 +182,7 @@ impl Message {
             Self::GetBlocks(message) => NetworkMessage::GetBlocks(message.clone()),
             Self::GetHeaders(message) => NetworkMessage::GetHeaders(message.clone()),
             Self::MemPool => NetworkMessage::MemPool,
-            Self::Tx(_) | Self::Block(_) | Self::Headers(_) => {
+            Self::Tx(_) | Self::Block(_) | Self::BlockPayload(_) | Self::Headers(_) => {
                 unreachable!("native payloads are encoded directly")
             }
             Self::SendHeaders => NetworkMessage::SendHeaders,
@@ -266,28 +269,42 @@ pub fn write_message<W: Write + ?Sized>(
     magic: Magic,
     message: &Message,
 ) -> Result<usize, PeerError> {
-    let command = message.command();
-    let payload = encode_payload(message)?;
+    match message {
+        Message::BlockPayload(payload) => write_framed(writer, magic, &message.command(), payload),
+        other => {
+            let command = other.command();
+            let payload = encode_payload(other)?;
+            write_framed(writer, magic, &command, &payload)
+        }
+    }
+}
+
+fn write_framed<W: Write + ?Sized>(
+    writer: &mut W,
+    magic: Magic,
+    command: &CommandString,
+    payload: &[u8],
+) -> Result<usize, PeerError> {
     if payload.len() > MAX_MESSAGE_PAYLOAD {
         return Err(PeerError::PayloadTooLarge(payload.len()));
     }
 
     let mut header = [0u8; HEADER_LEN];
     header[..4].copy_from_slice(&magic.to_bytes());
-    header[4..16].copy_from_slice(&encode_command(&command)?);
+    header[4..16].copy_from_slice(&encode_command(command)?);
     header[16..20].copy_from_slice(
         &u32::try_from(payload.len())
             .map_err(|_| PeerError::PayloadTooLarge(payload.len()))?
             .to_le_bytes(),
     );
-    header[20..24].copy_from_slice(&checksum(&payload));
+    header[20..24].copy_from_slice(&checksum(payload));
 
     // Assemble header and payload into one vectored write so each message is
     // emitted with a single syscall instead of five (avoids header/payload
     // segment splits and per-part syscall overhead on TcpStream).
     let mut slices: &mut [std::io::IoSlice<'_>] = &mut [
         std::io::IoSlice::new(&header),
-        std::io::IoSlice::new(&payload),
+        std::io::IoSlice::new(payload),
     ];
     while !slices.is_empty() {
         match writer.write_vectored(slices) {
@@ -349,7 +366,11 @@ pub fn read_message<R: Read>(
 /// Admission accounts this exact count and `write_message` returns it for
 /// release, so budget accounting and wire emission charge identical bytes.
 pub fn wire_len(message: &Message) -> Result<usize, PeerError> {
-    Ok(HEADER_LEN + encode_payload(message)?.len())
+    let payload_len = match message {
+        Message::BlockPayload(payload) => payload.len(),
+        other => encode_payload(other)?.len(),
+    };
+    Ok(HEADER_LEN + payload_len)
 }
 
 /// Encode only a message payload.
@@ -358,6 +379,7 @@ pub fn encode_payload(message: &Message) -> Result<Vec<u8>, PeerError> {
     match message {
         Message::Tx(tx) => tx.consensus_encode(&mut payload)?,
         Message::Block(block) => block.consensus_encode(&mut payload)?,
+        Message::BlockPayload(bytes) => payload.extend_from_slice(bytes),
         Message::Headers(headers) => {
             let count = u64::try_from(headers.len())
                 .map_err(|_| PeerError::PayloadTooLarge(headers.len()))?;
@@ -736,6 +758,24 @@ mod tests {
     }
 
     #[test]
+    fn block_payload_writes_the_same_frame_as_decoded_block() -> Result<(), PeerError> {
+        let block = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest);
+        let block_bytes = serialize(&block);
+        let native_block = bitcoin_rs_primitives::Block::consensus_decode(&block_bytes)
+            .map_err(super::PeerError::NativeDecode)?;
+        let decoded = super::Message::Block(native_block);
+        let payload = super::Message::BlockPayload(bytes::Bytes::from(block_bytes));
+
+        let mut decoded_wire = Vec::new();
+        let mut payload_wire = Vec::new();
+        write_message(&mut decoded_wire, Magic::REGTEST, &decoded)?;
+        write_message(&mut payload_wire, Magic::REGTEST, &payload)?;
+        assert_eq!(decoded_wire, payload_wire);
+        assert_eq!(wire_len(&decoded)?, wire_len(&payload)?);
+        Ok(())
+    }
+
+    #[test]
     fn write_message_rejects_payload_exceeding_cap() -> Result<(), PeerError> {
         let oversize = MAX_MESSAGE_PAYLOAD + 1;
         let message = super::Message::Unknown {
@@ -763,6 +803,7 @@ mod tests {
             super::Message::Verack,
             super::Message::Headers(vec![bitcoin_rs_primitives::Header::default(); 2_000]),
             super::Message::Block(bitcoin_rs_primitives::Block::default()),
+            super::Message::BlockPayload(bytes::Bytes::from(vec![0_u8; 80])),
             super::Message::Unknown {
                 command: super::command_string("unknown")?,
                 payload: vec![7; 61],

--- a/crates/p2p/tests/core_compat.rs
+++ b/crates/p2p/tests/core_compat.rs
@@ -205,7 +205,7 @@ impl ChainQuery for FakeChain {
         &self,
         items: &[Inventory],
         headroom: &dyn Fn() -> bool,
-        serve: &mut dyn FnMut(Block) -> Result<(), PeerError>,
+        serve: &mut dyn FnMut(bytes::Bytes) -> Result<(), PeerError>,
     ) -> Result<InventoryServing, PeerError> {
         let mut outcome = InventoryServing::default();
         for item in items {
@@ -224,7 +224,7 @@ impl ChainQuery for FakeChain {
                     outcome.halted = true;
                     return Ok(outcome);
                 }
-                serve(self.bodies[&native].clone())?;
+                serve(consensus_bytes(&self.bodies[&native]).into())?;
             } else {
                 outcome.not_found.push(*item);
             }
@@ -261,8 +261,8 @@ fn serve_collect(
     items: &[Inventory],
 ) -> Result<(Vec<Block>, Vec<Inventory>), PeerError> {
     let blocks = std::cell::RefCell::new(Vec::new());
-    let outcome = chain.serve_inventory_blocks(items, &|| true, &mut |block| {
-        blocks.borrow_mut().push(block);
+    let outcome = chain.serve_inventory_blocks(items, &|| true, &mut |payload| {
+        blocks.borrow_mut().push(Block::consensus_decode(&payload)?);
         Ok(())
     })?;
     Ok((blocks.into_inner(), outcome.not_found))
@@ -786,7 +786,9 @@ fn inv_getdata_relay_round_trip_serves_blocks_and_notfounds_misses() -> Result<(
         Some(&chain),
     )?;
     let (served, not_found) = match response.as_slice() {
-        [Message::Block(block), Message::NotFound(items)] => (block, items),
+        [Message::BlockPayload(payload), Message::NotFound(items)] => {
+            (Block::consensus_decode(payload)?, items)
+        }
         other => return Err(format!("unexpected relay response {other:?}").into()),
     };
     assert_eq!(served.block_hash(), genesis.block_hash());
@@ -1077,7 +1079,8 @@ fn reorg_switches_which_chain_a_peer_sees() -> Result<(), Box<dyn Error>> {
         Some(&state),
     )?;
     match response.as_slice() {
-        [Message::Block(block), Message::NotFound(items)] => {
+        [Message::BlockPayload(payload), Message::NotFound(items)] => {
+            let block = Block::consensus_decode(payload)?;
             assert_eq!(block.block_hash(), branch_b[0].compute_hash());
             assert_eq!(
                 items,

--- a/docs/contracts/p2p-wire.md
+++ b/docs/contracts/p2p-wire.md
@@ -23,6 +23,9 @@ normative; it places them under the
 - Message framing, envelope decoder, service flags, and network magic follow
   the inventory and the policy document. v1 frames for handshake and inventory
   commands are byte-identical to rust-bitcoin's `RawNetworkMessage`.
+  `getdata` block serving writes stored consensus payload bytes
+  (`Message::BlockPayload`) without a decode/re-encode round trip. The
+  decoder still types inbound `block` as `Message::Block`.
 
 ### `P2P-02`: Connection lifecycle and peer lease ownership
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Stacked on #458. Serving a block to a peer decoded the stored body, built a `Message::Block`, then `write_message` consensus-encoded it again. At 1–2 MiB that is a full extra copy plus SHA-256d checksum over a buffer we already had.

## What changed

`ChainQuery::serve_inventory_blocks` delivers `bytes::Bytes` (the stored consensus payload). Dispatch emits `Message::BlockPayload`. `write_message` frames that payload without re-encoding. Identity is still checked: the first 80 bytes must decode as a header whose hash matches the inventory item, and the height must still be active.

The decoder is unchanged: inbound `block` is still `Message::Block`. `BlockPayload` is write-only.

## Breaking

- `ChainQuery::serve_inventory_blocks` now takes `FnMut(bytes::Bytes)` instead of `FnMut(Block)`.
- Exhaustive `Message` matches must handle `BlockPayload`.

## Not in this PR

- Dropping the unused `P2pService` download window — next stack
- RPC/HTTP `TCP_NODELAY` — later stack

## Verification

- `cargo clippy -p bitcoin-rs-p2p --features fjall --lib --tests -- -D warnings`
- `cargo test -p bitcoin-rs-p2p --lib --features fjall` — 169 passed
- `cargo test -p bitcoin-rs-p2p --test core_compat --features fjall` — 22 passed

## Related

- #458 — socket owner + vectored writes (this PR's base)
- #217 — P2P owns transport and chain serving
- `P2P-01` in `docs/contracts/p2p-wire.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1e252b6-32f0-4691-b4a1-0a620b71da25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1e252b6-32f0-4691-b4a1-0a620b71da25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

