### PR TITLE
Make native validation the only production apply path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,28 +56,10 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
-      # Pure-Rust clippy gate with -D warnings. consensus and node have
-      # `kernel` in their per-crate defaults, which would pull in the C++
-      # libbitcoinkernel build (cmake + libboost-dev); exclude them from the
-      # workspace-wide pass and lint them separately with --no-default-features
-      # so the PR gate needs no C++ toolchain install.
-      - run: |
-          cargo clippy --workspace --all-targets \
-            --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node \
-            -- -D warnings
-          # consensus without kernel: --all-targets compiles its unit tests
-          # (bip30/bip34/bip112/bip113/bip141/bip143 modules in src/),
-          # integration tests (vectors, coinbase_amount), and benches.
-          # Previously invisible to the hook lanes: the workspace-wide pass
-          # would either fail (no cmake for kernel) or the crate was excluded
-          # entirely, leaving its test-target lints unchecked.
-          cargo clippy -p bitcoin-rs-consensus \
-            --no-default-features --all-targets -- -D warnings
-          # node without kernel: add back fjall and zmq (the pure-Rust
-          # defaults from bin/bitcoin-rs) so the crate and its test/bench
-          # targets compile and are linted.
-          cargo clippy -p bitcoin-rs-node \
-            --no-default-features --features fjall,zmq --all-targets -- -D warnings
+      # Pure-Rust clippy gate with -D warnings. Library defaults no longer
+      # pull libbitcoinkernel, so the workspace pass covers consensus and
+      # node without a C++ toolchain.
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
     runs-on: ubuntu-latest
@@ -86,17 +68,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
       # Pure-Rust test gate: each workspace member tested with its own default
-      # features minus kernel. Deliberately no apt step -- the default path
-      # needs no CMake/Boost toolchain; the kernel engine is opt-in and
-      # exercised only by the main-only lanes in main.yml. consensus and node
-      # are excluded from the workspace pass (their defaults include kernel)
-      # and tested separately with --no-default-features.
-      - run: |
-          cargo test --workspace --no-fail-fast \
-            --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node
-          cargo test -p bitcoin-rs-consensus --no-default-features --no-fail-fast
-          cargo test -p bitcoin-rs-node \
-            --no-default-features --features fjall,zmq --no-fail-fast
+      # features. Deliberately no apt step -- the default path needs no
+      # CMake/Boost toolchain; the kernel oracle is opt-in and exercised only
+      # by the main-only lanes in main.yml.
+      - run: cargo test --workspace --no-fail-fast
       # Isolated so node's default `zmq` feature cannot unify this package on.
       - run: cargo test -p bitcoin-rs-rpc --no-default-features --no-fail-fast
       # Node / binary tests run with the full-node backend set, minus the
@@ -116,9 +91,8 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
-      # The kernel engine is built from C++ (cmake + libboost-dev); the default
-      # feature set now includes it, so every production lane installs the
-      # prerequisites up front.
+      # The kernel oracle is built from C++ (cmake + libboost-dev); benches
+      # that request FULL_NODE_FEATURES install the prerequisites up front.
       - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
       - run: |
           cargo bench -p bitcoin-rs --no-run \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       # Consensus fixture corpus: committed tests that are --ignored by
       # design (large deterministic vectors), so the workspace run never
       # picks them up.
-      - run: cargo test -p bitcoin-rs-consensus --no-fail-fast -- --include-ignored
+      - run: cargo test -p bitcoin-rs-consensus --features kernel --no-fail-fast -- --include-ignored
       # Full-node feature lint surface (the default-feature lint runs in
       # ci.yml). In a virtual workspace (no root [package]), `--features`
       # flags are not forwarded to library crates; use `-p bitcoin-rs` so the
@@ -64,12 +64,9 @@ jobs:
           # (virtual workspace: -p bitcoin-rs does not forward features to node's own
           # test targets, so their lints are silently skipped without this step).
           cargo clippy -p bitcoin-rs-node --all-targets -- -D warnings
-          # -p bitcoin-rs-consensus lints consensus's own test targets with
-          # kernel enabled (the PR-gate clippy lane lints them without kernel).
-          # Without this step, consensus's kernel-gated integration tests
-          # (kernel_block_parity, kernel_vector_parity) and the
-          # kernel_verify_spike example would never be linted.
-          cargo clippy -p bitcoin-rs-consensus --all-targets -- -D warnings
+          # Kernel-gated integration tests (kernel_block_parity,
+          # kernel_vector_parity) only compile with the feature on.
+          cargo clippy -p bitcoin-rs-consensus --all-targets --features kernel -- -D warnings
 
   bench-smoke:
     runs-on: ubuntu-latest
@@ -118,10 +115,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      # consensus and node have `kernel` in their per-crate defaults, so
-      # `cargo check --workspace --all-targets` compiles the C++ kernel
-      # engine; install its prerequisites.
-      - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
+      # consensus and node no longer default to kernel, so workspace check
+      # does not compile libbitcoinkernel.
       # dtolnay action installs the newest nightly via rustup in-job.
       - uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -127,7 +127,7 @@ retained Criterion benchmark targets are compiled in the `bench-smoke` CI lane
 ## Consensus validation
 
 ### bitcoinkernel
-Bitcoin Core's C++ consensus engine (`libbitcoinkernel`). The `kernel` feature compiles it as an independent oracle: tests (and a later runtime verification tap) compare Core's parse and script verdicts against the native path. Production apply never feeds kernel-owned data into Rust state. Builds with `kernel` need `cmake` and `libboost-dev`. See `docs/contracts/validation-default.md`.
+Bitcoin Core's C++ consensus engine (`libbitcoinkernel`). The `kernel` feature compiles it as an independent oracle: tests and `--verify-kernel` compare Core's parse, txids, and script verdicts against the native path. Production apply never feeds kernel-owned data into Rust state. Builds with `kernel` need `cmake` and `libboost-dev`. See `docs/contracts/validation-default.md`.
 
 ### Native Rust interpreter
 The production script path (`crates/script`). It executes legacy, P2SH, SegWit v0, and Taproot key-path and script-path spends through the opcode evaluator. Core's `script_tests`, `tx_valid`, and `tx_invalid` vectors currently pin zero native mismatches. Signature checks reuse the process-wide `secp256k1::SECP256K1` context. Apply-path verification precomputes BIP143/BIP341 sighash midstates once per transaction (`SighashCache::precompute`) and clones that cache into each input.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -109,7 +109,7 @@ Skipping script-signature verification for blocks at or below a trusted height w
 The mainnet checkpoint (height 938343, block `00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac`). Script verification is skipped at or below it only after the active header chain is shown to contain this exact hash; sub-anchor header tips and diverged chains verify fully.
 
 ### Optimized default posture
-The default mainnet configuration: `fjall` backend, multi-peer download (outbound target 8, pending block budget 128, 16 in-flight per peer), hash-pinned assume-valid, 450 MiB `dbcache`, `txindex` and pruning off. The checked-in Compose specialization compiles `fjall` + `bitcoinkernel`, runs unprivileged, and namespaces node and enforcer data by `BITCOIN_RS_NETWORK`.
+The default mainnet configuration: `fjall` backend, multi-peer download (outbound target 8, pending block budget 128, 16 in-flight per peer), hash-pinned assume-valid, 450 MiB `dbcache`, `txindex` and pruning off. The checked-in Compose specialization compiles `fjall`, runs unprivileged, and namespaces node and enforcer data by `BITCOIN_RS_NETWORK`.
 
 ### Node network selection
 `BITCOIN_RS_NETWORK`/`--network` atomically selects consensus rules and P2P bootstrap identity while preserving later low-level overrides. The internal consensus `Network` remains the consensus selector: `drynet4` keeps mainnet consensus with message start `eca5d404`, no Bitcoin DNS seeds, and `drynet4.drivechain.dev:8533`. See `docs/solutions/architecture-patterns/network-selection-keeps-p2p-identity-atomic.md`.
@@ -127,13 +127,13 @@ retained Criterion benchmark targets are compiled in the `bench-smoke` CI lane
 ## Consensus validation
 
 ### bitcoinkernel
-Bitcoin Core's C++ consensus engine (`libbitcoinkernel`). With the `kernel` feature it is both the input-script verifier for every script class and the block **parser** on the apply path (*One-shot kernel block parse*). Rust performs the surrounding non-script transaction and block checks. `kernel` is the production default in `bitcoin-rs-consensus` and `bitcoin-rs-node`, and in the Compose image; the `bin/bitcoin-rs` binary leaves it off so `cargo build -p bitcoin-rs` uses the native interpreter. Builds with `kernel` need `cmake` and `libboost-dev`. Issue #213 keeps this library default until native wins the signed-spend and full-replay gates (`docs/contracts/validation-default.md`).
+Bitcoin Core's C++ consensus engine (`libbitcoinkernel`). The `kernel` feature compiles it as an independent oracle: tests (and a later runtime verification tap) compare Core's parse and script verdicts against the native path. Production apply never feeds kernel-owned data into Rust state. Builds with `kernel` need `cmake` and `libboost-dev`. See `docs/contracts/validation-default.md`.
 
 ### Native Rust interpreter
-The pure-Rust script path used when `kernel` is off (`crates/script`). It executes legacy, P2SH, SegWit v0, and Taproot key-path and script-path spends through the opcode evaluator. Core's `script_tests`, `tx_valid`, and `tx_invalid` vectors currently pin zero native mismatches. Signature checks reuse the process-wide `secp256k1::SECP256K1` context. It is the C++-free quickstart engine, not the library production default.
+The production script path (`crates/script`). It executes legacy, P2SH, SegWit v0, and Taproot key-path and script-path spends through the opcode evaluator. Core's `script_tests`, `tx_valid`, and `tx_invalid` vectors currently pin zero native mismatches. Signature checks reuse the process-wide `secp256k1::SECP256K1` context. Apply-path verification precomputes BIP143/BIP341 sighash midstates once per transaction (`SighashCache::precompute`) and clones that cache into each input.
 
-### One-shot kernel block parse
-Parsing each block exactly once with `bitcoinkernel::Block::new` (`KernelBlock`, `crates/consensus/src/kernel.rs`) and reusing that parse downstream for txids and the transaction objects script preparation borrows via `TransactionRef`. Price a replacement by everything it subsumes, not by the line item that motivated it.
+### One-shot native block identities
+Apply hashes each already-decoded transaction once (`block_txids`) and reuses those txids for merkle, BIP30/BIP34, overlay, and script preparation. `KernelBlock` remains available under `--features kernel` so the Core parse can be compared, not substituted.
 
 ### Runtime-dispatched AVX2 Merkle
 Parent hashing of Merkle pairs uses Bitcoin Core's 8-way AVX2 SHA-256d kernel on x86-64 hosts that advertise AVX2, selected at runtime. Hosts without AVX2, and trees too small to fill one 8-pair batch, use the allocation-free scalar spine. Both paths implement Bitcoin's odd-leaf duplication and mutated-tree rule.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -133,7 +133,7 @@ Bitcoin Core's C++ consensus engine (`libbitcoinkernel`). The `kernel` feature c
 The production script path (`crates/script`). It executes legacy, P2SH, SegWit v0, and Taproot key-path and script-path spends through the opcode evaluator. Core's `script_tests`, `tx_valid`, and `tx_invalid` vectors currently pin zero native mismatches. Signature checks reuse the process-wide `secp256k1::SECP256K1` context. Apply-path verification precomputes BIP143/BIP341 sighash midstates once per transaction (`SighashCache::precompute`) and clones that cache into each input.
 
 ### One-shot native block identities
-Apply hashes each already-decoded transaction once (`block_txids`) and reuses those txids for merkle, BIP30/BIP34, overlay, and script preparation. `KernelBlock` remains available under `--features kernel` so the Core parse can be compared, not substituted.
+Apply hashes each already-decoded transaction once (`block_txids`) when it has no preserved wire bytes, and hashes txids from those bytes (`txids_from_serialized_block`) when it does: a legacy transaction is one contiguous double-SHA256, a BIP144 transaction hashes the non-witness layout and skips marker/flag/witness. That avoids re-encoding the decoded `Tx` graph. `KernelBlock` remains available under `--features kernel` so the Core parse can be compared, not substituted.
 
 ### Runtime-dispatched AVX2 Merkle
 Parent hashing of Merkle pairs uses Bitcoin Core's 8-way AVX2 SHA-256d kernel on x86-64 hosts that advertise AVX2, selected at runtime. Hosts without AVX2, and trees too small to fill one 8-pair batch, use the allocation-free scalar spine. Both paths implement Bitcoin's odd-leaf duplication and mutated-tree rule.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ workflow, coding standards, and verification commands used across the project.
 - Rust toolchain: Rust 2024 edition (MSRV 1.95.0 or newer).
 - Default build: Pure Rust. No C++ compiler or system libraries required.
   Script validation uses the native interpreter in `bitcoin-rs-script`.
-- Optional kernel engine: `cmake` and `libboost-dev` (only when building with
-  `--features kernel` for `libbitcoinkernel`). Library crates default to
-  `kernel`; the binary does not. See `docs/contracts/validation-default.md`.
+- Optional kernel oracle: `cmake` and `libboost-dev` (only when building with
+  `--features kernel` for `libbitcoinkernel`). Off by default. See
+  `docs/contracts/validation-default.md`.
 
 Install tools:
 
@@ -117,9 +117,7 @@ Key rules:
 - Storage isolation: storage backends remain behind `crates/storage`. `crates/rpc` consumes node-level capabilities, never storage engines directly.
 - Consensus authority: the native Rust interpreter in `crates/script` verifies
   every consensus spend class. `libbitcoinkernel` is an opt-in differential
-  oracle behind `--features kernel`. The `kernel` feature remains the default
-  in `bitcoin-rs-consensus` and `bitcoin-rs-node` until the #213 measurement
-  gate flips those crates.
+  oracle behind `--features kernel`.
 
 ## Commit and PR conventions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,8 @@ mimalloc = { version = ">=0.1.50, <0.2", default-features = false }
 # Keep `bitcoinconsensus-std` out of the workspace-wide dependency: the
 # `bitcoinconsensus` opt-in was removed and bitcoinkernel is the optional
 # consensus oracle, gated by the consensus crate's `kernel` feature. The
-# `kernel` feature defaults ON in `crates/consensus` and `crates/node` but
-# OFF in `bin/bitcoin-rs`. Issue #213 keeps that split until native wins
-# the signed-spend and full-replay gates (see docs/contracts/validation-default.md).
+# `kernel` feature is off by default in `crates/consensus`, `crates/node`,
+# and `bin/bitcoin-rs` (see docs/contracts/validation-default.md).
 bitcoin = { version = ">=0.32.9, <0.33", default-features = false, features = [
     "std", "secp-recovery", "serde", "rand-std",
 ] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ FROM rust:1.95-bookworm AS builder
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
-        clang \
-        cmake \
-        libboost-dev \
-        libclang-dev \
         libzmq3-dev \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
@@ -17,9 +13,10 @@ WORKDIR /workspace
 COPY . .
 
 # Build the production verifier with the default fjall storage backend, while
-# leaving the other storage engines out of the runtime image.
+# leaving the other storage engines and the optional kernel oracle out of the
+# runtime image.
 RUN cargo build --locked --release -p bitcoin-rs \
-    --no-default-features --features fjall,kernel
+    --no-default-features --features fjall
 
 FROM debian:bookworm-slim AS runtime
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # bitcoin-rs
 
-A Bitcoin full node in Rust 2024. The default binary build is pure Rust (no
-C++ toolchain required) and runs the native script interpreter for every
-consensus spend class. Enable `--features kernel` to route the same checks
-through `libbitcoinkernel` as an independent oracle. The `kernel` feature
-remains the default in the `bitcoin-rs-consensus` and `bitcoin-rs-node`
-library crates, and in the Compose image, until issue #213 promotes native
-(`docs/contracts/validation-default.md`).
+A Bitcoin full node in Rust 2024. The default build is pure Rust (no C++
+toolchain required). Production apply always runs the native script
+interpreter for every consensus spend class. `--features kernel` compiles
+`libbitcoinkernel` as an independent Core oracle; it does not replace the
+native apply path (`docs/contracts/validation-default.md`).
 
 [![CI](https://github.com/gosuda/bitcoin-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/gosuda/bitcoin-rs/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
@@ -85,14 +83,11 @@ risk of correlated implementation failures.
   and Taproot key-path and script-path spends. Core's committed `script_tests`,
   `tx_valid`, and `tx_invalid` vectors pin zero native mismatches. Script checks
   run in parallel across rayon workers with sighash midstate reuse per
-  transaction. `--features kernel` routes the same checks through
-  `libbitcoinkernel` (Bitcoin Core's C++ engine) as an independent oracle.
-- Kernel feature: `--features kernel` enables `libbitcoinkernel`. The
-  `crates/consensus` and `crates/node` library crates still default to `kernel`;
-  the `bin/bitcoin-rs` binary defaults to `["fjall", "redb", "zmq"]` (no kernel)
-  so a default binary build is pure Rust. Issue #213 keeps that split until
-  native wins the signed-spend and full-replay gates
-  (`docs/contracts/validation-default.md`).
+  transaction. `--features kernel` compiles `libbitcoinkernel` (Bitcoin Core's
+  C++ engine) as an independent oracle; production apply stays native.
+- Kernel feature: `--features kernel` enables `libbitcoinkernel`. It is off
+  by default in `crates/consensus`, `crates/node`, and `bin/bitcoin-rs`, so a
+  default build is pure Rust (`docs/contracts/validation-default.md`).
 - Pure-Rust storage defaults: LSM-tree storage backed by `fjall` by default,
   with `redb` compiled in, and `rocksdb`/`mdbx` available through optional Cargo
   features.
@@ -139,9 +134,9 @@ curl -s --user bitcoin-rs:bitcoin-rs \
 
 ### Kernel oracle build
 
-To route script verification through `libbitcoinkernel` instead of the native
-interpreter, install C++ dependencies (`cmake` and `libboost-dev` on
-Debian/Ubuntu), then pass `--features kernel`:
+To compile `libbitcoinkernel` as an independent Core oracle (differential
+tests; production apply stays native), install C++ dependencies (`cmake` and
+`libboost-dev` on Debian/Ubuntu), then pass `--features kernel`:
 
 ```sh
 cargo build --release -p bitcoin-rs --features kernel
@@ -178,8 +173,8 @@ Core & domain: crates/consensus, crates/script, crates/utxo, crates/chain, crate
 
 - Validation: script execution runs in parallel across rayon workers, with
   sighash midstate reuse per transaction. The native interpreter covers every
-  consensus spend class. Under the `kernel` feature, `libbitcoinkernel` is the
-  verifier instead.
+  consensus spend class. `--features kernel` compiles `libbitcoinkernel` as an
+  independent oracle; it does not become the apply engine.
 - Kernel boundary: `crates/consensus/src/kernel.rs` contains all
   `libbitcoinkernel` types behind `#[cfg(feature = "kernel")]`. Kernel types
   never leak into node state or apply logic.
@@ -193,8 +188,8 @@ Core & domain: crates/consensus, crates/script, crates/utxo, crates/chain, crate
 | Setting | Default |
 |---|---|
 | Storage backend | `fjall` |
-| Validation engine | Native Rust interpreter (default binary); `libbitcoinkernel` with `--features kernel` and as the consensus/node library default |
-| Kernel feature | Off in default binary build; on in `crates/consensus` and `crates/node` library defaults |
+| Validation engine | Native Rust interpreter |
+| Kernel feature | Off by default; compiles `libbitcoinkernel` as an independent oracle |
 | Database cache | 450 MiB (`--dbcache-mb`, split 80/20 when txindex is enabled) |
 | Multi-peer download | On (8 outbound peers, 128-block window) |
 | Transaction index | Off |

--- a/bin/bitcoin-rs/src/cli.rs
+++ b/bin/bitcoin-rs/src/cli.rs
@@ -61,7 +61,8 @@ pub(crate) struct CliArgs {
     pub(crate) metrics_bind: Option<SocketAddr>,
     #[arg(long = "assume-valid-height")]
     pub(crate) assume_valid_height: Option<u32>,
-    /// Compare native script verdicts against libbitcoinkernel. Requires `--features kernel`.
+    /// Compare native parse/txids and script verdicts against libbitcoinkernel.
+    /// Requires `--features kernel`.
     #[arg(long = "verify-kernel", num_args = 0..=1, default_missing_value = "true")]
     pub(crate) verify_kernel: Option<bool>,
     /// Watch-only coinbase payout address for solo mining templates.

--- a/bin/bitcoin-rs/src/cli.rs
+++ b/bin/bitcoin-rs/src/cli.rs
@@ -61,6 +61,9 @@ pub(crate) struct CliArgs {
     pub(crate) metrics_bind: Option<SocketAddr>,
     #[arg(long = "assume-valid-height")]
     pub(crate) assume_valid_height: Option<u32>,
+    /// Compare native script verdicts against libbitcoinkernel. Requires `--features kernel`.
+    #[arg(long = "verify-kernel", num_args = 0..=1, default_missing_value = "true")]
+    pub(crate) verify_kernel: Option<bool>,
     /// Watch-only coinbase payout address for solo mining templates.
     #[arg(long = "mining-payout-address")]
     pub(crate) mining_payout_address: Option<String>,
@@ -116,6 +119,7 @@ impl CliArgs {
             chainstate_journal: None,
             validation: ValidationOverrides {
                 assume_valid_height: self.assume_valid_height,
+                verify_kernel: self.verify_kernel,
             },
             mining: MiningOverrides {
                 payout_address: self.mining_payout_address,

--- a/bin/bitcoin-rs/src/env.rs
+++ b/bin/bitcoin-rs/src/env.rs
@@ -28,6 +28,7 @@ enum EnvSetting {
     LogLevel,
     MetricsBind,
     AssumeValidHeight,
+    VerifyKernel,
     MiningPayoutAddress,
     ChainstateJournal,
     ChainstateJournalBlocks,
@@ -76,6 +77,7 @@ fn env_setting(key: &str) -> Option<EnvSetting> {
         "BITCOIN_RS_LOG_LEVEL" => EnvSetting::LogLevel,
         "BITCOIN_RS_METRICS_BIND" => EnvSetting::MetricsBind,
         "BITCOIN_RS_ASSUME_VALID_HEIGHT" => EnvSetting::AssumeValidHeight,
+        "BITCOIN_RS_VERIFY_KERNEL" => EnvSetting::VerifyKernel,
         "BITCOIN_RS_MINING_PAYOUT_ADDRESS" => EnvSetting::MiningPayoutAddress,
         "BITCOIN_RS_CHAINSTATE_JOURNAL" => EnvSetting::ChainstateJournal,
         "BITCOIN_RS_CHAINSTATE_JOURNAL_BLOCKS" => EnvSetting::ChainstateJournalBlocks,
@@ -137,6 +139,9 @@ fn apply(layer: &mut UserConfig, setting: EnvSetting, value: &str) -> Result<()>
         EnvSetting::MetricsBind => layer.observability.metrics_bind = Some(value.parse()?),
         EnvSetting::AssumeValidHeight => {
             layer.validation.assume_valid_height = Some(value.parse()?);
+        }
+        EnvSetting::VerifyKernel => {
+            layer.validation.verify_kernel = Some(parse_bool(value)?);
         }
         EnvSetting::MiningPayoutAddress => {
             layer.mining.payout_address = Some(value.to_owned());

--- a/bin/bitcoin-rs/src/toml.rs
+++ b/bin/bitcoin-rs/src/toml.rs
@@ -36,6 +36,7 @@ struct TomlFile {
     notifications: Option<NotificationConfig>,
     chainstate_journal: Option<ChainstateJournalOverrides>,
     assume_valid_height: Option<u32>,
+    verify_kernel: Option<bool>,
     mining_payout_address: Option<String>,
 }
 
@@ -107,6 +108,7 @@ impl TomlFile {
             chainstate_journal: self.chainstate_journal,
             validation: ValidationOverrides {
                 assume_valid_height: self.assume_valid_height,
+                verify_kernel: self.verify_kernel,
             },
             mining: MiningOverrides {
                 payout_address: self.mining_payout_address,

--- a/bin/bitcoin-rs/tests/cli_help.rs
+++ b/bin/bitcoin-rs/tests/cli_help.rs
@@ -15,4 +15,8 @@ fn help_prints_binary_name() {
         String::from_utf8_lossy(&output.stdout).contains("--measure-storage"),
         "help must name the storage-footprint measurement command"
     );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("--verify-kernel"),
+        "help must name the kernel verification tap"
+    );
 }

--- a/bin/bitcoin-rs/tests/gates/g19_validation_default.rs
+++ b/bin/bitcoin-rs/tests/gates/g19_validation_default.rs
@@ -1,11 +1,10 @@
 //! G19 — Validation-engine default matches the recorded #213 verdict.
 //!
 //! **G19 — Validation default.** `bitcoin-rs-consensus` and `bitcoin-rs-node`
-//! default to `kernel` while [`RECORDED_VERDICT`] is [`Verdict::KeepKernel`].
-//! `bin/bitcoin-rs` default features never include `kernel`. Promoting native
-//! is one coordinated change: flip the verdict and drop `kernel` from the two
-//! library defaults in the same commit, after the measurement gates in
-//! `docs/benchmarks/native-validation-default.md` pass.
+//! omit `kernel` from `default` while [`RECORDED_VERDICT`] is
+//! [`Verdict::PromoteNative`]. `bin/bitcoin-rs` default features never include
+//! `kernel`. Reverting that split is one coordinated change: flip the verdict
+//! and put `kernel` back in the two library defaults in the same commit.
 //!
 //! The check walks each package's default feature graph, including local
 //! aliases and `crate/feature` / `dep:bitcoinkernel` forwarding, so an
@@ -23,16 +22,15 @@ use std::process::Command;
 /// Recorded #213 promotion verdict.
 ///
 /// Change this only together with the matching `default` lists in
-/// `crates/consensus/Cargo.toml` and `crates/node/Cargo.toml`, and only after
-/// every gate in `docs/benchmarks/native-validation-default.md` passes.
-const RECORDED_VERDICT: Verdict = Verdict::KeepKernel;
+/// `crates/consensus/Cargo.toml` and `crates/node/Cargo.toml`.
+const RECORDED_VERDICT: Verdict = Verdict::PromoteNative;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Verdict {
     /// Library crates keep `kernel` in `default`.
+    #[allow(dead_code, reason = "retained so a revert is one coordinated flip")]
     KeepKernel,
     /// Library crates have dropped `kernel` from `default`.
-    #[allow(dead_code, reason = "constructed when RECORDED_VERDICT flips")]
     PromoteNative,
 }
 

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -12,7 +12,9 @@ description = "bitcoin-rs :: consensus"
 workspace = true
 
 [features]
-default = ["kernel"]
+default = []
+# Compiles libbitcoinkernel as an independent Core oracle. Production apply
+# stays on the native interpreter even when this feature is on.
 kernel = ["dep:bitcoinkernel"]
 rocksdb = []
 fjall = []

--- a/crates/consensus/README.md
+++ b/crates/consensus/README.md
@@ -11,9 +11,10 @@ Rule checks live in small per-subject modules (`bip9`, `bip30`, `bip34`, `bip65`
 `bip66`, `bip68`, `bip112`, `bip113`, `bip141`, `bip143`, `bip341`, `bip342`), surfaced
 through the `verify_transaction` family (with median-time-past and borrowed variants),
 `is_final_tx`, and the `verify_block_rules` family including Merkle-root verification.
-`kernel::verify_tx_scripts` and `kernel::KernelBlock` are available under
-`--features kernel` so tests can compare Core's parse and script verdicts
-against the native path. BIP9 activation is `compute_state`
+`kernel::verify_tx_scripts`, `kernel::KernelBlock`, `kernel::compare_script_verdicts`,
+and `kernel::compare_block_parse` are available under `--features kernel` so tests
+and `--verify-kernel` can compare Core's parse, txids, and script verdicts against
+the native path. BIP9 activation is `compute_state`
 over a `DeploymentContext` with `DeploymentParams`. Consensus bounds are exported as
 `MAX_SCRIPT_SIZE`, `MAX_MONEY`, and `MAX_BLOCK_SIGOPS_COST`; failures are `ConsensusError`
 variants.

--- a/crates/consensus/README.md
+++ b/crates/consensus/README.md
@@ -1,30 +1,26 @@
 # bitcoin-rs-consensus
 
 Owns consensus validation: transaction and block rule checks for every active soft fork.
-Script verification has two backends. The native Rust interpreter executes every
-consensus spend class. The `kernel` feature (the production default in this crate
-and in `bitcoin-rs-node`, `VAL-01`) routes the same checks through bitcoinkernel —
-Bitcoin Core's C++ consensus engine. The `bin/bitcoin-rs` binary does not enable
-`kernel` by default, so `cargo build -p bitcoin-rs` uses the native interpreter.
-Issue #213 keeps that split until native wins the signed-spend and full-replay
-gates; see [`docs/contracts/validation-default.md`](../../docs/contracts/validation-default.md).
+Script verification always runs through the native Rust interpreter for every
+consensus spend class. The `kernel` feature compiles bitcoinkernel — Bitcoin
+Core's C++ consensus engine — as an independent oracle for differential tests.
+It does not replace the apply path. See
+[`docs/contracts/validation-default.md`](../../docs/contracts/validation-default.md).
 
 Rule checks live in small per-subject modules (`bip9`, `bip30`, `bip34`, `bip65`,
 `bip66`, `bip68`, `bip112`, `bip113`, `bip141`, `bip143`, `bip341`, `bip342`), surfaced
 through the `verify_transaction` family (with median-time-past and borrowed variants),
 `is_final_tx`, and the `verify_block_rules` family including Merkle-root verification.
-`kernel::KernelBlock` parses a serialized block exactly once with
-`bitcoinkernel::Block::new`, yielding the txids and borrowed transaction objects that
-script preparation reuses, and `kernel::KernelContext::verify_tx` verifies a
-transaction's inputs through bitcoinkernel over any `UtxoView`. BIP9 activation is
-`compute_state`
+`kernel::verify_tx_scripts` and `kernel::KernelBlock` are available under
+`--features kernel` so tests can compare Core's parse and script verdicts
+against the native path. BIP9 activation is `compute_state`
 over a `DeploymentContext` with `DeploymentParams`. Consensus bounds are exported as
 `MAX_SCRIPT_SIZE`, `MAX_MONEY`, and `MAX_BLOCK_SIGOPS_COST`; failures are `ConsensusError`
 variants.
 
 ## Features
-- `kernel` (default): routes script verification through
-  [bitcoinkernel](../../CONCEPTS.md#bitcoinkernel)
+- `kernel`: compiles [bitcoinkernel](../../CONCEPTS.md#bitcoinkernel) as an
+  independent Core oracle. Off by default.
 - `rocksdb`, `fjall`, `redb`: empty in this crate, accepted so workspace-wide feature
   selection does not fail here
 

--- a/crates/consensus/src/block_view.rs
+++ b/crates/consensus/src/block_view.rs
@@ -10,9 +10,8 @@ use bitcoin_rs_primitives::{Tx, TxOut, Txid, Wtxid};
 
 /// A decoded block's transactions, identities, and resolved prevouts.
 ///
-/// The node computes the transaction IDs once (the kernel parse provides them
-/// in kernel builds; the native build hashes each transaction once) and hands
-/// them here by value. Witness IDs are computed lazily at most once, because
+/// The node hashes each already-decoded transaction once and hands those
+/// identities here by value. Witness IDs are computed lazily at most once, because
 /// only witness-carrying blocks under active segwit ever need them (the BIP141
 /// witness-commitment check).
 pub struct BlockView<'b> {

--- a/crates/consensus/src/kernel.rs
+++ b/crates/consensus/src/kernel.rs
@@ -193,6 +193,39 @@ mod enabled {
             .map_err(|error| ConsensusError::Kernel(error.to_string()))?;
         Ok(bitcoinkernel::TxOut::new(&script, amount))
     }
+
+    /// Compares native accept/reject against Core. Agreement on reject is
+    /// `Ok` so the caller can keep the native error; disagreement is
+    /// [`ConsensusError::Kernel`].
+    pub fn compare_script_verdicts(
+        txs_and_spent: &[(&Tx, Vec<(OutPoint, TxOut)>)],
+        flags: VerifyFlags,
+        native_accepted: bool,
+    ) -> Result<(), ConsensusError> {
+        let mut kernel_error = None;
+        for (tx, spent) in txs_and_spent {
+            if spent.is_empty() {
+                continue;
+            }
+            if let Err(error) = verify_tx_scripts(tx, spent, flags) {
+                kernel_error = Some(error);
+                break;
+            }
+        }
+        let kernel_accepted = kernel_error.is_none();
+        match (native_accepted, kernel_accepted) {
+            (true, true) | (false, false) => Ok(()),
+            (true, false) => Err(ConsensusError::Kernel(format!(
+                "native accepted, kernel rejected: {}",
+                kernel_error
+                    .map(|error| error.to_string())
+                    .unwrap_or_else(|| "unknown kernel error".to_owned())
+            ))),
+            (false, true) => Err(ConsensusError::Kernel(
+                "native rejected, kernel accepted".to_owned(),
+            )),
+        }
+    }
 }
 
 /// Returns whether this build compiled `libbitcoinkernel`.
@@ -205,9 +238,28 @@ pub const fn kernel_compiled() -> bool {
 }
 
 #[cfg(feature = "kernel")]
-pub use enabled::{KernelBlock, KernelContext, verify_tx_scripts};
+pub use enabled::{KernelBlock, KernelContext, compare_script_verdicts, verify_tx_scripts};
 
 #[cfg(not(feature = "kernel"))]
 /// Stub kernel context available when the `kernel` feature is off.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct KernelContext;
+
+#[cfg(not(feature = "kernel"))]
+/// Runtime `--verify-kernel` requires a build that compiled `libbitcoinkernel`.
+pub fn compare_script_verdicts(
+    txs_and_spent: &[(
+        &bitcoin_rs_primitives::Tx,
+        Vec<(
+            bitcoin_rs_primitives::OutPoint,
+            bitcoin_rs_primitives::TxOut,
+        )>,
+    )],
+    flags: bitcoin_rs_script::VerifyFlags,
+    native_accepted: bool,
+) -> Result<(), crate::ConsensusError> {
+    let _ = (txs_and_spent, flags, native_accepted);
+    Err(crate::ConsensusError::Kernel(
+        "verify_kernel requires a build with --features kernel".to_owned(),
+    ))
+}

--- a/crates/consensus/src/kernel.rs
+++ b/crates/consensus/src/kernel.rs
@@ -8,17 +8,19 @@ mod enabled {
 
     /// Verifies every input script of `tx` through bitcoinkernel.
     ///
+    /// Independent Core oracle: callers compare this verdict against the native
+    /// interpreter. Production apply never routes here.
+    ///
     /// `spent_outputs` pairs each input's outpoint with the output it spends, in
     /// input order — the shape the verify path already holds after prevout
     /// resolution. One transaction serialization/parse and one
     /// [`bitcoinkernel::PrecomputedTransactionData`] are shared across all inputs.
     ///
-    /// Per-input verdict failures map to [`ConsensusError::Script`] (preserving
-    /// the verify entry's error contract); parse and precompute failures map to
-    /// [`ConsensusError::Kernel`]. A `spent_outputs` length that disagrees with
-    /// the input count is rejected outright: the loop below is driven by
-    /// `spent_outputs`, so a short slice would otherwise leave trailing inputs
-    /// silently unverified.
+    /// Per-input verdict failures map to [`ConsensusError::Script`]; parse and
+    /// precompute failures map to [`ConsensusError::Kernel`]. A `spent_outputs`
+    /// length that disagrees with the input count is rejected outright: the loop
+    /// below is driven by `spent_outputs`, so a short slice would otherwise
+    /// leave trailing inputs silently unverified.
     pub fn verify_tx_scripts(
         tx: &Tx,
         spent_outputs: &[(OutPoint, TxOut)],
@@ -36,12 +38,9 @@ mod enabled {
 
     /// A block parsed once by `libbitcoinkernel`.
     ///
-    /// Parsing here is worth far more than the parse itself. Core's
-    /// `CTransaction` hashes itself while deserializing, using the SHA-256
-    /// implementation Core selects at runtime (`avx2(8way)` on this host), so
-    /// every txid comes out of this parse for free and the per-transaction
-    /// serialization + `bitcoinkernel::Transaction::new` round-trip disappears
-    /// with it.
+    /// This is the independent Core parse used by `--verify-kernel` and by
+    /// differential tests. Production apply hashes native `Tx` values and
+    /// never feeds this handle into Rust state.
     pub struct KernelBlock {
         block: bitcoinkernel::Block,
     }
@@ -75,31 +74,17 @@ mod enabled {
         pub fn transaction_count(&self) -> usize {
             self.block.transaction_count()
         }
-
-        pub(crate) fn transaction(
-            &self,
-            index: usize,
-        ) -> Result<bitcoinkernel::TransactionRef<'_>, ConsensusError> {
-            self.block
-                .transaction(index)
-                .map_err(|error| ConsensusError::Kernel(error.to_string()))
-        }
     }
 
-    /// Kernel transaction plus sighash precompute retained for parallel
-    /// per-input verification.
-    ///
-    /// Generic over the transaction handle so the block path can hold a
-    /// borrowed [`bitcoinkernel::TransactionRef`] while the standalone
-    /// [`verify_tx_scripts`] entry keeps an owned one.
-    pub(crate) struct PreparedKernelTx<T: bitcoinkernel::prelude::TransactionExt> {
+    /// Kernel transaction plus sighash precompute retained across inputs.
+    struct PreparedKernelTx<T: bitcoinkernel::prelude::TransactionExt> {
         kernel_tx: T,
         precomputed: bitcoinkernel::PrecomputedTransactionData,
     }
 
     /// Builds the shared [`bitcoinkernel::PrecomputedTransactionData`] over an
     /// already-parsed kernel transaction.
-    pub(crate) fn prepare_kernel_tx<T: bitcoinkernel::prelude::TransactionExt>(
+    fn prepare_kernel_tx<T: bitcoinkernel::prelude::TransactionExt>(
         kernel_tx: T,
         input_count: usize,
         spent_outputs: &[(OutPoint, TxOut)],
@@ -124,7 +109,7 @@ mod enabled {
     }
 
     /// Verifies a single input against a previously prepared kernel transaction.
-    pub(crate) fn verify_prepared_input<T: bitcoinkernel::prelude::TransactionExt>(
+    fn verify_prepared_input<T: bitcoinkernel::prelude::TransactionExt>(
         prepared: &PreparedKernelTx<T>,
         prevout: &TxOut,
         input_index: usize,
@@ -210,35 +195,19 @@ mod enabled {
     }
 }
 
+/// Returns whether this build compiled `libbitcoinkernel`.
+///
+/// The production apply path is always native. This flag only tells callers
+/// whether the independent Core oracle is available for differential checks.
+#[must_use]
+pub const fn kernel_compiled() -> bool {
+    cfg!(feature = "kernel")
+}
+
 #[cfg(feature = "kernel")]
 pub use enabled::{KernelBlock, KernelContext, verify_tx_scripts};
-#[cfg(feature = "kernel")]
-pub(crate) use enabled::{PreparedKernelTx, prepare_kernel_tx, verify_prepared_input};
 
 #[cfg(not(feature = "kernel"))]
 /// Stub kernel context available when the `kernel` feature is off.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct KernelContext;
-
-#[cfg(not(feature = "kernel"))]
-/// Portable-build stand-in for the kernel's one-shot block parse.
-///
-/// The native apply path computes every transaction ID directly from the
-/// decoded block it already owns, so this marker carries no data. It keeps
-/// the prepared-apply shape identical across backends without taking a
-/// second owned copy of the block's txids.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct KernelBlock;
-
-#[cfg(not(feature = "kernel"))]
-impl KernelBlock {
-    /// Decodes `raw_block` to validate preserved block bytes.
-    ///
-    /// # Errors
-    /// Returns [`ConsensusError::Kernel`] if `raw_block` is not a valid block.
-    pub fn parse(raw_block: &[u8]) -> Result<Self, crate::ConsensusError> {
-        bitcoin_rs_primitives::Block::consensus_decode(raw_block)
-            .map_err(|error| crate::ConsensusError::Kernel(error.to_string()))?;
-        Ok(Self)
-    }
-}

--- a/crates/consensus/src/kernel.rs
+++ b/crates/consensus/src/kernel.rs
@@ -226,6 +226,30 @@ mod enabled {
             )),
         }
     }
+
+    /// Compares native txids against Core's parse of the same wire bytes.
+    ///
+    /// Kernel-owned `KernelBlock` / txids never leave this call. Agreement is
+    /// `Ok`; parse failure or a txid/count mismatch is [`ConsensusError::Kernel`].
+    pub fn compare_block_parse(raw: &[u8], native_txids: &[Txid]) -> Result<(), ConsensusError> {
+        let kernel_block = KernelBlock::parse(raw)?;
+        if kernel_block.transaction_count() != native_txids.len() {
+            return Err(ConsensusError::Kernel(format!(
+                "native tx count {}, kernel tx count {}",
+                native_txids.len(),
+                kernel_block.transaction_count(),
+            )));
+        }
+        let kernel_txids = kernel_block.txids()?;
+        for (index, (native, kernel)) in native_txids.iter().zip(kernel_txids.iter()).enumerate() {
+            if native != kernel {
+                return Err(ConsensusError::Kernel(format!(
+                    "txid mismatch at index {index}"
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Returns whether this build compiled `libbitcoinkernel`.
@@ -238,7 +262,9 @@ pub const fn kernel_compiled() -> bool {
 }
 
 #[cfg(feature = "kernel")]
-pub use enabled::{KernelBlock, KernelContext, compare_script_verdicts, verify_tx_scripts};
+pub use enabled::{
+    KernelBlock, KernelContext, compare_block_parse, compare_script_verdicts, verify_tx_scripts,
+};
 
 #[cfg(not(feature = "kernel"))]
 /// Stub kernel context available when the `kernel` feature is off.
@@ -262,4 +288,96 @@ pub fn compare_script_verdicts(
     Err(crate::ConsensusError::Kernel(
         "verify_kernel requires a build with --features kernel".to_owned(),
     ))
+}
+
+#[cfg(not(feature = "kernel"))]
+/// Runtime `--verify-kernel` requires a build that compiled `libbitcoinkernel`.
+pub fn compare_block_parse(
+    raw: &[u8],
+    native_txids: &[bitcoin_rs_primitives::Txid],
+) -> Result<(), crate::ConsensusError> {
+    let _ = (raw, native_txids);
+    Err(crate::ConsensusError::Kernel(
+        "verify_kernel requires a build with --features kernel".to_owned(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin_rs_primitives::{
+        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
+    };
+
+    use super::{compare_block_parse, kernel_compiled};
+
+    fn coinbase_block() -> Block {
+        let tx = Tx {
+            version: 1,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid::default(), u32::MAX),
+                script_sig: vec![1, 1],
+                sequence: u32::MAX,
+                witness: Vec::new(),
+            }],
+            outputs: vec![TxOut {
+                value: 50,
+                script_pubkey: Vec::new(),
+            }],
+            lock_time: 0,
+        };
+        Block {
+            header: Header {
+                version: 1,
+                prev_blockhash: BlockHash::default(),
+                merkle_root: Hash256::default(),
+                time: 0,
+                bits: 0,
+                nonce: 0,
+            },
+            txs: vec![tx],
+        }
+    }
+
+    #[test]
+    fn compare_block_parse_agrees_or_requires_kernel_feature() {
+        let block = coinbase_block();
+        let raw = consensus_bytes(&block);
+        let txids: Vec<Txid> = block.txs.iter().map(Tx::txid).collect();
+        let result = compare_block_parse(&raw, &txids);
+        if kernel_compiled() {
+            if let Err(error) = result {
+                panic!("Core parse must match native txids: {error}");
+            }
+        } else {
+            match result {
+                Err(crate::ConsensusError::Kernel(reason)) => {
+                    assert!(
+                        reason.contains("verify_kernel"),
+                        "unexpected kernel error: {reason}"
+                    );
+                }
+                other => panic!("expected Kernel compile-time error, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn compare_block_parse_rejects_txid_mismatch_when_compiled() {
+        if !kernel_compiled() {
+            return;
+        }
+        let block = coinbase_block();
+        let raw = consensus_bytes(&block);
+        let mut txids: Vec<Txid> = block.txs.iter().map(Tx::txid).collect();
+        txids[0] = Txid::default();
+        match compare_block_parse(&raw, &txids) {
+            Err(crate::ConsensusError::Kernel(reason)) => {
+                assert!(
+                    reason.contains("txid mismatch"),
+                    "unexpected kernel error: {reason}"
+                );
+            }
+            other => panic!("expected txid mismatch, got {other:?}"),
+        }
+    }
 }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -1,14 +1,9 @@
 //! Consensus validation surfaces for bitcoin-rs.
 //!
-//! Script verification has two backends. The native Rust interpreter in
-//! `bitcoin-rs-script` executes every consensus spend class: legacy, P2SH,
-//! `SegWit` v0, and Taproot key-path and script-path. The `kernel` feature
-//! routes the same checks through bitcoinkernel (Bitcoin Core's C++ engine)
-//! and is the production default in this crate and in `bitcoin-rs-node`.
-//! The `bin/bitcoin-rs` binary defaults to `["fjall", "redb", "zmq"]` (no
-//! `kernel`), so `cargo build -p bitcoin-rs` uses the native interpreter.
-//! Issue #213 keeps `kernel` as the library default until native wins the
-//! signed-spend and full-replay gates; see
+//! Script verification always runs through the native Rust interpreter in
+//! `bitcoin-rs-script`: legacy, P2SH, `SegWit` v0, and Taproot key-path and
+//! script-path. The `kernel` feature compiles `libbitcoinkernel` as an
+//! independent Core oracle; it does not replace the apply path. See
 //! `docs/contracts/validation-default.md`.
 
 #![forbid(unsafe_op_in_unsafe_fn)]
@@ -42,7 +37,7 @@ pub mod bip68;
 pub mod bip9;
 /// Parse-once block state shared by the native apply path.
 pub mod block_view;
-/// Feature-gated bitcoinkernel wrapper.
+/// Feature-gated `libbitcoinkernel` oracle.
 pub mod kernel;
 /// Portable Rust validator.
 pub mod rust_path;

--- a/crates/consensus/src/verify_tx.rs
+++ b/crates/consensus/src/verify_tx.rs
@@ -401,6 +401,35 @@ pub struct BlockScriptChecks<'b> {
     checks: Vec<InputCheck>,
 }
 
+impl BlockScriptChecks<'_> {
+    /// Compares this unit's native script verdict against `libbitcoinkernel`.
+    ///
+    /// Uses the already-resolved Rust prevouts. Kernel-owned handles never
+    /// leave this call.
+    pub fn compare_kernel_scripts(
+        &self,
+        flags: VerifyFlags,
+        native_accepted: bool,
+    ) -> Result<(), ConsensusError> {
+        let txs_and_spent: Vec<(&Tx, Vec<(OutPoint, TxOut)>)> = self
+            .prepared
+            .iter()
+            .filter(|prep| !prep.spent_outputs.is_empty())
+            .map(|prep| {
+                let spent = prep
+                    .tx
+                    .inputs
+                    .iter()
+                    .zip(prep.spent_outputs.iter())
+                    .map(|(input, prevout)| (input.previous_output, prevout.clone()))
+                    .collect();
+                (prep.tx, spent)
+            })
+            .collect();
+        crate::kernel::compare_script_verdicts(&txs_and_spent, flags, native_accepted)
+    }
+}
+
 /// Which unit failed, and how.
 ///
 /// The index is the position in the slice handed to [`verify_prepared_units`],

--- a/crates/consensus/src/verify_tx.rs
+++ b/crates/consensus/src/verify_tx.rs
@@ -5,7 +5,6 @@ use std::time::Instant;
 use bitcoin_rs_primitives::{OutPoint, Tx, TxOut, Txid};
 
 use crate::block_view::BlockView;
-#[cfg(not(feature = "kernel"))]
 use bitcoin_rs_script::Interpreter;
 use bitcoin_rs_script::script::instructions;
 use bitcoin_rs_script::{
@@ -152,7 +151,7 @@ pub fn verify_transaction(
 ///
 /// Checks finality, empty inputs/outputs, coinbase scriptSig size, duplicate inputs, null
 /// prevouts, missing prevouts, input/output value balance, and sigop limits. Skips
-/// kernel/script script execution. This is the assume-valid entry.
+/// script execution. This is the assume-valid entry.
 pub fn verify_transaction_non_script(
     tx: &Tx,
     prevouts: &impl UtxoView,
@@ -186,23 +185,17 @@ fn verify_transaction_with_locktime_cutoff(
     };
 
     if !skip_scripts {
-        // Under the kernel feature every script class routes through Core's
-        // engine — one transaction parse plus one sighash precompute shared across
-        // inputs. Without it, the native interpreter in bitcoin-rs-script runs.
-        #[cfg(feature = "kernel")]
-        crate::kernel::verify_tx_scripts(tx, &prep.prevouts, flags)?;
-        #[cfg(not(feature = "kernel"))]
-        {
-            // One clone of the spent outputs per transaction, shared by every
-            // input check; BIP341 sighashes commit to the full ordered set.
-            let spent_outputs: Vec<TxOut> = prep
-                .prevouts
-                .iter()
-                .map(|(_, prevout)| prevout.clone())
-                .collect();
-            for input_index in 0..tx.inputs.len() {
-                verify_input_script_portable(input_index, &spent_outputs, tx, flags)?;
-            }
+        // Native interpreter is the only production script engine. The `kernel`
+        // feature compiles an independent oracle; it never replaces this path.
+        let spent_outputs: Vec<TxOut> = prep
+            .prevouts
+            .iter()
+            .map(|(_, prevout)| prevout.clone())
+            .collect();
+        let mut cache = bitcoin_rs_primitives::SighashCache::new(tx);
+        cache.precompute(&spent_outputs);
+        for input_index in 0..tx.inputs.len() {
+            verify_input_script_portable(input_index, &spent_outputs, tx, flags, cache.clone())?;
         }
     }
 
@@ -303,26 +296,17 @@ fn finalize_tx_value_and_sigops(tx: &Tx, prep: &TxPrep) -> Result<(), ConsensusE
 
 /// Portable per-input script verdict: the native interpreter covers every
 /// consensus spend class (legacy, P2SH, `SegWit` v0, Taproot key-path and
-/// script-path).
-#[cfg(not(feature = "kernel"))]
+/// script-path). `cache` is a per-transaction midstate clone so parallel
+/// inputs do not rehash shared BIP143/BIP341 pieces.
 fn verify_input_script_portable(
     input_index: usize,
     spent_outputs: &[TxOut],
     tx: &Tx,
     flags: VerifyFlags,
+    cache: bitcoin_rs_primitives::SighashCache<'_>,
 ) -> Result<(), ConsensusError> {
-    let input = &tx.inputs[input_index];
-    let prevout = &spent_outputs[input_index];
     Interpreter
-        .execute_with_prevouts(
-            &prevout.script_pubkey,
-            &input.script_sig,
-            &input.witness,
-            flags,
-            spent_outputs,
-            tx,
-            input_index,
-        )
+        .execute_cached(flags, spent_outputs, tx, input_index, cache)
         .map_err(|error| ConsensusError::Script {
             input_index,
             reason: error.to_string(),
@@ -332,23 +316,19 @@ fn verify_input_script_portable(
 
 /// Per-transaction state retained across the flat block verify phases.
 struct PreparedTx<'b> {
-    #[cfg(not(feature = "kernel"))]
     /// Borrowed from the parse-once [`BlockView`]; every input check of this
     /// transaction reads the same decoded transaction without re-indexing.
     tx: &'b Tx,
-    #[cfg(feature = "kernel")]
-    prevouts: Vec<(OutPoint, TxOut)>,
-    /// The prevouts of `prevouts` as a plain slice, cloned once per
-    /// transaction instead of once per input check; the portable interpreter
-    /// commits to every spent output in its sighashes.
-    #[cfg(not(feature = "kernel"))]
+    /// The prevouts as a plain slice, cloned once per transaction instead of
+    /// once per input check; the native interpreter commits to every spent
+    /// output in its sighashes.
     spent_outputs: Vec<TxOut>,
+    /// Shared BIP143/BIP341 midstates, filled once during preparation.
+    sighash: bitcoin_rs_primitives::SighashCache<'b>,
     pre_error: Option<ConsensusError>,
     post_error: Option<ConsensusError>,
     checks_start: usize,
     checks_len: usize,
-    #[cfg(feature = "kernel")]
-    kernel_state: Option<crate::kernel::PreparedKernelTx<bitcoinkernel::TransactionRef<'b>>>,
 }
 
 /// One deferred per-input script check, indexing back into the prepared txs.
@@ -394,10 +374,9 @@ pub fn verify_block_input_scripts(
     locktime_cutoff: u32,
     flags: VerifyFlags,
     timings: &mut ScriptStageTimings,
-    kernel_block: &crate::kernel::KernelBlock,
 ) -> Result<(), ConsensusError> {
     let prepare_started = Instant::now();
-    let unit = prepare_block_script_checks(view, height, locktime_cutoff, kernel_block)?;
+    let unit = prepare_block_script_checks(view, height, locktime_cutoff)?;
     timings.prepare_seconds = prepare_started.elapsed().as_secs_f64();
 
     let parallel_started = Instant::now();
@@ -416,8 +395,7 @@ pub fn verify_block_input_scripts(
 
 /// One block's script checks, prepared but not executed.
 ///
-/// Holds borrows into the caller's parse-once [`BlockView`] transactions and
-/// parsed kernel block, so both must outlive every unit built from them.
+/// Holds borrows into the caller's parse-once [`BlockView`] transactions.
 pub struct BlockScriptChecks<'b> {
     prepared: Vec<PreparedTx<'b>>,
     checks: Vec<InputCheck>,
@@ -446,15 +424,11 @@ pub struct BatchScriptFailure {
 /// not errors here: they are retained in transaction order and reported by
 /// [`verify_prepared_units`], because reporting them now would let a later
 /// transaction's cheap failure outrank an earlier one.
-pub fn prepare_block_script_checks<'tx, 'checks>(
+pub fn prepare_block_script_checks<'tx>(
     view: &mut BlockView<'tx>,
     height: u32,
     locktime_cutoff: u32,
-    kernel_block: &'checks crate::kernel::KernelBlock,
-) -> Result<BlockScriptChecks<'checks>, ConsensusError>
-where
-    'tx: 'checks,
-{
+) -> Result<BlockScriptChecks<'tx>, ConsensusError> {
     let (txs, resolved) = view.parts_mut();
     if txs.len() != resolved.len() {
         return Err(ConsensusError::PrevoutMatrixSize {
@@ -462,8 +436,7 @@ where
             actual: resolved.len(),
         });
     }
-    let (prepared, checks) =
-        prepare_block_input_checks(txs, resolved, height, locktime_cutoff, kernel_block);
+    let (prepared, checks) = prepare_block_input_checks(txs, resolved, height, locktime_cutoff);
     Ok(BlockScriptChecks { prepared, checks })
 }
 
@@ -480,7 +453,7 @@ where
     if units.len() != flags_per_unit.len() {
         return Err(BatchScriptFailure {
             unit: 0,
-            error: ConsensusError::Kernel(format!(
+            error: ConsensusError::Encoding(format!(
                 "batch verify needs one flag set per unit: {} units, {} flag sets",
                 units.len(),
                 flags_per_unit.len()
@@ -563,7 +536,7 @@ pub fn verify_prepared_units(
 fn layout_failure(unit: usize) -> BatchScriptFailure {
     BatchScriptFailure {
         unit,
-        error: ConsensusError::Kernel(
+        error: ConsensusError::Encoding(
             "internal: prepared script-check layout does not match its results".to_owned(),
         ),
     }
@@ -614,13 +587,6 @@ fn prepare_block_input_checks<'b>(
     resolved: &mut [Vec<Option<TxOut>>],
     height: u32,
     locktime_cutoff: u32,
-    // Unused by the portable backend, which verifies the view's transactions
-    // directly; kept in the signature so both backends share one call shape.
-    #[cfg_attr(
-        not(feature = "kernel"),
-        expect(unused_variables, reason = "kernel-only")
-    )]
-    kernel_block: &'b crate::kernel::KernelBlock,
 ) -> (Vec<PreparedTx<'b>>, Vec<InputCheck>) {
     let mut prepared = Vec::with_capacity(txs.len());
     let mut checks = Vec::new();
@@ -631,72 +597,26 @@ fn prepare_block_input_checks<'b>(
         }) {
             Ok(Some(prep)) => prep,
             Ok(None) => {
-                prepared.push(PreparedTx {
-                    #[cfg(not(feature = "kernel"))]
-                    tx,
-                    #[cfg(feature = "kernel")]
-                    prevouts: Vec::new(),
-                    #[cfg(not(feature = "kernel"))]
-                    spent_outputs: Vec::new(),
-                    pre_error: None,
-                    post_error: None,
-                    checks_start: checks.len(),
-                    checks_len: 0,
-                    #[cfg(feature = "kernel")]
-                    kernel_state: None,
-                });
+                prepared.push(empty_prepared(tx, None, checks.len()));
                 continue;
             }
             Err(pre_error) => {
-                prepared.push(PreparedTx {
-                    #[cfg(not(feature = "kernel"))]
-                    tx,
-                    #[cfg(feature = "kernel")]
-                    prevouts: Vec::new(),
-                    #[cfg(not(feature = "kernel"))]
-                    spent_outputs: Vec::new(),
-                    pre_error: Some(pre_error),
-                    post_error: None,
-                    checks_start: checks.len(),
-                    checks_len: 0,
-                    #[cfg(feature = "kernel")]
-                    kernel_state: None,
-                });
-                break;
-            }
-        };
-
-        // Build retained kernel state before checks so setup failure cannot
-        // leave an InputCheck without its PreparedKernelTx.
-        #[cfg(feature = "kernel")]
-        let kernel_state = match kernel_block.transaction(tx_index).and_then(|kernel_tx| {
-            crate::kernel::prepare_kernel_tx(kernel_tx, tx.inputs.len(), &prep.prevouts)
-        }) {
-            Ok(state) => state,
-            Err(setup_error) => {
-                prepared.push(PreparedTx {
-                    #[cfg(not(feature = "kernel"))]
-                    tx,
-                    prevouts: prep.prevouts,
-                    pre_error: Some(setup_error),
-                    post_error: None,
-                    checks_start: checks.len(),
-                    checks_len: 0,
-                    kernel_state: None,
-                });
+                prepared.push(empty_prepared(tx, Some(pre_error), checks.len()));
                 break;
             }
         };
 
         // One clone of the spent outputs per transaction, not per input: the
-        // portable interpreter commits to every spent output, so each input
-        // check needs the full ordered set.
-        #[cfg(not(feature = "kernel"))]
+        // native interpreter commits to every spent output, so each input
+        // check needs the full ordered set. Sighash midstates are filled
+        // once here and cloned into each parallel checker.
         let spent_outputs: Vec<TxOut> = prep
             .prevouts
             .iter()
             .map(|(_, spent)| spent.clone())
             .collect();
+        let mut sighash = bitcoin_rs_primitives::SighashCache::new(tx);
+        sighash.precompute(&spent_outputs);
 
         let prepared_index = prepared.len();
         let checks_start = checks.len();
@@ -711,18 +631,13 @@ fn prepare_block_input_checks<'b>(
         let post_error = finalize_tx_value_and_sigops(tx, &prep).err();
         let stop_after_tx = post_error.is_some();
         prepared.push(PreparedTx {
-            #[cfg(not(feature = "kernel"))]
             tx,
-            #[cfg(feature = "kernel")]
-            prevouts: prep.prevouts,
-            #[cfg(not(feature = "kernel"))]
             spent_outputs,
+            sighash,
             pre_error: None,
             post_error,
             checks_start,
             checks_len,
-            #[cfg(feature = "kernel")]
-            kernel_state: Some(kernel_state),
         });
         // This tx's scripts still outrank its post error; that post error makes
         // every later transaction irrelevant to the ordered verdict.
@@ -733,27 +648,36 @@ fn prepare_block_input_checks<'b>(
     (prepared, checks)
 }
 
-/// Runs one deferred input's script verdict against its retained state. Forks on
-/// `cfg(kernel)` between the kernel and portable engines, sharing `&prepared` and
-/// `&txs` by shared reference only.
+fn empty_prepared(
+    tx: &Tx,
+    pre_error: Option<ConsensusError>,
+    checks_start: usize,
+) -> PreparedTx<'_> {
+    PreparedTx {
+        tx,
+        spent_outputs: Vec::new(),
+        sighash: bitcoin_rs_primitives::SighashCache::new(tx),
+        pre_error,
+        post_error: None,
+        checks_start,
+        checks_len: 0,
+    }
+}
+
+/// Runs one deferred input's script verdict against its retained native state.
 fn check_input(
     prepared: &[PreparedTx<'_>],
     check: &InputCheck,
     flags: VerifyFlags,
 ) -> Result<(), ConsensusError> {
     let prep = &prepared[check.prepared_index];
-    #[cfg(feature = "kernel")]
-    {
-        let (_, prevout) = &prep.prevouts[check.input_index];
-        let kernel_state = prep.kernel_state.as_ref().ok_or_else(|| {
-            ConsensusError::Kernel("clean non-coinbase tx lost prepared kernel state".to_owned())
-        })?;
-        crate::kernel::verify_prepared_input(kernel_state, prevout, check.input_index, flags)
-    }
-    #[cfg(not(feature = "kernel"))]
-    {
-        verify_input_script_portable(check.input_index, &prep.spent_outputs, prep.tx, flags)
-    }
+    verify_input_script_portable(
+        check.input_index,
+        &prep.spent_outputs,
+        prep.tx,
+        flags,
+        prep.sighash.clone(),
+    )
 }
 
 fn cached_prevout_lookup(
@@ -859,17 +783,11 @@ fn count_accurate(script: &[u8]) -> u32 {
 mod tests {
     use std::cell::Cell;
 
-    #[cfg(feature = "kernel")]
     use bitcoin::hashes::Hash as _;
     use bitcoin_rs_primitives::{
-        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-        deserialize,
+        Hash256, OutPoint, Sighash, SighashCache, Tx, TxIn, TxOut, Txid, deserialize,
     };
-    #[cfg(not(feature = "kernel"))]
-    use bitcoin_rs_primitives::{Sighash, SighashCache};
-    #[cfg(feature = "kernel")]
     use bitcoin_rs_script::opcode::{OP_EQUAL, OP_HASH160};
-    #[cfg(feature = "kernel")]
     use bitcoin_rs_script::push_data;
     use bitcoin_rs_script::{VerifyFlags, push_int};
 
@@ -877,24 +795,6 @@ mod tests {
         ScriptStageTimings, is_final_tx_with_locktime_cutoff, verify_coinbase_script_sig_size,
         verify_transaction,
     };
-
-    /// Wraps `txs` in a block and parses it the way production does, so tests
-    /// exercise the real one-shot parse rather than a stand-in.
-    fn kernel_block_for(txs: &[Tx]) -> crate::kernel::KernelBlock {
-        let block = Block {
-            header: Header {
-                version: 1,
-                prev_blockhash: BlockHash::default(),
-                merkle_root: Hash256::default(),
-                time: 0,
-                bits: 0x2000_ffff,
-                nonce: 0,
-            },
-            txs: txs.to_vec(),
-        };
-        crate::kernel::KernelBlock::parse(&consensus_bytes(&block))
-            .unwrap_or_else(|error| panic!("synthetic block must parse: {error}"))
-    }
 
     /// Wraps `txs` and its resolved prevouts in the parse-once view the node
     /// hands to verification, with identities computed once from the same
@@ -1081,7 +981,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "kernel"))]
     fn verify_transaction_routes_taproot_spends_to_interpreter() {
         let first = OutPoint {
             txid: Txid(Hash256::from_le_bytes(&[5; 32])),
@@ -1128,7 +1027,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "kernel"))]
     fn verify_transaction_accepts_valid_multi_input_taproot_keypath() {
         use secp256k1::{Keypair, Message, Scalar, Secp256k1, SecretKey, XOnlyPublicKey};
         use sha2::{Digest, Sha256};
@@ -1217,8 +1115,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "kernel")]
-    fn kernel_accepts_non_taproot_spend_with_script_sig_data() {
+    fn native_accepts_non_taproot_spend_with_script_sig_data() {
         let outpoint = OutPoint {
             txid: Txid(Hash256::from_le_bytes(&[7; 32])),
             vout: 0,
@@ -1252,12 +1149,9 @@ mod tests {
         );
     }
 
-    /// R2 pin: in the kernel build the script verdict carries the kernel
-    /// dispatch marker, proving the Rust interpreter (whose call site is
-    /// `cfg(not(feature = "kernel"))`) did not produce it.
+    /// Native interpreter rejects a mismatched `OP_EQUAL` scriptSig.
     #[test]
-    #[cfg(feature = "kernel")]
-    fn kernel_rejects_script_sig_mismatch_with_kernel_verdict() {
+    fn native_rejects_script_sig_mismatch() {
         let outpoint = OutPoint {
             txid: Txid(Hash256::from_le_bytes(&[8; 32])),
             vout: 0,
@@ -1292,16 +1186,14 @@ mod tests {
             Err(ConsensusError::Script {
                 input_index: 0,
                 reason
-            }) if reason.starts_with("kernel script verification failed:")
+            }) if !reason.is_empty()
         ));
     }
 
     /// Assume-valid semantics: the non-script entry must accept a transaction
-    /// whose script the kernel would reject — no kernel invocation when
-    /// scripts are skipped.
+    /// whose script the interpreter would reject.
     #[test]
-    #[cfg(feature = "kernel")]
-    fn kernel_skip_scripts_entry_accepts_invalid_script() {
+    fn skip_scripts_entry_accepts_invalid_script() {
         let outpoint = OutPoint {
             txid: Txid(Hash256::from_le_bytes(&[9; 32])),
             vout: 0,
@@ -1430,10 +1322,8 @@ mod tests {
     /// the per-block path would. These three tests are what make the offset
     /// table load-bearing; without them a running counter passes by accident.
     #[test]
-    #[cfg(feature = "kernel")]
     fn batched_units_report_the_earliest_failing_unit() {
         let good_txs = vec![coinbase_transaction_with_script_sig_len(2)];
-        let good_block = kernel_block_for(&good_txs);
 
         // Unit 0 fails on its SECOND transaction, unit 2 on its first. Block
         // order must win over position within a block.
@@ -1442,12 +1332,10 @@ mod tests {
             spend_tx(vec![true_spending_input(outpoint(1))], 50),
             spend_tx(vec![mismatch_input(outpoint(2))], 50),
         ];
-        let first_block = kernel_block_for(&first_txs);
         let last_txs = vec![
             coinbase_transaction_with_script_sig_len(2),
             spend_tx(vec![mismatch_input(outpoint(3))], 50),
         ];
-        let last_block = kernel_block_for(&last_txs);
 
         let units = [
             prepared_unit(
@@ -1457,14 +1345,9 @@ mod tests {
                     vec![Some(op1_txout(50))],
                     vec![Some(op_equal_txout(50))],
                 ],
-                &first_block,
             ),
-            prepared_unit(&good_txs, vec![Vec::new()], &good_block),
-            prepared_unit(
-                &last_txs,
-                vec![Vec::new(), vec![Some(op_equal_txout(50))]],
-                &last_block,
-            ),
+            prepared_unit(&good_txs, vec![Vec::new()]),
+            prepared_unit(&last_txs, vec![Vec::new(), vec![Some(op_equal_txout(50))]]),
         ];
         let flags = [VerifyFlags::MANDATORY; 3];
 
@@ -1482,14 +1365,12 @@ mod tests {
     /// failing unit is LAST and every earlier unit passes, so the verdict is
     /// decided purely by whether each unit reads its own slice of results.
     #[test]
-    #[cfg(feature = "kernel")]
     fn each_unit_reads_its_own_slice_of_results() {
         let clean_txs = vec![
             coinbase_transaction_with_script_sig_len(2),
             spend_tx(vec![true_spending_input(outpoint(11))], 50),
             spend_tx(vec![true_spending_input(outpoint(12))], 50),
         ];
-        let clean_block = kernel_block_for(&clean_txs);
         let clean_resolved = vec![
             Vec::new(),
             vec![Some(op1_txout(50))],
@@ -1499,16 +1380,11 @@ mod tests {
             coinbase_transaction_with_script_sig_len(2),
             spend_tx(vec![mismatch_input(outpoint(13))], 50),
         ];
-        let bad_block = kernel_block_for(&bad_txs);
 
         let units = [
-            prepared_unit(&clean_txs, clean_resolved.clone(), &clean_block),
-            prepared_unit(&clean_txs, clean_resolved, &clean_block),
-            prepared_unit(
-                &bad_txs,
-                vec![Vec::new(), vec![Some(op_equal_txout(50))]],
-                &bad_block,
-            ),
+            prepared_unit(&clean_txs, clean_resolved.clone()),
+            prepared_unit(&clean_txs, clean_resolved),
+            prepared_unit(&bad_txs, vec![Vec::new(), vec![Some(op_equal_txout(50))]]),
         ];
         let flags = [VerifyFlags::MANDATORY; 3];
 
@@ -1524,13 +1400,11 @@ mod tests {
     /// A batched unit must produce the identical error the single-block entry
     /// point produces for the same block, or batching changes consensus.
     #[test]
-    #[cfg(feature = "kernel")]
     fn a_batched_unit_matches_the_single_block_path() {
         let txs = vec![
             coinbase_transaction_with_script_sig_len(2),
             spend_tx(vec![mismatch_input(outpoint(7))], 50),
         ];
-        let block = kernel_block_for(&txs);
         let resolved = vec![Vec::new(), vec![Some(op_equal_txout(50))]];
 
         let mut timings = super::ScriptStageTimings::default();
@@ -1540,9 +1414,8 @@ mod tests {
             0,
             VerifyFlags::MANDATORY,
             &mut timings,
-            &block,
         );
-        let units = [prepared_unit(&txs, resolved, &block)];
+        let units = [prepared_unit(&txs, resolved)];
         let batched = super::verify_prepared_units(&units, &[VerifyFlags::MANDATORY]);
 
         match (single, batched) {
@@ -1562,13 +1435,11 @@ mod tests {
     /// Flags differ per block across softfork activation heights, so a unit
     /// must be checked under its own.
     #[test]
-    #[cfg(feature = "kernel")]
     fn each_unit_is_checked_under_its_own_flags() {
         let first_txs = vec![
             coinbase_transaction_with_script_sig_len(2),
             spend_tx(vec![true_spending_input(outpoint(9))], 50),
         ];
-        let first_block = kernel_block_for(&first_txs);
         let first_resolved = vec![Vec::new(), vec![Some(op1_txout(50))]];
 
         let redeem_script = [0_u8];
@@ -1594,12 +1465,11 @@ mod tests {
                 50,
             ),
         ];
-        let second_block = kernel_block_for(&second_txs);
         let second_resolved = vec![Vec::new(), vec![Some(p2sh_output)]];
 
         let units = [
-            prepared_unit(&first_txs, first_resolved, &first_block),
-            prepared_unit(&second_txs, second_resolved, &second_block),
+            prepared_unit(&first_txs, first_resolved),
+            prepared_unit(&second_txs, second_resolved),
         ];
         assert!(
             super::verify_prepared_units(&units[1..], &[VerifyFlags::MANDATORY],).is_err(),
@@ -1612,14 +1482,12 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "kernel")]
-    fn prepared_unit<'b>(
-        txs: &'b [Tx],
+    fn prepared_unit(
+        txs: &[Tx],
         resolved: Vec<Vec<Option<TxOut>>>,
-        block: &'b crate::kernel::KernelBlock,
-    ) -> super::BlockScriptChecks<'b> {
+    ) -> super::BlockScriptChecks<'_> {
         let mut view = block_view_for(txs, resolved);
-        match super::prepare_block_script_checks(&mut view, 0, 0, block) {
+        match super::prepare_block_script_checks(&mut view, 0, 0) {
             Ok(unit) => unit,
             Err(error) => panic!("test fixture prevout matrix is malformed: {error}"),
         }
@@ -1659,7 +1527,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "kernel"))]
     fn p2tr_script_pubkey() -> Vec<u8> {
         let mut bytes = Vec::with_capacity(34);
         bytes.push(0x51);
@@ -1685,7 +1552,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "kernel")]
     fn op1_txout(value: u64) -> TxOut {
         TxOut {
             value,
@@ -1693,7 +1559,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "kernel")]
     fn op_equal_txout(value: u64) -> TxOut {
         TxOut {
             value,
@@ -1702,8 +1567,7 @@ mod tests {
     }
 
     /// Input spending an `OP_EQUAL` prevout with a mismatched `7 8` scriptSig:
-    /// rejected by the kernel.
-    #[cfg(feature = "kernel")]
+    /// rejected by the native interpreter.
     fn mismatch_input(outpoint: OutPoint) -> TxIn {
         TxIn {
             previous_output: outpoint,
@@ -1713,7 +1577,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "kernel")]
     fn spend_tx(inputs: Vec<TxIn>, output_value: u64) -> Tx {
         Tx {
             version: 1,
@@ -1726,7 +1589,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "kernel")]
     fn outpoint(seed: u8) -> OutPoint {
         OutPoint {
             txid: Txid(Hash256::from_le_bytes(&[seed; 32])),
@@ -1744,7 +1606,6 @@ mod tests {
                 0,
                 VerifyFlags::MANDATORY,
                 &mut ScriptStageTimings::default(),
-                &kernel_block_for(&txs)
             ),
             Err(ConsensusError::PrevoutMatrixSize {
                 expected: 1,
@@ -1757,7 +1618,6 @@ mod tests {
     /// must outrank a later transaction's missing prevout, because prep emits the
     /// earlier tx's input checks before it breaks on the missing-prevout pre-error.
     #[test]
-    #[cfg(feature = "kernel")]
     fn earlier_tx_script_error_beats_later_tx_missing_prevout() {
         let txs = vec![
             coinbase_transaction_with_script_sig_len(2),
@@ -1771,7 +1631,6 @@ mod tests {
             0,
             VerifyFlags::MANDATORY,
             &mut ScriptStageTimings::default(),
-            &kernel_block_for(&txs),
         );
         assert!(
             matches!(result, Err(ConsensusError::Script { input_index: 0, .. })),
@@ -1782,7 +1641,6 @@ mod tests {
     /// The deferred post-error (value balance) must not outrank the same tx's
     /// script failure: script is phase 1, post is phase 2 in the intra-tx order.
     #[test]
-    #[cfg(feature = "kernel")]
     fn intra_tx_script_error_beats_value_and_sigop() {
         let txs = vec![
             coinbase_transaction_with_script_sig_len(2),
@@ -1795,7 +1653,6 @@ mod tests {
             0,
             VerifyFlags::MANDATORY,
             &mut ScriptStageTimings::default(),
-            &kernel_block_for(&txs),
         );
         assert!(
             matches!(result, Err(ConsensusError::Script { input_index: 0, .. })),
@@ -1806,7 +1663,6 @@ mod tests {
     /// A later transaction's pre-error must not outrank an earlier transaction's
     /// deferred post-error: the scan walks in block order and returns tx1 first.
     #[test]
-    #[cfg(feature = "kernel")]
     fn later_pre_error_does_not_outrank_earlier_post_error() {
         let txs = vec![
             coinbase_transaction_with_script_sig_len(2),
@@ -1830,7 +1686,6 @@ mod tests {
             0,
             VerifyFlags::MANDATORY,
             &mut ScriptStageTimings::default(),
-            &kernel_block_for(&txs),
         );
         assert_eq!(
             result,
@@ -1843,7 +1698,6 @@ mod tests {
 
     /// Parallel script checks still report the earliest block-ordered failure.
     #[test]
-    #[cfg(feature = "kernel")]
     fn parallel_script_checks_report_first_error() {
         let mut txs = vec![
             coinbase_transaction_with_script_sig_len(2),
@@ -1861,7 +1715,6 @@ mod tests {
             0,
             VerifyFlags::MANDATORY,
             &mut ScriptStageTimings::default(),
-            &kernel_block_for(&txs),
         );
         assert!(
             matches!(result, Err(ConsensusError::Script { input_index: 0, .. })),
@@ -1873,7 +1726,6 @@ mod tests {
     /// resolves it into `resolved`; a bad script in the producing tx surfaces that
     /// earlier transaction's Script error.
     #[test]
-    #[cfg(feature = "kernel")]
     fn same_block_spend_resolves_and_verifies() {
         let tx1 = spend_tx(vec![true_spending_input(outpoint(1))], 100);
         let tx1_out = OutPoint {
@@ -1895,7 +1747,6 @@ mod tests {
                 0,
                 VerifyFlags::MANDATORY,
                 &mut ScriptStageTimings::default(),
-                &kernel_block_for(&txs)
             ),
             Ok(())
         );
@@ -1923,7 +1774,6 @@ mod tests {
             0,
             VerifyFlags::MANDATORY,
             &mut ScriptStageTimings::default(),
-            &kernel_block_for(&txs),
         );
         assert!(
             matches!(bad, Err(ConsensusError::Script { input_index: 0, .. })),
@@ -1934,9 +1784,8 @@ mod tests {
     // ---- Taproot script-path public-seam regression ---------------------------
     //
     // The committed `taproot_scriptpath_spend.json` fixture is a real mainnet
-    // BIP342 script-path spend. Both the kernel path and the native interpreter
-    // accept it. These two tests pin `verify_transaction`'s public seam for
-    // both builds against this fixture.
+    // BIP342 script-path spend. The native interpreter accepts it. These tests
+    // pin `verify_transaction`'s public seam against this fixture.
 
     struct TaprootScriptPathFixture {
         tx: Tx,
@@ -2003,29 +1852,10 @@ mod tests {
         }
     }
 
-    /// Public-seam regression: under `feature = "kernel"`, `verify_transaction`
-    /// routes the real mainnet Taproot script-path spend to the kernel, which
-    /// accepts it.
+    /// Public-seam regression: `verify_transaction` accepts the committed
+    /// mainnet Taproot script-path spend through the native interpreter.
     #[test]
-    #[cfg(feature = "kernel")]
     fn verify_transaction_accepts_mainnet_taproot_scriptpath_spend() {
-        let fixture = load_taproot_scriptpath_fixture();
-        let mut utxos = hashbrown::HashMap::new();
-        for (index, prevout) in fixture.prevouts.iter().enumerate() {
-            utxos.insert(fixture.tx.inputs[index].previous_output, prevout.clone());
-        }
-        assert_eq!(
-            verify_transaction(&fixture.tx, &utxos, fixture.height, 0, fixture.flags),
-            Ok(())
-        );
-    }
-
-    /// Public-seam regression: without the kernel, `verify_transaction` routes
-    /// the Taproot script-path spend to the portable interpreter, which now
-    /// implements BIP342 script-path verification and accepts the spend.
-    #[test]
-    #[cfg(not(feature = "kernel"))]
-    fn verify_transaction_accepts_mainnet_taproot_scriptpath_under_portable() {
         let fixture = load_taproot_scriptpath_fixture();
         let mut utxos = hashbrown::HashMap::new();
         for (index, prevout) in fixture.prevouts.iter().enumerate() {
@@ -2039,19 +1869,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "kernel")]
     fn parallel_timing_is_captured_before_ordered_error_scan() {
         use std::cell::Cell;
 
+        let dummy = coinbase_transaction_with_script_sig_len(2);
         let prepared: Vec<super::PreparedTx> = (0..10)
-            .map(|_| super::PreparedTx {
-                prevouts: Vec::new(),
-                pre_error: None,
-                post_error: None,
-                checks_start: 0,
-                checks_len: 0,
-                kernel_state: None,
-            })
+            .map(|_| super::empty_prepared(&dummy, None, 0))
             .collect();
         let unit = super::BlockScriptChecks {
             prepared,

--- a/crates/consensus/tests/kernel_block_parity.rs
+++ b/crates/consensus/tests/kernel_block_parity.rs
@@ -4,8 +4,8 @@
 //! Consensus authority is `bitcoinkernel`. This harness replays real mainnet
 //! transactions — one committed fixture per script class under
 //! `tests/vectors/scripts/` — through the kernel entry the production apply
-//! path uses (`bitcoin_rs_consensus::kernel::verify_tx_scripts`, the seam
-//! `verify_transaction` dispatches to under `feature = "kernel"`), and asserts:
+//! through the kernel oracle (`bitcoin_rs_consensus::kernel::verify_tx_scripts`)
+//! and asserts:
 //!
 //! * every pristine fixture is **accepted**, and
 //! * every applicable in-code mutation (signature bit flip, scriptSig
@@ -15,14 +15,10 @@
 //! ## The differential is interpreter-vs-kernel, not kernel-vs-kernel (ADV-1)
 //!
 //! The Rust side of the differential calls `bitcoin_rs_script::Interpreter`
-//! **directly**. It must not route through `verify_transaction`: under
-//! `feature = "kernel"`, that function dispatches script verdicts to the same
-//! `kernel::verify_tx_scripts` path as the kernel side
-//! (by design, per R2/KTD5 of plan 2026-06-10-001), which would silently turn
-//! this differential into kernel-vs-kernel and make it unable to detect any
-//! interpreter divergence. That cfg structure is production-correct and is
-//! pinned elsewhere (`verify_tx.rs` kernel tests); this file deliberately
-//! bypasses it for the *test-only* Rust verdict. [`differential_is_non_vacuous`]
+//! **directly**. `verify_transaction` is always the native path, so routing
+//! through it would still be a valid native verdict; this file keeps the
+//! interpreter call explicit so a future dispatch change cannot silently
+//! compare kernel against itself. [`differential_is_non_vacuous`]
 //! proves the bypass holds: each engine is run twice on a committed taproot
 //! script-path fixture (pristine vs tampered control block) and must accept
 //! the first and reject the second.

--- a/crates/consensus/tests/kernel_vector_parity.rs
+++ b/crates/consensus/tests/kernel_vector_parity.rs
@@ -6,8 +6,8 @@
 //! natively executes only taproot key-path spends, so that differential is
 //! interpreter-scoped. This file takes a different angle: it feeds Core's own
 //! known-good and known-bad transaction vectors through the kernel's
-//! `verify_tx_scripts` (the production seam under `feature = "kernel"`) and
-//! asserts the kernel's verdict matches the vector's expected outcome.
+//! `verify_tx_scripts` (the independent Core oracle under `feature = "kernel"`)
+//! and asserts the kernel's verdict matches the vector's expected outcome.
 //!
 //! This is a **kernel oracle test**: the kernel is the authority, and the
 //! vectors are the oracle. Every assertion is a real kernel verdict on a real

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 # Note: `--workspace --features "..."` in a virtual workspace (no root [package])
 # does NOT forward CLI features to library crates; always use -p when features
 # must reach a specific crate.
-default = ["fjall", "kernel", "zmq"]
+default = ["fjall", "zmq"]
 rocksdb = [
     "bitcoin-rs-chain/rocksdb",
     "bitcoin-rs-consensus/rocksdb",

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -33,11 +33,11 @@ Large corpus/replay/evidence harnesses are intentionally not shipped by this
 runtime crate.
 
 ## Features
-- `default` (enables `fjall`, `kernel`, and `zmq`): the performance-oriented fjall
-  storage backend plus the bitcoinkernel consensus verifier and ZMQ notifications,
-  so per-crate `cargo check` works out of the box. The `bitcoin-rs` binary's own
-  defaults are the pure-Rust `fjall,redb,zmq`; `kernel` stays opt-in there. Issue
-  #213 is the measurement gate for dropping `kernel` from this crate's defaults.
+- `default` (enables `fjall` and `zmq`): the performance-oriented fjall
+  storage backend plus ZMQ notifications, so per-crate `cargo check` works
+  out of the box. The `bitcoin-rs` binary's own defaults are the pure-Rust
+  `fjall,redb,zmq`. `kernel` compiles the independent Core oracle and stays
+  off by default (`docs/contracts/validation-default.md`).
 - `rocksdb`, `fjall`, `redb`: forward the named storage backend to every subsystem
   crate.
 - `mdbx`: forward the mdbx backend to the crates that provide one.

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -949,6 +949,8 @@ pub struct Chainstate {
     pub(crate) chain_transition: Arc<parking_lot::Mutex<()>>,
     pub(crate) assume_valid_height: u32,
     pub(crate) assume_valid_gate: Arc<AssumeValidGate>,
+    /// When set, native script verdicts are compared against `libbitcoinkernel`.
+    pub(crate) verify_kernel: bool,
     /// Chainstate-journal writer, when the journal is enabled (issue #230).
     ///
     /// `None` = journal off: the apply path emits nothing and behaves exactly
@@ -1342,6 +1344,7 @@ impl Chainstate {
             chain_transition: Arc::new(parking_lot::Mutex::new(())),
             assume_valid_height: 0,
             assume_valid_gate: Arc::new(AssumeValidGate::with_anchor(None)),
+            verify_kernel: false,
             journal: None,
             checkpoint_publisher: None,
             capture_rawtx: false,
@@ -2307,6 +2310,13 @@ fn prove_window<'a>(
             .record(verify_started.elapsed().as_secs_f64());
         if verdict.is_err() {
             return Vec::new();
+        }
+        if handles.verify_kernel {
+            for (unit, unit_flags) in units.iter().zip(&flags) {
+                if unit.compare_kernel_scripts(*unit_flags, true).is_err() {
+                    return Vec::new();
+                }
+            }
         }
         if !units.is_empty() {
             metrics::counter!("node.window.verify_success_total").increment(1);
@@ -3486,6 +3496,32 @@ fn run_non_script_checks_only(
     Ok(())
 }
 
+fn spent_outputs_for_kernel_oracle<'a>(
+    block: &'a Block,
+    resolved: &[Vec<Option<TxOut>>],
+) -> Vec<(&'a Tx, Vec<(OutPoint, TxOut)>)> {
+    block
+        .txs
+        .iter()
+        .zip(resolved.iter())
+        .filter(|(tx, _)| !is_coinbase_tx(tx))
+        .map(|(tx, row)| {
+            let spent = tx
+                .inputs
+                .iter()
+                .enumerate()
+                .filter_map(|(index, input)| {
+                    row.get(index)
+                        .and_then(Option::as_ref)
+                        .cloned()
+                        .map(|prevout| (input.previous_output, prevout))
+                })
+                .collect();
+            (tx, spent)
+        })
+        .collect()
+}
+
 #[allow(
     clippy::as_conversions,
     clippy::cast_sign_loss,
@@ -3534,6 +3570,9 @@ fn verify_block_transactions(
     metrics::histogram!("node.apply_block.script_resolution_seconds")
         .record(resolution_dur.as_secs_f64());
     let resolved = resolution_result?;
+    let oracle_spent = handles
+        .verify_kernel
+        .then(|| spent_outputs_for_kernel_oracle(block, &resolved));
     view.set_resolved(resolved);
     // preparation and parallel input-check fan-out internally and reports both
     // sub-stage durations back; record them here on the success and error paths
@@ -3550,6 +3589,13 @@ fn verify_block_transactions(
         .record(script_timings.prepare_seconds);
     metrics::histogram!("node.apply_block.script_parallel_seconds")
         .record(script_timings.parallel_seconds);
+    if let Some(spent) = oracle_spent {
+        bitcoin_rs_consensus::kernel::compare_script_verdicts(
+            &spent,
+            context.flags,
+            script_input_result.is_ok(),
+        )?;
+    }
     script_input_result?;
     tracing::debug!(
         height = context.height,
@@ -4175,6 +4221,51 @@ mod consensus_rule_tests {
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::NONE),
             BlockProvenance::Network,
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn verify_kernel_tap_does_not_feed_kernel_data_into_apply()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let base_prevout = OutPoint::new(fixture_txid(0x61), 0);
+        let utxo = utxo_with_output(base_prevout, 1)?;
+        let mut handles = apply_handles(utxo);
+        handles.verify_kernel = true;
+        let funding_tx = spending_transaction_to_script(base_prevout, u32::MAX, op_true_script());
+        let funding_outpoint = OutPoint::new(funding_tx.txid(), 0);
+        let same_block_spend =
+            spending_transaction_to_script(funding_outpoint, u32::MAX, op_true_script());
+        let block = block_with_transactions(vec![funding_tx, same_block_spend]);
+
+        let result = verify_block_transactions(
+            &handles,
+            &block,
+            &mut bitcoin_rs_consensus::BlockView::new(&block.txs, block_txids(&block)),
+            &tx_plan(&block),
+            Arc::new(ResolvedUtxoView::resolve(
+                handles.utxo.as_ref(),
+                &block,
+                &tx_plan(&block),
+            )),
+            &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::NONE),
+            BlockProvenance::Network,
+        );
+        if bitcoin_rs_consensus::kernel::kernel_compiled() {
+            result?;
+        } else {
+            match result {
+                Ok(()) => panic!("verify_kernel without the kernel feature must fail"),
+                Err(ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Kernel(
+                    reason,
+                ))) => {
+                    assert!(
+                        reason.contains("verify_kernel"),
+                        "unexpected kernel error: {reason}"
+                    );
+                }
+                Err(other) => panic!("expected Kernel compile-time error, got {other:?}"),
+            }
+        }
         Ok(())
     }
 

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -949,7 +949,7 @@ pub struct Chainstate {
     pub(crate) chain_transition: Arc<parking_lot::Mutex<()>>,
     pub(crate) assume_valid_height: u32,
     pub(crate) assume_valid_gate: Arc<AssumeValidGate>,
-    /// When set, native script verdicts are compared against `libbitcoinkernel`.
+    /// When set, native parse/txids and script verdicts are compared against `libbitcoinkernel`.
     pub(crate) verify_kernel: bool,
     /// Chainstate-journal writer, when the journal is enabled (issue #230).
     ///
@@ -2169,10 +2169,15 @@ fn prove_window<'a>(
     // block, so the window does all of it at once. Only the overlay walk below
     // is order-dependent, and it is the cheaper half.
     let parse_started = quanta::Instant::now();
+    let verify_kernel = handles.verify_kernel;
     let parsed: Vec<core::result::Result<_, ApplyError>> = blocks
         .par_iter()
         .zip(serialized.par_iter())
-        .map(|(block, raw)| parse_block_for_apply(block, Some(raw.as_ref())))
+        .map(|(block, raw)| {
+            let txids = parse_block_for_apply(block, Some(raw.as_ref()))?;
+            maybe_compare_kernel_block_parse(verify_kernel, Some(raw.as_ref()), &txids)?;
+            Ok(txids)
+        })
         .collect();
     metrics::histogram!("node.window.parse_seconds").record(parse_started.elapsed().as_secs_f64());
 
@@ -2398,14 +2403,6 @@ struct PreparedApply<'b> {
     resolved: Arc<ResolvedUtxoView>,
 }
 
-/// Parses a block and resolves the outputs it spends.
-///
-/// `source` is where prevouts come from. Today that is always the committed
-/// UTXO set; a window passes an overlay so a block can see outputs an earlier
-/// block in the same window created.
-///
-/// Runs no consensus rule and mutates nothing, which is what lets a window
-/// prepare several blocks before committing any of them.
 /// A sink that compares what is written to it against `expected`.
 ///
 /// Used to check preserved bytes against a block without serialising the block
@@ -2454,6 +2451,21 @@ pub(crate) fn bytes_are_block(raw: &[u8], block: &Block) -> bool {
     sink.equal && sink.offset == raw.len()
 }
 
+fn maybe_compare_kernel_block_parse(
+    verify_kernel: bool,
+    provided_serialized: Option<&[u8]>,
+    txids: &[Txid],
+) -> core::result::Result<(), ApplyError> {
+    if !verify_kernel {
+        return Ok(());
+    }
+    let Some(raw) = provided_serialized else {
+        return Ok(());
+    };
+    bitcoin_rs_consensus::kernel::compare_block_parse(raw, txids)?;
+    Ok(())
+}
+
 fn parse_block_for_apply(
     block: &Block,
     provided_serialized: Option<&[u8]>,
@@ -2500,8 +2512,10 @@ fn prepare_apply<'b, S: crate::window_overlay::OutputSource + ?Sized>(
     block: &'b Block,
     provided_serialized: Option<&[u8]>,
     source: &S,
+    verify_kernel: bool,
 ) -> core::result::Result<PreparedApply<'b>, ApplyError> {
     let txids = parse_block_for_apply(block, provided_serialized)?;
+    maybe_compare_kernel_block_parse(verify_kernel, provided_serialized, &txids)?;
     let tx_plan = plan_block_transactions(block, &txids);
     let view = bitcoin_rs_consensus::BlockView::new(&block.txs, txids);
     let resolved = Arc::new(ResolvedUtxoView::resolve(source, block, &tx_plan));
@@ -2650,7 +2664,12 @@ fn apply_block_admitted<'b>(
         }
         Some(ProvenApply::AssumeValidSkipped(prepared)) => (prepared, false),
         Some(ProvenApply::Proven(_)) | None => (
-            prepare_apply(block, provided_serialized.as_deref(), handles.utxo.as_ref())?,
+            prepare_apply(
+                block,
+                provided_serialized.as_deref(),
+                handles.utxo.as_ref(),
+                handles.verify_kernel,
+            )?,
             false,
         ),
     };
@@ -4255,6 +4274,33 @@ mod consensus_rule_tests {
         } else {
             match result {
                 Ok(()) => panic!("verify_kernel without the kernel feature must fail"),
+                Err(ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Kernel(
+                    reason,
+                ))) => {
+                    assert!(
+                        reason.contains("verify_kernel"),
+                        "unexpected kernel error: {reason}"
+                    );
+                }
+                Err(other) => panic!("expected Kernel compile-time error, got {other:?}"),
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn verify_kernel_parse_tap_keeps_native_txids() -> Result<(), Box<dyn std::error::Error>> {
+        let utxo = utxo_with_output(OutPoint::new(fixture_txid(0x62), 0), 1)?;
+        let block = block_with_transactions(vec![coinbase_transaction(0x62)]);
+        let raw = consensus_bytes(&block);
+        let native = block_txids(&block);
+        let prepared = prepare_apply(&block, Some(raw.as_slice()), utxo.as_ref(), true);
+        if bitcoin_rs_consensus::kernel::kernel_compiled() {
+            let prepared = prepared?;
+            assert_eq!(prepared.view.txids(), native.as_slice());
+        } else {
+            match prepared {
+                Ok(_) => panic!("verify_kernel parse tap without the kernel feature must fail"),
                 Err(ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Kernel(
                     reason,
                 ))) => {

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -2484,9 +2484,15 @@ fn parse_block_for_apply(
             ),
         ));
     }
+    if let Some(raw) = provided_serialized {
+        return bitcoin_rs_primitives::txids_from_serialized_block(raw).map_err(|error| {
+            ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Encoding(
+                error.to_string(),
+            ))
+        });
+    }
     // Hash each transaction of the already-decoded block exactly once.
-    // Re-decoding preserved bytes here would make apply pay two full
-    // decodes plus one consensus re-serialization per block.
+    // Used when apply has no preserved wire bytes to hash in place.
     Ok(block_txids(block))
 }
 

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -1847,7 +1847,7 @@ pub fn replay_local_block(
 /// below the parallel threshold and wasted a further 11s above it. Sixty-four
 /// blocks turns roughly 21,000 dispatches into 330.
 ///
-/// Bounded by memory: the window holds every block's parsed kernel block and
+/// Bounded by memory: the window holds every block's prepared view and
 /// resolved prevouts at once, which costs far more than the block bytes.
 /// Measured over `0..150_000`, pinned to 32 cores, medians of interleaved runs:
 ///
@@ -2169,7 +2169,7 @@ fn prove_window<'a>(
     let parsed: Vec<core::result::Result<_, ApplyError>> = blocks
         .par_iter()
         .zip(serialized.par_iter())
-        .map(|(block, raw)| parse_block_for_apply(block, Some(raw.clone())))
+        .map(|(block, raw)| parse_block_for_apply(block, Some(raw.as_ref())))
         .collect();
     metrics::histogram!("node.window.parse_seconds").record(parse_started.elapsed().as_secs_f64());
 
@@ -2177,7 +2177,7 @@ fn prove_window<'a>(
     let mut overlay = crate::window_overlay::WindowOverlay::new(handles.utxo.as_ref());
     let mut prepared = Vec::with_capacity(blocks.len());
     for ((block, parsed), context) in blocks.iter().zip(parsed).zip(&contexts) {
-        let Ok((kernel_block, txids)) = parsed else {
+        let Ok(txids) = parsed else {
             return Vec::new();
         };
         let tx_plan = plan_block_transactions(block, &txids);
@@ -2195,7 +2195,6 @@ fn prove_window<'a>(
             return Vec::new();
         }
         prepared.push(PreparedApply {
-            kernel_block,
             view,
             tx_plan,
             resolved,
@@ -2245,8 +2244,8 @@ fn prove_window<'a>(
     // One slot per input block, so a skipped unit leaves a hole rather than
     // shifting every later block onto the wrong prepared state.
     let mut skipped = vec![false; prepared.len()];
-    // One dispatch for the whole window. The check units borrow their kernel
-    // blocks, so they live and die inside this scope, before anything commits.
+    // One dispatch for the whole window. Check units borrow the prepared
+    // BlockView, so they live and die inside this scope, before anything commits.
     {
         // Each block's checks are built from its own prepared state, so the
         // window builds them all at once. The overlay walk above already fixed
@@ -2289,7 +2288,6 @@ fn prove_window<'a>(
                 &mut unit.view,
                 context.height,
                 context.locktime_cutoff,
-                &unit.kernel_block,
             ) {
                 Ok(checks) => {
                     units.push(checks);
@@ -2380,9 +2378,8 @@ enum ProvenApply<'b> {
 /// Split out because a window of consecutive blocks can produce all of these
 /// at once, against one ordered overlay, and share a single script dispatch.
 /// The measured duplication that made an earlier batching attempt a wash was
-/// exactly the kernel parse and the prevout resolution below being done twice.
+/// exactly the txid pass and the prevout resolution below being done twice.
 struct PreparedApply<'b> {
-    kernel_block: bitcoin_rs_consensus::kernel::KernelBlock,
     /// Parse-once transaction state: identities computed once in
     /// [`parse_block_for_apply`], witness IDs on demand, and the prevout
     /// matrix installed once right before script verification.
@@ -2447,61 +2444,28 @@ pub(crate) fn bytes_are_block(raw: &[u8], block: &Block) -> bool {
     sink.equal && sink.offset == raw.len()
 }
 
-#[cfg_attr(
-    not(feature = "kernel"),
-    expect(
-        clippy::needless_pass_by_value,
-        reason = "the kernel build consumes preserved bytes through this shared signature"
-    )
-)]
 fn parse_block_for_apply(
     block: &Block,
-    provided_serialized: Option<bytes::Bytes>,
-) -> core::result::Result<(bitcoin_rs_consensus::kernel::KernelBlock, Vec<Txid>), ApplyError> {
+    provided_serialized: Option<&[u8]>,
+) -> core::result::Result<Vec<Txid>, ApplyError> {
     // Preserved bytes must BE this block, not merely agree with it on
-    // transaction count. In kernel builds the txids and the transactions that
-    // script verification runs come from these bytes, while the witness
-    // commitment check and the UTXO mutation use the decoded block. Changing a
-    // witness does not change a txid, so a count check lets a caller pair a
-    // block carrying an invalid witness with bytes carrying a valid one: the
-    // scripts verify against the bytes and the invalid block gets applied.
-    if let Some(raw) = provided_serialized.as_deref()
+    // transaction count. Changing a witness does not change a txid, so a
+    // count check lets a caller pair a block carrying an invalid witness
+    // with bytes carrying a valid one. Apply hashes the decoded block, so
+    // the bytes still have to match it exactly.
+    if let Some(raw) = provided_serialized
         && !bytes_are_block(raw, block)
     {
         return Err(ApplyError::Consensus(
-            bitcoin_rs_consensus::ConsensusError::Kernel(
+            bitcoin_rs_consensus::ConsensusError::Encoding(
                 "preserved bytes are not the serialization of the block they accompany".to_owned(),
             ),
         ));
     }
-    #[cfg(feature = "kernel")]
-    let (kernel_block, txids) = {
-        let raw_block: bytes::Bytes =
-            provided_serialized.unwrap_or_else(|| bytes::Bytes::from(consensus_bytes(block)));
-        let kernel_block = bitcoin_rs_consensus::kernel::KernelBlock::parse(&raw_block)
-            .map_err(ApplyError::Consensus)?;
-        if kernel_block.transaction_count() != block.txs.len() {
-            return Err(ApplyError::Consensus(
-                bitcoin_rs_consensus::ConsensusError::Kernel(format!(
-                    "kernel parsed {} transactions, decoder produced {}",
-                    kernel_block.transaction_count(),
-                    block.txs.len()
-                )),
-            ));
-        }
-        let txids = kernel_block.txids().map_err(ApplyError::Consensus)?;
-        (kernel_block, txids)
-    };
-    // Without the kernel there is no second parse to harvest identities from,
-    // so hash each transaction of the already-decoded block exactly once.
-    // Re-decoding the preserved bytes here would make the native path pay two
-    // full decodes plus one consensus re-serialization per block.
-    #[cfg(not(feature = "kernel"))]
-    let (kernel_block, txids) = (
-        bitcoin_rs_consensus::kernel::KernelBlock,
-        block_txids(block),
-    );
-    Ok((kernel_block, txids))
+    // Hash each transaction of the already-decoded block exactly once.
+    // Re-decoding preserved bytes here would make apply pay two full
+    // decodes plus one consensus re-serialization per block.
+    Ok(block_txids(block))
 }
 
 /// Transaction IDs of an already-decoded block, hashed exactly once.
@@ -2509,7 +2473,6 @@ fn parse_block_for_apply(
 /// Blocks beyond the threshold the window verifier uses fan the hashing out;
 /// below it, serial iteration wins because dispatch costs more than the
 /// per-transaction double SHA256.
-#[cfg(any(test, not(feature = "kernel")))]
 fn block_txids(block: &Block) -> Vec<Txid> {
     if block.txs.len() > 32 {
         block.txs.par_iter().map(Tx::txid).collect()
@@ -2525,15 +2488,14 @@ fn block_txids(block: &Block) -> Vec<Txid> {
 /// outputs an earlier block in the same window created.
 fn prepare_apply<'b, S: crate::window_overlay::OutputSource + ?Sized>(
     block: &'b Block,
-    provided_serialized: Option<bytes::Bytes>,
+    provided_serialized: Option<&[u8]>,
     source: &S,
 ) -> core::result::Result<PreparedApply<'b>, ApplyError> {
-    let (kernel_block, txids) = parse_block_for_apply(block, provided_serialized)?;
+    let txids = parse_block_for_apply(block, provided_serialized)?;
     let tx_plan = plan_block_transactions(block, &txids);
     let view = bitcoin_rs_consensus::BlockView::new(&block.txs, txids);
     let resolved = Arc::new(ResolvedUtxoView::resolve(source, block, &tx_plan));
     Ok(PreparedApply {
-        kernel_block,
         view,
         tx_plan,
         resolved,
@@ -2666,27 +2628,23 @@ fn apply_block_admitted<'b>(
         flags: verify_flags,
         locktime_cutoff,
     };
-    // Parse the block once with the kernel and take its txids. Core's
-    // `CTransaction` hashes itself while deserializing with the SHA-256
-    // implementation selected at runtime, so this one parse replaces the
-    // scalar `compute_txid` pass *and* the per-transaction serialize/reparse
-    // that script preparation used to perform.
-    // A window prepares several blocks against one overlay and hands the result
-    // back, so the kernel parse and the prevout resolution happen once. A proof
-    // whose context no longer matches is discarded together with its prepared
-    // view; the ordinary path rebuilds both from the live UTXO set.
+    // Hash each already-decoded transaction once and reuse those txids for
+    // merkle, BIP30/BIP34, overlay, and script preparation. A window prepares
+    // several blocks against one overlay and hands the result back, so the
+    // txid pass and the prevout resolution happen once. A proof whose context
+    // no longer matches is discarded together with its prepared view; the
+    // ordinary path rebuilds both from the live UTXO set.
     let (prepared, transactions_proven) = match proven {
         Some(ProvenApply::Proven(proof)) if proof.context == validation_context => {
             (proof.prepared, true)
         }
         Some(ProvenApply::AssumeValidSkipped(prepared)) => (prepared, false),
         Some(ProvenApply::Proven(_)) | None => (
-            prepare_apply(block, provided_serialized.clone(), handles.utxo.as_ref())?,
+            prepare_apply(block, provided_serialized.as_deref(), handles.utxo.as_ref())?,
             false,
         ),
     };
     let PreparedApply {
-        kernel_block,
         mut view,
         tx_plan,
         resolved,
@@ -2750,7 +2708,6 @@ fn apply_block_admitted<'b>(
             Arc::clone(&resolved),
             &validation_context,
             provenance,
-            &kernel_block,
         )
     };
     let script_verify_dur = script_verify_started.elapsed();
@@ -3264,11 +3221,9 @@ impl WitnessPresence {
 
 /// Plans a block whose txids are already known.
 ///
-/// Identities come from the parse-once view: the kernel parse hashes every
-/// transaction on the way past using the SHA-256 implementation Core picks at
-/// runtime, and the native build hashes each transaction once in
-/// [`block_txids`]. Either way the plan borrows them instead of re-hashing
-/// with a scalar implementation.
+/// Identities come from the parse-once view: [`block_txids`] hashes each
+/// already-decoded transaction once, and the plan borrows those hashes
+/// instead of re-hashing.
 fn plan_block_transactions(block: &Block, txids: &[Txid]) -> BlockTxPlan {
     let mut only_coinbase = true;
     let mut needs_local_utxo_overlay = false;
@@ -3531,13 +3486,6 @@ fn run_non_script_checks_only(
     Ok(())
 }
 
-#[cfg_attr(
-    not(feature = "kernel"),
-    expect(
-        clippy::trivially_copy_pass_by_ref,
-        reason = "the kernel build borrows an owning block handle through this shared signature"
-    )
-)]
 #[allow(
     clippy::as_conversions,
     clippy::cast_sign_loss,
@@ -3551,7 +3499,6 @@ fn verify_block_transactions(
     resolved: Arc<ResolvedUtxoView>,
     context: &BlockValidationContext,
     provenance: BlockProvenance,
-    kernel_block: &bitcoin_rs_consensus::kernel::KernelBlock,
 ) -> core::result::Result<(), ApplyError> {
     debug_assert_eq!(block.txs.len(), view.txids().len());
     if tx_plan.only_coinbase {
@@ -3598,7 +3545,6 @@ fn verify_block_transactions(
         context.locktime_cutoff,
         context.flags,
         &mut script_timings,
-        kernel_block,
     );
     metrics::histogram!("node.apply_block.script_prepare_seconds")
         .record(script_timings.prepare_seconds);
@@ -4085,13 +4031,6 @@ mod consensus_rule_tests {
     const MAINNET_POW_LIMIT_DIV_4_BITS: u32 = 0x1c3f_ffc0;
     const DAA_ANCHOR_TIME: u32 = 1_600_000_000;
 
-    /// Parses `block` the way production does, so tests exercise the real
-    /// one-shot kernel parse rather than a stand-in.
-    fn kernel_block_of(block: &Block) -> bitcoin_rs_consensus::kernel::KernelBlock {
-        bitcoin_rs_consensus::kernel::KernelBlock::parse(&consensus_bytes(block))
-            .unwrap_or_else(|error| panic!("test block must parse: {error}"))
-    }
-
     fn tx_plan(block: &Block) -> BlockTxPlan {
         plan_block_transactions(block, &block_txids(block))
     }
@@ -4235,7 +4174,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::NONE),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         )?;
         Ok(())
     }
@@ -4340,12 +4278,9 @@ mod consensus_rule_tests {
         Ok(())
     }
 
-    /// R2 pin (shared-view parallel path): under the kernel feature the script
-    /// verdict carries the kernel dispatch marker — the Rust interpreter did
-    /// not produce it.
+    /// Shared-view parallel path: a bad script is a Script consensus error.
     #[test]
-    #[cfg(feature = "kernel")]
-    fn verify_block_transactions_shared_view_path_uses_kernel_verdict()
+    fn verify_block_transactions_shared_view_path_rejects_bad_script()
     -> Result<(), Box<dyn std::error::Error>> {
         let (block, plan, utxo) = bad_script_spend_block()?;
         let handles = apply_handles(utxo);
@@ -4362,9 +4297,8 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::MANDATORY),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
-            Ok(()) => panic!("bad script must fail under the kernel build"),
+            Ok(()) => panic!("bad script must fail"),
             Err(error) => error,
         };
 
@@ -4372,17 +4306,16 @@ mod consensus_rule_tests {
             error,
             ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Script {
                 input_index: 0,
-                ref reason,
-            }) if reason.starts_with("kernel script verification failed:")
+                ..
+            })
         ));
         Ok(())
     }
 
-    /// R2 pin (overlay path): a same-block spend resolved against the frozen
-    /// per-tx snapshot view is also verdict-checked by the kernel.
+    /// Overlay path: a same-block spend resolved against the frozen per-tx
+    /// snapshot view is also a Script consensus error on a bad redeem.
     #[test]
-    #[cfg(feature = "kernel")]
-    fn verify_block_transactions_overlay_path_uses_kernel_verdict()
+    fn verify_block_transactions_overlay_path_rejects_bad_script()
     -> Result<(), Box<dyn std::error::Error>> {
         let base_prevout = OutPoint::new(fixture_txid(0x67), 0);
         let utxo = utxo_with_output(base_prevout, 1)?;
@@ -4421,9 +4354,8 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::MANDATORY),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
-            Ok(()) => panic!("bad same-block spend must fail under the kernel build"),
+            Ok(()) => panic!("bad same-block spend must fail"),
             Err(error) => error,
         };
 
@@ -4431,8 +4363,8 @@ mod consensus_rule_tests {
             error,
             ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Script {
                 input_index: 0,
-                ref reason,
-            }) if reason.starts_with("kernel script verification failed:")
+                ..
+            })
         ));
         Ok(())
     }
@@ -4440,8 +4372,7 @@ mod consensus_rule_tests {
     /// The unified full-verify path resolves same-block spends in order (tx1 spends
     /// tx0's output, forcing the overlay walk) yet still surfaces the *earlier*
     /// transaction's script failure deterministically — the node rewrite preserves
-    /// error identity through `verify_block_input_scripts`. Feature-agnostic: the
-    /// Script reason differs between the portable and kernel engines, so only the
+    /// error identity through `verify_block_input_scripts`. Only the Script
     /// variant and input index are asserted.
     #[test]
     fn verify_block_transactions_same_block_spend_surfaces_earlier_bad_script()
@@ -4498,7 +4429,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::MANDATORY),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("earlier tx bad script must reject the block"),
             Err(error) => error,
@@ -4539,7 +4469,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::NONE),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("cross-transaction duplicate spend must fail script verification"),
             Err(error) => error,
@@ -4573,7 +4502,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 1, 0, bitcoin_rs_script::VerifyFlags::MANDATORY),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("bad coinbase scriptSig length must fail transaction verification"),
             Err(error) => error,
@@ -4694,7 +4622,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::NONE),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("duplicate spend must fail when assume_valid_height is zero"),
             Err(error) => error,
@@ -4727,7 +4654,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::NONE),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("duplicate spend must fail even under assume_valid_height"),
             Err(error) => error,
@@ -4760,7 +4686,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 3, 0, bitcoin_rs_script::VerifyFlags::NONE),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("duplicate spend must fail above assume_valid_height"),
             Err(error) => error,
@@ -4793,7 +4718,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::MANDATORY),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         )?;
         Ok(())
     }
@@ -4816,7 +4740,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::MANDATORY),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("bad script must fail when assume_valid_height is zero"),
             Err(error) => error,
@@ -4850,7 +4773,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 3, 0, bitcoin_rs_script::VerifyFlags::MANDATORY),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("bad script must fail above assume_valid_height"),
             Err(error) => error,
@@ -4887,7 +4809,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::MANDATORY),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("outputs exceeding inputs must fail even under assume_valid_height"),
             Err(error) => error,
@@ -4925,7 +4846,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 1, 0, bitcoin_rs_script::VerifyFlags::MANDATORY),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         ) {
             Ok(()) => panic!("bad coinbase scriptSig length must fail under assume_valid_height"),
             Err(error) => error,
@@ -5136,8 +5056,7 @@ mod consensus_rule_tests {
                     &tx_plan(&block)
                 )),
                 &validation_context(&block, 1, 0, bitcoin_rs_script::VerifyFlags::NONE),
-                BlockProvenance::Network,
-                &kernel_block_of(&block),
+                BlockProvenance::Network
             )
             .is_ok()
         );
@@ -6896,7 +6815,7 @@ mod consensus_rule_tests {
             !bytes_are_block(&honest, &block),
             "bytes whose witness differs from the block must be rejected"
         );
-        let outcome = parse_block_for_apply(&block, Some(honest));
+        let outcome = parse_block_for_apply(&block, Some(honest.as_ref()));
         assert!(
             outcome.is_err(),
             "apply must refuse a block whose preserved bytes are not its serialization"
@@ -8746,10 +8665,6 @@ mod consensus_rule_tests {
     /// P2SH eval (P2SH ON): the last scriptSig push `[0x00]` is deserialized as the
     /// redeemScript `OP_0`, run with an empty stack -> pushes FALSE -> FAIL at input 0.
     ///
-    /// Gated to a real script backend: the acceptance arm asserts `Ok`, which only
-    /// holds when scripts actually execute. With no backend the verifier returns a
-    /// `Script { .. "backend disabled" }` error, so the helper would be dead code.
-    #[cfg(feature = "kernel")]
     fn p2sh_template_bare_spend_block()
     -> Result<(Block, BlockTxPlan, Arc<UtxoSet>), Box<dyn std::error::Error>> {
         // hash160([0x00]): the bare-eval arm only accepts when the redeem script
@@ -8797,9 +8712,6 @@ mod consensus_rule_tests {
         Ok((block, plan, utxo))
     }
 
-    // Asserts acceptance under the BIP16 exception, which needs a real script backend
-    // (the backend-less default build returns a "backend disabled" Script error).
-    #[cfg(feature = "kernel")]
     #[test]
     fn bip16_exception_accepts_bare_p2sh_template_spend_that_normal_p2sh_rejects()
     -> Result<(), Box<dyn std::error::Error>> {
@@ -8841,7 +8753,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block, 170_060, 0, exc_flags),
             BlockProvenance::Network,
-            &kernel_block_of(&block),
         )?;
 
         // Normal block at the same height: P2SH enforced -> REJECTED at input 0.
@@ -8859,7 +8770,6 @@ mod consensus_rule_tests {
             )),
             &validation_context(&block2, 170_060, 0, normal_flags),
             BlockProvenance::Network,
-            &kernel_block_of(&block2),
         ) {
             Ok(()) => {
                 panic!("normal P2SH enforcement must reject the bare-script redeem spend")

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -277,7 +277,7 @@ pub struct ObservabilityOverrides {
 pub struct ValidationOverrides {
     /// Height through which script verification may be skipped.
     pub assume_valid_height: Option<u32>,
-    /// Compare native script verdicts against `libbitcoinkernel`.
+    /// Compare native parse/txids and script verdicts against `libbitcoinkernel`.
     pub verify_kernel: Option<bool>,
 }
 
@@ -603,7 +603,7 @@ pub struct ObservabilityConfig {
 pub struct ValidationConfig {
     /// Height through which script verification may be skipped.
     pub assume_valid_height: u32,
-    /// Compare native script verdicts against `libbitcoinkernel`.
+    /// Compare native parse/txids and script verdicts against `libbitcoinkernel`.
     pub verify_kernel: bool,
 }
 

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -277,6 +277,8 @@ pub struct ObservabilityOverrides {
 pub struct ValidationOverrides {
     /// Height through which script verification may be skipped.
     pub assume_valid_height: Option<u32>,
+    /// Compare native script verdicts against `libbitcoinkernel`.
+    pub verify_kernel: Option<bool>,
 }
 
 /// User-supplied mining overrides.
@@ -500,6 +502,9 @@ impl ValidationOverrides {
         if other.assume_valid_height.is_some() {
             self.assume_valid_height = other.assume_valid_height;
         }
+        if other.verify_kernel.is_some() {
+            self.verify_kernel = other.verify_kernel;
+        }
     }
 }
 
@@ -598,6 +603,8 @@ pub struct ObservabilityConfig {
 pub struct ValidationConfig {
     /// Height through which script verification may be skipped.
     pub assume_valid_height: u32,
+    /// Compare native script verdicts against `libbitcoinkernel`.
+    pub verify_kernel: bool,
 }
 
 /// Resolved mining configuration.
@@ -670,6 +677,7 @@ impl NodeConfig {
             chainstate_journal: ChainstateJournalConfig::default(),
             validation: ValidationConfig {
                 assume_valid_height: 0,
+                verify_kernel: false,
             },
             mining: MiningConfig::default(),
         };
@@ -734,6 +742,10 @@ impl NodeConfig {
         anyhow::ensure!(
             journal.max_lag_seconds > 0,
             "chainstate_journal.max_lag_seconds must be positive"
+        );
+        anyhow::ensure!(
+            !self.validation.verify_kernel || bitcoin_rs_consensus::kernel::kernel_compiled(),
+            "verify_kernel requires a build with --features kernel"
         );
         Ok(())
     }
@@ -801,6 +813,9 @@ impl NodeConfig {
         }
         if let Some(value) = layer.validation.assume_valid_height {
             self.validation.assume_valid_height = value;
+        }
+        if let Some(value) = layer.validation.verify_kernel {
+            self.validation.verify_kernel = value;
         }
     }
 

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1892,6 +1892,7 @@ impl NodeState {
                 config.network,
                 config.validation.assume_valid_height,
             )),
+            verify_kernel: config.validation.verify_kernel,
             journal,
             checkpoint_publisher: None,
             capture_rawtx,

--- a/crates/node/tests/config_layered.rs
+++ b/crates/node/tests/config_layered.rs
@@ -278,12 +278,14 @@ fn assume_valid_height_override_has_precedence() -> Result<()> {
     let low = UserConfig {
         validation: ValidationOverrides {
             assume_valid_height: Some(10_000),
+            ..ValidationOverrides::default()
         },
         ..Default::default()
     };
     let high = UserConfig {
         validation: ValidationOverrides {
             assume_valid_height: Some(30_000),
+            ..ValidationOverrides::default()
         },
         ..Default::default()
     };
@@ -301,6 +303,52 @@ fn assume_valid_height_defaults_to_mainnet_anchor() -> Result<()> {
             .assume_valid_anchor()
             .map_or(0, |(height, _)| height)
     );
+    Ok(())
+}
+
+#[test]
+fn verify_kernel_defaults_off() -> Result<()> {
+    let config = resolve(&[])?;
+    assert!(!config.validation.verify_kernel);
+    Ok(())
+}
+
+#[test]
+fn verify_kernel_override_has_precedence() {
+    let mut low = UserConfig {
+        validation: ValidationOverrides {
+            verify_kernel: Some(false),
+            ..ValidationOverrides::default()
+        },
+        ..Default::default()
+    };
+    let high = UserConfig {
+        validation: ValidationOverrides {
+            verify_kernel: Some(true),
+            ..ValidationOverrides::default()
+        },
+        ..Default::default()
+    };
+    low.overlay(&high);
+    assert_eq!(low.validation.verify_kernel, Some(true));
+}
+
+#[test]
+fn verify_kernel_without_feature_fails_validate() -> Result<()> {
+    let mut config = NodeConfig::default_for_network(Network::Regtest);
+    config.validation.verify_kernel = true;
+    let result = config.validate();
+    if bitcoin_rs_consensus::kernel::kernel_compiled() {
+        result?;
+    } else {
+        match result {
+            Ok(()) => panic!("verify_kernel needs --features kernel"),
+            Err(error) => assert!(
+                error.to_string().contains("verify_kernel"),
+                "unexpected validate error: {error}"
+            ),
+        }
+    }
     Ok(())
 }
 

--- a/crates/primitives/src/encode.rs
+++ b/crates/primitives/src/encode.rs
@@ -389,6 +389,136 @@ impl ConsensusDecode for Block {
     }
 }
 
+const SERIALIZED_BLOCK_HEADER_LEN: usize = 80;
+
+/// Transaction ids of a serialized block, hashed from the wire bytes.
+///
+/// A legacy transaction is hashed as one contiguous slice. A BIP144 transaction
+/// hashes version, vin, vout, and locktime and skips the marker, flag, and
+/// witness. That is the same digest [`Tx::txid`] computes by re-encoding.
+pub fn txids_from_serialized_block(raw: &[u8]) -> Result<Vec<Txid>, DecodeError> {
+    let mut reader = raw;
+    let _header = take(&mut reader, SERIALIZED_BLOCK_HEADER_LEN)?;
+    let tx_count = read_compact(&mut reader)?;
+    let mut txids = Vec::new();
+    for _ in 0..tx_count {
+        txids.push(hash_txid_from_reader(&mut reader)?);
+    }
+    if !reader.is_empty() {
+        return Err(DecodeError::TrailingBytes {
+            remaining: reader.len(),
+        });
+    }
+    Ok(txids)
+}
+
+/// Double-SHA256 of one transaction's non-witness serialization, consumed from `reader`.
+fn hash_txid_from_reader(reader: &mut &[u8]) -> Result<Txid, DecodeError> {
+    let tx_start = *reader;
+    let _version = take(reader, 4)?;
+    let mut input_count = read_compact(reader)?;
+    if input_count != 0 {
+        skip_vin(reader, input_count)?;
+        let output_count = read_compact(reader)?;
+        skip_vout(reader, output_count)?;
+        let _lock_time = take(reader, 4)?;
+        let consumed = tx_start.len() - reader.len();
+        return Ok(Txid(double_sha256(&tx_start[..consumed])));
+    }
+
+    let flag = read_u8(reader)?;
+    if flag != 0x01 {
+        return Err(DecodeError::InvalidSegwitFlag { got: flag });
+    }
+    let mut engine = Sha256::new();
+    Digest::update(&mut engine, &tx_start[..4]);
+    input_count = read_compact_into(&mut engine, reader)?;
+    skip_vin_into(&mut engine, reader, input_count)?;
+    let output_count = read_compact_into(&mut engine, reader)?;
+    skip_vout_into(&mut engine, reader, output_count)?;
+    if !skip_witness(reader, input_count)? {
+        return Err(DecodeError::SuperfluousWitness);
+    }
+    take_into(&mut engine, reader, 4)?;
+    Ok(Txid(finalize_double_sha256(engine)))
+}
+
+fn read_compact_into(hasher: &mut Sha256, reader: &mut &[u8]) -> Result<u64, DecodeError> {
+    let (value, consumed) = varint::decode(reader)?;
+    Digest::update(hasher, &reader[..consumed]);
+    *reader = &reader[consumed..];
+    Ok(value)
+}
+
+fn take_into(hasher: &mut Sha256, reader: &mut &[u8], n: usize) -> Result<(), DecodeError> {
+    let bytes = take(reader, n)?;
+    Digest::update(hasher, bytes);
+    Ok(())
+}
+
+fn skip_prefixed_bytes(reader: &mut &[u8]) -> Result<(), DecodeError> {
+    let len = read_compact(reader)?;
+    let needed = usize::try_from(len).unwrap_or(usize::MAX);
+    let _ = take(reader, needed)?;
+    Ok(())
+}
+
+fn skip_vin(reader: &mut &[u8], count: u64) -> Result<(), DecodeError> {
+    for _ in 0..count {
+        let _ = take(reader, 36)?;
+        skip_prefixed_bytes(reader)?;
+        let _ = take(reader, 4)?;
+    }
+    Ok(())
+}
+
+fn skip_vout(reader: &mut &[u8], count: u64) -> Result<(), DecodeError> {
+    for _ in 0..count {
+        let _ = take(reader, 8)?;
+        skip_prefixed_bytes(reader)?;
+    }
+    Ok(())
+}
+
+fn skip_vin_into(hasher: &mut Sha256, reader: &mut &[u8], count: u64) -> Result<(), DecodeError> {
+    for _ in 0..count {
+        take_into(hasher, reader, 36)?;
+        skip_script_into(hasher, reader)?;
+        take_into(hasher, reader, 4)?;
+    }
+    Ok(())
+}
+
+fn skip_vout_into(hasher: &mut Sha256, reader: &mut &[u8], count: u64) -> Result<(), DecodeError> {
+    for _ in 0..count {
+        take_into(hasher, reader, 8)?;
+        skip_script_into(hasher, reader)?;
+    }
+    Ok(())
+}
+
+fn skip_script_into(hasher: &mut Sha256, reader: &mut &[u8]) -> Result<(), DecodeError> {
+    let len = read_compact_into(hasher, reader)?;
+    let needed = usize::try_from(len).unwrap_or(usize::MAX);
+    take_into(hasher, reader, needed)
+}
+
+fn skip_witness(reader: &mut &[u8], input_count: u64) -> Result<bool, DecodeError> {
+    let mut any = false;
+    for _ in 0..input_count {
+        let item_count = read_compact(reader)?;
+        if item_count > 0 {
+            any = true;
+        }
+        for _ in 0..item_count {
+            let len = read_compact(reader)?;
+            let needed = usize::try_from(len).unwrap_or(usize::MAX);
+            let _ = take(reader, needed)?;
+        }
+    }
+    Ok(any)
+}
+
 #[cfg(test)]
 mod tests {
     #![expect(clippy::expect_used, reason = "test assertions")]
@@ -554,6 +684,68 @@ mod tests {
             Err(DecodeError::SuperfluousWitness)
         );
         assert!(bitcoin_deserialize::<Transaction>(&zero_input).is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn wire_txid_matches_reencoded_txid_for_legacy_and_segwit() -> Result<()> {
+        use crate::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+
+        let legacy = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid::default(), 0),
+                script_sig: vec![0x51],
+                sequence: 0xffff_fffe,
+                witness: Vec::new(),
+            }],
+            outputs: vec![TxOut {
+                value: 50_000,
+                script_pubkey: vec![0x51],
+            }],
+            lock_time: 7,
+        };
+        let legacy_bytes = crate::encode::consensus_bytes(&legacy);
+        let mut legacy_reader = legacy_bytes.as_slice();
+        let legacy_wire = super::hash_txid_from_reader(&mut legacy_reader)?;
+        assert_eq!(legacy_wire, legacy.txid());
+        assert!(legacy_reader.is_empty());
+
+        let segwit = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid(Hash256::default()), 3),
+                script_sig: Vec::new(),
+                sequence: 0xffff_fffe,
+                witness: vec![vec![0xaa; 40]],
+            }],
+            outputs: vec![TxOut {
+                value: 50_000,
+                script_pubkey: vec![0x00, 0x14, 0xab],
+            }],
+            lock_time: 42,
+        };
+        let segwit_bytes = crate::encode::consensus_bytes(&segwit);
+        let mut segwit_reader = segwit_bytes.as_slice();
+        let segwit_wire = super::hash_txid_from_reader(&mut segwit_reader)?;
+        assert_eq!(segwit_wire, segwit.txid());
+        assert!(segwit_reader.is_empty());
+
+        let block = Block {
+            header: Header {
+                version: 1,
+                prev_blockhash: BlockHash::default(),
+                merkle_root: Hash256::default(),
+                time: 0,
+                bits: 0,
+                nonce: 0,
+            },
+            txs: vec![legacy, segwit],
+        };
+        let raw = crate::encode::consensus_bytes(&block);
+        let from_wire = super::txids_from_serialized_block(&raw)?;
+        let from_structs: Vec<Txid> = block.txs.iter().map(Tx::txid).collect();
+        assert_eq!(from_wire, from_structs);
         Ok(())
     }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -29,6 +29,7 @@ pub mod version;
 pub use block::Block;
 pub use encode::{
     ConsensusDecode, ConsensusEncode, DecodeError, consensus_bytes, consensus_len, deserialize,
+    txids_from_serialized_block,
 };
 pub use hash::{Hash256, HashError};
 pub use header::Header;

--- a/crates/primitives/src/sighash.rs
+++ b/crates/primitives/src/sighash.rs
@@ -162,6 +162,11 @@ impl EcdsaType {
 /// The taproot amount/scriptPubKey midstates assume the same prevout set is supplied to
 /// every call on this cache (the same assumption the `bitcoin` crate's cache makes);
 /// construct a fresh cache when the prevout set changes.
+///
+/// [`Self::precompute`] fills the shared BIP143/BIP341 hashes once per
+/// transaction. Cloning a filled cache is the cheap way to hand each input its
+/// own `&mut` checker without recomputing those midstates.
+#[derive(Clone)]
 pub struct SighashCache<'t> {
     tx: &'t Tx,
     segwit_prevouts: Option<Hash256>,
@@ -188,6 +193,25 @@ impl<'t> SighashCache<'t> {
             taproot_scriptpubkeys: None,
             taproot_sequences: None,
             taproot_outputs: None,
+        }
+    }
+
+    /// Fills every BIP143 and BIP341 midstate that does not depend on a
+    /// per-input script code.
+    ///
+    /// Call once per transaction before verifying its inputs. Cloned caches
+    /// then skip the shared hashes, matching Core's
+    /// `PrecomputedTransactionData` reuse without a second parse.
+    pub fn precompute(&mut self, prevouts: &[TxOut]) {
+        let _ = self.segwit_prevouts();
+        let _ = self.segwit_sequences();
+        let _ = self.segwit_outputs();
+        let _ = self.taproot_prevouts();
+        let _ = self.taproot_sequences();
+        let _ = self.taproot_outputs();
+        if prevouts.len() == self.tx.inputs.len() {
+            let _ = self.taproot_amounts(prevouts);
+            let _ = self.taproot_scriptpubkeys(prevouts);
         }
     }
 

--- a/crates/primitives/tests/golden.rs
+++ b/crates/primitives/tests/golden.rs
@@ -95,6 +95,11 @@ fn golden_blocks_decode_and_hash_to_blockstream_txids() -> Result<(), Box<dyn st
             );
         }
         assert_eq!(
+            bitcoin_rs_primitives::txids_from_serialized_block(&block_bytes)?,
+            expected_txids,
+            "height {height} wire txids"
+        );
+        assert_eq!(
             bitcoin_rs_primitives::consensus_bytes(&block),
             block_bytes,
             "height {height} re-encode"

--- a/crates/script/README.md
+++ b/crates/script/README.md
@@ -12,8 +12,8 @@ spends require the complete ordered prevout set. Around the interpreter sit
 `sigops` (signature-operation counting) and the signature checker. Failures
 surface as `ScriptError`. Core's `script_tests`, `tx_valid`, and `tx_invalid`
 vectors pin zero native mismatches in `tests/core_vectors.rs`. The `kernel`
-feature on `bitcoin-rs-consensus` remains the library production default;
-see [`docs/contracts/validation-default.md`](../../docs/contracts/validation-default.md).
+feature on `bitcoin-rs-consensus` compiles `libbitcoinkernel` as an independent
+oracle; see [`docs/contracts/validation-default.md`](../../docs/contracts/validation-default.md).
 
 ## Features
 

--- a/crates/script/src/checker.rs
+++ b/crates/script/src/checker.rs
@@ -118,12 +118,28 @@ impl<'a> TxSignatureChecker<'a> {
     /// input so taproot sighashes can commit to all spent outputs.
     #[must_use]
     pub fn new(tx: &'a Tx, input_index: usize, amount: u64, prevouts: &'a [TxOut]) -> Self {
+        Self::with_cache(tx, input_index, amount, prevouts, SighashCache::new(tx))
+    }
+
+    /// Builds a checker that reuses a caller-filled [`SighashCache`].
+    ///
+    /// The cache must have been constructed over the same `tx`. Apply-path
+    /// verification precomputes midstates once per transaction and clones that
+    /// cache into each input checker.
+    #[must_use]
+    pub fn with_cache(
+        tx: &'a Tx,
+        input_index: usize,
+        amount: u64,
+        prevouts: &'a [TxOut],
+        cache: SighashCache<'a>,
+    ) -> Self {
         Self {
             tx,
             input_index,
             amount,
             prevouts,
-            cache: SighashCache::new(tx),
+            cache,
             annex: None,
         }
     }

--- a/crates/script/src/interpreter.rs
+++ b/crates/script/src/interpreter.rs
@@ -481,6 +481,71 @@ impl Interpreter {
         tx: &Tx,
         input_idx: usize,
     ) -> Result<bool, ScriptError> {
+        self.execute_with_cache(
+            script_pubkey,
+            script_sig,
+            witness,
+            flags,
+            prevouts,
+            tx,
+            input_idx,
+            None,
+        )
+    }
+
+    /// Executes one input using a caller-filled sighash cache.
+    ///
+    /// The cache must have been constructed over `tx`. Apply-path verification
+    /// precomputes midstates once per transaction and clones that cache into
+    /// each input so parallel checks do not rehash prevouts, sequences, or
+    /// outputs.
+    pub fn execute_cached(
+        &self,
+        flags: VerifyFlags,
+        spent_outputs: &[TxOut],
+        tx: &Tx,
+        input_idx: usize,
+        cache: SighashCache<'_>,
+    ) -> Result<bool, ScriptError> {
+        let input = tx
+            .inputs
+            .get(input_idx)
+            .ok_or(ScriptError::InputIndexOutOfRange {
+                index: input_idx,
+                inputs: tx.inputs.len(),
+            })?;
+        self.execute_with_cache(
+            &spent_outputs
+                .get(input_idx)
+                .ok_or(ScriptError::TaprootPrevoutsUnavailable)?
+                .script_pubkey,
+            &input.script_sig,
+            &input.witness,
+            flags,
+            spent_outputs,
+            tx,
+            input_idx,
+            Some(cache),
+        )
+    }
+
+    #[allow(
+        clippy::too_many_arguments,
+        clippy::unused_self,
+        clippy::trivially_copy_pass_by_ref,
+        reason = "same driver shape as execute_with_prevouts plus the shared cache; Interpreter is a ZST"
+    )]
+    fn execute_with_cache(
+        &self,
+        script_pubkey: &[u8],
+        script_sig: &[u8],
+        witness: &[Vec<u8>],
+        flags: VerifyFlags,
+        prevouts: &[TxOut],
+        tx: &Tx,
+        input_idx: usize,
+        cache: Option<SighashCache<'_>>,
+    ) -> Result<bool, ScriptError> {
         let inputs = tx.inputs.len();
         let input = tx
             .inputs
@@ -527,6 +592,8 @@ impl Interpreter {
             Cow::Owned(grafted)
         };
 
+        let cache = if matches_tx { cache } else { None };
+
         if is_p2tr(script_pubkey) && flags.contains(VerifyFlags::TAPROOT) {
             return verify_taproot(
                 &spending,
@@ -535,10 +602,16 @@ impl Interpreter {
                 witness,
                 prevouts,
                 flags,
+                cache,
             );
         }
 
-        let mut checker = TxSignatureChecker::new(&spending, input_idx, prevout.value, prevouts);
+        let mut checker = match cache {
+            Some(cache) => {
+                TxSignatureChecker::with_cache(tx, input_idx, prevout.value, prevouts, cache)
+            }
+            None => TxSignatureChecker::new(&spending, input_idx, prevout.value, prevouts),
+        };
         verify_script(
             script_sig,
             script_pubkey,
@@ -781,6 +854,7 @@ fn verify_taproot(
     witness: &[Vec<u8>],
     prevouts: &[TxOut],
     flags: VerifyFlags,
+    cache: Option<SighashCache<'_>>,
 ) -> Result<bool, ScriptError> {
     if prevouts.len() != spending.inputs.len() {
         return Err(ScriptError::TaprootPrevoutsUnavailable);
@@ -811,6 +885,7 @@ fn verify_taproot(
             &stack,
             annex_bytes.as_deref(),
             prevouts,
+            cache,
         )
     } else {
         verify_taproot_scriptpath(
@@ -822,6 +897,7 @@ fn verify_taproot(
             annex_bytes,
             prevouts,
             flags,
+            cache,
         )
     }
 }
@@ -848,6 +924,7 @@ fn verify_taproot_keypath(
     stack: &[Vec<u8>],
     annex_bytes: Option<&[u8]>,
     prevouts: &[TxOut],
+    cache: Option<SighashCache<'_>>,
 ) -> Result<bool, ScriptError> {
     let signature_bytes = &stack[0];
     let sighash_type = match signature_bytes.len() {
@@ -864,7 +941,7 @@ fn verify_taproot_keypath(
         .map_err(|error| ScriptError::Verification(error.to_string()))?;
     let public_key = XOnlyPublicKey::from_slice(program)
         .map_err(|error| ScriptError::Verification(error.to_string()))?;
-    let mut cache = SighashCache::new(spending);
+    let mut cache = cache.unwrap_or_else(|| SighashCache::new(spending));
     let sighash = cache
         .taproot_signature_hash(input_idx, prevouts, annex_bytes, None, sighash_type)
         .map_err(|error| ScriptError::Verification(error.to_string()))?;
@@ -879,6 +956,10 @@ fn verify_taproot_keypath(
 }
 
 /// Verifies a taproot script-path spend (BIP341/BIP342).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "script-path needs witness, control, annex, flags, and the shared sighash cache"
+)]
 fn verify_taproot_scriptpath(
     spending: &Tx,
     input_idx: usize,
@@ -888,6 +969,7 @@ fn verify_taproot_scriptpath(
     annex_bytes: Option<Vec<u8>>,
     prevouts: &[TxOut],
     flags: VerifyFlags,
+    cache: Option<SighashCache<'_>>,
 ) -> Result<bool, ScriptError> {
     // Core: "const valtype& control = SpanPopBack(stack); const valtype& script = SpanPopBack(stack);"
     let control = stack
@@ -955,7 +1037,10 @@ fn verify_taproot_scriptpath(
         i64::try_from(witness_serialized_size).unwrap_or(i64::MAX) + eval::VALIDATION_WEIGHT_OFFSET,
     );
 
-    let mut checker = TxSignatureChecker::new(spending, input_idx, 0, prevouts);
+    let mut checker = match cache {
+        Some(cache) => TxSignatureChecker::with_cache(spending, input_idx, 0, prevouts, cache),
+        None => TxSignatureChecker::new(spending, input_idx, 0, prevouts),
+    };
     checker.set_annex(annex_bytes);
 
     eval::eval_script(

--- a/docs/benchmarks/native-validation-default.md
+++ b/docs/benchmarks/native-validation-default.md
@@ -11,23 +11,26 @@ requires every gate in the issue, not a subset.
 
 ## Decision
 
-Keep `kernel` as the `bitcoin-rs-consensus` and `bitcoin-rs-node` default,
-and in the Compose image. Leave `bin/bitcoin-rs` kernel-free. The native
-interpreter is a complete consensus script engine; it is not yet the
-measured winner. Recorded verdict: `KeepKernel`.
+Native is the production default in `bitcoin-rs-consensus`, `bitcoin-rs-node`,
+`bin/bitcoin-rs`, and the Compose image. `kernel` compiles `libbitcoinkernel`
+as an independent Core oracle; it does not replace apply. Recorded verdict:
+`PromoteNative`.
+
+The 2026-09-04 signed-spend cell still records native apply p50 9.2% behind
+the kernel arm *when kernel was the execution backend*. That comparison no
+longer chooses the production engine. Native apply now hashes decoded
+transactions once and reuses a filled `SighashCache` across inputs, which is
+the property the kernel arm was buying with `PrecomputedTransactionData`.
 
 ## Decision rule (issue #213)
 
-The native path becomes the library default only after:
+The architectural split this note now records:
 
-1. Identities for both arms are pinned (source, compiler, features, corpus,
-   machine, binary).
-2. Every verdict on the available consensus corpus matches Bitcoin Core.
-3. The signed-spend harness reports p50 / p95 / p99 / max, with at least
-   three independent-run medians, and both arms stay within five percent of
-   their own median.
-4. The native median is faster than the pinned kernel median.
-5. Changed validation boundaries pass the in-tree test and clippy gates.
+1. Production apply is always native.
+2. `--features kernel` compiles the Core oracle; it must not feed kernel
+   types into apply or state.
+3. Core-vector native columns stay at zero mismatches on runnable rows.
+4. Kernel-vs-interpreter differentials remain behind `--features kernel`.
 
 The signed-spend Criterion target times `NodeState::apply_block`. Keep it
 for engine diagnostics. It is not a daemon, P2P, or CLI wall. The named
@@ -43,14 +46,10 @@ not flip the default.
 | Surface | Script engine |
 |---|---|
 | `bin/bitcoin-rs` default features (`fjall,redb,zmq`) | Native interpreter |
-| `bitcoin-rs-consensus` / `bitcoin-rs-node` crate defaults | `kernel` (`libbitcoinkernel`) |
-| Compose image (`Dockerfile --features fjall,kernel`) | `kernel` |
+| `bitcoin-rs-consensus` / `bitcoin-rs-node` crate defaults | Native interpreter |
+| Compose image (`Dockerfile --features fjall`) | Native interpreter |
 
-Until the gates pass, the library crates and the image keep `kernel`. The
-binary already builds native so a default `cargo build -p bitcoin-rs` needs
-no C++ toolchain. Promoting native is one coordinated change: flip
-`RECORDED_VERDICT` in `g19_validation_default` and drop `kernel` from the
-two library defaults in the same commit.
+`--features kernel` compiles the oracle. Production apply stays native.
 
 ## Measured observations
 
@@ -126,6 +125,6 @@ count is not reported by this harness.
 | Gate | Status |
 |---|---|
 | Core vector parity (available corpus) | Pass (zero pinned native mismatches; skip counts and reasons pinned) |
-| Signed-spend native faster, stable medians | Fail (stable; native 9.2% slower on apply p50) |
+| Signed-spend native vs kernel-as-backend (historical) | Native 9.2% slower on 2026-09-04 apply p50 while kernel still owned apply |
 | Full-mainnet replay | Blocked on #34 (#42 corpus freeze is done) |
-| Recorded verdict | `KeepKernel` |
+| Recorded verdict | `PromoteNative` |

--- a/docs/contracts/validation-default.md
+++ b/docs/contracts/validation-default.md
@@ -47,8 +47,9 @@ Owners:
 - `bin/bitcoin-rs` default features are `fjall`, `redb`, and `zmq`. They
   never include `kernel`.
 - The Compose image (`Dockerfile`) builds `--features fjall`.
-- `--features kernel` compiles the independent Core oracle for
-  differential tests and a later runtime verification tap. Turning it on
+- `--features kernel` compiles the independent Core oracle. `--verify-kernel`
+  (env `BITCOIN_RS_VERIFY_KERNEL`, toml `verify_kernel`) sends the same
+  Rust-owned inputs to Core and compares accept/reject only. Turning it on
   must not become an alternative apply implementation.
 
 ## Proven by

--- a/docs/contracts/validation-default.md
+++ b/docs/contracts/validation-default.md
@@ -16,8 +16,9 @@ Owners:
 - `bitcoin-rs-consensus` and `bitcoin-rs-node` default features do not
   include `kernel` while the recorded verdict in `g19_validation_default.rs`
   is `PromoteNative`.
-- Production apply is always the native Rust path: decode once, hash native
-  `Tx` values once, verify scripts through `Interpreter` with a shared
+- Production apply is always the native Rust path: decode once, hash each
+  transaction once (from preserved wire bytes when present, otherwise from
+  the decoded `Tx`), verify scripts through `Interpreter` with a shared
   `SighashCache`. Enabling `--features kernel` compiles `libbitcoinkernel`;
   it does not replace that path or feed kernel-owned data into apply.
 - The verdict may move back to `KeepKernel` only together with those two

--- a/docs/contracts/validation-default.md
+++ b/docs/contracts/validation-default.md
@@ -11,33 +11,28 @@ Owners:
 
 ## Clauses
 
-### `VAL-01`: Library default stays on `kernel` until promotion
+### `VAL-01`: Library default is native; `kernel` is an oracle feature
 
-- `bitcoin-rs-consensus` and `bitcoin-rs-node` default features include
-  `kernel` while the recorded verdict in `g19_validation_default.rs` is
-  `KeepKernel`.
-- The verdict may move to `PromoteNative` only together with those two
-  manifests dropping `kernel` from `default`, and only after the
-  measurement gates in
-  [`docs/benchmarks/native-validation-default.md`](../benchmarks/native-validation-default.md)
-  all pass: Core-vector parity, signed-spend **apply-path** native median
-  faster than the pinned kernel median with both arms inside five percent
-  of their own three-run median, and the end-to-end full-mainnet replay
-  wall owned by #34. #42 froze the C150/Cmodern corpus contracts; that
-  freeze does not run the comparator.
-- The signed-spend Criterion target times `NodeState::apply_block`. It is
-  the in-tree engine comparison that can run without the held corpus. It
-  is not a CLI/P2P wall and does not substitute for the missing replay
-  cell. A failed or unstable measurement leaves `KeepKernel` in place.
+- `bitcoin-rs-consensus` and `bitcoin-rs-node` default features do not
+  include `kernel` while the recorded verdict in `g19_validation_default.rs`
+  is `PromoteNative`.
+- Production apply is always the native Rust path: decode once, hash native
+  `Tx` values once, verify scripts through `Interpreter` with a shared
+  `SighashCache`. Enabling `--features kernel` compiles `libbitcoinkernel`;
+  it does not replace that path or feed kernel-owned data into apply.
+- The verdict may move back to `KeepKernel` only together with those two
+  manifests putting `kernel` in `default` again. That would reintroduce a
+  C++ execution backend and is not the intended architecture.
 
-### `VAL-02`: Native interpreter is the complete portable engine
+### `VAL-02`: Native interpreter is the complete production engine
 
-- With `kernel` off, `Interpreter::execute` / `execute_with_prevouts` in
+- `Interpreter::execute` / `execute_with_prevouts` / `execute_cached` in
   `crates/script/src/interpreter.rs` verify every consensus spend class:
   legacy and P2SH through `eval::eval_script`, SegWit v0 through BIP143,
   Taproot key-path and script-path through local BIP341/BIP342.
-- `crates/consensus/src/verify_tx.rs` routes that path through
-  `verify_input_script_portable` under `#[cfg(not(feature = "kernel"))]`.
+- `crates/consensus/src/verify_tx.rs` always routes scripts through
+  `verify_input_script_portable`. The `kernel` feature does not change that
+  dispatch.
 - Core `script_tests.json`, `tx_valid.json`, and `tx_invalid.json` native
   columns pin zero mismatches on **runnable** rows in
   `crates/script/tests/core_vectors.rs`, and pin skip counts **and**
@@ -47,14 +42,14 @@ Owners:
   `CheckTransaction` before script verification). `tx_valid` accepts no
   skips.
 
-### `VAL-03`: Default binary stays kernel-free
+### `VAL-03`: Default binary and image stay kernel-free
 
 - `bin/bitcoin-rs` default features are `fjall`, `redb`, and `zmq`. They
   never include `kernel`.
-- `--features kernel` remains the opt-in production engine on the binary
-  and the Compose image (`Dockerfile` builds `fjall,kernel`).
-- This split is the C++-free quickstart. Promoting native in `VAL-01`
-  does not add `kernel` to the binary default.
+- The Compose image (`Dockerfile`) builds `--features fjall`.
+- `--features kernel` compiles the independent Core oracle for
+  differential tests and a later runtime verification tap. Turning it on
+  must not become an alternative apply implementation.
 
 ## Proven by
 
@@ -70,6 +65,6 @@ Owners:
 - `crates/consensus/tests/kernel_block_parity.rs`:
   `script_verdict_parity` (Taproot key-path differential),
   `differential_is_non_vacuous` (script-path non-vacuity).
-- Manifests: `crates/consensus/Cargo.toml` `default = ["kernel"]`,
-  `crates/node/Cargo.toml` `default = ["fjall", "kernel", "zmq"]`,
+- Manifests: `crates/consensus/Cargo.toml` `default = []`,
+  `crates/node/Cargo.toml` `default = ["fjall", "zmq"]`,
   `bin/bitcoin-rs/Cargo.toml` `default = ["fjall", "redb", "zmq"]`.

--- a/docs/contracts/validation-default.md
+++ b/docs/contracts/validation-default.md
@@ -49,8 +49,10 @@ Owners:
 - The Compose image (`Dockerfile`) builds `--features fjall`.
 - `--features kernel` compiles the independent Core oracle. `--verify-kernel`
   (env `BITCOIN_RS_VERIFY_KERNEL`, toml `verify_kernel`) sends the same
-  Rust-owned inputs to Core and compares accept/reject only. Turning it on
-  must not become an alternative apply implementation.
+  Rust-owned inputs to Core and compares accept/reject only: block parse
+  and txids from the preserved wire bytes, then script verdicts from the
+  already-resolved Rust prevouts. Turning it on must not become an
+  alternative apply implementation.
 
 ## Proven by
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,7 +85,7 @@ Configuration defaults:
 | `--txindex` | off |
 | `--scriptindex` | off (accepts `full`, `utxo`, or boolean; defaults to `full` when passed without a value) |
 | `--features kernel` (build-time) | off in default binary; compiles `libbitcoinkernel` as a verification oracle |
-| `--verify-kernel` | off; compares native script verdicts against Core. Requires `--features kernel` |
+| `--verify-kernel` | off; compares native parse/txids and script verdicts against Core. Requires `--features kernel` |
 
 The node logs its startup banner, effective cache allocation, and the address
 the JSON-RPC listener bound to.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,8 @@ Configuration defaults:
 | `--prune-target-mb` | 0 (no pruning) |
 | `--txindex` | off |
 | `--scriptindex` | off (accepts `full`, `utxo`, or boolean; defaults to `full` when passed without a value) |
-| `--features kernel` (build-time) | off in default binary; enables `libbitcoinkernel` as a verification oracle |
+| `--features kernel` (build-time) | off in default binary; compiles `libbitcoinkernel` as a verification oracle |
+| `--verify-kernel` | off; compares native script verdicts against Core. Requires `--features kernel` |
 
 The node logs its startup banner, effective cache allocation, and the address
 the JSON-RPC listener bound to.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,10 +10,8 @@ verify progress before moving on.
   libraries. It uses the native Rust script interpreter, which verifies
   legacy, P2SH, SegWit v0, and Taproot key-path and script-path spends.
   Core's committed script and transaction vectors currently pin zero native
-  mismatches. `libbitcoinkernel` remains the library production default and
-  the Compose image engine until issue #213 promotes native
-  (`docs/contracts/validation-default.md`). For that engine, enable the
-  `kernel` feature.
+  mismatches. `libbitcoinkernel` is an optional independent oracle behind the
+  `kernel` feature (`docs/contracts/validation-default.md`).
 
 If you plan to compile with the `kernel` feature to run `libbitcoinkernel` as
 an independent verification oracle, install `cmake` and `libboost-dev`:
@@ -34,8 +32,7 @@ cargo build --release -p bitcoin-rs
 This produces `./target/release/bitcoin-rs`. The default configuration includes
 the `fjall` storage backend, `redb`, and `zmq` sequence publishing. The default
 binary build uses the native Rust script interpreter for every consensus spend
-class. Library crates and the Compose image still default to
-`libbitcoinkernel` (`docs/contracts/validation-default.md`).
+class.
 
 To compile with `libbitcoinkernel` as an independent verification oracle:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Production apply is now always native Rust: decode once, hash native `Tx` values once, verify scripts through `Interpreter` with a shared `SighashCache`. `bitcoinkernel` is no longer an execution backend.

`--features kernel` still compiles `libbitcoinkernel` as an independent Core oracle (parse + `verify_tx_scripts`). Kernel types (`KernelBlock`, `TransactionRef`, `PrecomputedTransactionData`, kernel txids) never enter apply or state.

This is the first of two stacked PRs. The follow-up adds runtime `--verify-kernel` so the same inputs can be sent to Core and compared by verdict only.

## What changed

- Apply no longer parses a `KernelBlock` or threads it into script verification.
- `verify_tx` always uses the native interpreter. Per-transaction `SighashCache::precompute` is cloned into each input so parallel checks do not rehash BIP143/BIP341 midstates.
- Library defaults drop `kernel`: `bitcoin-rs-consensus` `default = []`, `bitcoin-rs-node` `default = ["fjall", "zmq"]`.
- G19 recorded verdict is `PromoteNative`. Compose image builds `--features fjall`.
- PR CI clippy/test no longer need to exclude consensus/node to avoid C++.

## Contract

`docs/contracts/validation-default.md`: VAL-01 native default, VAL-02 native engine always, VAL-03 binary and image stay kernel-free. Enabling `kernel` must not become an alternative apply implementation.

## Test plan

- [x] `cargo test -p bitcoin-rs-consensus`
- [x] `cargo test -p bitcoin-rs-node --no-default-features --features fjall --lib` (579 passed)
- [x] `cargo test -p bitcoin-rs --test g19_validation_default`
- [x] `cargo clippy -p bitcoin-rs-consensus --all-targets -- -D warnings`
- [x] `cargo clippy -p bitcoin-rs-node --no-default-features --features fjall --lib -- -D warnings`
- [x] `cargo test -p bitcoin-rs-script` (Core vector native columns still zero-mismatch)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-996af3b4-a8cd-45bf-aad7-e32419922de0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-996af3b4-a8cd-45bf-aad7-e32419922de0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

