### PR TITLE
Stop mining from re-validating the mempool snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "bitcoin-rs-script",
  "compact_str",
  "criterion",
+ "hashbrown 0.17.1",
  "proptest",
  "thiserror",
 ]

--- a/crates/mining/Cargo.toml
+++ b/crates/mining/Cargo.toml
@@ -17,6 +17,7 @@ bitcoin-rs-consensus.workspace = true
 bitcoin-rs-script.workspace = true
 bitcoin-rs-chain.workspace = true
 bitcoin-rs-mempool.workspace = true
+hashbrown.workspace = true
 compact_str.workspace = true
 thiserror.workspace = true
 

--- a/crates/mining/README.md
+++ b/crates/mining/README.md
@@ -5,7 +5,9 @@ Transport-neutral block-candidate assembly for solo mining.
 `assemble_candidate` builds a [`Candidate`](crate::Candidate) from a
 [`CandidateContext`](crate::CandidateContext) and a mempool mining snapshot.
 The `policy` module selects dependency-closed packages by modified fee rate
-within weight, serialized-size, and sigop limits. The `coinbase` module funds
+within weight, serialized-size, and sigop limits. It consumes the snapshot's
+ancestor lists and consensus `is_final_tx`; it does not re-validate the
+mempool DAG. The `coinbase` module funds
 the coinbase (subsidy plus actual fees) and, when `SegWit` is active, attaches the
 witness commitment through consensus `compute_merkle_root` (the same AVX2/spine
 fold block rules use).

--- a/crates/mining/src/coinbase.rs
+++ b/crates/mining/src/coinbase.rs
@@ -31,12 +31,6 @@ pub enum MiningError {
         /// Invalid ancestor position.
         ancestor: u32,
     },
-    /// The immutable snapshot's dependency graph contains a cycle.
-    #[error("snapshot dependency graph contains a cycle at entry {entry}")]
-    DependencyCycle {
-        /// Snapshot position at which the cycle was detected.
-        entry: usize,
-    },
     /// A selected fee sum exceeded the satoshi range.
     #[error("selected transaction fees overflow the satoshi range")]
     FeeOverflow,
@@ -65,7 +59,7 @@ pub(crate) fn build_coinbase(
     height: u32,
     subsidy_halving_interval: u32,
     fees: u64,
-    payout: Vec<u8>,
+    payout: &[u8],
     witness_commitment: Option<&Hash256>,
 ) -> Result<Tx, MiningError> {
     let value = bitcoin_rs_consensus::block_subsidy(height, subsidy_halving_interval)
@@ -75,7 +69,7 @@ pub(crate) fn build_coinbase(
     let mut witness = Vec::new();
     let mut outputs = vec![TxOut {
         value,
-        script_pubkey: payout,
+        script_pubkey: payout.to_vec(),
     }];
 
     if let Some(commitment) = witness_commitment {

--- a/crates/mining/src/policy.rs
+++ b/crates/mining/src/policy.rs
@@ -1,9 +1,10 @@
 #[cfg(test)]
 use std::cell::Cell;
-use std::collections::BTreeMap;
+use std::collections::HashSet;
 
+use bitcoin_rs_consensus::is_final_tx;
 use bitcoin_rs_mempool::{MempoolMiningSnapshot, SnapshotEntry};
-use bitcoin_rs_primitives::Tx;
+use bitcoin_rs_primitives::{Tx, Txid};
 
 use crate::MiningError;
 use crate::template::CandidateContext;
@@ -12,12 +13,6 @@ use crate::template::CandidateContext;
 thread_local! {
     static RESIDUAL_PACKAGE_CONSTRUCTIONS: Cell<usize> = const { Cell::new(0) };
 }
-
-/// BIP113 locktime threshold: values below this are height-based, at or above
-/// are timestamp-based.
-const LOCKTIME_THRESHOLD: u32 = 500_000_000;
-/// Sequence value that marks an input as final (disables locktime).
-const SEQUENCE_FINAL: u32 = 0xffff_ffff;
 
 /// One dependency-closed package selected for a candidate.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -63,6 +58,7 @@ pub(crate) fn select_packages(
     let mut used_size = reserved_size;
     let mut used_sigops = reserved_sigops;
     let mut fees = 0_u64;
+    let pooled: HashSet<Txid> = snapshot.entries.iter().map(|entry| entry.txid).collect();
 
     for index in 0..snapshot.entries.len() {
         if (context.max_weight > 0 && used_weight >= context.max_weight)
@@ -75,7 +71,7 @@ pub(crate) fn select_packages(
         }
 
         let package = residual_package(snapshot, index, &selected)?;
-        if !package_is_final(context, snapshot, &package) {
+        if !package_is_final(context, snapshot, &pooled, &package) {
             continue;
         }
 
@@ -142,13 +138,15 @@ fn residual_package(
             indices.push(ancestor);
         }
     }
-    indices.push(tip);
 
-    // Parents have strictly fewer in-pool ancestors than their descendants, so
-    // sorting by ancestor count yields a deterministic topological order. Equal
-    // counts break on snapshot position.
+    // Snapshot ancestor lists are a mempool invariant. Mining does not re-check
+    // the DAG; parents have strictly fewer in-pool ancestors, so sorting by
+    // that count is topological. Equal counts break on snapshot position.
+    if indices.is_empty() {
+        return Ok(single_entry_package(tip_entry, tip));
+    }
+    indices.push(tip);
     indices.sort_by_key(|&index| (snapshot.entries[index].ancestors.len(), index));
-    detect_cycles(snapshot, tip, &indices)?;
 
     let mut fee = 0_u64;
     let mut weight = 0_u64;
@@ -179,74 +177,32 @@ fn residual_package(
     })
 }
 
-fn detect_cycles(
-    snapshot: &MempoolMiningSnapshot,
-    tip: usize,
-    ordered: &[usize],
-) -> Result<(), MiningError> {
-    let positions: BTreeMap<usize, usize> = ordered
-        .iter()
-        .copied()
-        .enumerate()
-        .map(|(position, index)| (index, position))
-        .collect();
-
-    for &index in ordered {
-        for &ancestor in &snapshot.entries[index].ancestors {
-            let ancestor = usize::try_from(ancestor).map_err(|_| MiningError::MissingAncestor {
-                entry: index,
-                ancestor,
-            })?;
-            let Some(&ancestor_position) = positions.get(&ancestor) else {
-                continue;
-            };
-            let self_position = positions[&index];
-            if ancestor_position >= self_position {
-                return Err(MiningError::DependencyCycle { entry: tip });
-            }
-        }
+fn single_entry_package(entry: &SnapshotEntry, index: usize) -> SelectedPackage {
+    SelectedPackage {
+        indices: vec![index],
+        fee: entry.fee,
+        weight: entry.weight,
+        size: u64::from(entry.size),
+        sigop_cost: u64::from(entry.sigop_cost),
     }
-    Ok(())
 }
 
 fn package_is_final(
     context: &CandidateContext,
     snapshot: &MempoolMiningSnapshot,
+    pooled: &HashSet<Txid>,
     package: &SelectedPackage,
 ) -> bool {
     package.indices.iter().all(|&index| {
         let entry = &snapshot.entries[index];
         is_final_tx(&entry.tx, context.height, context.locktime_cutoff)
-            && next_block_sequence_locks_final(context, snapshot, &entry.tx)
+            && next_block_sequence_locks_final(context, pooled, &entry.tx)
     })
-}
-
-/// Inlined BIP113/BIP68 finality check matching consensus `is_final_tx`.
-///
-/// - locktime == 0: always final.
-/// - locktime < `LOCKTIME_THRESHOLD`: height-based; final iff locktime < `block_height`.
-/// - locktime >= `LOCKTIME_THRESHOLD`: timestamp-based; final iff locktime < `locktime_cutoff`.
-/// - all inputs sequence == `SEQUENCE_FINAL`: final regardless of locktime.
-fn is_final_tx(tx: &Tx, block_height: u32, locktime_cutoff: u32) -> bool {
-    if tx.lock_time == 0 {
-        return true;
-    }
-    let threshold = if tx.lock_time < LOCKTIME_THRESHOLD {
-        block_height
-    } else {
-        locktime_cutoff
-    };
-    if tx.lock_time < threshold {
-        return true;
-    }
-    tx.inputs
-        .iter()
-        .all(|input| input.sequence == SEQUENCE_FINAL)
 }
 
 fn next_block_sequence_locks_final(
     context: &CandidateContext,
-    snapshot: &MempoolMiningSnapshot,
+    pooled: &HashSet<Txid>,
     tx: &Tx,
 ) -> bool {
     if !context.csv_active {
@@ -256,17 +212,12 @@ fn next_block_sequence_locks_final(
         return true;
     }
     tx.inputs.iter().all(|input| {
-        let sequence = input.sequence;
-        let parent_unconfirmed = snapshot
-            .entries
-            .iter()
-            .any(|entry| entry.txid == input.previous_output.txid);
-        if !parent_unconfirmed {
+        if !pooled.contains(&input.previous_output.txid) {
             return true;
         }
         bitcoin_rs_consensus::bip68::sequence_lock_satisfied(
             tx.version,
-            sequence,
+            input.sequence,
             context.height,
             context.locktime_cutoff,
             context.height,

--- a/crates/mining/src/template.rs
+++ b/crates/mining/src/template.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use bitcoin_rs_chain::compact_is_met_by;
@@ -7,6 +6,7 @@ use bitcoin_rs_mempool::MempoolMiningSnapshot;
 use bitcoin_rs_primitives::{
     Block, BlockHash, Hash256, Header, Network, Tx, Txid, Wtxid, encode::double_sha256,
 };
+use hashbrown::HashMap;
 
 use crate::MiningError;
 use crate::coinbase::{WITNESS_RESERVED_VALUE, build_coinbase};
@@ -273,7 +273,7 @@ fn coinbase_reservation(
         context.height,
         context.network.subsidy_halving_interval(),
         0,
-        payout.to_vec(),
+        payout,
         context.segwit_active.then_some(&dummy_commitment),
     )?;
     let size = u64::try_from(reservation.total_size()).map_err(|_| {
@@ -359,7 +359,7 @@ fn finish_candidate(
         context.height,
         context.network.subsidy_halving_interval(),
         body.fees,
-        payout.to_vec(),
+        payout,
         witness_commitment.as_ref(),
     )?;
     let coinbase_value = coinbase
@@ -418,7 +418,7 @@ fn candidate_transactions(
     snapshot: &MempoolMiningSnapshot,
     ordered: &[usize],
 ) -> Result<Vec<CandidateTransaction>, MiningError> {
-    let mut tx_positions = BTreeMap::<Txid, u32>::new();
+    let mut tx_positions = HashMap::<Txid, u32>::with_capacity(ordered.len());
     for (offset, &index) in ordered.iter().enumerate() {
         let position = u32::try_from(offset.saturating_add(1)).map_err(|_| {
             MiningError::CandidateScalarOverflow {
@@ -447,7 +447,7 @@ fn candidate_transactions(
     Ok(transactions)
 }
 
-fn depends(tx: &Tx, tx_positions: &BTreeMap<Txid, u32>) -> Vec<u32> {
+fn depends(tx: &Tx, tx_positions: &HashMap<Txid, u32>) -> Vec<u32> {
     let mut depends = tx
         .inputs
         .iter()

--- a/crates/mining/tests/policy_pareto.rs
+++ b/crates/mining/tests/policy_pareto.rs
@@ -397,7 +397,7 @@ fn non_final_packages_are_skipped() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn missing_and_cyclic_ancestors_fail_assembly() {
+fn missing_ancestors_fail_assembly_without_rechecking_the_dag() {
     let missing = MempoolMiningSnapshot {
         sequence: 1,
         entries: vec![snapshot_entry(
@@ -415,6 +415,8 @@ fn missing_and_cyclic_ancestors_fail_assembly() {
         Err(MiningError::MissingAncestor { .. })
     ));
 
+    // Cyclic ancestor lists are a mempool snapshot defect. Mining orders by
+    // ancestor count and does not run a second DAG checker.
     let cyclic = MempoolMiningSnapshot {
         sequence: 2,
         entries: vec![
@@ -422,10 +424,9 @@ fn missing_and_cyclic_ancestors_fail_assembly() {
             snapshot_entry(Arc::new(independent_tx(2)), 1_000, 0, 100, 100, 0, vec![0]),
         ],
     };
-    assert!(matches!(
-        assemble_candidate(&context(4_000_000, 4_000_000, 80_000), &cyclic, &[0x51],),
-        Err(MiningError::DependencyCycle { .. })
-    ));
+    let assembled = assemble_candidate(&context(4_000_000, 4_000_000, 80_000), &cyclic, &[0x51])
+        .expect("mining does not re-validate snapshot topology");
+    assert_eq!(assembled.transactions.len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Destination

Mining selection is not a second validation engine. Packages walk the snapshot’s ancestor list and consensus `is_final_tx`; they do not re-check the mempool DAG, copy locktime rules, or scan the snapshot linearly for BIP68 parents.

Stacked on #485 (`cursor/mining-consensus-merkle-99bf`) → #451. Parent wayfinder: #151.

## What was deleted

- Mining’s inlined `is_final_tx` (consensus already owns it)
- `detect_cycles` and `MiningError::DependencyCycle`
- Per-input `snapshot.entries.iter().any(txid == parent)` BIP68 scan
- Extra `payout` clones into coinbase assembly

## What remains

- Bounds checks on ancestor indexes (`MissingAncestor`) — that is missing snapshot data, not a DAG verdict
- Residual packages with no unselected ancestors use the entry’s own weight/size/fee/sigops
- BIP68 unconfirmed-parent checks use one `HashSet<Txid>` built per `select_packages`
- GBT `depends` indexes use `hashbrown::HashMap`

## Proof

- `cargo test -p bitcoin-rs-mining`
- `cargo clippy -p bitcoin-rs-mining --all-targets -- -D warnings`
- `missing_ancestors_fail_assembly_without_rechecking_the_dag` keeps the bounds error and shows a cyclic ancestor list is not rejected
- Existing BIP68 skip / CSV-inactive tests still pass

## Out of scope

- Coordinator lock scopes / hashps parent walk (next stacked PR)
- Numeric p95 budgets

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd4a1918-79c1-4cad-bc1b-8a144b3699bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd4a1918-79c1-4cad-bc1b-8a144b3699bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

