### PR TITLE
Make IndexWriter the sole index mutation owner

### DIFF
--- a/crates/index/README.md
+++ b/crates/index/README.md
@@ -6,9 +6,11 @@ rows to an exact active-chain prefix. `ScriptLive` is the compact reverse view
 of the authoritative UTXO set: each row stores an empty value and a complete
 outpoint after an eight-byte script-hash prefix.
 
-`Indexer<S: KvStore>` walks a serialized block once (`ingest_block`) and writes txid,
-script-funding, previous-outpoint spending, and live-outpoint rows (counted by
-`IndexRowCounts`); `iter_funding_rows` and `iter_live_outpoints` scan a
+`IndexWriter` is the sole mutation owner: it walks a serialized block once
+(`prepare_block` / `prepare_block_with_spent_scripts`) and commits bounded
+`PreparedBatch` writes of txid, script-funding, previous-outpoint spending,
+and live-outpoint rows (counted by `IndexRowCounts`). `Indexer<S: KvStore>`
+is the read side over the same store. `iter_funding_rows` and `iter_live_outpoints` scan a
 scripthash prefix, and `resolve_script_history` exact-resolves
 the lossy 8-byte prefix against a `BlockSource` that fetches block bytes by height and
 range. `PreparedBlock`/`PreparedBatch` under `PreparedBatchLimits` bound one atomic

--- a/crates/index/benches/history_resolve.rs
+++ b/crates/index/benches/history_resolve.rs
@@ -21,7 +21,7 @@
 use std::hint::black_box;
 use std::sync::Arc;
 
-use bitcoin_rs_index::{BlockSource, Indexer, ScriptHash};
+use bitcoin_rs_index::{BlockSource, IndexWriter, Indexer, ScriptHash};
 use bitcoin_rs_primitives::{
     Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
     deserialize,
@@ -35,9 +35,9 @@ use hashbrown::HashMap;
 const TXS_PER_BLOCK_250K: usize = 2_200;
 /// Filler transactions per block for the ~1 MB shape.
 const TXS_PER_BLOCK_1M: usize = 9_000;
-/// First height a fixture block is placed at. Non-zero so height 0 never
-/// doubles as a "missing" sentinel.
-const BASE_HEIGHT: u32 = 100;
+/// First height a fixture block is placed at. Sequential `commit_block`
+/// requires a contiguous watermark from height 0.
+const BASE_HEIGHT: u32 = 0;
 
 /// Block source over a real flat-file store.
 ///
@@ -168,17 +168,6 @@ fn target_tx(height: u32, target_script: &[u8]) -> Tx {
     }
 }
 
-fn empty_header() -> Header {
-    Header {
-        version: 1,
-        prev_blockhash: BlockHash::default(),
-        merkle_root: Hash256::default(),
-        time: 0,
-        bits: 0,
-        nonce: 0,
-    }
-}
-
 /// Builds `heights` blocks of `txs_per_block` filler transactions, each with
 /// one target transaction planted at the **midpoint**.
 ///
@@ -190,7 +179,7 @@ fn build_fixture(heights: u32, txs_per_block: usize) -> Fixture {
     let blocks_dir = tempfile::tempdir().expect("blocks tempdir");
     let store = Arc::new(RocksDbStore::open(dir.path()).expect("open rocksdb"));
     let files = FlatFileBlockStore::open(blocks_dir.path()).expect("open block files");
-    let mut indexer = Indexer::new(store);
+    let mut writer = IndexWriter::open(Arc::clone(&store), 1).expect("open IndexWriter");
 
     let target_script = witness_script(0xdead_beef);
     let target = ScriptHash::from_script_bytes(&target_script);
@@ -198,6 +187,7 @@ fn build_fixture(heights: u32, txs_per_block: usize) -> Fixture {
     let mut positions = HashMap::new();
     let mut last_target = None;
     let midpoint = txs_per_block / 2;
+    let mut prev_blockhash = BlockHash::default();
 
     for index in 0..heights {
         let height = BASE_HEIGHT + index;
@@ -216,13 +206,21 @@ fn build_fixture(heights: u32, txs_per_block: usize) -> Fixture {
         }
 
         let block = Block {
-            header: empty_header(),
+            header: Header {
+                version: 1,
+                prev_blockhash,
+                merkle_root: Hash256::default(),
+                time: 0,
+                bits: 0,
+                nonce: 0,
+            },
             txs: txdata,
         };
         let bytes = consensus_bytes(&block);
-        indexer
-            .ingest_block(&bytes, height)
-            .expect("ingest fixture block");
+        writer
+            .commit_block(height, &bytes)
+            .expect("commit fixture block");
+        prev_blockhash = block.block_hash();
         let hash = *block.block_hash().as_bytes();
         let position = files
             .persist(None, height, hash, &bytes)
@@ -230,7 +228,9 @@ fn build_fixture(heights: u32, txs_per_block: usize) -> Fixture {
         positions.insert(height, (position, hash));
         last_target = Some((planted_txid, OutPoint::new(planted_txid, 0)));
     }
+    drop(writer);
 
+    let indexer = Indexer::new(store);
     let (target_txid, target_outpoint) = last_target.expect("at least one fixture height");
 
     let source = FlatFileBlockSource { files, positions };

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -1796,22 +1796,14 @@ fn pending_rows_for_block_with_header(
     height: u32,
     capabilities: IndexCapabilities,
     spent_scripts: &dyn SpentCoinScripts,
-) -> Result<
-    (
-        PendingRows,
-        usize,
-        Option<[u8; crate::types::HEADER_ROW_SIZE]>,
-    ),
-    IndexError,
-> {
+) -> Result<(PendingRows, Option<[u8; crate::types::HEADER_ROW_SIZE]>), IndexError> {
     let mut rows = PendingRows::default();
     let mut header = None;
-    let (txid_count, live_created, live_spent) = {
+    let (live_created, live_spent) = {
         let mut visitor = IndexBlockVisitor {
             rows: &mut rows,
             header: &mut header,
             height_bytes: height.to_le_bytes(),
-            txid_count: 0,
             invalid_header_len: None,
             block,
             pending_funding: Vec::new(),
@@ -1822,7 +1814,7 @@ fn pending_rows_for_block_with_header(
             capabilities,
         };
         match bsl::Block::visit(block, &mut visitor) {
-            Ok(_) => (visitor.txid_count, visitor.live_created, visitor.live_spent),
+            Ok(_) => (visitor.live_created, visitor.live_spent),
             Err(bitcoin_slices::Error::VisitBreak) => {
                 if let Some(len) = visitor.invalid_header_len {
                     return Err(IndexError::InvalidHeaderLength { len });
@@ -1835,7 +1827,7 @@ fn pending_rows_for_block_with_header(
     if capabilities.script_live {
         push_live_ops(&mut rows, live_created, live_spent, height, spent_scripts)?;
     }
-    Ok((rows, txid_count, header))
+    Ok((rows, header))
 }
 
 /// Turns a block's created and spent outputs into ordered live mutations.
@@ -2164,7 +2156,6 @@ struct IndexBlockVisitor<'a> {
     rows: &'a mut PendingRows,
     header: &'a mut Option<[u8; crate::types::HEADER_ROW_SIZE]>,
     height_bytes: [u8; crate::types::HEIGHT_SIZE],
-    txid_count: usize,
     invalid_header_len: Option<usize>,
     /// The serialized block being visited, used as the base for byte offsets.
     block: &'a [u8],
@@ -2262,7 +2253,6 @@ impl Visitor for IndexBlockVisitor<'_> {
                 self.push_txid_row(hash.as_slice(), position);
             }
         }
-        self.txid_count += 1;
         ControlFlow::Continue(())
     }
 
@@ -2928,7 +2918,7 @@ impl<S: KvStore> IndexWriter<S> {
                 watermark: self.watermark()?,
             });
         }
-        let (mut rows, _txid_count, header) =
+        let (mut rows, header) =
             pending_rows_for_block_with_header(body, height, capabilities, spent_scripts)?;
         let header = header.ok_or(IndexError::InvalidHeaderLength { len: 0 })?;
         let actual_hash = encode::double_sha256(header.as_slice()).to_le_bytes();
@@ -2969,6 +2959,11 @@ impl<S: KvStore> IndexWriter<S> {
     /// discard derived state and retry from the persisted watermark.
     /// [`IndexError::Storage`] is not retried by the index worker; supervision
     /// marks it failed (`IDX-07`).
+    ///
+    /// This path selects [`IndexCapabilities::HISTORICAL`]: it advances
+    /// `TxLookup` and `ScriptHistory` only. Callers that maintain `ScriptLive`
+    /// must use [`Self::prepare_block_with_spent_scripts`] with `script_live`
+    /// selected and a spent-script source, then [`Self::commit_forward`].
     pub fn commit_block(&mut self, height: u32, body: &[u8]) -> Result<IndexWatermark, IndexError> {
         let header = body.get(..crate::types::HEADER_ROW_SIZE).ok_or_else(|| {
             IndexError::InvalidHeaderLength {
@@ -3170,6 +3165,15 @@ impl<S: KvStore> IndexWriter<S> {
 
     /// Atomically rolls back one block with the exact scripts of its spent
     /// coins. This is the anchored variant used when `ScriptLive` is selected.
+    ///
+    /// The fenced store batch is the commit point (`IDX-06`), same as
+    /// [`Self::commit_forward`]: `Ok` means row deletes, the selected
+    /// watermark, and the cursor disposition are durable together. A crash
+    /// before that write leaves the previous tip; a crash after it leaves the
+    /// parent watermark. Fence races ([`IndexError::StaleIndexState`],
+    /// [`IndexError::ResetInProgress`]) mean discard derived state and retry
+    /// from the persisted watermark. [`IndexError::Storage`] is not retried by
+    /// the index worker; supervision marks it failed (`IDX-07`).
     pub fn commit_rollback_one_for_with_cursor_with_spent_scripts(
         &mut self,
         fence: IndexWriteFence,

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -1,6 +1,6 @@
 use std::ops::ControlFlow;
 
-use bitcoin_rs_primitives::{Block, Hash256, OutPoint, Tx, Txid, encode, varint};
+use bitcoin_rs_primitives::{Block, Hash256, OutPoint, Tx, Txid, encode};
 use bitcoin_rs_storage::{
     ColumnFamily, KvSnapshot, KvStore, PrefixScanLimit, StorageError, WriteBatch, WriteCondition,
 };
@@ -101,9 +101,6 @@ pub enum IndexError {
         /// Watermark found in the store.
         actual: Option<IndexWatermark>,
     },
-    /// A prepared transition cannot mix with legacy buffered rows.
-    #[error("cannot write prepared TxIndex mutations with buffered legacy rows")]
-    PendingLegacyRows,
     /// A capability set containing `ScriptLive` was prepared through a path
     /// that carries no spent-coin script source. Live deletes need the spent
     /// coin's exact script (#225), and a prevout-only block parse cannot
@@ -1117,6 +1114,11 @@ impl PreparedBlock {
             hash: self.hash,
         }
     }
+
+    /// Row-family counts retained by this prepared block.
+    pub fn row_counts(&self) -> IndexRowCounts {
+        self.rows.counts()
+    }
 }
 
 /// Prepared blocks admitted to one bounded atomic forward write.
@@ -1211,7 +1213,7 @@ impl PreparedBatch {
     }
 }
 
-/// Counts of rows written by a confirmed block ingest.
+/// Counts of rows written by a confirmed prepared commit.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct IndexRowCounts {
     /// Transaction-id index rows written to [`ColumnFamily::TxConfirmed`].
@@ -1227,16 +1229,12 @@ pub struct IndexRowCounts {
 }
 
 /// Electrs-shaped block indexer backed by a workspace [`KvStore`].
+///
+/// Reads and format/watermark queries live here. Durable row mutation is
+/// owned exclusively by [`IndexWriter`].
 pub struct Indexer<S: KvStore> {
     store: std::sync::Arc<S>,
     last_counts: IndexRowCounts,
-    pending_rows: PendingRows,
-    batch_depth: u32,
-    /// Reset-state observation covering every buffered row, captured before
-    /// the first store read that produced them and held until they flush.
-    fence: Option<IndexWriteFence>,
-    /// Process generation fencing this indexer's reset adoption work.
-    generation: u64,
 }
 
 impl<S: KvStore> Indexer<S> {
@@ -1245,10 +1243,6 @@ impl<S: KvStore> Indexer<S> {
         Self {
             store,
             last_counts: IndexRowCounts::default(),
-            pending_rows: PendingRows::default(),
-            batch_depth: 0,
-            fence: None,
-            generation: 0,
         }
     }
 
@@ -1257,7 +1251,7 @@ impl<S: KvStore> Indexer<S> {
         &self.store
     }
 
-    /// Returns the row counts from the last successful ingest.
+    /// Returns the row counts from the last successful prepared commit.
     pub const fn last_counts(&self) -> IndexRowCounts {
         self.last_counts
     }
@@ -1795,294 +1789,11 @@ impl<S: KvStore> Indexer<S> {
         let mut rows = self.store.iter_prefix(ColumnFamily::BlockHeaders, &[])?;
         Ok(rows.next().transpose()?.is_some())
     }
-
-    const FLUSH_THRESHOLD_ROWS: usize = 500_000;
-
-    /// Walks one serialized block once with `bitcoin_slices` and writes electrs-shaped rows.
-    pub fn ingest_block(
-        &mut self,
-        block: &[u8],
-        height: u32,
-    ) -> Result<IndexRowCounts, IndexError> {
-        let (rows, _txid_count) = pending_rows_for_block(block, height, TxidSource::Compute)?;
-        self.ingest_rows(rows)
-    }
-
-    /// Walks one serialized block and reuses caller-supplied transaction IDs after validation.
-    ///
-    /// Falls back to hashing transactions from `block` for any missing or mismatched entry,
-    /// preserving `ingest_block` semantics for mismatched input.
-    pub fn ingest_block_with_txids(
-        &mut self,
-        block: &[u8],
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        let (rows, txid_count) =
-            pending_rows_for_block(block, height, TxidSource::Validate(txids))?;
-        if txids.len() != txid_count {
-            return self.ingest_block(block, height);
-        }
-        self.ingest_rows(rows)
-    }
-
-    /// Walks one serialized block using caller-verified transaction IDs.
-    ///
-    /// This preserves [`Self::ingest_block_with_txids`] for untrusted callers while allowing
-    /// block-apply code to avoid hashing transactions a second time after it has already built
-    /// txids from the same block.
-    pub fn ingest_block_with_verified_txids(
-        &mut self,
-        block: &[u8],
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        let (rows, txid_count) = pending_rows_for_block(block, height, TxidSource::Trusted(txids))?;
-        if txids.len() != txid_count {
-            return self.ingest_block(block, height);
-        }
-        self.ingest_rows(rows)
-    }
-
-    /// Walks one decoded block using caller-verified transaction IDs.
-    ///
-    /// The serialized block is retained only as the safe fallback path when the caller-provided
-    /// transaction-id count does not match the decoded block. Normal callers must pass the
-    /// consensus serialization of `block` as `serialized_block`.
-    pub fn ingest_decoded_block_with_verified_txids(
-        &mut self,
-        block: &Block,
-        serialized_block: &[u8],
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        if txids.len() != block.txs.len() {
-            return self.ingest_block_with_verified_txids(serialized_block, height, txids);
-        }
-        let rows = pending_rows_for_decoded_block(block, height, txids)?;
-        self.ingest_rows(rows)
-    }
-
-    /// Deletes every index row that ingesting `block` at `height` would have written.
-    ///
-    /// Derives the same txid, funding, spending, and header row keys as
-    /// [`Self::ingest_decoded_block_with_verified_txids`] by reusing the shared
-    /// row-construction code, then issues all deletions in a single atomic
-    /// [`KvStore::write`] batch. Either the entire block's rows are removed or
-    /// the method returns `Err` having deleted nothing observable.
-    ///
-    /// Deleting a row that is already absent is not an error: the indexer may
-    /// have been enabled after `block` was applied, so its rows may never have
-    /// existed. The returned [`IndexRowCounts`] reflects the rows targeted for
-    /// deletion (the same counts a matching ingest would have written), which
-    /// may be zero on a repeat call or when the block was never indexed.
-    ///
-    /// Any buffered rows are flushed first. Deletion writes straight to the
-    /// store, so unflushed rows for the block being disconnected would survive
-    /// in `pending_rows` and a later [`Self::end_batch`] would resurrect the
-    /// very block just rolled back. Flushing first also keeps the all-or-
-    /// nothing property: a failing flush returns `Err` before anything is
-    /// deleted.
-    pub fn rollback_block(
-        &mut self,
-        block: &Block,
-        height: u32,
-    ) -> Result<IndexRowCounts, IndexError> {
-        // Buffered rows must reach the store before the deletes, or a later
-        // end_batch would write back the block being disconnected.
-        self.flush()?;
-        let fence = capture_write_fence(self.store.as_ref(), self.generation)?;
-        let txids: Vec<Txid> = block.txs.iter().map(Tx::txid).collect();
-        self.rollback_block_inner(block, height, &txids, &fence)
-    }
-
-    /// Same as [`Self::rollback_block`] but reuses caller-verified transaction
-    /// IDs, avoiding a second pass of `compute_txid` when the caller has
-    /// already computed them for merkle verification.
-    ///
-    /// Falls back to [`Self::rollback_block`] when the supplied txid count
-    /// does not match the block's transaction count, preserving semantics for
-    /// mismatched input.
-    pub fn rollback_block_with_verified_txids(
-        &mut self,
-        block: &Block,
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        self.flush()?;
-        if txids.len() != block.txs.len() {
-            return self.rollback_block(block, height);
-        }
-        let fence = capture_write_fence(self.store.as_ref(), self.generation)?;
-        self.rollback_block_inner(block, height, txids, &fence)
-    }
-
-    fn rollback_block_inner(
-        &self,
-        block: &Block,
-        height: u32,
-        txids: &[Txid],
-        fence: &IndexWriteFence,
-    ) -> Result<IndexRowCounts, IndexError> {
-        let mut rows = pending_rows_for_decoded_block(block, height, txids)?;
-        rows.sort();
-        let counts = rows.counts();
-
-        // Only delete if this block's header row is still there.
-        //
-        // Funding, spending, and txid keys are an 8-byte prefix plus the
-        // height, carrying no block identity, so a replacement block at the
-        // same height that shares any data — the same output script is enough —
-        // derives the same keys. Rolling this block back a second time, after
-        // the replacement was indexed, would delete the replacement's rows and
-        // leave ScriptIndex missing active-chain history.
-        //
-        // The header row is the identity: its key is the 80-byte serialized
-        // header, and the block hash is the double-SHA256 of exactly those
-        // bytes, so no two blocks share one. Its absence means this block is
-        // already rolled back and the keys now belong to whatever replaced it.
-        // Rekeying the other three families would carry block identity
-        // directly, but it would break the electrs-compatible layout and force
-        // a reindex, which is a far larger change than the bug warrants.
-        // A read failure is propagated, not treated as absence: silently
-        // reporting a clean rollback because storage was unreachable would
-        // leave the caller believing the block is gone.
-        let identity_present = match rows.header_rows.first() {
-            Some(header) => self
-                .store
-                .get(ColumnFamily::BlockHeaders, header)?
-                .is_some(),
-            None => false,
-        };
-        if !identity_present {
-            ensure_fence_live(self.store.as_ref(), self.generation, fence)?;
-        }
-        if !identity_present {
-            debug!(
-                height,
-                "rollback skipped: block header row absent, rows belong to another block"
-            );
-            return Ok(counts);
-        }
-
-        let mut batch = self.store.new_batch();
-        // Rollback deletes by key only. Positions live in the value, so they
-        // disappear with the row and need no separate handling.
-        for_each_row_group(&rows.txid_rows, |row, _positions| {
-            batch.delete(ColumnFamily::TxConfirmed, row.as_bytes());
-        });
-        for_each_row_group(&rows.funding_rows, |row, _positions| {
-            batch.delete(ColumnFamily::Funding, row.as_bytes());
-        });
-        for_each_row_group(&rows.spending_rows, |row, _positions| {
-            batch.delete(ColumnFamily::Spending, row.as_bytes());
-        });
-        for row in &rows.header_rows {
-            batch.delete(ColumnFamily::BlockHeaders, row);
-        }
-        commit_ordinary(self.store.as_ref(), self.generation, fence, batch)?;
-        debug!(
-            txids = counts.txids,
-            funding = counts.funding,
-            spending = counts.spending,
-            headers = counts.headers,
-            "rolled back block"
-        );
-        Ok(counts)
-    }
-
-    fn ingest_rows(&mut self, mut rows: PendingRows) -> Result<IndexRowCounts, IndexError> {
-        // Dedup before counting: a block can generate the same funding or
-        // spending row twice, and only one copy is ever written. Counting the
-        // raw rows would report more rows than the store receives.
-        if self.fence.is_none() {
-            self.fence = Some(capture_write_fence(self.store.as_ref(), self.generation)?);
-        }
-        rows.sort();
-        let block_counts = rows.counts();
-        self.pending_rows.append(rows);
-        if self.batch_depth == 0 || self.pending_rows.total() >= Self::FLUSH_THRESHOLD_ROWS {
-            self.flush()?;
-        }
-        Ok(block_counts)
-    }
-
-    fn flush(&mut self) -> Result<IndexRowCounts, IndexError> {
-        self.pending_rows.sort();
-        let counts = self.pending_rows.counts();
-        if counts.txids + counts.funding + counts.spending + counts.headers + counts.live == 0 {
-            return Ok(counts);
-        }
-        let fence = match self.fence.take() {
-            Some(fence) => fence,
-            None => capture_write_fence(self.store.as_ref(), self.generation)?,
-        };
-        let mut batch = self.store.new_batch();
-        for_each_row_group(&self.pending_rows.txid_rows, |row, positions| {
-            batch.put(
-                ColumnFamily::TxConfirmed,
-                row.as_bytes(),
-                &crate::types::TxPositionValue::encode(positions),
-            );
-        });
-        for_each_row_group(&self.pending_rows.funding_rows, |row, positions| {
-            batch.put(
-                ColumnFamily::Funding,
-                row.as_bytes(),
-                &crate::types::TxPositionValue::encode(positions),
-            );
-        });
-        for_each_row_group(&self.pending_rows.spending_rows, |row, positions| {
-            batch.put(
-                ColumnFamily::Spending,
-                row.as_bytes(),
-                &crate::types::TxPositionValue::encode(positions),
-            );
-        });
-        for row in &self.pending_rows.header_rows {
-            batch.put(ColumnFamily::BlockHeaders, row, &[]);
-        }
-        apply_live_ops(&mut batch, &self.pending_rows.live_ops, false);
-        if let Err(error) = commit_ordinary(self.store.as_ref(), self.generation, &fence, batch) {
-            if matches!(
-                error,
-                IndexError::ResetInProgress | IndexError::StaleIndexState
-            ) {
-                self.pending_rows = PendingRows::default();
-            }
-            return Err(error);
-        }
-        self.last_counts = counts;
-        self.pending_rows = PendingRows::default();
-        debug!(
-            txids = counts.txids,
-            funding = counts.funding,
-            spending = counts.spending,
-            headers = counts.headers,
-            "indexed batch"
-        );
-        Ok(counts)
-    }
-
-    /// Disables per-block flushing so multiple ingests can be written in one batch.
-    pub fn begin_batch(&mut self) {
-        self.batch_depth = self.batch_depth.saturating_add(1);
-    }
-
-    /// Re-enables per-block flushing and flushes any accumulated rows.
-    pub fn end_batch(&mut self) -> Result<(), IndexError> {
-        self.batch_depth = self.batch_depth.saturating_sub(1);
-        if self.batch_depth == 0 {
-            self.flush()?;
-        }
-        Ok(())
-    }
 }
 
 fn pending_rows_for_block_with_header(
     block: &[u8],
     height: u32,
-    txids: TxidSource<'_>,
     capabilities: IndexCapabilities,
     spent_scripts: &dyn SpentCoinScripts,
 ) -> Result<
@@ -2100,7 +1811,6 @@ fn pending_rows_for_block_with_header(
             rows: &mut rows,
             header: &mut header,
             height_bytes: height.to_le_bytes(),
-            txids,
             txid_count: 0,
             invalid_header_len: None,
             block,
@@ -2126,21 +1836,6 @@ fn pending_rows_for_block_with_header(
         push_live_ops(&mut rows, live_created, live_spent, height, spent_scripts)?;
     }
     Ok((rows, txid_count, header))
-}
-
-fn pending_rows_for_block(
-    block: &[u8],
-    height: u32,
-    txids: TxidSource<'_>,
-) -> Result<(PendingRows, usize), IndexError> {
-    let (rows, txid_count, _) = pending_rows_for_block_with_header(
-        block,
-        height,
-        txids,
-        IndexCapabilities::HISTORICAL,
-        &NoSpentScripts,
-    )?;
-    Ok((rows, txid_count))
 }
 
 /// Turns a block's created and spent outputs into ordered live mutations.
@@ -2203,68 +1898,6 @@ fn push_live_ops(
     }
     rows.live_ops.extend(deletes);
     Ok(())
-}
-
-fn pending_rows_for_decoded_block(
-    block: &Block,
-    height: u32,
-    txids: &[Txid],
-) -> Result<PendingRows, IndexError> {
-    let mut rows = PendingRows::default();
-    let header_bytes = encode::consensus_bytes(&block.header);
-    let Some(header) = HeaderRow::from_header_bytes(&header_bytes) else {
-        return Err(IndexError::InvalidHeaderLength {
-            len: header_bytes.len(),
-        });
-    };
-    rows.header_rows.push(header.to_db_row());
-
-    // Byte offsets are derived arithmetically rather than by re-serializing: a
-    // serialized block is `header || varint(tx_count) || tx...`, so the first
-    // transaction starts after the header and the count, and each subsequent one
-    // starts a `total_size()` further on. `both_ingest_paths_write_identical_row_values`
-    // pins this against the byte offsets the zero-copy path measures directly.
-    let prologue = crate::types::HEADER_ROW_SIZE
-        + varint::encode(u64::try_from(block.txs.len()).unwrap_or(u64::MAX)).len();
-    let mut offset = u32::try_from(prologue).map_err(|_| IndexError::UnaddressablePosition {
-        offset: u64::try_from(prologue).unwrap_or(u64::MAX),
-    })?;
-
-    for (tx, txid) in block.txs.iter().zip(txids) {
-        let byte_len =
-            u32::try_from(tx.total_size()).map_err(|_| IndexError::UnaddressablePosition {
-                offset: u64::from(offset),
-            })?;
-        let position = crate::types::TxPosition::new(offset, byte_len);
-        offset = offset
-            .checked_add(byte_len)
-            .ok_or_else(|| IndexError::UnaddressablePosition {
-                offset: u64::from(offset),
-            })?;
-
-        rows.txid_rows.push(PositionedRow {
-            row: TxidRow::row(txid, height),
-            position,
-        });
-        for tx_in in &tx.inputs {
-            if !is_null_outpoint(&tx_in.previous_output) {
-                rows.spending_rows.push(PositionedRow {
-                    row: SpendingPrefixRow::row(&tx_in.previous_output, height),
-                    position,
-                });
-            }
-        }
-        for tx_out in &tx.outputs {
-            if !is_op_return_script(&tx_out.script_pubkey) {
-                let scripthash = ScriptHash::new(&tx_out.script_pubkey);
-                rows.funding_rows.push(PositionedRow {
-                    row: ScriptHashRow::row(scripthash, height),
-                    position,
-                });
-            }
-        }
-    }
-    Ok(rows)
 }
 
 /// One index row together with the transaction byte range that produced it.
@@ -2360,10 +1993,6 @@ impl PendingRows {
     fn total(&self) -> usize {
         let counts = self.counts();
         counts.txids + counts.funding + counts.spending + counts.headers + counts.live
-    }
-
-    fn is_empty(&self) -> bool {
-        self.total() == 0
     }
 
     fn encoded_bytes(&self) -> Result<usize, IndexError> {
@@ -2535,7 +2164,6 @@ struct IndexBlockVisitor<'a> {
     rows: &'a mut PendingRows,
     header: &'a mut Option<[u8; crate::types::HEADER_ROW_SIZE]>,
     height_bytes: [u8; crate::types::HEIGHT_SIZE],
-    txids: TxidSource<'a>,
     txid_count: usize,
     invalid_header_len: Option<usize>,
     /// The serialized block being visited, used as the base for byte offsets.
@@ -2622,45 +2250,16 @@ impl Visitor for IndexBlockVisitor<'_> {
                 .spending_rows
                 .push(PositionedRow { row, position });
         }
-        if !self.pending_live.is_empty() {
-            let txid = tx.txid_sha2();
+        let txid =
+            (self.capabilities.tx_lookup || !self.pending_live.is_empty()).then(|| tx.txid_sha2());
+        if let Some(hash) = txid {
             let mut txid_bytes = [0_u8; 32];
-            txid_bytes.copy_from_slice(txid.as_slice());
+            txid_bytes.copy_from_slice(hash.as_slice());
             for (vout, scripthash) in self.pending_live.drain(..) {
                 self.live_created.push((txid_bytes, vout, scripthash));
             }
-        }
-        if !self.capabilities.tx_lookup {
-            self.txid_count += 1;
-            return ControlFlow::Continue(());
-        }
-        match self.txids {
-            TxidSource::Compute => {
-                let txid = tx.txid_sha2();
-                self.push_txid_row(txid.as_slice(), position);
-            }
-            TxidSource::Validate(txids) => {
-                if let Some(txid) = txids.get(self.txid_count) {
-                    let computed = tx.txid_sha2();
-                    let txid_bytes: &[u8] = txid.as_bytes();
-                    if txid_bytes == computed.as_slice() {
-                        self.push_txid_row(txid_bytes, position);
-                    } else {
-                        self.push_txid_row(computed.as_slice(), position);
-                    }
-                } else {
-                    let txid = tx.txid_sha2();
-                    self.push_txid_row(txid.as_slice(), position);
-                }
-            }
-            TxidSource::Trusted(txids) => {
-                if let Some(txid) = txids.get(self.txid_count) {
-                    let txid_bytes: &[u8] = txid.as_bytes();
-                    self.push_txid_row(txid_bytes, position);
-                } else {
-                    let txid = tx.txid_sha2();
-                    self.push_txid_row(txid.as_slice(), position);
-                }
+            if self.capabilities.tx_lookup {
+                self.push_txid_row(hash.as_slice(), position);
             }
         }
         self.txid_count += 1;
@@ -2715,20 +2314,9 @@ fn is_null_prevout(prevout: &bsl::OutPoint<'_>) -> bool {
     prevout.vout() == u32::MAX && prevout.txid().iter().all(|byte| *byte == 0)
 }
 
-fn is_null_outpoint(outpoint: &OutPoint) -> bool {
-    outpoint.vout == u32::MAX && outpoint.txid.as_bytes().iter().all(|&byte| byte == 0)
-}
-
 #[inline]
 fn is_op_return_script(script: &[u8]) -> bool {
     matches!(script.first(), Some(0x6a))
-}
-
-#[derive(Clone, Copy)]
-enum TxidSource<'a> {
-    Compute,
-    Validate(&'a [Txid]),
-    Trusted(&'a [Txid]),
 }
 
 /// Reads and decodes the single transaction a position names.
@@ -3145,6 +2733,11 @@ impl<S: KvStore> IndexWriter<S> {
         self.indexer.watermark()
     }
 
+    /// Returns the row counts from the last successful prepared commit.
+    pub const fn last_counts(&self) -> IndexRowCounts {
+        self.indexer.last_counts()
+    }
+
     /// Loads both independently durable capability watermarks.
     pub fn watermarks(&self) -> Result<IndexWatermarks, IndexError> {
         self.indexer.watermarks()
@@ -3197,7 +2790,6 @@ impl<S: KvStore> IndexWriter<S> {
         ) -> Result<(), IndexError>,
     {
         const SEED_BATCH_ROWS: usize = 4_096;
-        self.ensure_prepared_ready()?;
         let existing = capture_write_fence(self.indexer.store.as_ref(), self.generation)?;
         if existing.watermarks.script_live.is_some() {
             return Err(IndexError::LiveAlreadySeeded);
@@ -3287,7 +2879,6 @@ impl<S: KvStore> IndexWriter<S> {
     /// completion CASes the exact claim to the next idle version.
     /// `open` resumes an interrupted reset before exposing the writer again.
     pub fn reset_capabilities(&self, capabilities: IndexCapabilities) -> Result<(), IndexError> {
-        self.ensure_prepared_ready()?;
         if capabilities.is_empty() {
             return Err(IndexError::InvalidResetMarker);
         }
@@ -3337,13 +2928,8 @@ impl<S: KvStore> IndexWriter<S> {
                 watermark: self.watermark()?,
             });
         }
-        let (mut rows, _txid_count, header) = pending_rows_for_block_with_header(
-            body,
-            height,
-            TxidSource::Compute,
-            capabilities,
-            spent_scripts,
-        )?;
+        let (mut rows, _txid_count, header) =
+            pending_rows_for_block_with_header(body, height, capabilities, spent_scripts)?;
         let header = header.ok_or(IndexError::InvalidHeaderLength { len: 0 })?;
         let actual_hash = encode::double_sha256(header.as_slice()).to_le_bytes();
         if actual_hash != hash {
@@ -3369,6 +2955,31 @@ impl<S: KvStore> IndexWriter<S> {
         })
     }
 
+    /// Commits one serialized block through the prepared-write owner.
+    ///
+    /// Production catch-up uses [`Self::prepare_block_with_spent_scripts`] plus
+    /// [`PreparedBatch`] to bound multi-block writes. This is the same owner
+    /// for a single block: tests and benches must not grow a second ingest path.
+    pub fn commit_block(&mut self, height: u32, body: &[u8]) -> Result<IndexWatermark, IndexError> {
+        let header = body.get(..crate::types::HEADER_ROW_SIZE).ok_or_else(|| {
+            IndexError::InvalidHeaderLength {
+                len: body.len().min(crate::types::HEADER_ROW_SIZE),
+            }
+        })?;
+        let hash = encode::double_sha256(header).to_le_bytes();
+        let prepared = self.prepare_block(height, hash, body)?;
+        let mut batch = PreparedBatch::new(PreparedBatchLimits {
+            max_rows: usize::MAX,
+            max_bytes: usize::MAX,
+        });
+        if let Err(_block) = batch.try_push(prepared) {
+            return Err(IndexError::NonContiguousPrepared {
+                watermark: self.watermark()?,
+            });
+        }
+        self.commit_forward(batch)
+    }
+
     /// Atomically connects a bounded batch and advances the durable watermark.
     ///
     /// Captures its own fence before any store-dependent derivation and keeps
@@ -3386,7 +2997,6 @@ impl<S: KvStore> IndexWriter<S> {
         batch: PreparedBatch,
         cursor: ConsumerCursorUpdate<'_>,
     ) -> Result<IndexWatermark, IndexError> {
-        self.ensure_prepared_ready()?;
         if batch.is_empty() {
             return Err(IndexError::NonContiguousPrepared {
                 watermark: fence.watermarks.tx_lookup,
@@ -3556,7 +3166,6 @@ impl<S: KvStore> IndexWriter<S> {
         cursor: ConsumerCursorUpdate<'_>,
         spent_scripts: &dyn SpentCoinScripts,
     ) -> Result<(), IndexError> {
-        self.ensure_prepared_ready()?;
         let current = selected_watermark(fence.watermarks, capabilities)?
             .ok_or(IndexError::NonContiguousPrepared { watermark: None })?;
         let prepared = self.prepare_block_with_spent_scripts(
@@ -3675,7 +3284,6 @@ impl<S: KvStore> IndexWriter<S> {
         fence: IndexWriteFence,
         cursor: &[u8],
     ) -> Result<(), IndexError> {
-        self.ensure_prepared_ready()?;
         let mut store_batch = self.indexer.store.new_batch();
         store_batch.put(ColumnFamily::UtxoMeta, CONSUMER_CURSOR_KEY, cursor);
         commit_ordinary(
@@ -3689,13 +3297,6 @@ impl<S: KvStore> IndexWriter<S> {
     /// Forces all completed writes to durable storage.
     pub fn flush(&self) -> Result<(), IndexError> {
         self.indexer.store.flush().map_err(IndexError::Storage)
-    }
-
-    fn ensure_prepared_ready(&self) -> Result<(), IndexError> {
-        if self.indexer.batch_depth != 0 || !self.indexer.pending_rows.is_empty() {
-            return Err(IndexError::PendingLegacyRows);
-        }
-        Ok(())
     }
 }
 
@@ -3722,131 +3323,6 @@ fn has_any_index_row<S: KvStore>(store: &S) -> Result<bool, IndexError> {
         }
     }
     Ok(false)
-}
-
-/// Storage-agnostic block-ingest interface.
-///
-/// Use this trait when consumers must hold the indexer behind a trait
-/// object (e.g. when the storage backend is selected at runtime).
-pub trait IndexerLike: Send + Sync {
-    /// Walks `block` once and writes index rows. See `Indexer::ingest_block`.
-    fn ingest_block(&mut self, block: &[u8], height: u32) -> Result<IndexRowCounts, IndexError>;
-
-    /// Reports the row-value format. See [`Indexer::ensure_format_version`].
-    ///
-    /// Defaults to [`IndexFormat::Current`] for the in-memory and stub indexers
-    /// used in tests, which have no persisted rows and therefore no legacy ones.
-    /// A store-backed implementation must override this.
-    fn ensure_format_version(&self) -> Result<IndexFormat, IndexError> {
-        Ok(IndexFormat::Current)
-    }
-
-    /// Walks `block` once and writes index rows, reusing precomputed transaction IDs when supported.
-    ///
-    /// The default implementation preserves existing implementations by ignoring `txids` and
-    /// delegating to [`IndexerLike::ingest_block`].
-    fn ingest_block_with_txids(
-        &mut self,
-        block: &[u8],
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        let _ = txids;
-        self.ingest_block(block, height)
-    }
-
-    /// Walks `block` once and writes index rows, trusting caller-verified transaction IDs when
-    /// supported.
-    ///
-    /// The default implementation preserves existing implementations by validating through
-    /// [`IndexerLike::ingest_block_with_txids`].
-    fn ingest_block_with_verified_txids(
-        &mut self,
-        block: &[u8],
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        self.ingest_block_with_txids(block, height, txids)
-    }
-
-    /// Walks a decoded block and writes rows, trusting caller-verified transaction IDs when
-    /// supported.
-    ///
-    /// The default implementation preserves existing implementations by validating through
-    /// [`IndexerLike::ingest_block_with_verified_txids`].
-    fn ingest_decoded_block_with_verified_txids(
-        &mut self,
-        block: &Block,
-        serialized_block: &[u8],
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        let _ = block;
-        self.ingest_block_with_verified_txids(serialized_block, height, txids)
-    }
-
-    /// Deletes every index row that ingesting `block` at `height` would have written.
-    ///
-    /// The inverse of the ingest methods above. The default returns
-    /// [`IndexError::UnsupportedRollback`] rather than succeeding: an
-    /// implementation that silently reports a successful rollback while
-    /// deleting nothing would let the node advance its tip believing the index
-    /// is consistent, and `ScriptIndex` queries would then serve transactions
-    /// that are no longer in the chain. Failing loudly is the only safe
-    /// default. Concrete indexers that persist rows override this.
-    fn rollback_block(&mut self, block: &Block, height: u32) -> Result<IndexRowCounts, IndexError> {
-        let _ = (block, height);
-        Err(IndexError::UnsupportedRollback)
-    }
-
-    /// Same as [`IndexerLike::rollback_block`] but reuses caller-verified
-    /// transaction IDs when supported.
-    ///
-    /// The default implementation preserves existing implementations by
-    /// ignoring `txids` and delegating to [`IndexerLike::rollback_block`].
-    fn rollback_block_with_verified_txids(
-        &mut self,
-        block: &Block,
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        let _ = txids;
-        self.rollback_block(block, height)
-    }
-
-    /// Begins a batch of block ingests; rows are not flushed until [`IndexerLike::end_batch`].
-    fn begin_batch(&mut self) {}
-
-    /// Ends a batch of block ingests, flushing any accumulated rows.
-    fn end_batch(&mut self) -> Result<(), IndexError> {
-        Ok(())
-    }
-
-    /// Resolves a confirmed transaction by txid via `source`.
-    ///
-    /// Default implementations may return `Ok(None)` when the concrete indexer
-    /// does not support transaction lookup.
-    fn resolve_transaction(
-        &self,
-        txid: Txid,
-        source: &dyn BlockSource,
-    ) -> Result<Option<Tx>, IndexError> {
-        let _ = (txid, source);
-        Ok(None)
-    }
-
-    /// Resolves the satoshi value of the transaction output at `outpoint` via
-    /// `source`. Returns `Ok(None)` when the transaction is not indexed or the
-    /// `vout` is out of range.
-    ///
-    /// Composes `resolve_transaction(outpoint.txid, source)` and reads the
-    /// `output[vout].value.to_sat()`. Building block for real fee derivation
-    /// in transaction-broadcast and prevout-value lookups.
-    fn resolve_outpoint_value(
-        &self,
-        outpoint: OutPoint,
-        source: &dyn BlockSource,
-    ) -> Result<Option<u64>, IndexError>;
 }
 
 /// Metadata key marking which row-value format an index was written with.
@@ -3918,81 +3394,6 @@ pub trait BlockSource {
     }
 }
 
-impl<S: KvStore + Send + Sync + 'static> IndexerLike for Indexer<S> {
-    fn ingest_block(&mut self, block: &[u8], height: u32) -> Result<IndexRowCounts, IndexError> {
-        Self::ingest_block(self, block, height)
-    }
-
-    fn ensure_format_version(&self) -> Result<IndexFormat, IndexError> {
-        Self::ensure_format_version(self)
-    }
-
-    fn ingest_block_with_txids(
-        &mut self,
-        block: &[u8],
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        Self::ingest_block_with_txids(self, block, height, txids)
-    }
-
-    fn ingest_block_with_verified_txids(
-        &mut self,
-        block: &[u8],
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        Self::ingest_block_with_verified_txids(self, block, height, txids)
-    }
-
-    fn ingest_decoded_block_with_verified_txids(
-        &mut self,
-        block: &Block,
-        serialized_block: &[u8],
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        Self::ingest_decoded_block_with_verified_txids(self, block, serialized_block, height, txids)
-    }
-
-    fn rollback_block(&mut self, block: &Block, height: u32) -> Result<IndexRowCounts, IndexError> {
-        Self::rollback_block(self, block, height)
-    }
-
-    fn rollback_block_with_verified_txids(
-        &mut self,
-        block: &Block,
-        height: u32,
-        txids: &[Txid],
-    ) -> Result<IndexRowCounts, IndexError> {
-        Self::rollback_block_with_verified_txids(self, block, height, txids)
-    }
-
-    fn begin_batch(&mut self) {
-        Self::begin_batch(self);
-    }
-
-    fn end_batch(&mut self) -> Result<(), IndexError> {
-        Self::end_batch(self)
-    }
-
-    fn resolve_transaction(
-        &self,
-        txid: Txid,
-        source: &dyn BlockSource,
-    ) -> Result<Option<Tx>, IndexError> {
-        Self::resolve_transaction(self, txid, source)
-    }
-
-    fn resolve_outpoint_value(
-        &self,
-        outpoint: OutPoint,
-        source: &dyn BlockSource,
-    ) -> Result<Option<u64>, IndexError> {
-        Self::resolve_outpoint_value(self, outpoint, source)
-    }
-}
-
 #[cfg(all(test, feature = "rocksdb"))]
 mod tests {
     use std::sync::Arc;
@@ -4001,12 +3402,11 @@ mod tests {
         Block, BlockHash, Hash256, Header, Network, OutPoint, Tx, TxIn, TxOut, Txid,
         consensus_bytes,
     };
-    use bitcoin_rs_storage::{ColumnFamily, KvStore, RocksDbStore};
+    use bitcoin_rs_storage::{ColumnFamily, KvStore, RocksDbStore, WriteBatch};
 
-    use super::{BlockSource, Indexer, is_op_return_script};
+    use super::{BlockSource, IndexError, IndexWriter, Indexer, is_op_return_script};
     use crate::{ScriptHash, ScriptHashRow, ScriptHistoryEntry, SpendingPrefixRow, TxidRow};
 
-    const HEIGHT: u32 = 42;
     type StoredRows = Vec<(ColumnFamily, Vec<u8>)>;
 
     #[test]
@@ -4021,14 +3421,14 @@ mod tests {
     fn iter_funding_rows_returns_indexed_rows() -> Result<(), Box<dyn std::error::Error>> {
         let script = vec![0x51, 0x01];
         let tx = tx(spent_outpoint(1, 0), script.clone());
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block(vec![tx])), HEIGHT)?;
+        writer.commit_block(0, &consensus_bytes(&block(vec![tx])))?;
 
         let scripthash = ScriptHash::from_script_bytes(&script);
         assert_eq!(
-            indexer.iter_funding_rows(scripthash)?,
-            vec![ScriptHashRow::row(scripthash, HEIGHT)]
+            writer.indexer().iter_funding_rows(scripthash)?,
+            vec![ScriptHashRow::row(scripthash, 0)]
         );
         Ok(())
     }
@@ -4046,13 +3446,11 @@ mod tests {
     -> Result<(), Box<dyn std::error::Error>> {
         let script = vec![0x51, 0x01];
         let scripthash = ScriptHash::from_script_bytes(&script);
-        let (_dir, mut indexer) = indexer()?;
-
-        let tx_at_1 = tx(spent_outpoint(1, 0), script.clone());
-        let tx_at_256 = tx(spent_outpoint(2, 0), script);
-        indexer.ingest_block(&consensus_bytes(&block(vec![tx_at_1])), 1)?;
-        indexer.ingest_block(&consensus_bytes(&block(vec![tx_at_256])), 256)?;
-        indexer.flush()?;
+        let dir = tempfile::tempdir()?;
+        let store = Arc::new(RocksDbStore::open(dir.path())?);
+        put_funding_row(&store, scripthash, 1)?;
+        put_funding_row(&store, scripthash, 256)?;
+        let indexer = Indexer::new(store);
 
         let rows = indexer.iter_funding_rows(scripthash)?;
         assert_eq!(rows.len(), 2, "two heights funded the same script");
@@ -4084,13 +3482,13 @@ mod tests {
     fn iter_spending_rows_returns_indexed_rows() -> Result<(), Box<dyn std::error::Error>> {
         let outpoint = spent_outpoint(2, 3);
         let tx = tx(outpoint, vec![0x51, 0x02]);
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block(vec![tx])), HEIGHT)?;
+        writer.commit_block(0, &consensus_bytes(&block(vec![tx])))?;
 
         assert_eq!(
-            indexer.iter_spending_rows(&outpoint)?,
-            vec![SpendingPrefixRow::row(&outpoint, HEIGHT)]
+            writer.indexer().iter_spending_rows(&outpoint)?,
+            vec![SpendingPrefixRow::row(&outpoint, 0)]
         );
         Ok(())
     }
@@ -4099,90 +3497,12 @@ mod tests {
     fn iter_txid_rows_returns_indexed_rows() -> Result<(), Box<dyn std::error::Error>> {
         let tx = tx(spent_outpoint(4, 5), vec![0x51, 0x03]);
         let txid = tx.txid();
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block(vec![tx])), HEIGHT)?;
+        writer.commit_block(0, &consensus_bytes(&block(vec![tx])))?;
 
-        let rows = indexer.iter_txid_rows(&txid)?;
-        assert!(rows.contains(&TxidRow::row(&txid, HEIGHT)));
-        Ok(())
-    }
-
-    #[test]
-    fn decoded_verified_txid_ingest_matches_serialized_ingest()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let coinbase = tx(OutPoint::new(Txid::default(), u32::MAX), vec![0x51, 0x04]);
-        let spender = Tx {
-            version: 2,
-            lock_time: 0,
-            inputs: vec![TxIn {
-                previous_output: spent_outpoint(9, 1),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
-            }],
-            outputs: vec![
-                TxOut {
-                    value: 5_000,
-                    script_pubkey: vec![0x51, 0x05],
-                },
-                TxOut {
-                    value: 0,
-                    script_pubkey: vec![0x6a, 0x01, 0x00],
-                },
-            ],
-        };
-        let block = block(vec![coinbase, spender]);
-        let block_bytes = consensus_bytes(&block);
-        let txids = block.txs.iter().map(Tx::txid).collect::<Vec<_>>();
-        let (_serialized_dir, mut serialized_indexer) = indexer()?;
-        let (_decoded_dir, mut decoded_indexer) = indexer()?;
-
-        let serialized_counts =
-            serialized_indexer.ingest_block_with_verified_txids(&block_bytes, HEIGHT, &txids)?;
-        let decoded_counts = decoded_indexer.ingest_decoded_block_with_verified_txids(
-            &block,
-            &block_bytes,
-            HEIGHT,
-            &txids,
-        )?;
-
-        assert_eq!(decoded_counts, serialized_counts);
-        assert_eq!(
-            stored_rows(&decoded_indexer)?,
-            stored_rows(&serialized_indexer)?
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn decoded_verified_txid_ingest_mismatch_falls_back_to_serialized_ingest()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let decoded_block = block(vec![tx(
-            OutPoint::new(Txid::default(), u32::MAX),
-            vec![0x51, 0x08],
-        )]);
-        let serialized_block = block(vec![
-            tx(OutPoint::new(Txid::default(), u32::MAX), vec![0x51, 0x06]),
-            tx(spent_outpoint(10, 0), vec![0x51, 0x07]),
-        ]);
-        let serialized_block_bytes = consensus_bytes(&serialized_block);
-        let (_serialized_dir, mut serialized_indexer) = indexer()?;
-        let (_decoded_dir, mut decoded_indexer) = indexer()?;
-
-        let serialized_counts = serialized_indexer.ingest_block(&serialized_block_bytes, HEIGHT)?;
-        let decoded_counts = decoded_indexer.ingest_decoded_block_with_verified_txids(
-            &decoded_block,
-            &serialized_block_bytes,
-            HEIGHT,
-            &[],
-        )?;
-
-        assert_eq!(decoded_counts, serialized_counts);
-        assert_eq!(
-            stored_rows(&decoded_indexer)?,
-            stored_rows(&serialized_indexer)?
-        );
+        let rows = writer.indexer().iter_txid_rows(&txid)?;
+        assert!(rows.contains(&TxidRow::row(&txid, 0)));
         Ok(())
     }
 
@@ -4198,15 +3518,17 @@ mod tests {
         };
         let scripthash = ScriptHash::from_script_bytes(&output.script_pubkey);
         let txid = tx.txid();
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block), 0)?;
+        writer.commit_block(0, &consensus_bytes(&block))?;
 
         let source = FakeSource {
             block,
             target_height: 0,
         };
-        let entries = indexer.resolve_script_history(scripthash, &source)?;
+        let entries = writer
+            .indexer()
+            .resolve_script_history(scripthash, &source)?;
 
         assert_eq!(entries, vec![ScriptHistoryEntry::confirmed(txid, 0)]);
         Ok(())
@@ -4224,15 +3546,17 @@ mod tests {
         let scripthash = ScriptHash::from_script_bytes(&output.script_pubkey);
         let txid = tx.txid();
         let value = output.value;
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block), 0)?;
+        writer.commit_block(0, &consensus_bytes(&block))?;
 
         let source = FakeSource {
             block,
             target_height: 0,
         };
-        let outputs = indexer.resolve_unspent_outputs(scripthash, &source)?;
+        let outputs = writer
+            .indexer()
+            .resolve_unspent_outputs(scripthash, &source)?;
 
         assert_eq!(outputs, vec![(txid, 0, value)]);
         Ok(())
@@ -4247,15 +3571,15 @@ mod tests {
         };
         let coinbase = tx.clone();
         let txid = tx.txid();
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block), 0)?;
+        writer.commit_block(0, &consensus_bytes(&block))?;
 
         let source = FakeSource {
             block,
             target_height: 0,
         };
-        let resolved = indexer.resolve_transaction(txid, &source)?;
+        let resolved = writer.indexer().resolve_transaction(txid, &source)?;
 
         assert_eq!(resolved, Some(coinbase));
         Ok(())
@@ -4269,15 +3593,15 @@ mod tests {
             return Err(std::io::Error::other("genesis block has no transactions").into());
         };
         let txid = tx.txid();
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block), 0)?;
+        writer.commit_block(0, &consensus_bytes(&block))?;
 
         let source = FakeSource {
             block,
             target_height: 1,
         };
-        let resolved = indexer.resolve_transaction(txid, &source)?;
+        let resolved = writer.indexer().resolve_transaction(txid, &source)?;
 
         assert_eq!(resolved, None);
         Ok(())
@@ -4292,15 +3616,15 @@ mod tests {
         };
         let coinbase = tx.clone();
         let txid = tx.txid();
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block), 0)?;
+        writer.commit_block(0, &consensus_bytes(&block))?;
 
         let source = FakeSource {
             block,
             target_height: 0,
         };
-        let resolved = indexer.resolve_tx_with_height(txid, &source)?;
+        let resolved = writer.indexer().resolve_tx_with_height(txid, &source)?;
 
         assert_eq!(resolved, Some((coinbase, 0)));
         Ok(())
@@ -4309,14 +3633,17 @@ mod tests {
     #[test]
     fn resolve_tx_with_height_returns_none_for_unknown_txid()
     -> Result<(), Box<dyn std::error::Error>> {
-        let (_dir, indexer) = indexer()?;
+        let (_dir, writer) = writer()?;
         let txid = Txid(Hash256::from_le_bytes(&[0xff; 32]));
         let source = FakeSource {
             block: Network::Regtest.genesis_block(),
             target_height: 0,
         };
 
-        assert_eq!(indexer.resolve_tx_with_height(txid, &source)?, None);
+        assert_eq!(
+            writer.indexer().resolve_tx_with_height(txid, &source)?,
+            None
+        );
         Ok(())
     }
 
@@ -4328,41 +3655,41 @@ mod tests {
             return Err(std::io::Error::other("genesis block has no transactions").into());
         };
         let txid = tx.txid();
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block), 0)?;
+        writer.commit_block(0, &consensus_bytes(&block))?;
 
         let source = FakeSource {
             block,
             target_height: 0,
         };
         let outpoint = OutPoint { txid, vout: 0 };
-        let value = indexer.resolve_outpoint_value(outpoint, &source)?;
+        let value = writer.indexer().resolve_outpoint_value(outpoint, &source)?;
 
         assert_eq!(value, Some(5_000_000_000));
         Ok(())
     }
 
     #[test]
-    fn resolve_outpoint_value_via_indexerlike_dyn_source() -> Result<(), Box<dyn std::error::Error>>
-    {
+    fn resolve_outpoint_value_via_dyn_block_source() -> Result<(), Box<dyn std::error::Error>> {
         let block = Network::Regtest.genesis_block();
         let Some(tx) = block.txs.first() else {
             return Err(std::io::Error::other("genesis block has no transactions").into());
         };
         let txid = tx.txid();
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block), 0)?;
+        writer.commit_block(0, &consensus_bytes(&block))?;
 
         let source = FakeSource {
             block,
             target_height: 0,
         };
-        let dyn_indexer: &dyn super::IndexerLike = &indexer;
         let dyn_source: &dyn super::BlockSource = &source;
         let outpoint = OutPoint { txid, vout: 0 };
-        let value = dyn_indexer.resolve_outpoint_value(outpoint, dyn_source)?;
+        let value = writer
+            .indexer()
+            .resolve_outpoint_value(outpoint, dyn_source)?;
 
         assert_eq!(value, Some(5_000_000_000));
         Ok(())
@@ -4376,9 +3703,9 @@ mod tests {
             return Err(std::io::Error::other("genesis block has no transactions").into());
         };
         let txid = tx.txid();
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block), 0)?;
+        writer.commit_block(0, &consensus_bytes(&block))?;
 
         let source = FakeSource {
             block,
@@ -4386,14 +3713,17 @@ mod tests {
         };
         let outpoint = OutPoint { txid, vout: 99 };
 
-        assert_eq!(indexer.resolve_outpoint_value(outpoint, &source)?, None);
+        assert_eq!(
+            writer.indexer().resolve_outpoint_value(outpoint, &source)?,
+            None
+        );
         Ok(())
     }
 
     #[test]
     fn resolve_outpoint_value_returns_none_for_unknown_txid()
     -> Result<(), Box<dyn std::error::Error>> {
-        let (_dir, indexer) = indexer()?;
+        let (_dir, writer) = writer()?;
         let outpoint = OutPoint {
             txid: Txid(Hash256::from_le_bytes(&[0xff; 32])),
             vout: 0,
@@ -4403,7 +3733,10 @@ mod tests {
             target_height: 0,
         };
 
-        assert_eq!(indexer.resolve_outpoint_value(outpoint, &source)?, None);
+        assert_eq!(
+            writer.indexer().resolve_outpoint_value(outpoint, &source)?,
+            None
+        );
         Ok(())
     }
 
@@ -4420,15 +3753,17 @@ mod tests {
         let scripthash = ScriptHash::from_script_bytes(&output.script_pubkey);
         let txid = tx.txid();
         let value = output.value;
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
 
-        indexer.ingest_block(&consensus_bytes(&block), 0)?;
+        writer.commit_block(0, &consensus_bytes(&block))?;
 
         let source = FakeSource {
             block,
             target_height: 0,
         };
-        let outputs = indexer.resolve_unspent_outputs_with_height(scripthash, &source)?;
+        let outputs = writer
+            .indexer()
+            .resolve_unspent_outputs_with_height(scripthash, &source)?;
 
         assert_eq!(outputs, vec![(txid, 0, value, 0)]);
         Ok(())
@@ -4458,19 +3793,19 @@ mod tests {
     }
 
     #[test]
-    fn rollback_removes_every_row_a_matching_ingest_wrote() -> Result<(), Box<dyn std::error::Error>>
+    fn rollback_removes_every_row_a_matching_commit_wrote() -> Result<(), Box<dyn std::error::Error>>
     {
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
         let candidate = rollback_fixture_block();
-        let before = stored_rows(&indexer)?;
+        let body = consensus_bytes(&candidate);
+        let before = stored_rows(writer.indexer())?;
 
-        let written = indexer.ingest_block(&consensus_bytes(&candidate), HEIGHT)?;
-        let after_ingest = stored_rows(&indexer)?;
+        writer.commit_block(0, &body)?;
+        let after_commit = stored_rows(writer.indexer())?;
         assert!(
-            after_ingest.len() > before.len(),
+            after_commit.len() > before.len(),
             "fixture must write rows to be a meaningful rollback test"
         );
-        // All four column families must be exercised, or the test proves little.
         for cf in [
             ColumnFamily::TxConfirmed,
             ColumnFamily::Funding,
@@ -4478,107 +3813,58 @@ mod tests {
             ColumnFamily::BlockHeaders,
         ] {
             assert!(
-                after_ingest.iter().any(|(family, _)| *family == cf),
+                after_commit.iter().any(|(family, _)| *family == cf),
                 "fixture wrote no rows to {cf:?}"
             );
         }
 
-        let removed = indexer.rollback_block(&candidate, HEIGHT)?;
-        assert_eq!(removed.txids, written.txids);
-        assert_eq!(removed.funding, written.funding);
-        assert_eq!(removed.spending, written.spending);
-        assert_eq!(removed.headers, written.headers);
+        writer.commit_rollback_one(None, &body)?;
         assert_eq!(
-            stored_rows(&indexer)?,
+            stored_rows(writer.indexer())?,
             before,
-            "rollback must restore the pre-ingest row set exactly"
+            "rollback must restore the pre-commit row set exactly"
         );
         Ok(())
     }
 
     #[test]
-    fn last_counts_remains_ingest_after_rollback() -> Result<(), Box<dyn std::error::Error>> {
-        let (_dir, mut indexer) = indexer()?;
-        let old = rollback_fixture_block();
-        let old_written = indexer.ingest_block(&consensus_bytes(&old), HEIGHT)?;
-        let _ = indexer.rollback_block(&old, HEIGHT)?;
-
-        // A replacement at the same height with a different shape so its
-        // ingest counts differ from the old block's rollback counts.
-        let replacement = block(vec![
-            tx(OutPoint::new(Txid::default(), u32::MAX), vec![0x51]),
-            tx(OutPoint::new(Txid::default(), u32::MAX), vec![0x52]),
-        ]);
-        let replacement_written = indexer.ingest_block(&consensus_bytes(&replacement), HEIGHT)?;
-        assert_ne!(
-            replacement_written, old_written,
-            "replacement counts must differ from the old block's counts"
-        );
-
-        // Re-rolling the already-gone old block returns its original counts
-        // but must not overwrite the last successful ingest counts.
-        let old_again = indexer.rollback_block(&old, HEIGHT)?;
-        assert_eq!(old_again, old_written);
-        assert_eq!(
-            indexer.last_counts(),
-            replacement_written,
-            "last_counts must stay the last ingest counts, not the rollback counts"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn rollback_of_a_never_indexed_block_is_not_an_error() -> Result<(), Box<dyn std::error::Error>>
-    {
-        let (_dir, mut indexer) = indexer()?;
+    fn rollback_without_a_watermark_is_rejected() -> Result<(), Box<dyn std::error::Error>> {
+        let (_dir, mut writer) = writer()?;
         let candidate = rollback_fixture_block();
+        let body = consensus_bytes(&candidate);
 
-        // An indexer enabled after the block was applied never wrote its rows.
-        indexer.rollback_block(&candidate, HEIGHT)?;
-        assert!(stored_rows(&indexer)?.is_empty());
+        assert!(matches!(
+            writer.commit_rollback_one(None, &body),
+            Err(IndexError::NonContiguousPrepared { watermark: None })
+        ));
+        assert!(stored_rows(writer.indexer())?.is_empty());
         Ok(())
     }
 
     #[test]
-    fn repeated_rollback_is_not_an_error() -> Result<(), Box<dyn std::error::Error>> {
-        let (_dir, mut indexer) = indexer()?;
-        let candidate = rollback_fixture_block();
-        indexer.ingest_block(&consensus_bytes(&candidate), HEIGHT)?;
-
-        indexer.rollback_block(&candidate, HEIGHT)?;
-        let after_first = stored_rows(&indexer)?;
-        indexer.rollback_block(&candidate, HEIGHT)?;
-        assert_eq!(
-            stored_rows(&indexer)?,
-            after_first,
-            "a second rollback must be observationally inert"
-        );
-        Ok(())
-    }
-
-    /// Regression: rollback writes deletions straight to the store, so rows
-    /// still buffered in `pending_rows` used to survive it and a later
-    /// `end_batch` resurrected the disconnected block.
-    #[test]
-    fn rollback_inside_an_open_batch_is_not_undone_by_end_batch()
+    fn a_second_rollback_is_rejected_once_the_watermark_is_gone()
     -> Result<(), Box<dyn std::error::Error>> {
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
         let candidate = rollback_fixture_block();
+        let body = consensus_bytes(&candidate);
+        writer.commit_block(0, &body)?;
+        writer.commit_rollback_one(None, &body)?;
+        let after_first = stored_rows(writer.indexer())?;
 
-        indexer.begin_batch();
-        indexer.ingest_block(&consensus_bytes(&candidate), HEIGHT)?;
-        indexer.rollback_block(&candidate, HEIGHT)?;
-        indexer.end_batch()?;
-
-        assert!(
-            stored_rows(&indexer)?.is_empty(),
-            "end_batch must not write back rows for a rolled-back block"
+        assert!(matches!(
+            writer.commit_rollback_one(None, &body),
+            Err(IndexError::NonContiguousPrepared { watermark: None })
+        ));
+        assert_eq!(
+            stored_rows(writer.indexer())?,
+            after_first,
+            "a rejected second rollback must be observationally inert"
         );
         Ok(())
     }
 
     /// Delegates reads to a real store but fails every write API, so the
-    /// all-or-nothing claim on `rollback_block` is exercised through its
+    /// all-or-nothing claim on `commit_rollback_one` is exercised through its
     /// current conditional durable path.
     struct FailingWriteStore(RocksDbStore);
 
@@ -4637,13 +3923,12 @@ mod tests {
     fn rollback_deletes_nothing_when_the_write_fails() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let candidate = rollback_fixture_block();
+        let body = consensus_bytes(&candidate);
 
-        // Populate through a normal indexer, then reopen behind the failing
-        // store so the rows exist but no write can land.
         {
             let store = Arc::new(RocksDbStore::open(dir.path())?);
-            let mut indexer = Indexer::new(store);
-            indexer.ingest_block(&consensus_bytes(&candidate), HEIGHT)?;
+            let mut writer = IndexWriter::open(store, 1)?;
+            writer.commit_block(0, &body)?;
         }
         let store = Arc::new(RocksDbStore::open(dir.path())?);
         let before = stored_rows(&Indexer::new(Arc::clone(&store)))?;
@@ -4651,10 +3936,10 @@ mod tests {
         drop(store);
 
         let failing = Arc::new(FailingWriteStore(RocksDbStore::open(dir.path())?));
-        let mut indexer = Indexer::new(Arc::clone(&failing));
-        let outcome = indexer.rollback_block(&candidate, HEIGHT);
+        let mut writer = IndexWriter::open(Arc::clone(&failing), 1)?;
+        let outcome = writer.commit_rollback_one(None, &body);
         assert!(outcome.is_err(), "a failing write must surface as an error");
-        drop(indexer);
+        drop(writer);
         drop(failing);
 
         let reopened = Indexer::new(Arc::new(RocksDbStore::open(dir.path())?));
@@ -4666,64 +3951,17 @@ mod tests {
         Ok(())
     }
 
-    /// An indexer that persists nothing and does not override the rollback
-    /// default. It must refuse rather than report a successful no-op, or the
-    /// node would advance its tip believing a stale index is consistent.
-    struct RollbackUnawareIndexer;
-
-    impl super::IndexerLike for RollbackUnawareIndexer {
-        fn ingest_block(
-            &mut self,
-            _block: &[u8],
-            _height: u32,
-        ) -> Result<super::IndexRowCounts, super::IndexError> {
-            Ok(super::IndexRowCounts::default())
-        }
-
-        fn resolve_transaction(
-            &self,
-            _txid: Txid,
-            _source: &dyn BlockSource,
-        ) -> Result<Option<Tx>, super::IndexError> {
-            Ok(None)
-        }
-
-        fn resolve_outpoint_value(
-            &self,
-            _outpoint: OutPoint,
-            _source: &dyn BlockSource,
-        ) -> Result<Option<u64>, super::IndexError> {
-            Ok(None)
-        }
-    }
-
-    #[test]
-    fn the_rollback_default_refuses_rather_than_silently_succeeding() {
-        let mut indexer = RollbackUnawareIndexer;
-        let candidate = rollback_fixture_block();
-        assert!(matches!(
-            super::IndexerLike::rollback_block(&mut indexer, &candidate, HEIGHT),
-            Err(super::IndexError::UnsupportedRollback)
-        ));
-    }
-
-    /// A repeated rollback must not delete a replacement block's rows.
+    /// A rollback of a replaced tip must not delete the replacement's rows.
     ///
-    /// Funding, spending, and txid keys are an 8-byte prefix plus the height
-    /// and carry no block identity, so a replacement at the same height that
-    /// shares an output script derives the same keys. Without the header-row
-    /// identity check, rolling the old block back twice deleted the
-    /// replacement's history.
+    /// `commit_rollback_one` checks the current watermark hash against the
+    /// serialized body, so a stale body's identity cannot satisfy the tip
+    /// and the replacement's prefix-colliding history stays put.
     #[test]
-    fn a_repeated_rollback_leaves_a_replacement_blocks_rows_alone()
+    fn a_stale_rollback_body_leaves_a_replacement_blocks_rows_alone()
     -> Result<(), Box<dyn std::error::Error>> {
-        let (_dir, mut indexer) = indexer()?;
+        let (_dir, mut writer) = writer()?;
         let shared_script = vec![0x51];
 
-        // Two different blocks at the same height that both pay the same
-        // script, so their funding rows collide.
-        // The shared `block` fixture pins a zero merkle root, so the nonce is
-        // what distinguishes these two headers.
         let mut old_block = block(vec![tx(
             OutPoint::new(Txid(Hash256::from_le_bytes(&[0xa1; 32])), 0),
             shared_script.clone(),
@@ -4740,33 +3978,51 @@ mod tests {
             "the two blocks must differ, or there is nothing to confuse"
         );
 
-        indexer.ingest_block(&consensus_bytes(&old_block), HEIGHT)?;
-        indexer.rollback_block(&old_block, HEIGHT)?;
-        indexer.ingest_block(&consensus_bytes(&replacement), HEIGHT)?;
-        indexer.flush()?;
-        let after_replacement = stored_rows(&indexer)?;
+        let old_body = consensus_bytes(&old_block);
+        writer.commit_block(0, &old_body)?;
+        writer.commit_rollback_one(None, &old_body)?;
+        writer.commit_block(0, &consensus_bytes(&replacement))?;
+        writer.flush()?;
+        let after_replacement = stored_rows(writer.indexer())?;
         assert!(
             !after_replacement.is_empty(),
             "the replacement must have written rows"
         );
 
-        // Roll the OLD block back again. It is already gone; its keys now
-        // belong to the replacement.
-        indexer.rollback_block(&old_block, HEIGHT)?;
-        indexer.flush()?;
+        assert!(
+            writer.commit_rollback_one(None, &old_body).is_err(),
+            "rolling back the old body against the replacement watermark must fail"
+        );
+        writer.flush()?;
 
         assert_eq!(
-            stored_rows(&indexer)?,
+            stored_rows(writer.indexer())?,
             after_replacement,
-            "a repeated rollback must not touch the replacement's rows"
+            "a stale rollback body must not touch the replacement's rows"
         );
         Ok(())
     }
 
-    fn indexer() -> Result<(tempfile::TempDir, Indexer<RocksDbStore>), Box<dyn std::error::Error>> {
+    fn writer() -> Result<(tempfile::TempDir, IndexWriter<RocksDbStore>), Box<dyn std::error::Error>>
+    {
         let dir = tempfile::tempdir()?;
         let store = Arc::new(RocksDbStore::open(dir.path())?);
-        Ok((dir, Indexer::new(store)))
+        Ok((dir, IndexWriter::open(store, 1)?))
+    }
+
+    fn put_funding_row(
+        store: &RocksDbStore,
+        scripthash: ScriptHash,
+        height: u32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut batch = store.new_batch();
+        batch.put(
+            ColumnFamily::Funding,
+            &ScriptHashRow::row(scripthash, height).to_db_row(),
+            &[],
+        );
+        store.write(batch)?;
+        Ok(())
     }
 
     fn stored_rows(

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -2960,6 +2960,15 @@ impl<S: KvStore> IndexWriter<S> {
     /// Production catch-up uses [`Self::prepare_block_with_spent_scripts`] plus
     /// [`PreparedBatch`] to bound multi-block writes. This is the same owner
     /// for a single block: tests and benches must not grow a second ingest path.
+    ///
+    /// [`Self::commit_forward`] is the commit point (`IDX-06`): `Ok` means the
+    /// prepared rows and capability watermark are durable together in one store
+    /// batch. A crash before that write leaves the previous watermark and rows;
+    /// a crash after it leaves both. Fence races
+    /// ([`IndexError::StaleIndexState`], [`IndexError::ResetInProgress`]) mean
+    /// discard derived state and retry from the persisted watermark.
+    /// [`IndexError::Storage`] is not retried by the index worker; supervision
+    /// marks it failed (`IDX-07`).
     pub fn commit_block(&mut self, height: u32, body: &[u8]) -> Result<IndexWatermark, IndexError> {
         let header = body.get(..crate::types::HEADER_ROW_SIZE).ok_or_else(|| {
             IndexError::InvalidHeaderLength {
@@ -2983,7 +2992,11 @@ impl<S: KvStore> IndexWriter<S> {
     /// Atomically connects a bounded batch and advances the durable watermark.
     ///
     /// Captures its own fence before any store-dependent derivation and keeps
-    /// the consumer cursor untouched.
+    /// the consumer cursor untouched. Rows and the selected watermarks land in
+    /// one `write_durable_if` batch; `Ok` is the commit point (`IDX-06`). Fence
+    /// races return [`IndexError::StaleIndexState`] or
+    /// [`IndexError::ResetInProgress`]; the worker re-reads watermarks and
+    /// re-plans. [`IndexError::Storage`] fails the worker (`IDX-07`).
     pub fn commit_forward(&mut self, batch: PreparedBatch) -> Result<IndexWatermark, IndexError> {
         let (fence, _) = self.fenced_watermarks()?;
         self.commit_forward_with_cursor(fence, batch, ConsumerCursorUpdate::Keep)

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -11,9 +11,9 @@ pub mod types;
 pub use index::{
     BlockSource, ConsumerCursorUpdate, INDEX_FORMAT_VERSION, IndexCapabilities, IndexCapability,
     IndexError, IndexFormat, IndexReader, IndexRowCounts, IndexWatermark, IndexWatermarks,
-    IndexWriteFence, IndexWriter, Indexer, IndexerLike, MAX_LIVE_SCRIPT_SIZE, NoSpentScripts,
-    PreparedBatch, PreparedBatchLimits, PreparedBlock, ScriptHistoryEntry, ScriptLiveScan,
-    SpentCoinScripts, TxIndexScan, TxIndexScanRow, TxIndexSnapshot,
+    IndexWriteFence, IndexWriter, Indexer, MAX_LIVE_SCRIPT_SIZE, NoSpentScripts, PreparedBatch,
+    PreparedBatchLimits, PreparedBlock, ScriptHistoryEntry, ScriptLiveScan, SpentCoinScripts,
+    TxIndexScan, TxIndexScanRow, TxIndexSnapshot,
 };
 pub use mempool::{MempoolRowCounts, MempoolRowWriter};
 pub use types::{

--- a/crates/index/tests/common/mod.rs
+++ b/crates/index/tests/common/mod.rs
@@ -7,6 +7,8 @@
 
 use std::collections::BTreeMap;
 
+use bitcoin_rs_index::{ScriptHash, ScriptHashRow, SpendingPrefixRow};
+use bitcoin_rs_primitives::OutPoint;
 use bitcoin_rs_storage::{
     ColumnFamily, KvIter, KvSnapshot, KvStore, StorageError, WriteBatch, WriteCondition,
 };
@@ -148,6 +150,36 @@ impl KvSnapshot for MemorySnapshot {
             .collect::<Vec<_>>();
         Ok(Box::new(rows.into_iter()))
     }
+}
+
+/// Writes one funding-row key at `height` with an empty value.
+///
+/// Empty values take the scan-fallback resolver path. Tests that pin
+/// little-endian key order, not watermark contiguity, use this instead of
+/// [`bitcoin_rs_index::IndexWriter::commit_block`].
+pub(crate) fn put_funding_row(
+    store: &MemoryStore,
+    scripthash: ScriptHash,
+    height: u32,
+) -> Result<(), StorageError> {
+    store.put(
+        ColumnFamily::Funding,
+        &ScriptHashRow::row(scripthash, height).to_db_row(),
+        &[],
+    )
+}
+
+/// Writes one spending-row key at `height` with an empty value.
+pub(crate) fn put_spending_row(
+    store: &MemoryStore,
+    outpoint: &OutPoint,
+    height: u32,
+) -> Result<(), StorageError> {
+    store.put(
+        ColumnFamily::Spending,
+        &SpendingPrefixRow::row(outpoint, height).to_db_row(),
+        &[],
+    )
 }
 
 /// Folds one batch's operations into the column families, in order.

--- a/crates/index/tests/index_roundtrip.rs
+++ b/crates/index/tests/index_roundtrip.rs
@@ -9,8 +9,7 @@ use std::{
 };
 
 use bitcoin_rs_primitives::{
-    Block, Hash256, Network, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-    encode::double_sha256,
+    Block, Network, OutPoint, Tx, TxIn, TxOut, consensus_bytes, encode::double_sha256,
 };
 use parking_lot::{Mutex, RwLock};
 
@@ -497,7 +496,7 @@ impl KvSnapshot for MemorySnapshot {
 }
 
 #[test]
-fn ingest_golden_blocks_writes_expected_electrs_rows() -> Result<(), Box<dyn std::error::Error>> {
+fn commit_golden_blocks_writes_expected_electrs_rows() -> Result<(), Box<dyn std::error::Error>> {
     let cases = [
         (
             0_u32,
@@ -533,12 +532,25 @@ fn ingest_golden_blocks_writes_expected_electrs_rows() -> Result<(), Box<dyn std
 
     for (height, expected) in cases {
         let store = std::sync::Arc::new(MemoryStore::default());
-        let mut indexer = Indexer::new(std::sync::Arc::clone(&store));
+        let mut writer = IndexWriter::open(std::sync::Arc::clone(&store), 1)?;
         let block = read_fixture(height)?;
+        let hash = block_hash(&block);
+        let prepared = writer.prepare_block(height, hash, &block)?;
+        assert_eq!(
+            prepared.row_counts(),
+            expected,
+            "height {height} prepared counts"
+        );
 
-        let counts = indexer.ingest_block(&block, height)?;
-
-        assert_eq!(counts, expected, "height {height} returned counts");
+        // Watermark contiguity starts at height 0. Commit the same body at
+        // genesis so store occupancy is checked through the sole mutation
+        // owner; row cardinality does not depend on the height suffix.
+        writer.commit_block(0, &block)?;
+        assert_eq!(
+            writer.last_counts(),
+            expected,
+            "height {height} committed counts"
+        );
         assert_eq!(
             store.count(ColumnFamily::TxConfirmed),
             expected.txids,
@@ -563,94 +575,11 @@ fn ingest_golden_blocks_writes_expected_electrs_rows() -> Result<(), Box<dyn std
     Ok(())
 }
 
-#[test]
-fn ingest_with_precomputed_txids_matches_standard_ingest() -> Result<(), Box<dyn std::error::Error>>
-{
-    let height = 170_u32;
-    let block_bytes = read_fixture(height)?;
-    let block = Block::consensus_decode(&block_bytes)?;
-    let txids = block.txs.iter().map(Tx::txid).collect::<Vec<_>>();
-
-    assert_precomputed_ingest_matches_standard(&block_bytes, height, &txids)
-}
-
-#[test]
-fn ingest_with_verified_txids_matches_standard_ingest() -> Result<(), Box<dyn std::error::Error>> {
-    let height = 170_u32;
-    let block_bytes = read_fixture(height)?;
-    let block = Block::consensus_decode(&block_bytes)?;
-    let txids = block.txs.iter().map(Tx::txid).collect::<Vec<_>>();
-
-    assert_verified_ingest_matches_standard(&block_bytes, height, &txids)
-}
-
-#[test]
-fn ingest_with_mismatched_precomputed_txids_falls_back_to_standard_ingest()
--> Result<(), Box<dyn std::error::Error>> {
-    let height = 170_u32;
-    let block_bytes = read_fixture(height)?;
-
-    assert_precomputed_ingest_matches_standard(&block_bytes, height, &[])
-}
-
-#[test]
-fn ingest_with_same_length_wrong_precomputed_txids_falls_back_to_standard_ingest()
--> Result<(), Box<dyn std::error::Error>> {
-    let height = 170_u32;
-    let block_bytes = read_fixture(height)?;
-    let block = Block::consensus_decode(&block_bytes)?;
-    let stale_txids = vec![Txid(Hash256::from_le_bytes(&[0x42; 32])); block.txs.len()];
-
-    assert_precomputed_ingest_matches_standard(&block_bytes, height, &stale_txids)
-}
-
 fn read_fixture(height: u32) -> Result<Vec<u8>, std::io::Error> {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../primitives/tests/testdata")
         .join(format!("{height}.bin"));
     std::fs::read(path)
-}
-
-fn assert_precomputed_ingest_matches_standard(
-    block: &[u8],
-    height: u32,
-    txids: &[Txid],
-) -> Result<(), Box<dyn std::error::Error>> {
-    assert_ingest_matches_standard(block, height, |indexer| {
-        indexer.ingest_block_with_txids(block, height, txids)
-    })
-}
-
-fn assert_verified_ingest_matches_standard(
-    block: &[u8],
-    height: u32,
-    txids: &[Txid],
-) -> Result<(), Box<dyn std::error::Error>> {
-    assert_ingest_matches_standard(block, height, |indexer| {
-        indexer.ingest_block_with_verified_txids(block, height, txids)
-    })
-}
-
-fn assert_ingest_matches_standard(
-    block: &[u8],
-    height: u32,
-    ingest: impl FnOnce(
-        &mut Indexer<MemoryStore>,
-    ) -> Result<IndexRowCounts, bitcoin_rs_index::IndexError>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let standard_store = std::sync::Arc::new(MemoryStore::default());
-    let mut standard_indexer = Indexer::new(std::sync::Arc::clone(&standard_store));
-    let candidate_store = std::sync::Arc::new(MemoryStore::default());
-    let mut candidate_indexer = Indexer::new(std::sync::Arc::clone(&candidate_store));
-
-    let standard_counts = standard_indexer.ingest_block(block, height)?;
-    let candidate_counts = ingest(&mut candidate_indexer)?;
-
-    assert_eq!(candidate_counts, standard_counts);
-    for &cf in ColumnFamily::ALL {
-        assert_eq!(candidate_store.rows(cf), standard_store.rows(cf));
-    }
-    Ok(())
 }
 
 fn block_hash(body: &[u8]) -> [u8; 32] {
@@ -743,9 +672,7 @@ fn format_3_open_resets_only_script_history() -> Result<(), Box<dyn std::error::
 #[test]
 fn unversioned_rows_are_rejected() -> Result<(), Box<dyn std::error::Error>> {
     let store = Arc::new(MemoryStore::default());
-    let mut indexer = Indexer::new(Arc::clone(&store));
-    let body = read_fixture(0)?;
-    indexer.ingest_block(&body, 0)?;
+    store.put(ColumnFamily::TxConfirmed, b"orphan-row", &[])?;
 
     assert!(matches!(
         IndexWriter::open(Arc::clone(&store), 1),
@@ -1369,42 +1296,11 @@ fn consumer_cursor_commit_is_excluded_by_a_reset_claim() -> Result<(), Box<dyn s
 }
 
 #[test]
-fn legacy_flush_discards_rows_rejected_by_a_reset_fence() -> Result<(), Box<dyn std::error::Error>>
-{
-    let store = Arc::new(MemoryStore::default());
-    let mut indexer = Indexer::new(Arc::clone(&store));
-    indexer.begin_batch();
-    indexer.ingest_block(&read_fixture(0)?, 0)?;
-    let mut claim = store.new_batch();
-    claim.put(
-        ColumnFamily::UtxoMeta,
-        RESET_KEY,
-        &fenced_marker(TX_LOOKUP_MASK, 9),
-    );
-    claim.put(ColumnFamily::UtxoMeta, FORMAT_KEY, &FORMAT_VALUE);
-    claim.delete(ColumnFamily::UtxoMeta, TX_WATERMARK_KEY);
-    claim.delete(ColumnFamily::UtxoMeta, CURSOR_KEY);
-    store.write_durable(claim)?;
-
-    assert!(matches!(
-        indexer.end_batch(),
-        Err(IndexError::ResetInProgress)
-    ));
-    IndexWriter::open(Arc::clone(&store), 4)?;
-    indexer.begin_batch();
-    indexer.end_batch()?;
-    assert_eq!(store.count(ColumnFamily::TxConfirmed), 0);
-    assert_eq!(store.count(ColumnFamily::BlockHeaders), 0);
-    Ok(())
-}
-
-#[test]
-fn legacy_rollback_is_excluded_by_a_reset_fence() -> Result<(), Box<dyn std::error::Error>> {
+fn rollback_is_excluded_by_a_reset_fence() -> Result<(), Box<dyn std::error::Error>> {
     let store = Arc::new(MemoryStore::default());
     let body = read_fixture(0)?;
-    let block: Block = bitcoin_rs_primitives::deserialize(&body)?;
-    let mut indexer = Indexer::new(Arc::clone(&store));
-    indexer.ingest_block(&body, 0)?;
+    let mut writer = IndexWriter::open(Arc::clone(&store), 1)?;
+    writer.commit_block(0, &body)?;
     let rows_before = store.rows(ColumnFamily::TxConfirmed);
     let mut claim = store.new_batch();
     claim.put(
@@ -1418,7 +1314,7 @@ fn legacy_rollback_is_excluded_by_a_reset_fence() -> Result<(), Box<dyn std::err
     store.write_durable(claim)?;
 
     assert!(matches!(
-        indexer.rollback_block(&block, 0),
+        writer.commit_rollback_one(None, &body),
         Err(IndexError::ResetInProgress)
     ));
     assert_eq!(store.rows(ColumnFamily::TxConfirmed), rows_before);
@@ -2787,16 +2683,19 @@ fn each_ordinary_mutator_advances_the_revision_exactly_once()
     )?;
     assert_state_revision(&store, Some(3))?;
 
-    // 4. legacy batched ingest flush
-    let mut indexer = Indexer::new(Arc::clone(&store));
-    indexer.begin_batch();
-    indexer.ingest_block(&body0, 0)?;
-    indexer.end_batch()?;
+    // 4. reconnect the rolled-back capability
+    let block =
+        writer.prepare_block_for(IndexCapabilities::TX_LOOKUP, 0, block_hash(&body0), &body0)?;
+    let mut prepared = PreparedBatch::new(PreparedBatchLimits {
+        max_rows: 100,
+        max_bytes: 1_000_000,
+    });
+    assert!(prepared.try_push(block).is_ok());
+    writer.commit_forward(prepared)?;
     assert_state_revision(&store, Some(4))?;
 
-    // 5. legacy rollback
-    let block: Block = bitcoin_rs_primitives::deserialize(&body0)?;
-    indexer.rollback_block(&block, 0)?;
+    // 5. rollback that capability again
+    writer.commit_rollback_one_for(IndexCapabilities::TX_LOOKUP, None, &body0)?;
     assert_state_revision(&store, Some(5))?;
     assert_eq!(
         stored_state_revision(&store)?,

--- a/crates/index/tests/index_roundtrip.rs
+++ b/crates/index/tests/index_roundtrip.rs
@@ -495,6 +495,7 @@ impl KvSnapshot for MemorySnapshot {
     }
 }
 
+/// CONTRACT: IDX-06 — electrs-shaped occupancy after one atomic forward commit.
 #[test]
 fn commit_golden_blocks_writes_expected_electrs_rows() -> Result<(), Box<dyn std::error::Error>> {
     let cases = [

--- a/crates/index/tests/le_order.rs
+++ b/crates/index/tests/le_order.rs
@@ -12,11 +12,9 @@ mod common;
 use std::sync::Arc;
 
 use bitcoin_rs_index::{BlockSource, Indexer, ScriptHash};
-use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-};
+use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
 
-use common::MemoryStore;
+use common::{MemoryStore, put_funding_row, put_spending_row};
 
 /// A block source backed by a simple map, serving multiple heights.
 struct MultiHeightSource {
@@ -65,14 +63,18 @@ fn spent_outpoint(label: u8, vout: u32) -> OutPoint {
 /// iterate in numeric order under LE keys, but `resolve_script_history` DOES
 /// sort by numeric height.
 #[test]
-fn le_key_order_differs_from_numeric_and_history_sorts_by_height() {
+fn le_key_order_differs_from_numeric_and_history_sorts_by_height()
+-> Result<(), Box<dyn std::error::Error>> {
     let script = vec![0x51, 0x01];
     let scripthash = ScriptHash::from_script_bytes(&script);
-    let mut indexer = Indexer::new(Arc::new(MemoryStore::default()));
+    let store = Arc::new(MemoryStore::default());
+    put_funding_row(&store, scripthash, 1)?;
+    put_funding_row(&store, scripthash, 256)?;
+    let indexer = Indexer::new(store);
 
-    // Ingest a block at height 1 funding the script, then a block at height 256
-    // funding the same script. Both produce a funding row with the same 8-byte
-    // prefix; only the height suffix differs.
+    // Direct keys at heights 1 and 256: both produce a funding row with the
+    // same 8-byte prefix; only the height suffix differs. `commit_block`
+    // cannot write a gapped height, so these tests own the keys themselves.
     let block_at_1 = Block {
         header: header(),
         txs: vec![tx_with_script(spent_outpoint(1, 0), script.clone())],
@@ -82,18 +84,9 @@ fn le_key_order_differs_from_numeric_and_history_sorts_by_height() {
         txs: vec![tx_with_script(spent_outpoint(2, 0), script)],
     };
 
-    let Ok(_) = indexer.ingest_block(&consensus_bytes(&block_at_1), 1) else {
-        panic!("ingest height 1");
-    };
-    let Ok(_) = indexer.ingest_block(&consensus_bytes(&block_at_256), 256) else {
-        panic!("ingest height 256");
-    };
-
     // --- Part A: iter_funding_rows returns LE byte order, not numeric ---
 
-    let Ok(rows) = indexer.iter_funding_rows(scripthash) else {
-        panic!("iter_funding_rows");
-    };
+    let rows = indexer.iter_funding_rows(scripthash)?;
     assert_eq!(rows.len(), 2, "two heights funded the same script");
 
     // Height 256 is [0x00, 0x01, 0x00, 0x00]; height 1 is [0x01, 0x00, 0x00, 0x00].
@@ -125,9 +118,7 @@ fn le_key_order_differs_from_numeric_and_history_sorts_by_height() {
     let source = MultiHeightSource {
         blocks: [(1, block_at_1), (256, block_at_256)].into_iter().collect(),
     };
-    let Ok(entries) = indexer.resolve_script_history(scripthash, &source) else {
-        panic!("resolve_script_history");
-    };
+    let entries = indexer.resolve_script_history(scripthash, &source)?;
 
     assert_eq!(entries.len(), 2, "two confirmed entries");
     // Entries must be in numeric height order: 1 before 256, even though
@@ -141,15 +132,19 @@ fn le_key_order_differs_from_numeric_and_history_sorts_by_height() {
     // The first entry's txid must come from the height-1 block.
     assert_eq!(entries[0].txid, txid_at_1);
     assert_eq!(entries[1].txid, txid_at_256);
+    Ok(())
 }
 
 /// The scan reference resolver also sorts by numeric height, agreeing with
 /// the fast resolver.
 #[test]
-fn history_scan_resolver_also_sorts_by_height() {
+fn history_scan_resolver_also_sorts_by_height() -> Result<(), Box<dyn std::error::Error>> {
     let script = vec![0x51, 0x02];
     let scripthash = ScriptHash::from_script_bytes(&script);
-    let mut indexer = Indexer::new(Arc::new(MemoryStore::default()));
+    let store = Arc::new(MemoryStore::default());
+    put_funding_row(&store, scripthash, 1)?;
+    put_funding_row(&store, scripthash, 256)?;
+    let indexer = Indexer::new(store);
 
     let block_at_1 = Block {
         header: header(),
@@ -160,23 +155,12 @@ fn history_scan_resolver_also_sorts_by_height() {
         txs: vec![tx_with_script(spent_outpoint(4, 0), script)],
     };
 
-    let Ok(_) = indexer.ingest_block(&consensus_bytes(&block_at_1), 1) else {
-        panic!("ingest height 1");
-    };
-    let Ok(_) = indexer.ingest_block(&consensus_bytes(&block_at_256), 256) else {
-        panic!("ingest height 256");
-    };
-
     let source = MultiHeightSource {
         blocks: [(1, block_at_1), (256, block_at_256)].into_iter().collect(),
     };
 
-    let Ok(fast) = indexer.resolve_script_history(scripthash, &source) else {
-        panic!("fast resolver");
-    };
-    let Ok(scan) = indexer.resolve_script_history_scan(scripthash, &source) else {
-        panic!("scan resolver");
-    };
+    let fast = indexer.resolve_script_history(scripthash, &source)?;
+    let scan = indexer.resolve_script_history_scan(scripthash, &source)?;
 
     assert_eq!(fast, scan, "fast and scan resolvers must agree on order");
     assert_eq!(
@@ -184,14 +168,18 @@ fn history_scan_resolver_also_sorts_by_height() {
         vec![1, 256],
         "both resolvers sort by numeric height"
     );
+    Ok(())
 }
 
 /// `resolve_unspent_outputs_with_height` also sorts by numeric height.
 #[test]
-fn unspent_outputs_with_height_sorts_by_numeric_height() {
+fn unspent_outputs_with_height_sorts_by_numeric_height() -> Result<(), Box<dyn std::error::Error>> {
     let script = vec![0x51, 0x03];
     let scripthash = ScriptHash::from_script_bytes(&script);
-    let mut indexer = Indexer::new(Arc::new(MemoryStore::default()));
+    let store = Arc::new(MemoryStore::default());
+    put_funding_row(&store, scripthash, 1)?;
+    put_funding_row(&store, scripthash, 256)?;
+    let indexer = Indexer::new(store);
 
     let block_at_1 = Block {
         header: header(),
@@ -202,20 +190,11 @@ fn unspent_outputs_with_height_sorts_by_numeric_height() {
         txs: vec![tx_with_script(spent_outpoint(6, 0), script)],
     };
 
-    let Ok(_) = indexer.ingest_block(&consensus_bytes(&block_at_1), 1) else {
-        panic!("ingest height 1");
-    };
-    let Ok(_) = indexer.ingest_block(&consensus_bytes(&block_at_256), 256) else {
-        panic!("ingest height 256");
-    };
-
     let source = MultiHeightSource {
         blocks: [(1, block_at_1), (256, block_at_256)].into_iter().collect(),
     };
 
-    let Ok(outputs) = indexer.resolve_unspent_outputs_with_height(scripthash, &source) else {
-        panic!("resolve_unspent_outputs_with_height");
-    };
+    let outputs = indexer.resolve_unspent_outputs_with_height(scripthash, &source)?;
 
     assert_eq!(outputs.len(), 2);
     assert_eq!(
@@ -223,42 +202,25 @@ fn unspent_outputs_with_height_sorts_by_numeric_height() {
         vec![1, 256],
         "unspent outputs must be sorted by numeric height"
     );
+    Ok(())
 }
 
 /// Spending rows share the same LE height-order caveat as funding rows.
 /// This test confirms the on-disk key for spending rows also uses LE height,
 /// so `iter_spending_rows` returns LE byte order, not numeric.
 #[test]
-fn spending_rows_also_use_le_height_order() {
-    let script = vec![0x51, 0x04];
+fn spending_rows_also_use_le_height_order() -> Result<(), Box<dyn std::error::Error>> {
     let outpoint = spent_outpoint(7, 0);
+    let store = Arc::new(MemoryStore::default());
+    put_spending_row(&store, &outpoint, 1)?;
+    put_spending_row(&store, &outpoint, 256)?;
+    let indexer = Indexer::new(store);
 
-    // Block at height 1 spends the outpoint; block at height 256 also spends
-    // it (different block, same prevout — unrealistic on a real chain but
-    // sufficient to create two spending rows with the same prefix).
-    let block_at_1 = Block {
-        header: header(),
-        txs: vec![tx_with_script(outpoint, script.clone())],
-    };
-    let block_at_256 = Block {
-        header: header(),
-        txs: vec![tx_with_script(outpoint, script)],
-    };
-
-    let mut indexer = Indexer::new(Arc::new(MemoryStore::default()));
-    let Ok(_) = indexer.ingest_block(&consensus_bytes(&block_at_1), 1) else {
-        panic!("ingest height 1");
-    };
-    let Ok(_) = indexer.ingest_block(&consensus_bytes(&block_at_256), 256) else {
-        panic!("ingest height 256");
-    };
-
-    let Ok(rows) = indexer.iter_spending_rows(&outpoint) else {
-        panic!("iter_spending_rows");
-    };
+    let rows = indexer.iter_spending_rows(&outpoint)?;
     assert_eq!(rows.len(), 2, "two spending rows at two heights");
 
     // LE byte order: 256 before 1.
     assert_eq!(rows[0].height(), 256);
     assert_eq!(rows[1].height(), 1);
+    Ok(())
 }

--- a/crates/index/tests/resolver_fallback.rs
+++ b/crates/index/tests/resolver_fallback.rs
@@ -6,7 +6,9 @@ mod common;
 use std::sync::Arc;
 
 use bitcoin_rs_index::types::{TxPosition, TxPositionValue};
-use bitcoin_rs_index::{BlockSource, Indexer, ScriptHash, ScriptHashRow, ScriptHistoryEntry};
+use bitcoin_rs_index::{
+    BlockSource, IndexWriter, Indexer, ScriptHash, ScriptHashRow, ScriptHistoryEntry,
+};
 use bitcoin_rs_primitives::{
     Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes, varint,
 };
@@ -14,7 +16,7 @@ use bitcoin_rs_storage::{ColumnFamily, KvStore as _, WriteBatch as _};
 
 use common::MemoryStore;
 
-const HEIGHT: u32 = 100;
+const HEIGHT: u32 = 0;
 
 struct FixtureSource {
     block: Block,
@@ -93,8 +95,8 @@ fn eight_byte_prefix_collision_resolves_full_script_identity()
     let target = ScriptHash::from_script_bytes(&target_script);
     let row = ScriptHashRow::row(target, HEIGHT).to_db_row();
     let store = Arc::new(MemoryStore::default());
-    let mut indexer = Indexer::new(Arc::clone(&store));
-    indexer.ingest_block(&bytes, HEIGHT)?;
+    IndexWriter::open(Arc::clone(&store), 1)?.commit_block(0, &bytes)?;
+    let indexer = Indexer::new(Arc::clone(&store));
 
     // A real eight-byte collision makes the writer merge both valid positions
     // under one row key. Model that persisted result directly; unlike the

--- a/crates/index/tests/tx_positions.rs
+++ b/crates/index/tests/tx_positions.rs
@@ -12,7 +12,7 @@ mod common;
 use std::sync::Arc;
 
 use bitcoin_rs_index::types::{TxPosition, TxPositionValue};
-use bitcoin_rs_index::{Indexer, ScriptHash};
+use bitcoin_rs_index::{IndexWriter, ScriptHash};
 use bitcoin_rs_primitives::{
     Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
     deserialize,
@@ -21,8 +21,6 @@ use bitcoin_rs_storage::{ColumnFamily, KvStore};
 use proptest::prelude::*;
 
 use common::MemoryStore;
-
-const HEIGHT: u32 = 321;
 
 fn header() -> Header {
     Header {
@@ -109,9 +107,10 @@ fn funding_positions_address_the_transactions_that_funded_the_script() {
     let bytes = consensus_bytes(&block);
 
     let store = Arc::new(MemoryStore::default());
-    Indexer::new(Arc::clone(&store))
-        .ingest_block(&bytes, HEIGHT)
-        .expect("ingest");
+    IndexWriter::open(Arc::clone(&store), 1)
+        .expect("open")
+        .commit_block(0, &bytes)
+        .expect("commit");
 
     // Script 0x11 is funded by transaction 0 and again by transaction 1, which
     // collapse into a single row: one key, two positions.
@@ -147,9 +146,10 @@ fn txid_positions_address_their_own_transaction() {
     let bytes = consensus_bytes(&block);
 
     let store = Arc::new(MemoryStore::default());
-    Indexer::new(Arc::clone(&store))
-        .ingest_block(&bytes, HEIGHT)
-        .expect("ingest");
+    IndexWriter::open(Arc::clone(&store), 1)
+        .expect("open")
+        .commit_block(0, &bytes)
+        .expect("commit");
 
     let rows = rows_with_values(&store, ColumnFamily::TxConfirmed);
     assert_eq!(rows.len(), block.txs.len());

--- a/docs/contracts/indexing.md
+++ b/docs/contracts/indexing.md
@@ -169,6 +169,9 @@ remove another script's output.
 - **Deep reorg memory bounding**: Disconnect planning preloads branch block bodies into memory; streaming bounded-memory disconnect is tracked under #206 (open).
 ## Proven by
 
+- `crates/index/tests/index_roundtrip.rs`
+  `commit_golden_blocks_writes_expected_electrs_rows`: electrs family
+  occupancy after one atomic `IndexWriter::commit_block` (`IDX-06`).
 - `crates/node/src/txindex_worker_recovery_tests.rs`:
   - `shallow_reorg_rewinds_to_common_ancestor_then_replays`
   - `absent_tip_rewinds_index_to_empty`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follows merged #532 (256-block IBD window). Second PR in the sync/index stack for #494.

**Stack:** #532 (merged) → **this PR** → #572 (one prepare/rollback) → #571 (count-and-byte prepare chunks)

## What changed

`IndexWriter` is the only durable mutation owner. The `Indexer` ingest/rollback/batch dual path is gone (`ingest_block*`, `rollback_block`, `begin_batch`/`end_batch`, `IndexerLike`, `TxidSource`).

Single-block tests and benches go through `prepare_block` / `commit_block` (same owner as production `PreparedBatch` commits). Height-gapped LE key-order tests write funding/spending row keys directly because watermark contiguity starts at height 0.

## Review follow-up

Evaluated closed fix PR #568 and CodeRabbit nits; did not apply them wholesale.

- **Taken (rewritten):** `commit_block` / `commit_forward` / rollback rustdoc names the `IDX-06` commit point and classifies fence races vs `IDX-07` storage failure. The golden occupancy test cites `IDX-06` instead of a new clause.
- **Taken:** `commit_block` is documented as `HISTORICAL`-only (`TxLookup` + `ScriptHistory`; `ScriptLive` needs `prepare_block_with_spent_scripts`).
- **Taken:** dropped the unused `IndexBlockVisitor::txid_count` left after deleting the ingest dual path.
- **Rejected:** new `IDX-08` / `IDX-09` clauses (they duplicate `IDX-06`/`IDX-07` and would have split `IDX-05`).
- **Rejected:** composite `end_to_end_resolve` Criterion target. `history_resolve` already times the resolvers; fixture `commit_block` is setup, not the measured path.
- **Kept:** direct KV puts in LE key-order tests. `commit_block` cannot write gapped heights 1 and 256.
- **Skipped:** the compile-blocking `IndexerLike` comment CodeRabbit cited is not in the tree.

## Verification

- `cargo fmt --all`
- `cargo clippy -p bitcoin-rs-index --all-targets -- -D warnings`
- `cargo test -p bitcoin-rs-index --no-fail-fast`

RocksDB-gated `index` unit tests were rewritten onto `IndexWriter`; they are not in the default pure-Rust gate.

Does not touch ScriptIndex endian/format (#452/#462) or P2P socket/writev work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38dcd083-f48e-4d38-a071-a4689f747d56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38dcd083-f48e-4d38-a071-a4689f747d56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

