### PR TITLE
Drop the dual ScriptIndex format marker and Legacy dual-read

### DIFF
--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -164,6 +164,9 @@ const FORMAT_VERSION_VALUE: [u8; 4] = [0x05, 0x00, 0x00, 0x00];
 /// authoritative chain/UTXO state. There is no dual-read, dual-write, or
 /// in-place conversion.
 const PREVIOUS_FORMAT_VERSIONS: &[[u8; 4]] = &[[0x03, 0x00, 0x00, 0x00], [0x04, 0x00, 0x00, 0x00]];
+/// Leftover ASCII row-value marker from formats 1–4. Written nowhere; deleted
+/// on reset so a store does not carry two version keys.
+const INDEX_FORMAT_VERSION_KEY: &[u8] = b"index:format_version";
 const TX_LOOKUP_WATERMARK_KEY: &[u8] = &[0x00, b'T'];
 const SCRIPT_HISTORY_WATERMARK_KEY: &[u8] = &[0x00, b'S'];
 const SCRIPT_LIVE_WATERMARK_KEY: &[u8] = &[0x00, b'L'];
@@ -704,17 +707,13 @@ fn acquire_capability_reset<S: KvStore>(
             FORMAT_VERSION_KEY,
             &FORMAT_VERSION_VALUE,
         );
+        batch.delete(ColumnFamily::UtxoMeta, INDEX_FORMAT_VERSION_KEY);
         let capabilities = IndexCapabilities::from_mask(mask)?;
         if capabilities.tx_lookup {
             batch.delete(ColumnFamily::UtxoMeta, TX_LOOKUP_WATERMARK_KEY);
         }
         if capabilities.script_history {
             batch.delete(ColumnFamily::UtxoMeta, SCRIPT_HISTORY_WATERMARK_KEY);
-            batch.put(
-                ColumnFamily::UtxoMeta,
-                INDEX_FORMAT_VERSION_KEY,
-                &INDEX_FORMAT_VERSION.to_le_bytes(),
-            );
         }
         if capabilities.script_live {
             batch.delete(ColumnFamily::UtxoMeta, SCRIPT_LIVE_WATERMARK_KEY);
@@ -811,15 +810,6 @@ fn resume_capability_reset<S: KvStore>(
             ORDINARY_STATE_REVISION_KEY,
             &work.next_revision,
         );
-        if capabilities.script_history {
-            // Resume of a claim that predates the acquire-batch marker
-            // still publishes the current row-value format.
-            completion.put(
-                ColumnFamily::UtxoMeta,
-                INDEX_FORMAT_VERSION_KEY,
-                &INDEX_FORMAT_VERSION.to_le_bytes(),
-            );
-        }
         if store.write_durable_if(&conditions, completion)? {
             return Ok(());
         }
@@ -1721,72 +1711,47 @@ impl<S: KvStore> Indexer<S> {
         Ok(None)
     }
 
-    /// Reports whether this index's rows carry transaction positions, adopting
-    /// the current format when the index is empty.
+    /// Confirms this store carries the current layout, adopting it when empty.
     ///
-    /// Reading is always correct either way — a row without positions takes the
-    /// scan fallback — so this exists to tell an operator which path their node
-    /// is on, not to gate correctness. The difference is three orders of
-    /// magnitude on history resolution, which is worth a startup line.
+    /// A populated store with a missing or foreign marker is an error, not a
+    /// slower dual-read path. Empty-or-malformed *row values* still scan the
+    /// block: that is corruption safety, not an old-format decoder.
     ///
-    /// An index with rows but no version marker predates the format and is
-    /// reported as [`IndexFormat::Legacy`]. The marker is written only for an
-    /// empty index, because that is the only case where every row that will ever
-    /// exist is going to be written with positions. Writing it for a populated
-    /// legacy index would claim positions that are not there.
-    pub fn ensure_format_version(&self) -> Result<IndexFormat, IndexError> {
-        match self.read_format_version()? {
-            Some(FormatMarker::Version(found)) => {
-                return Ok(if found == INDEX_FORMAT_VERSION {
-                    IndexFormat::Current
-                } else {
-                    IndexFormat::Legacy { found: Some(found) }
-                });
+    /// Emptiness matches [`IndexWriter::open`]: any row in `TxConfirmed`,
+    /// `Funding`, `Spending`, `BlockHeaders`, or `ScriptLive` is an index row.
+    /// A markerless store that already has one is
+    /// [`IndexError::LegacyCursorlessIndex`].
+    ///
+    /// Adopting an empty store writes format 5 and deletes the leftover ASCII
+    /// marker in one [`bitcoin_rs_storage::KvStore::write_durable`] batch
+    /// (`IDX-05`). The commit point is that durable batch. A crash before it
+    /// is durable leaves the store unmarked; the next call retries. Storage
+    /// errors belong to the caller.
+    pub fn ensure_format_version(&self) -> Result<(), IndexError> {
+        match self.store.get(ColumnFamily::UtxoMeta, FORMAT_VERSION_KEY)? {
+            Some(value) if value.as_slice() == FORMAT_VERSION_VALUE => Ok(()),
+            Some(value) => {
+                let version = value
+                    .get(..4)
+                    .and_then(|bytes| <[u8; 4]>::try_from(bytes).ok())
+                    .map_or(0, u32::from_le_bytes);
+                Err(IndexError::UnsupportedTxIndexFormatVersion { version })
             }
-            Some(FormatMarker::Unreadable { len }) => {
-                return Ok(IndexFormat::UnreadableMarker { len });
+            None if has_any_index_row(self.store.as_ref())? => {
+                Err(IndexError::LegacyCursorlessIndex)
             }
-            None => {}
+            None => {
+                let mut batch = self.store.new_batch();
+                batch.put(
+                    ColumnFamily::UtxoMeta,
+                    FORMAT_VERSION_KEY,
+                    &FORMAT_VERSION_VALUE,
+                );
+                batch.delete(ColumnFamily::UtxoMeta, INDEX_FORMAT_VERSION_KEY);
+                self.store.write_durable(batch)?;
+                Ok(())
+            }
         }
-        if self.has_any_header()? {
-            return Ok(IndexFormat::Legacy { found: None });
-        }
-        let mut batch = self.store.new_batch();
-        batch.put(
-            ColumnFamily::UtxoMeta,
-            INDEX_FORMAT_VERSION_KEY,
-            &INDEX_FORMAT_VERSION.to_le_bytes(),
-        );
-        self.store.write(batch)?;
-        Ok(IndexFormat::Current)
-    }
-
-    fn read_format_version(&self) -> Result<Option<FormatMarker>, IndexError> {
-        let Some(bytes) = self
-            .store
-            .get(ColumnFamily::UtxoMeta, INDEX_FORMAT_VERSION_KEY)?
-        else {
-            return Ok(None);
-        };
-        let Ok(encoded) = <[u8; 4]>::try_from(bytes.as_slice()) else {
-            // Reported as its own outcome rather than folded into version 0: an
-            // operator told "your index is at version 0" deletes and re-syncs,
-            // which is the wrong response to bytes that should be a `u32` and
-            // are not.
-            return Ok(Some(FormatMarker::Unreadable { len: bytes.len() }));
-        };
-        Ok(Some(FormatMarker::Version(u32::from_le_bytes(encoded))))
-    }
-
-    /// True when the header column family holds at least one row.
-    ///
-    /// Deliberately not `header_count`: a leftover index takes this branch on
-    /// every start, and counting would read every row in the column family —
-    /// roughly a million 32-byte hash keys at mainnet height — to answer a
-    /// question that is only ever yes or no.
-    fn has_any_header(&self) -> Result<bool, IndexError> {
-        let mut rows = self.store.iter_prefix(ColumnFamily::BlockHeaders, &[])?;
-        Ok(rows.next().transpose()?.is_some())
     }
 
     const FLUSH_THRESHOLD_ROWS: usize = 500_000;
@@ -3731,13 +3696,12 @@ pub trait IndexerLike: Send + Sync {
     /// Walks `block` once and writes index rows. See `Indexer::ingest_block`.
     fn ingest_block(&mut self, block: &[u8], height: u32) -> Result<IndexRowCounts, IndexError>;
 
-    /// Reports the row-value format. See [`Indexer::ensure_format_version`].
+    /// Confirms the store carries the current layout. See [`Indexer::ensure_format_version`].
     ///
-    /// Defaults to [`IndexFormat::Current`] for the in-memory and stub indexers
-    /// used in tests, which have no persisted rows and therefore no legacy ones.
-    /// A store-backed implementation must override this.
-    fn ensure_format_version(&self) -> Result<IndexFormat, IndexError> {
-        Ok(IndexFormat::Current)
+    /// Defaults to success for in-memory and stub indexers, which have no
+    /// persisted rows. A store-backed implementation must override this.
+    fn ensure_format_version(&self) -> Result<(), IndexError> {
+        Ok(())
     }
 
     /// Walks `block` once and writes index rows, reusing precomputed transaction IDs when supported.
@@ -3848,52 +3812,6 @@ pub trait IndexerLike: Send + Sync {
     ) -> Result<Option<u64>, IndexError>;
 }
 
-/// Metadata key marking which row-value format an index was written with.
-const INDEX_FORMAT_VERSION_KEY: &[u8] = b"index:format_version";
-
-/// Current row-value format.
-///
-/// Version 1 added transaction byte positions to funding and txid row values;
-/// version 2 added positions to spending row values; version 3 packed each
-/// position into 6 bytes (`u24` offset + `u24` length). Version 0 (unmarked)
-/// has empty values.
-pub const INDEX_FORMAT_VERSION: u32 = 3;
-
-/// Which row-value format an opened index carries.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum IndexFormat {
-    /// Rows carry transaction positions; resolvers take the fast path.
-    Current,
-    /// Rows predate transaction positions; resolvers scan whole blocks.
-    ///
-    /// Correct but far slower. Clearing the index directory and re-syncing
-    /// rebuilds it in the current format.
-    Legacy {
-        /// The version marker found, or `None` when the index carries none.
-        found: Option<u32>,
-    },
-    /// A version marker exists but is not the 4 little-endian bytes of a `u32`.
-    ///
-    /// Resolvers scan, exactly as for [`Self::Legacy`], but the operator
-    /// response differs: this is damaged metadata, not an old index, and
-    /// deleting the directory would discard the evidence of whatever wrote it.
-    UnreadableMarker {
-        /// Byte length of the marker value that failed to decode.
-        len: usize,
-    },
-}
-
-/// What the format-version marker key holds, when it is present at all.
-enum FormatMarker {
-    /// Four little-endian bytes that decoded to this version.
-    Version(u32),
-    /// Present, but not a 4-byte little-endian `u32`.
-    Unreadable {
-        /// Byte length of the value found.
-        len: usize,
-    },
-}
-
 /// Provides block lookups for resolving lossy index prefixes to full identities.
 ///
 /// The index column families store 8-byte prefixes of txids/scripthashes/outpoints.
@@ -3925,7 +3843,7 @@ impl<S: KvStore + Send + Sync + 'static> IndexerLike for Indexer<S> {
         Self::ingest_block(self, block, height)
     }
 
-    fn ensure_format_version(&self) -> Result<IndexFormat, IndexError> {
+    fn ensure_format_version(&self) -> Result<(), IndexError> {
         Self::ensure_format_version(self)
     }
 

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -9,11 +9,11 @@ pub mod mempool;
 pub mod types;
 
 pub use index::{
-    BlockSource, ConsumerCursorUpdate, INDEX_FORMAT_VERSION, IndexCapabilities, IndexCapability,
-    IndexError, IndexFormat, IndexReader, IndexRowCounts, IndexWatermark, IndexWatermarks,
-    IndexWriteFence, IndexWriter, Indexer, IndexerLike, MAX_LIVE_SCRIPT_SIZE, NoSpentScripts,
-    PreparedBatch, PreparedBatchLimits, PreparedBlock, ScriptHistoryEntry, ScriptLiveScan,
-    SpentCoinScripts, TxIndexScan, TxIndexScanRow, TxIndexSnapshot,
+    BlockSource, ConsumerCursorUpdate, IndexCapabilities, IndexCapability, IndexError, IndexReader,
+    IndexRowCounts, IndexWatermark, IndexWatermarks, IndexWriteFence, IndexWriter, Indexer,
+    IndexerLike, MAX_LIVE_SCRIPT_SIZE, NoSpentScripts, PreparedBatch, PreparedBatchLimits,
+    PreparedBlock, ScriptHistoryEntry, ScriptLiveScan, SpentCoinScripts, TxIndexScan,
+    TxIndexScanRow, TxIndexSnapshot,
 };
 pub use mempool::{MempoolRowCounts, MempoolRowWriter};
 pub use types::{

--- a/crates/index/tests/index_roundtrip.rs
+++ b/crates/index/tests/index_roundtrip.rs
@@ -18,7 +18,7 @@ use parking_lot::{Mutex, RwLock};
 use bitcoin_rs_index::ScriptHash;
 use bitcoin_rs_index::types::{TxPosition, TxPositionValue};
 use bitcoin_rs_index::{
-    ConsumerCursorUpdate, IndexCapabilities, IndexError, IndexFormat, IndexReader, IndexRowCounts,
+    ConsumerCursorUpdate, IndexCapabilities, IndexError, IndexReader, IndexRowCounts,
     IndexWatermark, IndexWatermarks, IndexWriter, Indexer, PreparedBatch, PreparedBatchLimits,
 };
 use bitcoin_rs_storage::{
@@ -716,11 +716,11 @@ fn format_4_open_resets_all_derived_capabilities() -> Result<(), Box<dyn std::er
         store.get(ColumnFamily::UtxoMeta, &[0x00, b'V'])?.as_deref(),
         Some(5_u32.to_le_bytes().as_slice())
     );
-    assert_eq!(
+    assert!(
         store
             .get(ColumnFamily::UtxoMeta, b"index:format_version")?
-            .as_deref(),
-        Some(3_u32.to_le_bytes().as_slice())
+            .is_none(),
+        "the leftover ASCII row-value marker must not survive a format reset"
     );
     assert_eq!(
         writer.watermarks()?,
@@ -748,6 +748,30 @@ fn unversioned_rows_are_rejected() -> Result<(), Box<dyn std::error::Error>> {
         IndexWriter::open(Arc::clone(&store), 1),
         Err(IndexError::LegacyCursorlessIndex)
     ));
+    Ok(())
+}
+
+/// `IDX-05`: a markerless store with Funding rows and no headers is refused,
+/// not stamped format 5.
+#[test]
+fn ensure_format_version_rejects_markerless_funding_rows() -> Result<(), Box<dyn std::error::Error>>
+{
+    let store = Arc::new(MemoryStore::default());
+    store.put(
+        ColumnFamily::Funding,
+        &[0u8; bitcoin_rs_index::HASH_PREFIX_ROW_SIZE],
+        &[],
+    )?;
+
+    let indexer = Indexer::new(Arc::clone(&store));
+    assert!(matches!(
+        indexer.ensure_format_version(),
+        Err(IndexError::LegacyCursorlessIndex)
+    ));
+    assert!(
+        store.get(ColumnFamily::UtxoMeta, &[0x00, b'V'])?.is_none(),
+        "must not stamp format 5 onto a markerless populated store"
+    );
     Ok(())
 }
 
@@ -1243,8 +1267,9 @@ fn reset_claim_carries_mask_epoch_and_base_version() -> Result<(), Box<dyn std::
         "claim value is mask(1) || process_epoch(8 LE) || base_version(8 LE)"
     );
     assert_eq!(
-        marker_puts[0].deletes, 2,
-        "the claim atomically deletes the selected watermark and global cursor"
+        marker_puts[0].deletes, 3,
+        "the claim atomically deletes the selected watermark, global cursor, \
+         and leftover ASCII format marker"
     );
     assert_eq!(
         marker_puts[1].marker_put.as_deref(),
@@ -1906,6 +1931,8 @@ fn reset_index_adopts_a_foreign_fence_as_an_all_capability_reset()
     Ok(())
 }
 
+/// `IDX-05`: format 5 remains the only durable marker after historical reset
+/// and rebuild; the leftover ASCII dual-read key stays deleted.
 #[test]
 fn format_stays_current_after_reset_and_rebuild() -> Result<(), Box<dyn std::error::Error>> {
     let store = Arc::new(MemoryStore::default());
@@ -1915,21 +1942,25 @@ fn format_stays_current_after_reset_and_rebuild() -> Result<(), Box<dyn std::err
     writer.reset_capabilities(IndexCapabilities::HISTORICAL)?;
     drop(writer);
 
-    // The emptied index claims the current row format before rebuilding.
+    // The emptied index claims the current store format before rebuilding.
     let indexer = Indexer::new(Arc::clone(&store));
-    assert_eq!(indexer.ensure_format_version()?, IndexFormat::Current);
+    indexer.ensure_format_version()?;
     drop(indexer);
 
     seed_populated_store(&store, 1)?;
 
     let indexer = Indexer::new(Arc::clone(&store));
-    assert_eq!(indexer.ensure_format_version()?, IndexFormat::Current);
+    indexer.ensure_format_version()?;
     assert_eq!(
+        store.get(ColumnFamily::UtxoMeta, &[0x00, b'V'])?.as_deref(),
+        Some(5_u32.to_le_bytes().as_slice()),
+        "the store format marker survives reset and rebuild"
+    );
+    assert!(
         store
             .get(ColumnFamily::UtxoMeta, b"index:format_version")?
-            .as_deref(),
-        Some(3u32.to_le_bytes().as_slice()),
-        "the row-format marker survives reset and rebuild"
+            .is_none(),
+        "the leftover ASCII row-value marker must not return after rebuild"
     );
     assert!(
         store
@@ -3078,8 +3109,8 @@ fn union_growth_preserves_claim_identity_and_deletes_full_union_state()
         "growth changes byte zero only; width, process epoch, and base survive raw"
     );
     assert_eq!(
-        markers[0].deletes, 3,
-        "the claim deletes the union watermarks and the consumer cursor"
+        markers[0].deletes, 4,
+        "the claim deletes the union watermarks, the consumer cursor, and the leftover ASCII format marker"
     );
     assert_eq!(
         markers[1].marker_put.as_deref(),

--- a/docs/benchmarks/scriptindex-format.md
+++ b/docs/benchmarks/scriptindex-format.md
@@ -165,7 +165,7 @@ decoder, or conversion pass.
 | BlockHeaders | `sha256d(header)(32)` | empty |
 | ScriptLive | `prefix(8) \|\| txid(32) \|\| vout_u24(3)` | empty |
 
-`INDEX_FORMAT_VERSION` is 3 (packed positions). High-level history resolvers
+`spending_prefix` still uses electrs' big-endian wrapping mix. High-level history resolvers
 still sort by numeric height so API order does not depend on the raw key
 encoding.
 
@@ -265,10 +265,13 @@ capabilities. A later change that touches only Live can reset only
 reset TxLookup and ScriptHistory together because they share
 `HashPrefixRow` / `TxPosition`.
 
-`INDEX_FORMAT_VERSION` (currently 3) is the packed-position marker written
-alongside a ScriptHistory reset. A foreign store version that is not 3, 4,
-or 5 still refuses start.
+`[0x00, b'V']` is the only layout marker. The leftover ASCII
+`index:format_version` key from formats 1–4 is deleted on reset and is
+not read. A foreign store version that is not 3, 4, or 5 still refuses
+start.
 
 **No dual-read path, no migration.** Previous ScriptIndex bytes are
-deleted and rebuilt from authoritative chain/UTXO sources. Live is cheap
-to re-seed (one pass over the UTXO set); History is a reindex.
+deleted and rebuilt from authoritative chain/UTXO sources. Empty or
+malformed *row values* still scan the block: that is corruption safety,
+not an old-format decoder. Live is cheap to re-seed (one pass over the
+UTXO set); History is a reindex.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #503. Second slice of #226: one store format marker, no legacy dual-read.

## What this removes

The index previously carried two version keys:

- `[0x00, b'V']` — store format (5 after #503)
- `index:format_version` — row-value format (3), with `IndexFormat::Legacy` telling operators (and only operators) that resolvers would scan

#226 forbids dual-read paths and leftover decoders for old index files. Empty or malformed *row values* still scan the block; that is corruption safety, not an old-format reader.

## What remains

`[0x00, b'V']` is the only layout marker. Reset deletes the leftover ASCII key. `ensure_format_version` writes the current marker on an empty store and returns `UnsupportedTxIndexFormatVersion` or `LegacyCursorlessIndex` otherwise.

Emptiness matches `IndexWriter::open`: any row in `TxConfirmed`, `Funding`, `Spending`, `BlockHeaders`, or `ScriptLive` is an index row. Empty adoption is one `write_durable` batch (`IDX-05`). Formats 3 and 4 still reset **all** derived capabilities (from #503: packed positions, hash header keys, and the Live locator all change).

## Proof

`format_4_open_resets_all_derived_capabilities`, `format_stays_current_after_reset_and_rebuild`, `ensure_format_version_rejects_markerless_funding_rows`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-209932d8-c946-4202-b763-0127f348d23d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-209932d8-c946-4202-b763-0127f348d23d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

