### PR TITLE
Add --verify-kernel as a verdict-only Core oracle tap

### DIFF
--- a/bin/bitcoin-rs/src/cli.rs
+++ b/bin/bitcoin-rs/src/cli.rs
@@ -61,6 +61,9 @@ pub(crate) struct CliArgs {
     pub(crate) metrics_bind: Option<SocketAddr>,
     #[arg(long = "assume-valid-height")]
     pub(crate) assume_valid_height: Option<u32>,
+    /// Compare native script verdicts against libbitcoinkernel. Requires `--features kernel`.
+    #[arg(long = "verify-kernel", num_args = 0..=1, default_missing_value = "true")]
+    pub(crate) verify_kernel: Option<bool>,
     /// Watch-only coinbase payout address for solo mining templates.
     #[arg(long = "mining-payout-address")]
     pub(crate) mining_payout_address: Option<String>,
@@ -116,6 +119,7 @@ impl CliArgs {
             chainstate_journal: None,
             validation: ValidationOverrides {
                 assume_valid_height: self.assume_valid_height,
+                verify_kernel: self.verify_kernel,
             },
             mining: MiningOverrides {
                 payout_address: self.mining_payout_address,

--- a/bin/bitcoin-rs/src/env.rs
+++ b/bin/bitcoin-rs/src/env.rs
@@ -28,6 +28,7 @@ enum EnvSetting {
     LogLevel,
     MetricsBind,
     AssumeValidHeight,
+    VerifyKernel,
     MiningPayoutAddress,
     ChainstateJournal,
     ChainstateJournalBlocks,
@@ -76,6 +77,7 @@ fn env_setting(key: &str) -> Option<EnvSetting> {
         "BITCOIN_RS_LOG_LEVEL" => EnvSetting::LogLevel,
         "BITCOIN_RS_METRICS_BIND" => EnvSetting::MetricsBind,
         "BITCOIN_RS_ASSUME_VALID_HEIGHT" => EnvSetting::AssumeValidHeight,
+        "BITCOIN_RS_VERIFY_KERNEL" => EnvSetting::VerifyKernel,
         "BITCOIN_RS_MINING_PAYOUT_ADDRESS" => EnvSetting::MiningPayoutAddress,
         "BITCOIN_RS_CHAINSTATE_JOURNAL" => EnvSetting::ChainstateJournal,
         "BITCOIN_RS_CHAINSTATE_JOURNAL_BLOCKS" => EnvSetting::ChainstateJournalBlocks,
@@ -137,6 +139,9 @@ fn apply(layer: &mut UserConfig, setting: EnvSetting, value: &str) -> Result<()>
         EnvSetting::MetricsBind => layer.observability.metrics_bind = Some(value.parse()?),
         EnvSetting::AssumeValidHeight => {
             layer.validation.assume_valid_height = Some(value.parse()?);
+        }
+        EnvSetting::VerifyKernel => {
+            layer.validation.verify_kernel = Some(parse_bool(value)?);
         }
         EnvSetting::MiningPayoutAddress => {
             layer.mining.payout_address = Some(value.to_owned());

--- a/bin/bitcoin-rs/src/toml.rs
+++ b/bin/bitcoin-rs/src/toml.rs
@@ -36,6 +36,7 @@ struct TomlFile {
     notifications: Option<NotificationConfig>,
     chainstate_journal: Option<ChainstateJournalOverrides>,
     assume_valid_height: Option<u32>,
+    verify_kernel: Option<bool>,
     mining_payout_address: Option<String>,
 }
 
@@ -107,6 +108,7 @@ impl TomlFile {
             chainstate_journal: self.chainstate_journal,
             validation: ValidationOverrides {
                 assume_valid_height: self.assume_valid_height,
+                verify_kernel: self.verify_kernel,
             },
             mining: MiningOverrides {
                 payout_address: self.mining_payout_address,

--- a/bin/bitcoin-rs/tests/cli_help.rs
+++ b/bin/bitcoin-rs/tests/cli_help.rs
@@ -15,4 +15,8 @@ fn help_prints_binary_name() {
         String::from_utf8_lossy(&output.stdout).contains("--measure-storage"),
         "help must name the storage-footprint measurement command"
     );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("--verify-kernel"),
+        "help must name the kernel verification tap"
+    );
 }

--- a/crates/consensus/src/kernel.rs
+++ b/crates/consensus/src/kernel.rs
@@ -193,6 +193,39 @@ mod enabled {
             .map_err(|error| ConsensusError::Kernel(error.to_string()))?;
         Ok(bitcoinkernel::TxOut::new(&script, amount))
     }
+
+    /// Compares native accept/reject against Core. Agreement on reject is
+    /// `Ok` so the caller can keep the native error; disagreement is
+    /// [`ConsensusError::Kernel`].
+    pub fn compare_script_verdicts(
+        txs_and_spent: &[(&Tx, Vec<(OutPoint, TxOut)>)],
+        flags: VerifyFlags,
+        native_accepted: bool,
+    ) -> Result<(), ConsensusError> {
+        let mut kernel_error = None;
+        for (tx, spent) in txs_and_spent {
+            if spent.is_empty() {
+                continue;
+            }
+            if let Err(error) = verify_tx_scripts(tx, spent, flags) {
+                kernel_error = Some(error);
+                break;
+            }
+        }
+        let kernel_accepted = kernel_error.is_none();
+        match (native_accepted, kernel_accepted) {
+            (true, true) | (false, false) => Ok(()),
+            (true, false) => Err(ConsensusError::Kernel(format!(
+                "native accepted, kernel rejected: {}",
+                kernel_error
+                    .map(|error| error.to_string())
+                    .unwrap_or_else(|| "unknown kernel error".to_owned())
+            ))),
+            (false, true) => Err(ConsensusError::Kernel(
+                "native rejected, kernel accepted".to_owned(),
+            )),
+        }
+    }
 }
 
 /// Returns whether this build compiled `libbitcoinkernel`.
@@ -205,9 +238,28 @@ pub const fn kernel_compiled() -> bool {
 }
 
 #[cfg(feature = "kernel")]
-pub use enabled::{KernelBlock, KernelContext, verify_tx_scripts};
+pub use enabled::{KernelBlock, KernelContext, compare_script_verdicts, verify_tx_scripts};
 
 #[cfg(not(feature = "kernel"))]
 /// Stub kernel context available when the `kernel` feature is off.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct KernelContext;
+
+#[cfg(not(feature = "kernel"))]
+/// Runtime `--verify-kernel` requires a build that compiled `libbitcoinkernel`.
+pub fn compare_script_verdicts(
+    txs_and_spent: &[(
+        &bitcoin_rs_primitives::Tx,
+        Vec<(
+            bitcoin_rs_primitives::OutPoint,
+            bitcoin_rs_primitives::TxOut,
+        )>,
+    )],
+    flags: bitcoin_rs_script::VerifyFlags,
+    native_accepted: bool,
+) -> Result<(), crate::ConsensusError> {
+    let _ = (txs_and_spent, flags, native_accepted);
+    Err(crate::ConsensusError::Kernel(
+        "verify_kernel requires a build with --features kernel".to_owned(),
+    ))
+}

--- a/crates/consensus/src/verify_tx.rs
+++ b/crates/consensus/src/verify_tx.rs
@@ -401,6 +401,35 @@ pub struct BlockScriptChecks<'b> {
     checks: Vec<InputCheck>,
 }
 
+impl BlockScriptChecks<'_> {
+    /// Compares this unit's native script verdict against `libbitcoinkernel`.
+    ///
+    /// Uses the already-resolved Rust prevouts. Kernel-owned handles never
+    /// leave this call.
+    pub fn compare_kernel_scripts(
+        &self,
+        flags: VerifyFlags,
+        native_accepted: bool,
+    ) -> Result<(), ConsensusError> {
+        let txs_and_spent: Vec<(&Tx, Vec<(OutPoint, TxOut)>)> = self
+            .prepared
+            .iter()
+            .filter(|prep| !prep.spent_outputs.is_empty())
+            .map(|prep| {
+                let spent = prep
+                    .tx
+                    .inputs
+                    .iter()
+                    .zip(prep.spent_outputs.iter())
+                    .map(|(input, prevout)| (input.previous_output, prevout.clone()))
+                    .collect();
+                (prep.tx, spent)
+            })
+            .collect();
+        crate::kernel::compare_script_verdicts(&txs_and_spent, flags, native_accepted)
+    }
+}
+
 /// Which unit failed, and how.
 ///
 /// The index is the position in the slice handed to [`verify_prepared_units`],

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -949,6 +949,8 @@ pub struct Chainstate {
     pub(crate) chain_transition: Arc<parking_lot::Mutex<()>>,
     pub(crate) assume_valid_height: u32,
     pub(crate) assume_valid_gate: Arc<AssumeValidGate>,
+    /// When set, native script verdicts are compared against `libbitcoinkernel`.
+    pub(crate) verify_kernel: bool,
     /// Chainstate-journal writer, when the journal is enabled (issue #230).
     ///
     /// `None` = journal off: the apply path emits nothing and behaves exactly
@@ -1342,6 +1344,7 @@ impl Chainstate {
             chain_transition: Arc::new(parking_lot::Mutex::new(())),
             assume_valid_height: 0,
             assume_valid_gate: Arc::new(AssumeValidGate::with_anchor(None)),
+            verify_kernel: false,
             journal: None,
             checkpoint_publisher: None,
             capture_rawtx: false,
@@ -2307,6 +2310,13 @@ fn prove_window<'a>(
             .record(verify_started.elapsed().as_secs_f64());
         if verdict.is_err() {
             return Vec::new();
+        }
+        if handles.verify_kernel {
+            for (unit, unit_flags) in units.iter().zip(&flags) {
+                if unit.compare_kernel_scripts(*unit_flags, true).is_err() {
+                    return Vec::new();
+                }
+            }
         }
         if !units.is_empty() {
             metrics::counter!("node.window.verify_success_total").increment(1);
@@ -3486,6 +3496,32 @@ fn run_non_script_checks_only(
     Ok(())
 }
 
+fn spent_outputs_for_kernel_oracle<'a>(
+    block: &'a Block,
+    resolved: &[Vec<Option<TxOut>>],
+) -> Vec<(&'a Tx, Vec<(OutPoint, TxOut)>)> {
+    block
+        .txs
+        .iter()
+        .zip(resolved.iter())
+        .filter(|(tx, _)| !is_coinbase_tx(tx))
+        .map(|(tx, row)| {
+            let spent = tx
+                .inputs
+                .iter()
+                .enumerate()
+                .filter_map(|(index, input)| {
+                    row.get(index)
+                        .and_then(Option::as_ref)
+                        .cloned()
+                        .map(|prevout| (input.previous_output, prevout))
+                })
+                .collect();
+            (tx, spent)
+        })
+        .collect()
+}
+
 #[allow(
     clippy::as_conversions,
     clippy::cast_sign_loss,
@@ -3534,6 +3570,9 @@ fn verify_block_transactions(
     metrics::histogram!("node.apply_block.script_resolution_seconds")
         .record(resolution_dur.as_secs_f64());
     let resolved = resolution_result?;
+    let oracle_spent = handles
+        .verify_kernel
+        .then(|| spent_outputs_for_kernel_oracle(block, &resolved));
     view.set_resolved(resolved);
     // preparation and parallel input-check fan-out internally and reports both
     // sub-stage durations back; record them here on the success and error paths
@@ -3550,6 +3589,13 @@ fn verify_block_transactions(
         .record(script_timings.prepare_seconds);
     metrics::histogram!("node.apply_block.script_parallel_seconds")
         .record(script_timings.parallel_seconds);
+    if let Some(spent) = oracle_spent {
+        bitcoin_rs_consensus::kernel::compare_script_verdicts(
+            &spent,
+            context.flags,
+            script_input_result.is_ok(),
+        )?;
+    }
     script_input_result?;
     tracing::debug!(
         height = context.height,
@@ -4175,6 +4221,51 @@ mod consensus_rule_tests {
             &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::NONE),
             BlockProvenance::Network,
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn verify_kernel_tap_does_not_feed_kernel_data_into_apply()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let base_prevout = OutPoint::new(fixture_txid(0x61), 0);
+        let utxo = utxo_with_output(base_prevout, 1)?;
+        let mut handles = apply_handles(utxo);
+        handles.verify_kernel = true;
+        let funding_tx = spending_transaction_to_script(base_prevout, u32::MAX, op_true_script());
+        let funding_outpoint = OutPoint::new(funding_tx.txid(), 0);
+        let same_block_spend =
+            spending_transaction_to_script(funding_outpoint, u32::MAX, op_true_script());
+        let block = block_with_transactions(vec![funding_tx, same_block_spend]);
+
+        let result = verify_block_transactions(
+            &handles,
+            &block,
+            &mut bitcoin_rs_consensus::BlockView::new(&block.txs, block_txids(&block)),
+            &tx_plan(&block),
+            Arc::new(ResolvedUtxoView::resolve(
+                handles.utxo.as_ref(),
+                &block,
+                &tx_plan(&block),
+            )),
+            &validation_context(&block, 2, 0, bitcoin_rs_script::VerifyFlags::NONE),
+            BlockProvenance::Network,
+        );
+        if bitcoin_rs_consensus::kernel::kernel_compiled() {
+            result?;
+        } else {
+            match result {
+                Ok(()) => panic!("verify_kernel without the kernel feature must fail"),
+                Err(ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Kernel(
+                    reason,
+                ))) => {
+                    assert!(
+                        reason.contains("verify_kernel"),
+                        "unexpected kernel error: {reason}"
+                    );
+                }
+                Err(other) => panic!("expected Kernel compile-time error, got {other:?}"),
+            }
+        }
         Ok(())
     }
 

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -277,6 +277,8 @@ pub struct ObservabilityOverrides {
 pub struct ValidationOverrides {
     /// Height through which script verification may be skipped.
     pub assume_valid_height: Option<u32>,
+    /// Compare native script verdicts against `libbitcoinkernel`.
+    pub verify_kernel: Option<bool>,
 }
 
 /// User-supplied mining overrides.
@@ -500,6 +502,9 @@ impl ValidationOverrides {
         if other.assume_valid_height.is_some() {
             self.assume_valid_height = other.assume_valid_height;
         }
+        if other.verify_kernel.is_some() {
+            self.verify_kernel = other.verify_kernel;
+        }
     }
 }
 
@@ -598,6 +603,8 @@ pub struct ObservabilityConfig {
 pub struct ValidationConfig {
     /// Height through which script verification may be skipped.
     pub assume_valid_height: u32,
+    /// Compare native script verdicts against `libbitcoinkernel`.
+    pub verify_kernel: bool,
 }
 
 /// Resolved mining configuration.
@@ -670,6 +677,7 @@ impl NodeConfig {
             chainstate_journal: ChainstateJournalConfig::default(),
             validation: ValidationConfig {
                 assume_valid_height: 0,
+                verify_kernel: false,
             },
             mining: MiningConfig::default(),
         };
@@ -734,6 +742,10 @@ impl NodeConfig {
         anyhow::ensure!(
             journal.max_lag_seconds > 0,
             "chainstate_journal.max_lag_seconds must be positive"
+        );
+        anyhow::ensure!(
+            !self.validation.verify_kernel || bitcoin_rs_consensus::kernel::kernel_compiled(),
+            "verify_kernel requires a build with --features kernel"
         );
         Ok(())
     }
@@ -801,6 +813,9 @@ impl NodeConfig {
         }
         if let Some(value) = layer.validation.assume_valid_height {
             self.validation.assume_valid_height = value;
+        }
+        if let Some(value) = layer.validation.verify_kernel {
+            self.validation.verify_kernel = value;
         }
     }
 

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1892,6 +1892,7 @@ impl NodeState {
                 config.network,
                 config.validation.assume_valid_height,
             )),
+            verify_kernel: config.validation.verify_kernel,
             journal,
             checkpoint_publisher: None,
             capture_rawtx,

--- a/crates/node/tests/config_layered.rs
+++ b/crates/node/tests/config_layered.rs
@@ -278,12 +278,14 @@ fn assume_valid_height_override_has_precedence() -> Result<()> {
     let low = UserConfig {
         validation: ValidationOverrides {
             assume_valid_height: Some(10_000),
+            ..ValidationOverrides::default()
         },
         ..Default::default()
     };
     let high = UserConfig {
         validation: ValidationOverrides {
             assume_valid_height: Some(30_000),
+            ..ValidationOverrides::default()
         },
         ..Default::default()
     };
@@ -301,6 +303,52 @@ fn assume_valid_height_defaults_to_mainnet_anchor() -> Result<()> {
             .assume_valid_anchor()
             .map_or(0, |(height, _)| height)
     );
+    Ok(())
+}
+
+#[test]
+fn verify_kernel_defaults_off() -> Result<()> {
+    let config = resolve(&[])?;
+    assert!(!config.validation.verify_kernel);
+    Ok(())
+}
+
+#[test]
+fn verify_kernel_override_has_precedence() {
+    let mut low = UserConfig {
+        validation: ValidationOverrides {
+            verify_kernel: Some(false),
+            ..ValidationOverrides::default()
+        },
+        ..Default::default()
+    };
+    let high = UserConfig {
+        validation: ValidationOverrides {
+            verify_kernel: Some(true),
+            ..ValidationOverrides::default()
+        },
+        ..Default::default()
+    };
+    low.overlay(&high);
+    assert_eq!(low.validation.verify_kernel, Some(true));
+}
+
+#[test]
+fn verify_kernel_without_feature_fails_validate() -> Result<()> {
+    let mut config = NodeConfig::default_for_network(Network::Regtest);
+    config.validation.verify_kernel = true;
+    let result = config.validate();
+    if bitcoin_rs_consensus::kernel::kernel_compiled() {
+        result?;
+    } else {
+        match result {
+            Ok(()) => panic!("verify_kernel needs --features kernel"),
+            Err(error) => assert!(
+                error.to_string().contains("verify_kernel"),
+                "unexpected validate error: {error}"
+            ),
+        }
+    }
     Ok(())
 }
 

--- a/docs/contracts/validation-default.md
+++ b/docs/contracts/validation-default.md
@@ -47,8 +47,9 @@ Owners:
 - `bin/bitcoin-rs` default features are `fjall`, `redb`, and `zmq`. They
   never include `kernel`.
 - The Compose image (`Dockerfile`) builds `--features fjall`.
-- `--features kernel` compiles the independent Core oracle for
-  differential tests and a later runtime verification tap. Turning it on
+- `--features kernel` compiles the independent Core oracle. `--verify-kernel`
+  (env `BITCOIN_RS_VERIFY_KERNEL`, toml `verify_kernel`) sends the same
+  Rust-owned inputs to Core and compares accept/reject only. Turning it on
   must not become an alternative apply implementation.
 
 ## Proven by

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,8 @@ Configuration defaults:
 | `--prune-target-mb` | 0 (no pruning) |
 | `--txindex` | off |
 | `--scriptindex` | off (accepts `full`, `utxo`, or boolean; defaults to `full` when passed without a value) |
-| `--features kernel` (build-time) | off in default binary; enables `libbitcoinkernel` as a verification oracle |
+| `--features kernel` (build-time) | off in default binary; compiles `libbitcoinkernel` as a verification oracle |
+| `--verify-kernel` | off; compares native script verdicts against Core. Requires `--features kernel` |
 
 The node logs its startup banner, effective cache allocation, and the address
 the JSON-RPC listener bound to.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Stacked on #530. Native apply stays the only execution path. This PR adds the runtime verification tap so Core can check the same inputs without feeding kernel-owned data back into apply or state.

```text
                    -> Rust validation -> authoritative result
input/state --------|
                    -> bitcoinkernel/Core oracle -> compare only
```

`--verify-kernel` (env `BITCOIN_RS_VERIFY_KERNEL`, toml `verify_kernel`) is off by default. `NodeConfig::validate()` rejects it unless the binary was built with `--features kernel`.

## What changed

- CLI, env, and toml all resolve into `ValidationConfig::verify_kernel`.
- Apply clones already-resolved Rust prevouts, runs native scripts, then calls `kernel::compare_script_verdicts`. Agreement on reject keeps the native error; disagreement is `ConsensusError::Kernel`.
- Window proofs that disagree with Core are discarded so commit re-runs full verify plus the oracle.
- Assume-valid skip and coinbase-only blocks do not call the oracle.
- Kernel types (`KernelBlock`, `TransactionRef`, `PrecomputedTransactionData`, kernel txids) stay inside the adapter.

## Contract

VAL-03 now names the tap: turning `kernel` / `--verify-kernel` on adds verification, not an alternative implementation.

## Follow-up

The next stacked PR expands the tap past scripts to parse/txid (and other coarse kernel surfaces) without changing the production path.

## Test plan

- [x] `cargo clippy -p bitcoin-rs-consensus --all-targets -- -D warnings`
- [x] `cargo clippy -p bitcoin-rs-node --no-default-features --features fjall --lib -- -D warnings`
- [x] `cargo test -p bitcoin-rs-node --no-default-features --features fjall --lib verify_kernel`
- [x] `cargo test -p bitcoin-rs-node --no-default-features --features fjall --test config_layered`
- [x] `cargo test -p bitcoin-rs --no-default-features --features fjall,redb --test cli_help`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-996af3b4-a8cd-45bf-aad7-e32419922de0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-996af3b4-a8cd-45bf-aad7-e32419922de0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

