### PR TITLE
Drop the unused P2pService download window

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -100,7 +100,8 @@ A peer holding up the apply frontier by failing to deliver a frontier block it w
 helpers. Ready snapshots carry `PeerSource`, and identity-checked table
 methods are what authorize a mutation. Address equality alone never does.
 `BlockSync` owns the production download window and may call those table
-methods directly. See `docs/solutions/architecture-patterns/p2p-owns-peer-lifecycle.md`.
+methods directly. `P2pService` does not hold a second window. See
+`docs/solutions/architecture-patterns/p2p-owns-peer-lifecycle.md`.
 
 ### assumevalid
 Skipping script-signature verification for blocks at or below a trusted height while performing every other consensus check. Mainnet defaults to the hash-pinned anchor below; other networks default to height 0. `--assume-valid-height 0` requests full verification; a custom nonzero height skips without hash gating.

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1801,7 +1801,6 @@ impl NodeState {
                 outbound_peer_target: P2P_OUTBOUND_QUEUE_LIMIT,
                 outbound_queue_limit: P2P_OUTBOUND_QUEUE_LIMIT,
                 inbound_block_queue_limit: INBOUND_BLOCK_CHANNEL_LIMIT,
-                download_budget: bitcoin_rs_p2p::default_sync_budget(),
             },
             Arc::clone(&shutdown),
         ));

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -51,7 +51,7 @@ type ExpectedBlockHashes = SmallVec<[Hash256; RECEIVED_BLOCK_BUDGET]>;
 ///
 /// Owns the production [`DownloadWindow`]. Session identity stays on the
 /// shared [`PeerTable`]; this orchestrator calls identity-checked table
-/// methods and does not schedule through `P2pService::select_download_peers`.
+/// methods. The P2P service does not hold a second window.
 pub struct BlockSync {
     handles: crate::apply::Chainstate,
     followers: crate::chain_effects::ChainFollowers,

--- a/crates/p2p/src/connection.rs
+++ b/crates/p2p/src/connection.rs
@@ -447,15 +447,6 @@ impl PeerLifecycle {
         self.table.lease_source(source)
     }
 
-    /// Selects and disconnects a ready address while excluding same-address
-    /// replacement registration from the selection through the removal.
-    pub(crate) fn disconnect_selected_ready(
-        &self,
-        select: impl FnOnce() -> Option<SocketAddr>,
-    ) -> Option<(SocketAddr, PeerSource)> {
-        self.table.disconnect_selected_ready(select)
-    }
-
     /// Sends a message only while `source` remains the current connection.
     ///
     /// The source check and lease lookup share one read-side critical section,

--- a/crates/p2p/src/peer_table.rs
+++ b/crates/p2p/src/peer_table.rs
@@ -300,22 +300,6 @@ impl PeerTable {
             })
             .collect()
     }
-
-    /// Selects and disconnects a ready address while holding the table lock
-    /// from selection through removal, so a replacement cannot be chosen.
-    pub fn disconnect_selected_ready(
-        &self,
-        select: impl FnOnce() -> Option<SocketAddr>,
-    ) -> Option<(SocketAddr, PeerSource)> {
-        let mut entries = self.entries.write();
-        let addr = select()?;
-        let entry = entries.get(&addr)?;
-        entry.info.as_ref()?;
-        let source = entry.lease.source(addr);
-        let removed = entries.remove(&addr)?;
-        removed.lease.cancel();
-        Some((addr, source))
-    }
 }
 
 #[cfg(test)]

--- a/crates/p2p/src/service.rs
+++ b/crates/p2p/src/service.rs
@@ -19,9 +19,6 @@ use parking_lot::{Mutex, RwLock};
 use thiserror::Error;
 
 use crate::connection::{PeerLifecycle, PeerSource};
-use crate::download_window::{
-    DownloadWindow, FanoutCandidate, SyncBudget, configure_request_mode, statically_fanout_eligible,
-};
 use crate::listener::ListenerError;
 
 const DEFAULT_OUTBOUND_TARGET: usize = 8;
@@ -57,9 +54,6 @@ pub struct P2pServiceConfig {
     pub outbound_queue_limit: usize,
     /// Inbound block queue capacity.
     pub inbound_block_queue_limit: usize,
-    /// Budget for the service-held download window. Production scheduling
-    /// uses `BlockSync`'s window.
-    pub download_budget: SyncBudget,
 }
 
 impl Default for P2pServiceConfig {
@@ -75,7 +69,6 @@ impl Default for P2pServiceConfig {
             outbound_peer_target: DEFAULT_OUTBOUND_TARGET,
             outbound_queue_limit: DEFAULT_OUTBOUND_QUEUE_LIMIT,
             inbound_block_queue_limit: DEFAULT_INBOUND_BLOCK_QUEUE_LIMIT,
-            download_budget: crate::default_sync_budget(),
         }
     }
 }
@@ -146,9 +139,6 @@ pub struct P2pService {
     inbound_headers_rx: Arc<Mutex<Receiver<crate::InboundHeaders>>>,
     inbound_blocks_tx: Sender<crate::InboundBlock>,
     inbound_blocks_rx: Arc<Mutex<Receiver<crate::InboundBlock>>>,
-    /// Service-held window. Production `BlockSync` owns a separate window
-    /// and does not call [`Self::select_download_peers`].
-    download_window: Arc<Mutex<DownloadWindow>>,
     workers: Mutex<Option<Workers>>,
     /// Per-start cancellation observed by listener and connection threads.
     /// A failed start leaves this token asserted; the next start installs a
@@ -169,7 +159,6 @@ impl P2pService {
     /// Creates an unstarted P2P service and allocates all P2P-owned state.
     #[must_use]
     pub fn new(config: P2pServiceConfig, shutdown: Arc<AtomicBool>) -> Self {
-        let download_budget = config.download_budget;
         let (outbound_tx, outbound_rx) = crossbeam_channel::bounded(config.outbound_queue_limit);
         let (inbound_headers_tx, inbound_headers_rx) = crossbeam_channel::unbounded();
         let (inbound_blocks_tx, inbound_blocks_rx) =
@@ -189,7 +178,6 @@ impl P2pService {
             inbound_headers_rx: Arc::new(Mutex::new(inbound_headers_rx)),
             inbound_blocks_tx,
             inbound_blocks_rx: Arc::new(Mutex::new(inbound_blocks_rx)),
-            download_window: Arc::new(Mutex::new(DownloadWindow::new(download_budget))),
             workers: Mutex::new(None),
         }
     }
@@ -207,13 +195,7 @@ impl P2pService {
     ) -> Result<(), P2pServiceError> {
         let chain_query = chain_query.cloned();
         let sync_wake_tx = sync_wake_tx.cloned();
-        let scheduler_window = Arc::clone(&self.download_window);
         let peer_ready = peer_ready.clone();
-        let peer_ready: Arc<dyn Fn(crate::PeerSource) + Send + Sync> =
-            Arc::new(move |source: crate::PeerSource| {
-                scheduler_window.lock().forget_peer(source.addr);
-                peer_ready(source);
-            });
         let mut slot = self.workers.lock();
         if slot.is_some() {
             return Err(P2pServiceError::AlreadyStarted);
@@ -645,127 +627,6 @@ impl P2pService {
         self.lifecycle.disconnect_source(source)
     }
 
-    /// Selects source-bearing peers from the service-held download window.
-    ///
-    /// Production `BlockSync` owns a separate window and does not call this
-    /// helper. The lifecycle snapshot and this window are still read in
-    /// lifecycle-before-window order so a future caller cannot invert locks.
-    #[must_use]
-    pub fn select_download_peers(&self, our_height: u32, now: Instant) -> crate::SyncPeerSelection {
-        // Keep lifecycle-before-window ordering consistent with staller
-        // eviction. Taking the window first and then snapshotting lifecycle
-        // state would permit a lock inversion.
-        let ready_peers = self.lifecycle.ready_peers();
-        let mut window = self.download_window.lock();
-        let candidates: Vec<FanoutCandidate> = ready_peers
-            .iter()
-            .filter_map(|peer| {
-                let height = u32::try_from(peer.info.start_height).ok()?;
-                (height > our_height).then_some(FanoutCandidate {
-                    peer: crate::SyncPeer {
-                        addr: peer.source.addr,
-                        start_height: peer.info.start_height,
-                    },
-                    fanout_eligible: statically_fanout_eligible(&peer.info)
-                        && !window.peer_has_expired_pending(peer.source.addr, now)
-                        && !window.peer_in_staller_cooldown(peer.source.addr, now),
-                    soft_blocked: window.peer_has_expired_pending(peer.source.addr, now)
-                        || window.peer_in_staller_cooldown(peer.source.addr, now),
-                })
-            })
-            .collect();
-        let preferred = configure_request_mode(&mut window, &candidates, now);
-        crate::SyncPeerSelection {
-            header_peer: preferred.or_else(|| {
-                candidates
-                    .iter()
-                    .max_by_key(|candidate| candidate.peer.start_height)
-                    .map(|candidate| candidate.peer)
-            }),
-            request_peers: candidates
-                .iter()
-                .filter(|candidate| !candidate.soft_blocked)
-                .map(|candidate| candidate.peer)
-                .collect(),
-            probe_peers: candidates.iter().map(|candidate| candidate.peer).collect(),
-        }
-    }
-
-    /// Returns the highest ready peer that can extend `our_height`.
-    #[must_use]
-    pub fn best_header_peer(&self, our_height: u32) -> Option<crate::SyncPeer> {
-        self.lifecycle
-            .ready_peers()
-            .into_iter()
-            .filter_map(|peer| {
-                let height = u32::try_from(peer.info.start_height).ok()?;
-                (height > our_height).then_some(crate::SyncPeer {
-                    addr: peer.source.addr,
-                    start_height: peer.info.start_height,
-                })
-            })
-            .fold(None, |best, peer| {
-                if best
-                    .is_none_or(|current: crate::SyncPeer| current.start_height < peer.start_height)
-                {
-                    Some(peer)
-                } else {
-                    best
-                }
-            })
-    }
-
-    /// Selects ready witness peers for a one-shot cold-front hedge.
-    #[must_use]
-    pub fn cold_front_hedge_peers(
-        &self,
-        owner: SocketAddr,
-        front_height: u32,
-        now: Instant,
-    ) -> Vec<crate::SyncPeer> {
-        let candidates = self
-            .lifecycle
-            .ready_peers()
-            .into_iter()
-            .filter(|peer| {
-                peer.source.addr != owner
-                    && statically_fanout_eligible(&peer.info)
-                    && u32::try_from(peer.info.start_height)
-                        .is_ok_and(|height| height >= front_height)
-            })
-            .map(|peer| crate::SyncPeer {
-                addr: peer.source.addr,
-                start_height: peer.info.start_height,
-            });
-        let window = self.download_window.lock();
-        candidates
-            .filter(|peer| {
-                !window.peer_has_expired_pending(peer.addr, now)
-                    && !window.peer_in_staller_cooldown(peer.addr, now)
-            })
-            .collect()
-    }
-
-    /// Releases scheduler assignments for connections no longer live.
-    pub fn release_disconnected_download_peers(&self) {
-        let live = self.lifecycle.live_addresses();
-        self.download_window
-            .lock()
-            .release_disconnected_peers(|peer| live.contains(peer));
-    }
-
-    /// Selects and disconnects a window owner without re-resolving its address
-    /// after a same-address replacement can have registered.
-    pub fn select_and_disconnect_download_peer(
-        &self,
-        select: impl FnOnce(&mut DownloadWindow) -> Option<SocketAddr>,
-    ) -> Option<(SocketAddr, PeerSource)> {
-        self.lifecycle.disconnect_selected_ready(|| {
-            let mut window = self.download_window.lock();
-            select(&mut window)
-        })
-    }
-
     /// Returns a cloned inbound headers receiver for the node sync coordinator.
     #[must_use]
     pub fn inbound_headers_receiver(&self) -> Arc<Mutex<Receiver<crate::InboundHeaders>>> {
@@ -788,16 +649,6 @@ impl P2pService {
     #[must_use]
     pub fn inbound_blocks_sender(&self) -> Sender<crate::InboundBlock> {
         self.inbound_blocks_tx.clone()
-    }
-
-    /// Runs a download-window operation under the P2P owner's lock.
-    pub fn with_download_window<R>(&self, operation: impl FnOnce(&mut DownloadWindow) -> R) -> R {
-        operation(&mut self.download_window.lock())
-    }
-
-    /// Replaces the P2P-owned download budget.
-    pub fn install_download_budget(&self, budget: SyncBudget) {
-        self.with_download_window(|window| *window = DownloadWindow::new(budget));
     }
 }
 

--- a/docs/solutions/architecture-patterns/p2p-owns-peer-lifecycle.md
+++ b/docs/solutions/architecture-patterns/p2p-owns-peer-lifecycle.md
@@ -40,6 +40,7 @@ operation cannot publish, send to, or cancel a replacement.
 - The node starts one `P2pService`. RPC applies the same network-activity
   transition (`apply_network_active`) on the shared flag and `PeerTable`.
   Production block-download scheduling stays on `BlockSync`'s download window.
+  `P2pService` does not keep a shadow window or call `forget_peer` on ready.
 - Ready-peer selection carries `PeerSource` through the final send.
 - Disconnect requests caused by received data use the data's `PeerSource`.
 - Same-address replacement tests must cover stale publication and stale


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Stacked on #482. `P2pService` allocated a `DownloadWindow` that production never scheduled through. On peer-ready it called `forget_peer` on that unused copy; `BlockSync::on_peer_ready` already forgets on the real window. The service APIs (`select_download_peers`, `cold_front_hedge_peers`, `with_download_window`, …) had no callers.

## What changed

`P2pService` no longer holds a download window or a `download_budget`. Ready notification is passed through to `BlockSync` unchanged. `PeerTable::disconnect_selected_ready` is deleted with the only caller.

`BlockSync` remains the single owner of production download-window state.

## Breaking

- `P2pServiceConfig::download_budget` is gone
- `select_download_peers`, `best_header_peer`, `cold_front_hedge_peers`, `release_disconnected_download_peers`, `select_and_disconnect_download_peer`, `with_download_window`, `install_download_budget` are gone
- `PeerTable::disconnect_selected_ready` is gone

## Not in this PR

- RPC/HTTP `TCP_NODELAY` — next stack

## Verification

- `cargo clippy -p bitcoin-rs-p2p --features fjall --lib --tests -- -D warnings`
- `cargo clippy -p bitcoin-rs-node --no-default-features --features fjall --lib -- -D warnings`
- `cargo test -p bitcoin-rs-p2p --lib --features fjall -- service:: peer_table::` — 13 passed

## Related

- #458 — peer socket owner
- #482 — serve stored block bodies (this PR's base)
- #217 — one owner for P2P scheduling state

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1e252b6-32f0-4691-b4a1-0a620b71da25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1e252b6-32f0-4691-b4a1-0a620b71da25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

