### PR TITLE
Disable Nagle on RPC HTTP and metrics scrape sockets

### DIFF
--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -284,6 +284,7 @@ fn serve_metrics(
         }
         match listener.accept() {
             Ok((mut stream, _)) => {
+                let _ = stream.set_nodelay(true);
                 let _ = stream.set_nonblocking(false);
                 let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
                 let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -97,6 +97,7 @@ impl RpcServer {
     }
 
     fn handle_accept(&self, active: &Arc<Mutex<usize>>, mut stream: TcpStream) -> io::Result<()> {
+        configure_rpc_stream(&stream)?;
         let should_accept = {
             let mut count = active.lock();
             if *count >= self.max_connections {
@@ -129,6 +130,12 @@ impl RpcServer {
     }
 }
 
+/// Applies HTTP-session socket policy: `TCP_NODELAY` so a small response is
+/// not delayed by Nagle after the status line.
+fn configure_rpc_stream(stream: &TcpStream) -> io::Result<()> {
+    stream.set_nodelay(true)
+}
+
 fn serve_connection(
     stream: TcpStream,
     auth: &Auth,
@@ -136,6 +143,7 @@ fn serve_connection(
     rest_enabled: bool,
     idle_timeout: Duration,
 ) -> io::Result<()> {
+    configure_rpc_stream(&stream)?;
     stream.set_read_timeout(Some(idle_timeout))?;
     stream.set_write_timeout(Some(idle_timeout))?;
     let mut reader = BufReader::new(stream);
@@ -564,6 +572,19 @@ mod tests {
     use core::sync::atomic::{AtomicBool, Ordering};
 
     use crate::context::Context;
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+
+    #[test]
+    fn configure_rpc_stream_disables_nagle() {
+        let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let client = TcpStream::connect(addr).expect("connect");
+        let (server, _) = listener.accept().expect("accept");
+        configure_rpc_stream(&client).expect("configure client");
+        configure_rpc_stream(&server).expect("configure server");
+        assert!(client.nodelay().expect("client nodelay"));
+        assert!(server.nodelay().expect("server nodelay"));
+    }
 
     #[test]
     #[allow(clippy::expect_used)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Stacked on #495. Completes the network-stack half of this series: JSON-RPC/REST/Esplora and the Prometheus scrape listener never set `TCP_NODELAY`. Small HTTP responses (status line then body) are the Nagle case.

## What changed

`configure_rpc_stream` owns RPC socket flags. Every accepted HTTP connection, including the 503 busy path, gets `TCP_NODELAY` before any write. The metrics scrape accept path sets it too.

## Breaking

RPC and metrics sockets now disable Nagle. Callers that accepted a stream and expected delayed coalescing of tiny writes will see them flush immediately.

## Stack

1. #458 — peer `TCP_NODELAY` + vectored `CountingStream`
2. #482 — serve `getdata` from stored body bytes
3. #495 — drop unused `P2pService` download window
4. This PR — RPC/metrics `TCP_NODELAY`

## Verification

- `cargo clippy -p bitcoin-rs-rpc --lib -- -D warnings`
- `cargo test -p bitcoin-rs-rpc --lib -- configure_rpc_stream`
- `cargo clippy -p bitcoin-rs-node --no-default-features --features fjall --lib -- -D warnings`

## Related

- #458 / #482 / #495 — this stack
- Bitcoin Core always sets `TCP_NODELAY` on peer and HTTP sockets

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1e252b6-32f0-4691-b4a1-0a620b71da25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1e252b6-32f0-4691-b4a1-0a620b71da25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

