### PR TITLE
Bound index prepare chunks by count and body bytes

### DIFF
--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -93,9 +93,13 @@ const IDENTITY_CHUNK_BLOCKS: u32 = 65_536;
 const POSITION_PREFETCH_BLOCKS: usize = 65_536;
 /// Maximum number of blocks whose bodies are held in memory and whose
 /// `prepare_block_with_spent_scripts` row-build work is fanned out across the rayon pool
-/// in one parallel prepare step. Bounds memory while keeping the CPU-bound
-/// decode/row-build off the single writer thread.
-const PREPARE_CHUNK_BLOCKS: usize = 128;
+/// in one parallel prepare step. Matches the IBD download window so a filled
+/// 256-block staging cap can prepare in one pass when bodies are small.
+const PREPARE_CHUNK_BLOCKS: usize = 256;
+/// Serialized-body budget for one parallel prepare step. Stops a 1 MiB-class
+/// window from holding 256 bodies in RAM while still packing early-chain
+/// blocks up to the count cap.
+const PREPARE_CHUNK_BYTES: usize = 32 << 20;
 const REVISION_QUIET_PERIOD: Duration = Duration::from_millis(100);
 const FORWARD_BATCH_DELAY: Duration = Duration::from_millis(100);
 
@@ -2274,14 +2278,16 @@ impl Worker {
                 .prefetch_positions(&requests)
                 .map_err(TxIndexWorkerError::Storage)?;
 
-            // Sub-chunk: load bodies serially (preserving the reader's
-            // prefetch state), prepare blocks in parallel across the rayon
-            // pool, then push prepared blocks into the batch in height order.
-            // The single-writer commit and watermark publish remain the only
-            // ordering points (#209 invariants).
-            for sub_chunk in identities.chunks(PREPARE_CHUNK_BLOCKS) {
+            // Sub-chunk: load bodies serially until the count or byte cap
+            // (preserving the reader's prefetch state), prepare blocks in
+            // parallel across the rayon pool, then push prepared blocks into
+            // the batch in height order. The single-writer commit and
+            // watermark publish remain the only ordering points (#209
+            // invariants).
+            let mut remaining = identities;
+            while !remaining.is_empty() {
                 match self.prepare_and_admit_chunk(
-                    sub_chunk,
+                    &mut remaining,
                     &mut body_reader,
                     capabilities,
                     &mut state,
@@ -2297,15 +2303,16 @@ impl Worker {
         self.finish_catch_up(state, chunk_end, target, pending)
     }
 
-    /// Loads bodies serially, prepares blocks in parallel across the rayon pool,
-    /// then admits them into the batch in height order on the single writer
-    /// thread. Returns `Stalled` if a body is missing or shutdown was requested,
-    /// `Progressed` if the batch filled and was committed, or `Continue` to keep
-    /// processing.
+    /// Loads bodies serially until the count or byte cap, prepares that prefix
+    /// in parallel across the rayon pool, then admits them into the batch in
+    /// height order on the single writer thread. Advances `identities` past
+    /// the loaded prefix. Returns `Stalled` if a body is missing or shutdown
+    /// was requested, `Progressed` if the batch filled and was committed, or
+    /// `Continue` to keep processing.
     #[allow(clippy::too_many_lines)]
     fn prepare_and_admit_chunk(
         &self,
-        sub_chunk: &[BlockIdentity],
+        identities: &mut &[BlockIdentity],
         body_reader: &mut Box<dyn PruneBodyReader + '_>,
         capabilities: IndexCapabilities,
         state: &mut PendingForward,
@@ -2315,15 +2322,20 @@ impl Worker {
             return Ok(ChunkAction::Stalled);
         }
 
-        // Load bodies serially through the single reader.
-        let mut bodies = Vec::with_capacity(sub_chunk.len());
-        for identity in sub_chunk {
+        // Load bodies serially through the single reader until either cap.
+        // An oversized first body is still loaded so catch-up always moves.
+        let mut bodies = Vec::new();
+        let mut loaded_bytes = 0_usize;
+        for identity in *identities {
             if self.runtime.should_stop() {
                 return Ok(ChunkAction::Stalled);
             }
             let hash = Hash256::from_le_bytes(&identity.hash);
             match body_reader.load_block_body(identity.height, hash) {
-                Ok(Some(body)) => bodies.push(body),
+                Ok(Some(body)) => {
+                    loaded_bytes = loaded_bytes.saturating_add(body.len());
+                    bodies.push(body);
+                }
                 Ok(None) => {
                     if !state.batch.is_empty() {
                         let replacement = PendingForward {
@@ -2340,7 +2352,12 @@ impl Worker {
                 }
                 Err(e) => return Err(TxIndexWorkerError::Storage(e)),
             }
+            if bodies.len() >= PREPARE_CHUNK_BLOCKS || loaded_bytes >= PREPARE_CHUNK_BYTES {
+                break;
+            }
         }
+        let loaded = bodies.len();
+        let sub_chunk = &identities[..loaded];
 
         let anchors = if capabilities.script_live {
             let mut anchors = Vec::with_capacity(sub_chunk.len());
@@ -2436,6 +2453,7 @@ impl Worker {
                 };
             }
         }
+        *identities = &identities[loaded..];
         Ok(ChunkAction::Continue)
     }
     fn finish_catch_up(

--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -91,10 +91,10 @@ pub(crate) const DEFAULT_ROLLBACK_REBUILD_CUTOVER: u32 = 100_000;
 
 const IDENTITY_CHUNK_BLOCKS: u32 = 65_536;
 const POSITION_PREFETCH_BLOCKS: usize = 65_536;
-/// Maximum number of blocks whose bodies are held in memory and whose
-/// `prepare_block_with_spent_scripts` row-build work is fanned out across the rayon pool
-/// in one parallel prepare step. Matches the IBD download window so a filled
-/// 256-block staging cap can prepare in one pass when bodies are small.
+/// In-memory parallel-prepare cap owned by this worker. 256 matches the IBD
+/// download window so a filled staging set can prepare in one pass when bodies
+/// are small; catch-up also prepares already-stored bodies, so this is not
+/// `RECEIVED_BLOCK_BUDGET`. The byte budget below is independent of P2P staging.
 const PREPARE_CHUNK_BLOCKS: usize = 256;
 /// Serialized-body budget for one parallel prepare step. Stops a 1 MiB-class
 /// window from holding 256 bodies in RAM while still packing early-chain

--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -96,9 +96,10 @@ const POSITION_PREFETCH_BLOCKS: usize = 65_536;
 /// are small; catch-up also prepares already-stored bodies, so this is not
 /// `RECEIVED_BLOCK_BUDGET`. The byte budget below is independent of P2P staging.
 const PREPARE_CHUNK_BLOCKS: usize = 256;
-/// Serialized-body budget for one parallel prepare step. Stops a 1 MiB-class
-/// window from holding 256 bodies in RAM while still packing early-chain
-/// blocks up to the count cap.
+/// Serialized-body budget for one parallel prepare step. Later bodies are not
+/// retained once this bound would be exceeded. Stops a 1 MiB-class window from
+/// holding 256 bodies in RAM while still packing early-chain blocks up to the
+/// count cap.
 const PREPARE_CHUNK_BYTES: usize = 32 << 20;
 const REVISION_QUIET_PERIOD: Duration = Duration::from_millis(100);
 const FORWARD_BATCH_DELAY: Duration = Duration::from_millis(100);
@@ -2323,7 +2324,8 @@ impl Worker {
         }
 
         // Load bodies serially through the single reader until either cap.
-        // An oversized first body is still loaded so catch-up always moves.
+        // The first body is always retained so catch-up moves; a later body
+        // that would cross the byte cap is left at the front of `identities`.
         let mut bodies = Vec::new();
         let mut loaded_bytes = 0_usize;
         for identity in *identities {
@@ -2333,6 +2335,11 @@ impl Worker {
             let hash = Hash256::from_le_bytes(&identity.hash);
             match body_reader.load_block_body(identity.height, hash) {
                 Ok(Some(body)) => {
+                    if !bodies.is_empty()
+                        && loaded_bytes.saturating_add(body.len()) > PREPARE_CHUNK_BYTES
+                    {
+                        break;
+                    }
                     loaded_bytes = loaded_bytes.saturating_add(body.len());
                     bodies.push(body);
                 }
@@ -2352,7 +2359,7 @@ impl Worker {
                 }
                 Err(e) => return Err(TxIndexWorkerError::Storage(e)),
             }
-            if bodies.len() >= PREPARE_CHUNK_BLOCKS || loaded_bytes >= PREPARE_CHUNK_BYTES {
+            if bodies.len() >= PREPARE_CHUNK_BLOCKS {
                 break;
             }
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #572 (one prepare/rollback). Last PR in the current sync/index stack for #494.

**Stack:** #532 (merged) → #563 (merged) → #572 → **this PR**

## What changed

Index catch-up prepare chunks are bounded by **count and serialized-body bytes**:

- Count cap raised from 128 to **256**, matching the IBD download window from #532, so a filled staging window of small C150 blocks can prepare in one parallel pass.
- **32 MiB** body-byte cap so 1 MiB-class blocks do not pin 256 bodies in RAM. Later bodies are checked before retain so a chunk cannot overshoot by a maximum-size block; the first body is always taken.

`prepare_and_admit_chunk` loads until either cap, prepares that prefix, and advances the remaining identity slice so a byte-capped stop does not skip the rest of the prefetch window.

## Review follow-up

- **#576 / #584:** Rejected aliasing `PREPARE_CHUNK_BLOCKS` to `RECEIVED_BLOCK_BUDGET`. Catch-up prepares already-stored bodies, and the 32 MiB byte cap is independent of P2P staging. The count stays a worker-owned cap that happens to match the IBD window; the comment states that ownership.
- **Byte-cap overshoot:** Taken. A non-first body that would cross 32 MiB is left at the front of the identity slice for the next chunk.

## Verification

- `cargo fmt --all`
- `cargo clippy -p bitcoin-rs-node --no-default-features --features fjall --lib --tests -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38dcd083-f48e-4d38-a071-a4689f747d56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38dcd083-f48e-4d38-a071-a4689f747d56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

