### PR TITLE
Delete the unused mining header-check sidecar

### DIFF
--- a/crates/mining/src/context.rs
+++ b/crates/mining/src/context.rs
@@ -1,14 +1,12 @@
-//! Candidate chain context: version, work, time, and proposal checks.
+//! Candidate chain context: version, work, and time.
 //!
 //! Consensus owns BIP9/finality rules. Chain owns historical/MTP lookups
 //! and next-work. This module resolves those facts into the one record a
-//! candidate builder needs, and dry-runs a proposal through the same
-//! header validators full validation applies.
+//! candidate builder needs. Proposal validation is the apply path
+//! (`Chainstate::validate_block`), not a second header checker here.
 
 use bitcoin_rs_chain::{
-    BlockTree, ChainError, candidate_version, header_sync,
-    node::{BlockHeader, NodeId},
-    softfork_state,
+    BlockTree, ChainError, candidate_version, header_sync, node::NodeId, softfork_state,
 };
 use bitcoin_rs_consensus::{MEDIAN_TIME_PAST_WINDOW, locktime_cutoff};
 use bitcoin_rs_primitives::{Hash256, Network};
@@ -84,35 +82,12 @@ impl MiningChainContext {
     }
 }
 
-/// Dry-run contextual check for a proposed block header.
-///
-/// Runs exactly the contextual validators full validation runs — nBits via
-/// [`header_sync::validate_header_nbits`] and the median-time-past/future
-/// bounds via [`header_sync::validate_header_timestamp`] — without mutating
-/// the tree, so a proposal verdict and a later apply verdict cannot disagree
-/// by construction.
-///
-/// # Errors
-///
-/// Propagates the underlying [`ChainError`] from either validator.
-pub fn check_candidate_header(
-    tree: &BlockTree,
-    network: Network,
-    previous_tip_id: NodeId,
-    header: &BlockHeader,
-    hash: Hash256,
-    now_secs: u32,
-) -> Result<(), ChainError> {
-    header_sync::validate_header_nbits(tree, previous_tip_id, header, network)?;
-    header_sync::validate_header_timestamp(tree, header, hash, now_secs)
-}
-
 #[cfg(test)]
 mod tests {
     use bitcoin_rs_chain::{BlockTree, ChainError, node::NodeStatus};
     use bitcoin_rs_primitives::{BlockHash, Hash256, Header, Network};
 
-    use super::{MiningChainContext, check_candidate_header};
+    use super::MiningChainContext;
 
     fn synthetic_header_with_version(prev_blockhash: BlockHash, time: u32, version: i32) -> Header {
         Header {
@@ -198,46 +173,6 @@ mod tests {
             active.prev_median_time_past
         );
         Ok(())
-    }
-
-    #[test]
-    fn check_candidate_header_shares_full_validation_verdicts()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let mut tree = BlockTree::new();
-        let chain_bits: u32 = 0x207f_fffe;
-        let tip = append_chain_with_bits(&mut tree, 12, 1_000_000, |_| 0x2000_0000, chain_bits)?;
-        let context = MiningChainContext::resolve(&tree, Network::Regtest, tip, 1_003_600 + 600)?;
-        let tip_blockhash = BlockHash(context.previous_block_hash);
-
-        let candidate = candidate_header(tip_blockhash, context.min_time, context.bits);
-        let hash = candidate.compute_hash().0;
-        check_candidate_header(&tree, Network::Regtest, tip, &candidate, hash, u32::MAX)?;
-
-        let bad_bits = candidate_header(tip_blockhash, context.min_time, 0x207f_fffd);
-        let hash = bad_bits.compute_hash().0;
-        assert!(matches!(
-            check_candidate_header(&tree, Network::Regtest, tip, &bad_bits, hash, u32::MAX),
-            Err(ChainError::NbitsMismatch { .. })
-        ));
-
-        let early = candidate_header(tip_blockhash, context.prev_median_time_past, context.bits);
-        let hash = early.compute_hash().0;
-        assert!(matches!(
-            check_candidate_header(&tree, Network::Regtest, tip, &early, hash, u32::MAX),
-            Err(ChainError::TimestampTooEarly { .. })
-        ));
-        Ok(())
-    }
-
-    fn candidate_header(prev_blockhash: BlockHash, time: u32, bits: u32) -> Header {
-        Header {
-            version: 0x2000_0000,
-            prev_blockhash,
-            merkle_root: Hash256::default(),
-            time,
-            bits,
-            nonce: 0,
-        }
     }
 
     fn append_chain(

--- a/crates/mining/src/lib.rs
+++ b/crates/mining/src/lib.rs
@@ -3,7 +3,7 @@
 
 /// Coinbase transaction assembly.
 pub mod coinbase;
-/// Candidate chain context and proposal header checks.
+/// Candidate chain context.
 pub mod context;
 /// Node-facing mining control contract.
 pub mod control;
@@ -13,7 +13,7 @@ pub mod policy;
 pub mod template;
 
 pub use coinbase::{MiningError, WITNESS_RESERVED_VALUE, witness_commitment_script};
-pub use context::{MiningChainContext, check_candidate_header};
+pub use context::MiningChainContext;
 pub use control::{
     AvailableMiningRule, BlockTemplate, BlockTemplateMode, BlockTemplateRequest,
     BlockTemplateResult, BlockValidationResult, GenerateRequest, GenerateSelection, GenerateTx,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Destination

Delete `check_candidate_header`. Proposal mode already dry-runs `Chainstate::validate_block` (the apply-path consensus gates). The public header wrapper had no production consumer and was a second checker.

Stacked on #513 → #498 → #485 → #451. Parent wayfinder: #151.

## What remains

`MiningChainContext::resolve` still owns candidate version, nBits, MTP, and CSV/SegWit flags. Header nBits and timestamp stay in `bitcoin_rs_chain::header_sync`, used by apply.

## Proof

- `cargo test -p bitcoin-rs-mining`
- `cargo clippy -p bitcoin-rs-mining --all-targets -- -D warnings`
- `rg check_candidate_header` is empty

## Out of scope

- Stratum / `generatetodescriptor`
- Numeric p95 budgets

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd4a1918-79c1-4cad-bc1b-8a144b3699bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd4a1918-79c1-4cad-bc1b-8a144b3699bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

