### PR TITLE
Unblock clippy and combo-descriptor tests

### DIFF
--- a/crates/node/tests/mining.rs
+++ b/crates/node/tests/mining.rs
@@ -1114,7 +1114,7 @@ fn generate_mines_coinbase_only_blocks_to_the_tip() -> anyhow::Result<()> {
     assert_eq!(tip.height, 2);
     assert_eq!(
         tip.hash,
-        Hash256::from(hashes.last().expect("two hashes").hash)
+        Hash256::from(hashes.last().unwrap_or_else(|| panic!("two hashes")).hash)
     );
     Ok(())
 }
@@ -1134,7 +1134,8 @@ fn generateblock_rejects_unknown_mempool_txid() -> anyhow::Result<()> {
             selection: GenerateSelection::Ordered(vec![GenerateTx::Mempool(missing)]),
             submit: true,
         })
-        .expect_err("missing mempool txid must fail");
+        .err()
+        .unwrap_or_else(|| panic!("missing mempool txid must fail"));
     assert!(matches!(error, MiningControlError::InvalidRequest(_)));
     Ok(())
 }
@@ -1169,7 +1170,8 @@ fn generateblock_raw_tx_does_not_require_mempool_admission() -> anyhow::Result<(
             selection: GenerateSelection::Ordered(vec![GenerateTx::Raw(raw)]),
             submit: false,
         })
-        .expect_err("invalid raw spend must fail validation, not mempool lookup");
+        .err()
+        .unwrap_or_else(|| panic!("invalid raw spend must fail validation, not mempool lookup"));
     assert!(
         matches!(error, MiningControlError::Failed(_)),
         "raw generateblock txs skip mempool membership: {error:?}"
@@ -1184,7 +1186,11 @@ fn network_hash_ps_matches_mining_info_default_window() -> anyhow::Result<()> {
     let mining = coordinator(&state);
     let info = mining.mining_info()?;
     let rate = mining.network_hash_ps(120, -1)?;
-    assert_eq!(rate, info.network_hashes_per_second);
+    assert!(
+        (rate - info.network_hashes_per_second).abs() < f64::EPSILON,
+        "default-window hash rate must match mining info: {rate} vs {}",
+        info.network_hashes_per_second
+    );
     Ok(())
 }
 

--- a/crates/rpc/src/handlers/mining.rs
+++ b/crates/rpc/src/handlers/mining.rs
@@ -1454,7 +1454,7 @@ mod tests {
     #[test]
     fn generateblock_projects_hash_object() {
         let control = FakeMiningControl::with_template(sample_template());
-        let ctx = ctx_with_control(Arc::clone(&control) as Arc<dyn MiningControl>);
+        let ctx = ctx_with_control(control.clone());
         let result = generateblock(&ctx, &json!([MAINNET_ADDRESS, []]))
             .unwrap_or_else(|err| panic!("generateblock failed: {err}"));
         assert!(
@@ -1473,11 +1473,11 @@ mod tests {
         assert!(request.submit);
     }
 
-    /// API-05: generateblock accepts addr() without a checksum.
+    /// API-05: generateblock accepts `addr()` without a checksum.
     #[test]
     fn generateblock_accepts_addr_descriptor() {
         let control = FakeMiningControl::with_template(sample_template());
-        let ctx = ctx_with_control(Arc::clone(&control) as Arc<dyn MiningControl>);
+        let ctx = ctx_with_control(control.clone());
         let result = generateblock(&ctx, &json!([format!("addr({MAINNET_ADDRESS})"), []]))
             .unwrap_or_else(|err| panic!("addr() descriptor must be accepted: {err}"));
         assert!(
@@ -1506,7 +1506,7 @@ mod tests {
     #[test]
     fn generateblock_without_submit_includes_hex() {
         let control = FakeMiningControl::with_template(sample_template());
-        let ctx = ctx_with_control(Arc::clone(&control) as Arc<dyn MiningControl>);
+        let ctx = ctx_with_control(control.clone());
         let result = generateblock(&ctx, &json!([MAINNET_ADDRESS, [], false]))
             .unwrap_or_else(|err| panic!("generateblock failed: {err}"));
         assert!(
@@ -1550,7 +1550,7 @@ mod tests {
     #[test]
     fn generateblock_keeps_raw_transactions() {
         let control = FakeMiningControl::with_template(sample_template());
-        let ctx = ctx_with_control(Arc::clone(&control) as Arc<dyn MiningControl>);
+        let ctx = ctx_with_control(control.clone());
         let tx = sample_raw_tx();
         let raw_hex = to_lower_hex(&consensus_bytes(&tx));
         let txid = Txid::from(Hash256::from_le_bytes(&[0xcd; 32]));

--- a/crates/rpc/src/handlers/util.rs
+++ b/crates/rpc/src/handlers/util.rs
@@ -208,10 +208,10 @@ pub(crate) fn getdescriptorinfo(ctx: &Arc<Context>, params: &Value) -> Result<Va
     // Optional here, as in Core: `Parse` is called without `require_checksum`,
     // so a bare descriptor is analysed and one carrying a checksum has it
     // checked.
-    let checksum = checked_checksum(descriptor, ChecksumRequirement::Optional)?;
+    let (payload, checksum) = checked_checksum(descriptor, ChecksumRequirement::Optional)?;
 
-    let info = analyse(descriptor, convert::bitcoin_network(ctx.chain_network))
-        .map_err(descriptor_error)?;
+    let info =
+        analyse(payload, convert::bitcoin_network(ctx.chain_network)).map_err(descriptor_error)?;
 
     typed_to_sonic_omitting_nulls(&v31::GetDescriptorInfo {
         // The canonical form comes from the parse, so a descriptor handed to this
@@ -248,19 +248,16 @@ pub(crate) fn deriveaddresses(ctx: &Arc<Context>, params: &Value) -> Result<Valu
     // addresses are what someone will send money to; a mistyped descriptor
     // derives perfectly good addresses that nobody holds the keys for, and the
     // checksum is the only thing between a typo and that.
-    let _checksum = checked_checksum(descriptor, ChecksumRequirement::Required)?;
+    let (payload, _checksum) = checked_checksum(descriptor, ChecksumRequirement::Required)?;
     let range = array
         .get(1)
         .filter(|value| !value.is_null())
         .map(parse_derivation_range)
         .transpose()?;
 
-    let expansions = derive_descriptor_addresses(
-        descriptor,
-        convert::bitcoin_network(ctx.chain_network),
-        range,
-    )
-    .map_err(descriptor_error)?;
+    let expansions =
+        derive_descriptor_addresses(payload, convert::bitcoin_network(ctx.chain_network), range)
+            .map_err(descriptor_error)?;
 
     // Core returns a flat array for a single-path descriptor and an array per
     // expansion for a multipath one.
@@ -312,9 +309,13 @@ pub(crate) enum ChecksumRequirement {
     Required,
 }
 
-/// Verifies a descriptor's checksum and returns the computed one.
+/// Verifies a descriptor's checksum and returns the body plus the computed sum.
 ///
 /// Bitcoin Core's `CheckChecksum` in `script/descriptor.cpp`, rule for rule.
+/// Callers parse the returned payload. `combo(` / `addr(` / `raw(` look for a
+/// trailing `)`, so the original `desc#checksum` string is not a descriptor
+/// body.
+///
 /// The previous implementation split the text on its last `#` and threw the
 /// supplied checksum away, which meant a *wrong* checksum was accepted and
 /// silently replaced with the right one in the response. The checksum exists to
@@ -330,10 +331,8 @@ pub(crate) enum ChecksumRequirement {
 fn checked_checksum(
     descriptor: &str,
     requirement: ChecksumRequirement,
-) -> Result<String, RpcError> {
-    checksummed_payload(descriptor, requirement)
-        .map(|(_, computed)| computed)
-        .map_err(RpcError::InvalidAddressOrKey)
+) -> Result<(&str, String), RpcError> {
+    checksummed_payload(descriptor, requirement).map_err(RpcError::InvalidAddressOrKey)
 }
 
 /// Splits an optional BIP380 checksum and verifies it when present.
@@ -498,6 +497,8 @@ impl core::fmt::Display for DescriptorError {
 /// material back separately, and this function keeps only the fact that there
 /// was some. Echoing the caller's text back would return an `xprv` to whoever
 /// asked, which is the one thing this call must not do.
+///
+/// `text` is the descriptor body after checksum verification (no `#checksum`).
 fn analyse(text: &str, network: bitcoin::Network) -> Result<DescriptorInfo, DescriptorError> {
     if let Some(key) = parse_combo(text)? {
         let combo = parse_combo_info(key, network)?;
@@ -543,7 +544,7 @@ fn analyse(text: &str, network: bitcoin::Network) -> Result<DescriptorInfo, Desc
         // and Core reports them as the unsolvable ones they are rather than
         // refusing the question -- but it still checks that what is inside the
         // brackets is an address or a script, and so does this.
-        Err(error) => match parse_unspendable(strip_checksum(text)) {
+        Err(error) => match parse_unspendable(text) {
             Some(unspendable) => {
                 let unspendable = unspendable?;
                 if let Unspendable::Address(address) = &unspendable {
@@ -664,7 +665,7 @@ fn require_range_match(
 ///
 /// The outer vector is one entry per multipath expansion, in specifier order;
 /// a single-path descriptor yields exactly one. `range` is inclusive at both
-/// ends, matching Bitcoin Core.
+/// ends, matching Bitcoin Core. `text` is the checksum-verified descriptor body.
 fn derive_descriptor_addresses(
     text: &str,
     network: bitcoin::Network,
@@ -681,7 +682,7 @@ fn derive_descriptor_addresses(
     }
 
     // An `addr()` or `raw()` descriptor has exactly one output and no range.
-    if let Some(unspendable) = parse_unspendable(strip_checksum(text)) {
+    if let Some(unspendable) = parse_unspendable(text) {
         if range.is_some() {
             return Err(DescriptorError::Range(
                 "Range should not be specified for an un-ranged descriptor",
@@ -912,11 +913,6 @@ fn parse_unspendable(text: &str) -> Option<Result<Unspendable, DescriptorError>>
             .map(Unspendable::Raw)
             .map_err(|error| DescriptorError::Parse(error.to_string())),
     )
-}
-
-/// Drops a trailing `#checksum`, which is not part of the descriptor body.
-fn strip_checksum(text: &str) -> &str {
-    text.rsplit_once('#').map_or(text, |(body, _)| body)
 }
 
 /// Coinbase script for `generateblock`'s `output` argument (`API-05`).
@@ -1591,6 +1587,22 @@ mod descriptor_checksum_tests {
             canonical.starts_with(&format!("combo({xpub}/0/0)#")),
             "the canonical form is the public combo: {canonical}"
         );
+    }
+
+    /// A supplied checksum is verified, then the body is analysed. `combo` is
+    /// not miniscript, so the parser must see `combo(KEY)` and not `combo(KEY)#sum`.
+    #[test]
+    fn checksummed_combo_is_analysed() {
+        let ctx = Arc::new(Context::new());
+        let key = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
+        let bare = format!("combo({key})");
+        let checksum =
+            descriptor_checksum(&bare).unwrap_or_else(|| panic!("{bare} must have a checksum"));
+        let without = getdescriptorinfo(&ctx, &json!([bare.clone()]))
+            .unwrap_or_else(|err| panic!("bare combo must analyse: {err}"));
+        let with = getdescriptorinfo(&ctx, &json!([format!("{bare}#{checksum}")]))
+            .unwrap_or_else(|err| panic!("checksummed combo must analyse: {err}"));
+        assert_eq!(without, with);
     }
 
     /// Core's `getdescriptorinfo` expands a multipath descriptor into one


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bottom of the #174 stack. Main's clippy and test lanes are red for reasons unrelated to dependency-range work; this PR is the merge prerequisite so the rest of the stack can go green.

## What changed

Combines the two already-open one-line-class fixes so this stack does not wait on merge order:

- Checksummed `combo(` / `addr(` / `raw(` descriptors are parsed from the verified payload, not `desc#checksum` (same change as #418).
- `generateblock` tests coerce `FakeMiningControl` without `as` casts and drop clippy-failing `expect` / float `assert_eq` in the mining control tests (same change as #437).

If #418 and #437 merge first, rebase this branch away.

## Stack

0. **This PR** — unblock main clippy/test
1. #444 — declared Cargo ranges at both ends
2. #455 — named feature matrix
3. #468 — validation/mempool fuzz
4. #478 — live Core differential (closes #174)

## Verification

Cherry-picks of `8d689b65` and `a79fa7a8` onto current `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ba9bbdb-3b54-46c4-aa73-29056f51592e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ba9bbdb-3b54-46c4-aa73-29056f51592e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

