### PR TITLE
Compare Core block parse and txids in the verify-kernel tap

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -127,7 +127,7 @@ retained Criterion benchmark targets are compiled in the `bench-smoke` CI lane
 ## Consensus validation
 
 ### bitcoinkernel
-Bitcoin Core's C++ consensus engine (`libbitcoinkernel`). The `kernel` feature compiles it as an independent oracle: tests (and a later runtime verification tap) compare Core's parse and script verdicts against the native path. Production apply never feeds kernel-owned data into Rust state. Builds with `kernel` need `cmake` and `libboost-dev`. See `docs/contracts/validation-default.md`.
+Bitcoin Core's C++ consensus engine (`libbitcoinkernel`). The `kernel` feature compiles it as an independent oracle: tests and `--verify-kernel` compare Core's parse, txids, and script verdicts against the native path. Production apply never feeds kernel-owned data into Rust state. Builds with `kernel` need `cmake` and `libboost-dev`. See `docs/contracts/validation-default.md`.
 
 ### Native Rust interpreter
 The production script path (`crates/script`). It executes legacy, P2SH, SegWit v0, and Taproot key-path and script-path spends through the opcode evaluator. Core's `script_tests`, `tx_valid`, and `tx_invalid` vectors currently pin zero native mismatches. Signature checks reuse the process-wide `secp256k1::SECP256K1` context. Apply-path verification precomputes BIP143/BIP341 sighash midstates once per transaction (`SighashCache::precompute`) and clones that cache into each input.

--- a/bin/bitcoin-rs/src/cli.rs
+++ b/bin/bitcoin-rs/src/cli.rs
@@ -61,7 +61,8 @@ pub(crate) struct CliArgs {
     pub(crate) metrics_bind: Option<SocketAddr>,
     #[arg(long = "assume-valid-height")]
     pub(crate) assume_valid_height: Option<u32>,
-    /// Compare native script verdicts against libbitcoinkernel. Requires `--features kernel`.
+    /// Compare native parse/txids and script verdicts against libbitcoinkernel.
+    /// Requires `--features kernel`.
     #[arg(long = "verify-kernel", num_args = 0..=1, default_missing_value = "true")]
     pub(crate) verify_kernel: Option<bool>,
     /// Watch-only coinbase payout address for solo mining templates.

--- a/crates/consensus/README.md
+++ b/crates/consensus/README.md
@@ -11,9 +11,10 @@ Rule checks live in small per-subject modules (`bip9`, `bip30`, `bip34`, `bip65`
 `bip66`, `bip68`, `bip112`, `bip113`, `bip141`, `bip143`, `bip341`, `bip342`), surfaced
 through the `verify_transaction` family (with median-time-past and borrowed variants),
 `is_final_tx`, and the `verify_block_rules` family including Merkle-root verification.
-`kernel::verify_tx_scripts` and `kernel::KernelBlock` are available under
-`--features kernel` so tests can compare Core's parse and script verdicts
-against the native path. BIP9 activation is `compute_state`
+`kernel::verify_tx_scripts`, `kernel::KernelBlock`, `kernel::compare_script_verdicts`,
+and `kernel::compare_block_parse` are available under `--features kernel` so tests
+and `--verify-kernel` can compare Core's parse, txids, and script verdicts against
+the native path. BIP9 activation is `compute_state`
 over a `DeploymentContext` with `DeploymentParams`. Consensus bounds are exported as
 `MAX_SCRIPT_SIZE`, `MAX_MONEY`, and `MAX_BLOCK_SIGOPS_COST`; failures are `ConsensusError`
 variants.

--- a/crates/consensus/src/kernel.rs
+++ b/crates/consensus/src/kernel.rs
@@ -226,6 +226,30 @@ mod enabled {
             )),
         }
     }
+
+    /// Compares native txids against Core's parse of the same wire bytes.
+    ///
+    /// Kernel-owned `KernelBlock` / txids never leave this call. Agreement is
+    /// `Ok`; parse failure or a txid/count mismatch is [`ConsensusError::Kernel`].
+    pub fn compare_block_parse(raw: &[u8], native_txids: &[Txid]) -> Result<(), ConsensusError> {
+        let kernel_block = KernelBlock::parse(raw)?;
+        if kernel_block.transaction_count() != native_txids.len() {
+            return Err(ConsensusError::Kernel(format!(
+                "native tx count {}, kernel tx count {}",
+                native_txids.len(),
+                kernel_block.transaction_count(),
+            )));
+        }
+        let kernel_txids = kernel_block.txids()?;
+        for (index, (native, kernel)) in native_txids.iter().zip(kernel_txids.iter()).enumerate() {
+            if native != kernel {
+                return Err(ConsensusError::Kernel(format!(
+                    "txid mismatch at index {index}"
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Returns whether this build compiled `libbitcoinkernel`.
@@ -238,7 +262,9 @@ pub const fn kernel_compiled() -> bool {
 }
 
 #[cfg(feature = "kernel")]
-pub use enabled::{KernelBlock, KernelContext, compare_script_verdicts, verify_tx_scripts};
+pub use enabled::{
+    KernelBlock, KernelContext, compare_block_parse, compare_script_verdicts, verify_tx_scripts,
+};
 
 #[cfg(not(feature = "kernel"))]
 /// Stub kernel context available when the `kernel` feature is off.
@@ -262,4 +288,94 @@ pub fn compare_script_verdicts(
     Err(crate::ConsensusError::Kernel(
         "verify_kernel requires a build with --features kernel".to_owned(),
     ))
+}
+
+#[cfg(not(feature = "kernel"))]
+/// Runtime `--verify-kernel` requires a build that compiled `libbitcoinkernel`.
+pub fn compare_block_parse(
+    raw: &[u8],
+    native_txids: &[bitcoin_rs_primitives::Txid],
+) -> Result<(), crate::ConsensusError> {
+    let _ = (raw, native_txids);
+    Err(crate::ConsensusError::Kernel(
+        "verify_kernel requires a build with --features kernel".to_owned(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin_rs_primitives::{
+        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
+    };
+
+    use super::{compare_block_parse, kernel_compiled};
+
+    fn coinbase_block() -> Block {
+        let tx = Tx {
+            version: 1,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid::default(), u32::MAX),
+                script_sig: vec![1, 1],
+                sequence: u32::MAX,
+                witness: Vec::new(),
+            }],
+            outputs: vec![TxOut {
+                value: 50,
+                script_pubkey: Vec::new(),
+            }],
+            lock_time: 0,
+        };
+        Block {
+            header: Header {
+                version: 1,
+                prev_blockhash: BlockHash::default(),
+                merkle_root: Hash256::default(),
+                time: 0,
+                bits: 0,
+                nonce: 0,
+            },
+            txs: vec![tx],
+        }
+    }
+
+    #[test]
+    fn compare_block_parse_agrees_or_requires_kernel_feature() {
+        let block = coinbase_block();
+        let raw = consensus_bytes(&block);
+        let txids: Vec<Txid> = block.txs.iter().map(Tx::txid).collect();
+        let result = compare_block_parse(&raw, &txids);
+        if kernel_compiled() {
+            result.expect("Core parse must match native txids");
+        } else {
+            match result {
+                Err(crate::ConsensusError::Kernel(reason)) => {
+                    assert!(
+                        reason.contains("verify_kernel"),
+                        "unexpected kernel error: {reason}"
+                    );
+                }
+                other => panic!("expected Kernel compile-time error, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn compare_block_parse_rejects_txid_mismatch_when_compiled() {
+        if !kernel_compiled() {
+            return;
+        }
+        let block = coinbase_block();
+        let raw = consensus_bytes(&block);
+        let mut txids: Vec<Txid> = block.txs.iter().map(Tx::txid).collect();
+        txids[0] = Txid::default();
+        match compare_block_parse(&raw, &txids) {
+            Err(crate::ConsensusError::Kernel(reason)) => {
+                assert!(
+                    reason.contains("txid mismatch"),
+                    "unexpected kernel error: {reason}"
+                );
+            }
+            other => panic!("expected txid mismatch, got {other:?}"),
+        }
+    }
 }

--- a/crates/consensus/src/kernel.rs
+++ b/crates/consensus/src/kernel.rs
@@ -345,7 +345,9 @@ mod tests {
         let txids: Vec<Txid> = block.txs.iter().map(Tx::txid).collect();
         let result = compare_block_parse(&raw, &txids);
         if kernel_compiled() {
-            result.expect("Core parse must match native txids");
+            if let Err(error) = result {
+                panic!("Core parse must match native txids: {error}");
+            }
         } else {
             match result {
                 Err(crate::ConsensusError::Kernel(reason)) => {

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -949,7 +949,7 @@ pub struct Chainstate {
     pub(crate) chain_transition: Arc<parking_lot::Mutex<()>>,
     pub(crate) assume_valid_height: u32,
     pub(crate) assume_valid_gate: Arc<AssumeValidGate>,
-    /// When set, native script verdicts are compared against `libbitcoinkernel`.
+    /// When set, native parse/txids and script verdicts are compared against `libbitcoinkernel`.
     pub(crate) verify_kernel: bool,
     /// Chainstate-journal writer, when the journal is enabled (issue #230).
     ///
@@ -2169,10 +2169,15 @@ fn prove_window<'a>(
     // block, so the window does all of it at once. Only the overlay walk below
     // is order-dependent, and it is the cheaper half.
     let parse_started = quanta::Instant::now();
+    let verify_kernel = handles.verify_kernel;
     let parsed: Vec<core::result::Result<_, ApplyError>> = blocks
         .par_iter()
         .zip(serialized.par_iter())
-        .map(|(block, raw)| parse_block_for_apply(block, Some(raw.as_ref())))
+        .map(|(block, raw)| {
+            let txids = parse_block_for_apply(block, Some(raw.as_ref()))?;
+            maybe_compare_kernel_block_parse(verify_kernel, Some(raw.as_ref()), &txids)?;
+            Ok(txids)
+        })
         .collect();
     metrics::histogram!("node.window.parse_seconds").record(parse_started.elapsed().as_secs_f64());
 
@@ -2398,14 +2403,6 @@ struct PreparedApply<'b> {
     resolved: Arc<ResolvedUtxoView>,
 }
 
-/// Parses a block and resolves the outputs it spends.
-///
-/// `source` is where prevouts come from. Today that is always the committed
-/// UTXO set; a window passes an overlay so a block can see outputs an earlier
-/// block in the same window created.
-///
-/// Runs no consensus rule and mutates nothing, which is what lets a window
-/// prepare several blocks before committing any of them.
 /// A sink that compares what is written to it against `expected`.
 ///
 /// Used to check preserved bytes against a block without serialising the block
@@ -2454,6 +2451,21 @@ pub(crate) fn bytes_are_block(raw: &[u8], block: &Block) -> bool {
     sink.equal && sink.offset == raw.len()
 }
 
+fn maybe_compare_kernel_block_parse(
+    verify_kernel: bool,
+    provided_serialized: Option<&[u8]>,
+    txids: &[Txid],
+) -> core::result::Result<(), ApplyError> {
+    if !verify_kernel {
+        return Ok(());
+    }
+    let Some(raw) = provided_serialized else {
+        return Ok(());
+    };
+    bitcoin_rs_consensus::kernel::compare_block_parse(raw, txids)?;
+    Ok(())
+}
+
 fn parse_block_for_apply(
     block: &Block,
     provided_serialized: Option<&[u8]>,
@@ -2500,8 +2512,10 @@ fn prepare_apply<'b, S: crate::window_overlay::OutputSource + ?Sized>(
     block: &'b Block,
     provided_serialized: Option<&[u8]>,
     source: &S,
+    verify_kernel: bool,
 ) -> core::result::Result<PreparedApply<'b>, ApplyError> {
     let txids = parse_block_for_apply(block, provided_serialized)?;
+    maybe_compare_kernel_block_parse(verify_kernel, provided_serialized, &txids)?;
     let tx_plan = plan_block_transactions(block, &txids);
     let view = bitcoin_rs_consensus::BlockView::new(&block.txs, txids);
     let resolved = Arc::new(ResolvedUtxoView::resolve(source, block, &tx_plan));
@@ -2650,7 +2664,12 @@ fn apply_block_admitted<'b>(
         }
         Some(ProvenApply::AssumeValidSkipped(prepared)) => (prepared, false),
         Some(ProvenApply::Proven(_)) | None => (
-            prepare_apply(block, provided_serialized.as_deref(), handles.utxo.as_ref())?,
+            prepare_apply(
+                block,
+                provided_serialized.as_deref(),
+                handles.utxo.as_ref(),
+                handles.verify_kernel,
+            )?,
             false,
         ),
     };
@@ -4255,6 +4274,33 @@ mod consensus_rule_tests {
         } else {
             match result {
                 Ok(()) => panic!("verify_kernel without the kernel feature must fail"),
+                Err(ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Kernel(
+                    reason,
+                ))) => {
+                    assert!(
+                        reason.contains("verify_kernel"),
+                        "unexpected kernel error: {reason}"
+                    );
+                }
+                Err(other) => panic!("expected Kernel compile-time error, got {other:?}"),
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn verify_kernel_parse_tap_keeps_native_txids() -> Result<(), Box<dyn std::error::Error>> {
+        let utxo = utxo_with_output(OutPoint::new(fixture_txid(0x62), 0), 1)?;
+        let block = block_with_transactions(vec![coinbase_transaction(0x62)]);
+        let raw = consensus_bytes(&block);
+        let native = block_txids(&block);
+        let prepared = prepare_apply(&block, Some(raw.as_slice()), utxo.as_ref(), true);
+        if bitcoin_rs_consensus::kernel::kernel_compiled() {
+            let prepared = prepared?;
+            assert_eq!(prepared.view.txids(), native.as_slice());
+        } else {
+            match prepared {
+                Ok(_) => panic!("verify_kernel parse tap without the kernel feature must fail"),
                 Err(ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Kernel(
                     reason,
                 ))) => {

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -277,7 +277,7 @@ pub struct ObservabilityOverrides {
 pub struct ValidationOverrides {
     /// Height through which script verification may be skipped.
     pub assume_valid_height: Option<u32>,
-    /// Compare native script verdicts against `libbitcoinkernel`.
+    /// Compare native parse/txids and script verdicts against `libbitcoinkernel`.
     pub verify_kernel: Option<bool>,
 }
 
@@ -603,7 +603,7 @@ pub struct ObservabilityConfig {
 pub struct ValidationConfig {
     /// Height through which script verification may be skipped.
     pub assume_valid_height: u32,
-    /// Compare native script verdicts against `libbitcoinkernel`.
+    /// Compare native parse/txids and script verdicts against `libbitcoinkernel`.
     pub verify_kernel: bool,
 }
 

--- a/docs/contracts/validation-default.md
+++ b/docs/contracts/validation-default.md
@@ -49,8 +49,10 @@ Owners:
 - The Compose image (`Dockerfile`) builds `--features fjall`.
 - `--features kernel` compiles the independent Core oracle. `--verify-kernel`
   (env `BITCOIN_RS_VERIFY_KERNEL`, toml `verify_kernel`) sends the same
-  Rust-owned inputs to Core and compares accept/reject only. Turning it on
-  must not become an alternative apply implementation.
+  Rust-owned inputs to Core and compares accept/reject only: block parse
+  and txids from the preserved wire bytes, then script verdicts from the
+  already-resolved Rust prevouts. Turning it on must not become an
+  alternative apply implementation.
 
 ## Proven by
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,7 +85,7 @@ Configuration defaults:
 | `--txindex` | off |
 | `--scriptindex` | off (accepts `full`, `utxo`, or boolean; defaults to `full` when passed without a value) |
 | `--features kernel` (build-time) | off in default binary; compiles `libbitcoinkernel` as a verification oracle |
-| `--verify-kernel` | off; compares native script verdicts against Core. Requires `--features kernel` |
+| `--verify-kernel` | off; compares native parse/txids and script verdicts against Core. Requires `--features kernel` |
 
 The node logs its startup banner, effective cache allocation, and the address
 the JSON-RPC listener bound to.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Stacked on #556. `--verify-kernel` now exercises the other coarse Core surface that `libbitcoinkernel` actually exposes: block parse and txids.

Native apply still owns identities (`block_txids` over already-decoded `Tx` values). When the tap is on and preserved wire bytes are present, those same bytes go to `KernelBlock::parse` and only count/txid equality is compared. The `KernelBlock` is dropped inside the adapter.

```text
raw bytes -> native decode + native txids -> apply / state
         \-> KernelBlock parse + kernel txids -> compare only
```

Script verdict comparison from #556 is unchanged. Kernel types still never enter apply.

## What changed

- `kernel::compare_block_parse(raw, native_txids)`: parse, compare count, compare txids, return only `Ok` or `ConsensusError::Kernel`.
- Apply calls it from `prepare_apply` and the window parse pass when `verify_kernel` is set and serialized bytes exist. Assume-valid still hashes native txids; the parse tap runs whenever bytes are present, independent of script skipping.
- Without `--features kernel`, the function fails the same way as `compare_script_verdicts`.

## Why this is the next surface

`bitcoinkernel` 0.2 does not expose `process_block` / kernel chainstate (KTD1). Parse + txids + scripts is the independent coarse verdict set it can give without feeding Core-owned data into Rust state.

Smaller contextual rules stay on replay, Core vectors, and the existing kernel-vs-interpreter fixtures.

## Test plan

- [x] `cargo test -p bitcoin-rs-consensus --lib kernel::`
- [x] `cargo test -p bitcoin-rs-node --no-default-features --features fjall --lib verify_kernel`
- [x] `cargo clippy -p bitcoin-rs-consensus --all-targets -- -D warnings`
- [x] `cargo clippy -p bitcoin-rs-node --no-default-features --features fjall --lib -- -D warnings`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-996af3b4-a8cd-45bf-aad7-e32419922de0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-996af3b4-a8cd-45bf-aad7-e32419922de0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

