### PR TITLE
Emit Core -3 type errors without an invalid type prefix

### DIFF
--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -20,7 +20,10 @@ pub enum RpcError {
     #[error("invalid params: {0}")]
     InvalidParams(&'static str),
     /// Parameter value has the wrong JSON type.
-    #[error("invalid type: {0}")]
+    ///
+    /// Bitcoin Core's `RPC_TYPE_ERROR` (-3). Display is the Core message text
+    /// with no wrapper prefix.
+    #[error("{0}")]
     InvalidType(&'static str),
     /// Requested object was not found.
     #[error("not found: {0}")]

--- a/crates/rpc/src/handlers/mining.rs
+++ b/crates/rpc/src/handlers/mining.rs
@@ -1236,6 +1236,7 @@ mod tests {
             RpcError::InvalidType("Missing data String key for proposal")
         ));
         assert_eq!(missing.code(), RpcError::CORE_INVALID_TYPE);
+        assert_eq!(missing.to_string(), "Missing data String key for proposal");
         for hex in ["", "00", "zz", "deadbeef"] {
             let error = getblocktemplate(&ctx, &json!([{"mode": "proposal", "data": hex}]))
                 .expect_err("undecodable proposal must fail");

--- a/docs/contracts/external-api.md
+++ b/docs/contracts/external-api.md
@@ -37,7 +37,9 @@ vocabulary.
   standard JSON-RPC codes (`-32700`, `-32600`..=`-32603`) and Core codes `-3`
   (invalid type), `-5` (not found), `-8` (invalid parameter), `-9` (not
   connected), `-10` (initial download), `-22` (deserialization), `-25`
-  (verify error), and `-26` (verify rejected).
+  (verify error), and `-26` (verify rejected). Core `-3`, `-8`, and `-22`
+  messages are the Core text with no wrapper prefix (`InvalidType`,
+  `InvalidParameter`, `Deserialization`).
 - The node ships no wallet and holds no private key material. Methods that
   would reveal, import, create, or use private keys return
   `RpcError::MethodNotFound`. PSBT combination/finalization and descriptor
@@ -162,7 +164,8 @@ vocabulary.
 - Unknown or non-string `mode` is Core `-8` (`Invalid mode`).
 - Proposal mode does not require the client to list the `proposal`
   capability. Missing `data` is Core `-3`
-  (`Missing data String key for proposal`). Decode uses
+  (`Missing data String key for proposal`) with no `invalid type:` prefix.
+  Decode uses
   `decode_submitted_block` (`API-11`): `-22` `Block decode failed`, leftover
   bytes ignored.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Destination

Match Bitcoin Core v31.0 `RPC_TYPE_ERROR` (-3) wire text. `RpcError::InvalidType` Display is the Core message with no `invalid type:` prefix, so GBT proposal missing `data` is exactly `Missing data String key for proposal`.

Stacked on #553 (`cursor/mining-submit-duplicate-1522`) → #535 → #514 → #499 → #479 → #451 → #442 → #436 → #428. Parent wayfinder: #151.

## Changes

- `InvalidType` Display matches `InvalidParameter` and `Deserialization`: Core text only.
- `getblocktemplate_proposal_decode_matches_core` pins the unprefixed `-3` message.
- `API-03` / `API-12` record the wire text.

## Not in this PR

- Unprefixing `-5` `not found:` or JSON-RPC `-32602` `invalid params:` wrappers.
- Stratum, pool, or invented p95 budgets.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-050f5304-793b-4730-9ed5-e0f85dff1522?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-050f5304-793b-4730-9ed5-e0f85dff1522&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

