### PR TITLE
Deepen the IBD download window to 256 blocks

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -109,7 +109,7 @@ Skipping script-signature verification for blocks at or below a trusted height w
 The mainnet checkpoint (height 938343, block `00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac`). Script verification is skipped at or below it only after the active header chain is shown to contain this exact hash; sub-anchor header tips and diverged chains verify fully.
 
 ### Optimized default posture
-The default mainnet configuration: `fjall` backend, multi-peer download (outbound target 8, pending block budget 128, 16 in-flight per peer), hash-pinned assume-valid, 450 MiB `dbcache`, `txindex` and pruning off. The checked-in Compose specialization compiles `fjall` + `bitcoinkernel`, runs unprivileged, and namespaces node and enforcer data by `BITCOIN_RS_NETWORK`.
+The default mainnet configuration: `fjall` backend, multi-peer download (outbound target 8, pending block budget 256, 16 in-flight per peer once fan-out engages), hash-pinned assume-valid, 450 MiB `dbcache`, `txindex` and pruning off. The checked-in Compose specialization compiles `fjall` + `bitcoinkernel`, runs unprivileged, and namespaces node and enforcer data by `BITCOIN_RS_NETWORK`.
 
 ### Node network selection
 `BITCOIN_RS_NETWORK`/`--network` atomically selects consensus rules and P2P bootstrap identity while preserving later low-level overrides. The internal consensus `Network` remains the consensus selector: `drynet4` keeps mainnet consensus with message start `eca5d404`, no Bitcoin DNS seeds, and `drynet4.drivechain.dev:8533`. See `docs/solutions/architecture-patterns/network-selection-keeps-p2p-identity-atomic.md`.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Core & domain: crates/consensus, crates/script, crates/utxo, crates/chain, crate
 | Validation engine | Native Rust interpreter (default binary); `libbitcoinkernel` with `--features kernel` and as the consensus/node library default |
 | Kernel feature | Off in default binary build; on in `crates/consensus` and `crates/node` library defaults |
 | Database cache | 450 MiB (`--dbcache-mb`, split 80/20 when txindex is enabled) |
-| Multi-peer download | On (8 outbound peers, 128-block window) |
+| Multi-peer download | On (8 outbound peers, 256-block window) |
 | Transaction index | Off |
 | Script index | Off |
 | Pruning | Off |

--- a/crates/node/benches/sync_pipeline.rs
+++ b/crates/node/benches/sync_pipeline.rs
@@ -618,13 +618,14 @@ impl SyncFixture {
     fn new_reverse_scan_overflow(tx_index_mode: TxIndexMode) -> Self {
         let mut fixture =
             Self::new_with_block_count(tx_index_mode, 0, SYNC_REVERSE_SCAN_OVERFLOW_BODY_BLOCKS);
-        // The bench stages 128 received blocks and still needs to request the
-        // full 128-block pending window, so the received-block budget must
-        // cover both the staged blocks and the new requests.
-        fixture.sync.install_budget(SyncBudget {
-            max_received_blocks: 256,
-            ..default_sync_budget()
-        });
+        // The bench stages 128 received blocks and still needs to request a
+        // full pending window, so the received-block budget must cover both
+        // the staged blocks and the new requests.
+        let mut budget = default_sync_budget();
+        budget.max_received_blocks = budget
+            .max_pending_blocks
+            .saturating_add(SYNC_REVERSE_SCAN_OVERFLOW_RECEIVED_BLOCKS);
+        fixture.sync.install_budget(budget);
         let first_index = SYNC_REVERSE_SCAN_OVERFLOW_RECEIVED_START_HEIGHT.saturating_sub(1);
         let last_index = first_index.saturating_add(SYNC_REVERSE_SCAN_OVERFLOW_RECEIVED_BLOCKS);
         for block in fixture

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -1868,12 +1868,11 @@ pub fn replay_local_block(
 /// other half, and the window is whichever bound hits first.
 ///
 /// Peer sync does not reach 1024 today. `RECEIVED_BLOCK_BUDGET` caps staging at
-/// 128 blocks, so the windows it forms are at most that, worth 525s CPU against
+/// 256 blocks, so the windows it forms are at most that, worth 471s CPU against
 /// 596s at 64 — a real gain, and not the 389s the replay driver reaches.
-/// Raising the staging cap is not a constant change: the staller-arming
-/// invariant in `sync.rs` ties the staged byte budget to the staged count at
+/// Raising the staging cap further is not a constant change: the staller-arming
+/// invariant ties the staged byte budget to the staged count at
 /// `MAX_SERIALIZED_BLOCK_SIZE`, so a 1024-block stage would demand a 2 GB bound.
-/// That invariant has to be reworked against typical block size first.
 pub const SCRIPT_BATCH_WINDOW: usize = 1024;
 
 /// How many bytes of block data one window may hold.

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -1558,7 +1558,8 @@ mod tests {
         let (dial_tx, dial_rx) = crossbeam_channel::unbounded();
         let seeds = signet_seeds();
         let mut recently_queued = hashbrown::HashMap::new();
-        let needed = crate::sync::MIN_PEERS_FOR_FANOUT - live_outbound_peer_count(&peer_table); // 5
+        let live = live_outbound_peer_count(&peer_table);
+        let needed = crate::sync::MIN_PEERS_FOR_FANOUT - live;
 
         let queued = drain_dns_peer_deficit(
             &OverlapResolver,
@@ -1571,9 +1572,9 @@ mod tests {
             needed,
         );
 
-        assert_eq!(queued, 5, "should queue exactly the deficit");
+        assert_eq!(queued, needed, "should queue exactly the deficit");
         let dialed: Vec<SocketAddr> = dial_rx.try_iter().collect();
-        assert_eq!(dialed.len(), 5);
+        assert_eq!(dialed.len(), needed);
         // None of the dialed addresses must overlap with the already-live set.
         for port in 10_000_u16..10_003 {
             let addr = SocketAddr::from(([127, 0, 0, 1], port));

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -52,9 +52,9 @@ pub(crate) const P2P_OUTBOUND_QUEUE_LIMIT: usize = 8;
 // than they drain — an OOM vector. A full channel applies TCP backpressure to
 // the sending peer's listener thread; `tick` drains independently and holds no
 // lock a listener needs, so the bound cannot deadlock. Sized well above the
-// in-flight request window (`PENDING_BUDGET` = 128) so honest delivery, which
+// in-flight request window (`PENDING_BUDGET` = 256) so honest delivery, which
 // wakes the drain on every block, is never throttled.
-pub(crate) const INBOUND_BLOCK_CHANNEL_LIMIT: usize = 256;
+pub(crate) const INBOUND_BLOCK_CHANNEL_LIMIT: usize = 512;
 // Bounds chain-event hints between the block-apply commit path and
 // reconciliation consumers (#77). Hints are wake-ups, never data: a consumer
 // that misses one recovers by reconciling `ChainSnapshot` against its own

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -3347,7 +3347,7 @@ mod tests {
         sync.tick();
 
         assert_applied_genesis(&applied_tip, &block_tree, &sync.handles)?;
-        let cap = super::PENDING_BUDGET.div_ceil(super::MIN_PEERS_FOR_FANOUT);
+        let cap = super::MAX_BLOCKS_IN_TRANSIT_PER_PEER;
         for (idx, rx) in rxs.iter().enumerate() {
             let Message::GetData(inventory) = rx.try_recv()? else {
                 return Err(
@@ -3701,7 +3701,7 @@ mod tests {
             "a timed-out peer must not immediately reacquire the same block stripe"
         );
 
-        let cap = super::PENDING_BUDGET.div_ceil(super::MIN_PEERS_FOR_FANOUT);
+        let cap = super::MAX_BLOCKS_IN_TRANSIT_PER_PEER;
         for (idx, rx) in rxs.iter().enumerate() {
             let Message::GetData(inventory) = rx.try_recv()? else {
                 return Err(std::io::Error::other("expected getdata for eligible peer").into());
@@ -7119,7 +7119,7 @@ mod tests {
         }
         sync.tick();
         assert_applied_genesis(&applied_tip, &block_tree, &sync.handles)?;
-        let cap = super::PENDING_BUDGET.div_ceil(super::MIN_PEERS_FOR_FANOUT);
+        let cap = super::MAX_BLOCKS_IN_TRANSIT_PER_PEER;
         for (idx, receiver) in receivers.iter().enumerate() {
             let Message::GetData(inventory) = receiver.try_recv()? else {
                 return Err(std::io::Error::other("expected fanout getdata").into());
@@ -7144,7 +7144,7 @@ mod tests {
     fn peer_disconnect_mid_window_requeues_blocks_to_remaining_peers()
     -> Result<(), Box<dyn std::error::Error>> {
         const PEER_COUNT: usize = 9;
-        const SELECTED_PEERS: usize = super::PENDING_BUDGET / super::MAX_BLOCKS_IN_TRANSIT_PER_PEER;
+        const SELECTED_PEERS: usize = super::MIN_PEERS_FOR_FANOUT;
         let (sync, peers, block_tree, applied_tip, expected) =
             sync_with_header_chain(u32::try_from(super::PENDING_BUDGET)?)?;
         install_budget(&sync, super::default_sync_budget());

--- a/crates/p2p/src/download_window.rs
+++ b/crates/p2p/src/download_window.rs
@@ -22,11 +22,16 @@ use crate::PeerInfo;
 /// Time after which a pending getdata is considered stuck and re-requestable.
 pub const PENDING_TIMEOUT: Duration = Duration::from_mins(1);
 /// Maximum number of in-flight getdata requests we'll track per `BlockSync`.
-pub const PENDING_BUDGET: usize = 128;
+///
+/// 256 is the measured single-peer IBD depth: a bounded 0–150,000 daemon
+/// run at this window was 1.52× the 128-block control. Fan-out still stripes
+/// at [`MAX_BLOCKS_IN_TRANSIT_PER_PEER`] once [`MIN_PEERS_FOR_FANOUT`] eligible
+/// peers exist, so a full outbound set does not deepen per-peer pipelines.
+pub const PENDING_BUDGET: usize = 256;
 /// Time after which a received out-of-order block is discarded.
 pub const RECEIVED_BLOCK_TIMEOUT: Duration = Duration::from_mins(1);
 /// Maximum number of received blocks waiting for their predecessor.
-pub const RECEIVED_BLOCK_BUDGET: usize = 128;
+pub const RECEIVED_BLOCK_BUDGET: usize = 256;
 /// Mainnet-oriented block-size estimate for sizing the in-flight request window.
 pub const PENDING_BLOCK_BYTE_ESTIMATE: usize = 2 * 1024 * 1024;
 /// Maximum estimated bytes in the in-flight request window.
@@ -51,7 +56,7 @@ pub const MAX_SERIALIZED_BLOCK_SIZE: usize = 4_000_000;
 // count below the arming fraction and byte-shaped wedges would stop arming at
 // production budgets, degrading to the 60s pending-timeout fallback. Rebalance
 // both constants together; this assertion turns silent drift into a build
-// failure. (Margin today: 128 * 2 MiB >= 64 * 4 MB, ~4.6%.)
+// failure. (Margin at 256: 256 * 2 MiB >= 128 * 4_000_000, ~4.9%.)
 const _: () = assert!(
     RECEIVED_BLOCK_BYTE_BUDGET >= RECEIVED_BLOCK_BUDGET / 2 * MAX_SERIALIZED_BLOCK_SIZE,
     "staged byte budget must admit half the staged count window at max block size"
@@ -76,13 +81,15 @@ pub const PEER_INFLIGHT_BUDGET: usize = PENDING_BUDGET;
 /// by a live-tested and reverted attempt (commit 5608279, recoverable from
 /// git history).
 pub const MAX_BLOCKS_IN_TRANSIT_PER_PEER: usize = 16;
-/// Minimum peer population that can fill the 128-block window at Core's
-/// 16-block per-peer floor.
+/// Minimum eligible peers before fan-out stripes.
 ///
-/// Below this count, one healthy peer's deep sequential pipeline beats
-/// fragmented stripes on real mainnet peers; the bounded cold-front hedge
-/// handles a silent owner without under-filling.
-pub const MIN_PEERS_FOR_FANOUT: usize = PENDING_BUDGET / MAX_BLOCKS_IN_TRANSIT_PER_PEER;
+/// Matches the default outbound target. Below this count, one healthy peer's
+/// deep sequential pipeline fills [`PENDING_BUDGET`]. At the threshold, each
+/// peer is capped at [`MAX_BLOCKS_IN_TRANSIT_PER_PEER`] so a full outbound set
+/// does not reproduce the recorded head-of-line collapse. Do not scale this
+/// with [`PENDING_BUDGET`]: `PENDING_BUDGET / 16` would be 16, and fan-out
+/// would never engage at the 8-outbound default.
+pub const MIN_PEERS_FOR_FANOUT: usize = 8;
 /// Initial window-blocked stalling threshold.
 ///
 /// Mirrors Bitcoin Core's `BLOCK_STALLING_TIMEOUT_DEFAULT` (2s,
@@ -115,6 +122,10 @@ pub const STALLER_COOLDOWN: Duration = BLOCK_STALLING_TIMEOUT_MAX;
 // byte-budget pair needs no twin assertion: `RECEIVED_BLOCK_BYTE_BUDGET` is
 // `PENDING_BYTE_BUDGET` by definition.
 const _: () = assert!(PENDING_BUDGET == RECEIVED_BLOCK_BUDGET);
+const _: () = assert!(
+    MIN_PEERS_FOR_FANOUT * MAX_BLOCKS_IN_TRANSIT_PER_PEER <= PENDING_BUDGET,
+    "fan-out at the outbound target must not exceed the download window"
+);
 
 /// Maximum number of block inventory entries we request per tick.
 ///


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes part of #494.

The 128-block pending/staging pair was the count bound that kept peer IBD from using the already-landed 256-block script window. A matched 0–150,000 single-seed daemon run at depth 256 was 1.52× the 128-block control (59.2s vs 90.0s). That candidate did not land because stall arming and staged count/byte headroom were missing. Those gates are now in tree:

- Stall arming is a **fraction** of the staged window (`arming_threshold_is_same_fraction_of_window_at_any_depth` already covers 128 and 256).
- Staged count and byte headroom clamp requests so a deeper window cannot evict the apply frontier.
- The staller-arming byte-budget assertion still holds at 256 (`256 × 2 MiB ≥ 128 × 4_000_000`).

Fan-out stays eight eligible peers × 16 in-flight. Scaling `MIN_PEERS_FOR_FANOUT` with the window would require 16 outbound peers and would never engage at the default outbound target of 8. Below that threshold, one healthy peer fills the 256-block window (the measured single-seed case).

The inbound block channel doubles with the window so honest delivery is not throttled.

This is stack PR 1 of the #494 sync/index series.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38dcd083-f48e-4d38-a071-a4689f747d56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38dcd083-f48e-4d38-a071-a4689f747d56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

