### PR TITLE
Give mining the consensus merkle fold

### DIFF
--- a/crates/consensus/README.md
+++ b/crates/consensus/README.md
@@ -13,6 +13,8 @@ Rule checks live in small per-subject modules (`bip9`, `bip30`, `bip34`, `bip65`
 `bip66`, `bip68`, `bip112`, `bip113`, `bip141`, `bip143`, `bip341`, `bip342`), surfaced
 through the `verify_transaction` family (with median-time-past and borrowed variants),
 `is_final_tx`, and the `verify_block_rules` family including Merkle-root verification.
+`compute_merkle_root` is the sole pairwise SHA-256d fold (AVX2 or spine) used by
+block rules, witness-commitment checks, and mining candidate assembly.
 `kernel::KernelBlock` parses a serialized block exactly once with
 `bitcoinkernel::Block::new`, yielding the txids and borrowed transaction objects that
 script preparation reuses, and `kernel::KernelContext::verify_tx` verifies a

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -61,7 +61,7 @@ pub use bip113::{MEDIAN_TIME_PAST_WINDOW, locktime_cutoff};
 pub use block_view::BlockView;
 pub use rust_path::{TipState, UtxoView};
 pub use verify_block::{
-    BlockRuleContext, verify_block_rules, verify_block_rules_precomputed,
+    BlockRuleContext, compute_merkle_root, verify_block_rules, verify_block_rules_precomputed,
     verify_merkle_root_with_txids,
 };
 pub use verify_tx::{

--- a/crates/consensus/src/verify_block.rs
+++ b/crates/consensus/src/verify_block.rs
@@ -355,7 +355,7 @@ pub fn block_witness_commitment_matches(block: &Block, wtxids: &[Wtxid]) -> bool
             *wtxid.as_bytes()
         });
     }
-    let Some(root) = merkle_root_bytes(&mut leaves) else {
+    let Some(root) = compute_merkle_root(&mut leaves) else {
         return false;
     };
 
@@ -369,7 +369,13 @@ fn sha256d(data: &[u8]) -> [u8; 32] {
     double_sha256(data).to_le_bytes()
 }
 
-fn merkle_root_bytes(leaves: &mut Vec<[u8; 32]>) -> Option<[u8; 32]> {
+/// Bitcoin merkle root over raw 32-byte leaves.
+///
+/// Duplicates the last leaf on odd levels. Empty input returns `None`.
+/// The vector is reduced in place through the same AVX2/spine walker the
+/// block-rule path uses; mining does not keep a second fold.
+#[must_use]
+pub fn compute_merkle_root(leaves: &mut Vec<[u8; 32]>) -> Option<[u8; 32]> {
     if leaves.is_empty() {
         return None;
     }
@@ -419,10 +425,10 @@ mod tests {
 
     use super::{
         BlockRuleContext, WITNESS_COMMITMENT_PREFIX, block_has_witness,
-        block_merkle_root_matches_txids, is_coinbase, merkle_root_and_mutation,
-        merkle_root_and_mutation_borrowed, merkle_root_and_mutation_scalar, merkle_root_bytes,
-        merkle_root_spine, sha256d, verify_block_rules, verify_block_rules_precomputed,
-        verify_merkle_root_with_txids,
+        block_merkle_root_matches_txids, compute_merkle_root, is_coinbase,
+        merkle_root_and_mutation, merkle_root_and_mutation_borrowed,
+        merkle_root_and_mutation_scalar, merkle_root_spine, sha256d, verify_block_rules,
+        verify_block_rules_precomputed, verify_merkle_root_with_txids,
     };
     use crate::ConsensusError;
 
@@ -729,7 +735,7 @@ mod tests {
         for leaf_count in 1..=33 {
             let leaves = txids(leaf_count);
             let mut bytes: Vec<[u8; 32]> = leaves.iter().map(|txid| *txid.as_bytes()).collect();
-            let bytes_root = merkle_root_bytes(&mut bytes);
+            let bytes_root = compute_merkle_root(&mut bytes);
             let mut hashes = leaves;
             let txid_root = merkle_root_and_mutation(&mut hashes).map(|(root, _)| *root.as_bytes());
             assert_eq!(bytes_root, txid_root, "leaf count {leaf_count}");
@@ -951,6 +957,30 @@ mod tests {
     }
 
     #[test]
+    fn compute_merkle_root_matches_the_txid_walker() {
+        assert_eq!(compute_merkle_root(&mut Vec::new()), None);
+
+        let one = *txid(1).as_bytes();
+        let mut single = vec![one];
+        assert_eq!(compute_merkle_root(&mut single), Some(one));
+
+        let leaves: Vec<Txid> = (1u8..=7).map(txid).collect();
+        let mut bytes: Vec<[u8; 32]> = leaves.iter().map(|id| *id.as_bytes()).collect();
+        let mut txids = leaves.clone();
+        let Some((root, _)) = merkle_root_and_mutation_borrowed(&leaves) else {
+            panic!("non-empty tree");
+        };
+        let Some(from_bytes) = compute_merkle_root(&mut bytes) else {
+            panic!("non-empty bytes tree");
+        };
+        let Some((in_place, _)) = merkle_root_and_mutation(&mut txids) else {
+            panic!("non-empty in-place tree");
+        };
+        assert_eq!(from_bytes, *root.as_bytes());
+        assert_eq!(from_bytes, *in_place.as_bytes());
+    }
+
+    #[test]
     fn merkle_root_error_precedes_mutation_error() {
         // Two duplicate transactions give a valid merkle root but the block
         // header is wrong. The wrong root must be reported before the mutation.
@@ -1112,7 +1142,7 @@ mod tests {
                 }
             })
             .collect();
-        let root = merkle_root_bytes(&mut leaves).unwrap_or([0u8; 32]);
+        let root = compute_merkle_root(&mut leaves).unwrap_or([0u8; 32]);
         let mut buffer = [0u8; 64];
         buffer[..32].copy_from_slice(&root);
         buffer[32..].copy_from_slice(reserved);

--- a/crates/mining/README.md
+++ b/crates/mining/README.md
@@ -7,9 +7,10 @@ Transport-neutral block-candidate assembly for solo mining.
 The `policy` module selects dependency-closed packages by modified fee rate
 within weight, serialized-size, and sigop limits. The `coinbase` module funds
 the coinbase (subsidy plus actual fees) and, when `SegWit` is active, attaches the
-witness commitment. [`Candidate::solve`](crate::Candidate::solve) turns that
-candidate into a header that meets its compact target. Failures surface as
-[`MiningError`](crate::MiningError).
+witness commitment through consensus `compute_merkle_root` (the same AVX2/spine
+fold block rules use).
+[`Candidate::solve`](crate::Candidate::solve) turns that candidate into a header
+that meets its compact target. Failures surface as [`MiningError`](crate::MiningError).
 
 The crate owns the domain `Candidate`, [`Candidate::solve`](crate::Candidate::solve),
 and the node-facing mining contract ([`MiningControl`](crate::MiningControl),

--- a/crates/mining/src/template.rs
+++ b/crates/mining/src/template.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use bitcoin_rs_chain::compact_is_met_by;
+use bitcoin_rs_consensus::compute_merkle_root;
 use bitcoin_rs_mempool::MempoolMiningSnapshot;
 use bitcoin_rs_primitives::{
     Block, BlockHash, Hash256, Header, Network, Tx, Txid, Wtxid, encode::double_sha256,
@@ -168,7 +169,10 @@ impl Candidate {
         let mut txs = Vec::with_capacity(self.transactions.len().saturating_add(1));
         txs.push(self.coinbase.clone());
         txs.extend(self.transactions.iter().map(|tx| (*tx.tx).clone()));
-        let merkle_root = merkle_root_from_txids(txs.iter().map(Tx::txid));
+        let merkle_root = merkle_root_from_txids(
+            core::iter::once(self.coinbase.txid())
+                .chain(self.transactions.iter().map(|tx| tx.txid)),
+        );
         Block {
             header: Header {
                 version: self.version,
@@ -454,8 +458,7 @@ fn depends(tx: &Tx, tx_positions: &BTreeMap<Txid, u32>) -> Vec<u32> {
     depends
 }
 
-/// BIP141 witness merkle root: pairwise `SHA256d` fold duplicating the last leaf
-/// on odd levels. The coinbase contributes the all-zero wtxid leaf.
+/// BIP141 witness merkle root. The coinbase contributes the all-zero wtxid leaf.
 fn witness_merkle_root(
     snapshot: &MempoolMiningSnapshot,
     ordered: &[usize],
@@ -466,39 +469,23 @@ fn witness_merkle_root(
     for &index in ordered {
         leaves.push(*snapshot.entries[index].wtxid.as_bytes());
     }
-    merkle_root_from_leaves(leaves)
+    merkle_root_from_leaves(&mut leaves)
 }
 
 fn merkle_root_from_txids(txids: impl IntoIterator<Item = Txid>) -> Hash256 {
-    let leaves = txids
+    let mut leaves = txids
         .into_iter()
         .map(|txid| *txid.as_bytes())
         .collect::<Vec<_>>();
-    merkle_root_from_leaves(leaves).unwrap_or_else(|_| Hash256::from_le_bytes(&[0_u8; 32]))
+    merkle_root_from_leaves(&mut leaves).unwrap_or_else(|_| Hash256::from_le_bytes(&[0_u8; 32]))
 }
 
-fn merkle_root_from_leaves(mut leaves: Vec<[u8; 32]>) -> Result<Hash256, MiningError> {
-    if leaves.is_empty() {
-        return Err(MiningError::CandidateScalarOverflow {
+fn merkle_root_from_leaves(leaves: &mut Vec<[u8; 32]>) -> Result<Hash256, MiningError> {
+    compute_merkle_root(leaves)
+        .map(|bytes| Hash256::from_le_bytes(&bytes))
+        .ok_or(MiningError::CandidateScalarOverflow {
             field: "merkle root",
-        });
-    }
-
-    while leaves.len() > 1 {
-        let original_len = leaves.len();
-        let mut next = Vec::with_capacity(original_len.div_ceil(2));
-        for pos in 0..original_len.div_ceil(2) {
-            let left = leaves[2 * pos];
-            let right = leaves[(2 * pos + 1).min(original_len - 1)];
-            let mut pair = [0_u8; 64];
-            pair[..32].copy_from_slice(&left);
-            pair[32..].copy_from_slice(&right);
-            next.push(*double_sha256(&pair).as_byte_array());
-        }
-        leaves = next;
-    }
-
-    Ok(Hash256::from_le_bytes(&leaves[0]))
+        })
 }
 
 fn witness_commitment_hash(witness_merkle_root: &Hash256, reserved: &[u8; 32]) -> Hash256 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Destination

Delete mining’s second Merkle engine. Candidate header roots and BIP141 witness commitments use the same `compute_merkle_root` walker block rules already own (AVX2 batch or allocation-free spine). One fold, one byte order, one consumer.

Stacked on #451 (`cursor/mining-candidate-bench-1522`). Parent wayfinder: #151.

## Contract

- Consensus owns pairwise SHA-256d reduction. Mining assembles leaves (coinbase-zero wtxid for BIP141; stored txids for the header) and does not reimplement the tree.
- `compute_merkle_root` is the public in-place reducer previously private as `merkle_root_bytes`. Empty input is `None`.
- Header merkle uses already-computed candidate txids, not a second serialization/hash of cloned transactions.

## Proof

- `cargo test -p bitcoin-rs-consensus --no-default-features compute_merkle_root`
- `cargo test -p bitcoin-rs-mining` (includes the pinned BIP141 witness-commitment vector)
- `cargo clippy -p bitcoin-rs-consensus --no-default-features --all-targets -- -D warnings`
- `cargo clippy -p bitcoin-rs-mining --all-targets -- -D warnings`

## Out of scope

- Package-selection recounts and BIP68 scans (next stacked PR)
- Coordinator lock scopes / hashps parent walk
- Numeric p95 budgets

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd4a1918-79c1-4cad-bc1b-8a144b3699bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd4a1918-79c1-4cad-bc1b-8a144b3699bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

