### PR TITLE
Collapse TxIndexWriter to one prepare and rollback path

### DIFF
--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -7759,11 +7759,13 @@ mod consensus_rule_tests {
             Err(bitcoin_rs_index::IndexError::UnsupportedRollback)
         }
 
-        fn prepare_block(
+        fn prepare_block_with_spent_scripts(
             &self,
+            _capabilities: bitcoin_rs_index::IndexCapabilities,
             _height: u32,
             _hash: [u8; 32],
             _body: &[u8],
+            _spent_scripts: &dyn bitcoin_rs_index::SpentCoinScripts,
         ) -> Result<bitcoin_rs_index::PreparedBlock, bitcoin_rs_index::IndexError> {
             Err(bitcoin_rs_index::IndexError::UnsupportedRollback)
         }
@@ -7779,13 +7781,14 @@ mod consensus_rule_tests {
         ) -> Result<(), bitcoin_rs_index::IndexError> {
             Err(bitcoin_rs_index::IndexError::UnsupportedRollback)
         }
-        fn commit_rollback_one_for_with_cursor(
+        fn commit_rollback_one_for_with_cursor_with_spent_scripts(
             &self,
             _fence: bitcoin_rs_index::IndexWriteFence,
             _capabilities: bitcoin_rs_index::IndexCapabilities,
             _prev: Option<bitcoin_rs_index::IndexWatermark>,
             _body: &[u8],
             _cursor: bitcoin_rs_index::ConsumerCursorUpdate<'_>,
+            _spent_scripts: &dyn bitcoin_rs_index::SpentCoinScripts,
         ) -> Result<(), bitcoin_rs_index::IndexError> {
             Err(bitcoin_rs_index::IndexError::UnsupportedRollback)
         }

--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -25,7 +25,7 @@ use std::time::{Duration, Instant};
 use bitcoin_rs_chain::{BlockBodySource, BlockTree, TipSnapshot};
 use bitcoin_rs_index::{
     BlockSource, ConsumerCursorUpdate, IndexCapabilities, IndexCapability, IndexError, IndexReader,
-    IndexWatermark, IndexWatermarks, IndexWriteFence, IndexWriter, PreparedBatch,
+    IndexWatermark, IndexWatermarks, IndexWriteFence, IndexWriter, NoSpentScripts, PreparedBatch,
     PreparedBatchLimits, PreparedBlock, ScriptHash, ScriptLiveScan, TxIndexScan, TxIndexScanRow,
     TxIndexSnapshot,
     types::{TxPosition, TxPositionValue},
@@ -92,7 +92,7 @@ pub(crate) const DEFAULT_ROLLBACK_REBUILD_CUTOVER: u32 = 100_000;
 const IDENTITY_CHUNK_BLOCKS: u32 = 65_536;
 const POSITION_PREFETCH_BLOCKS: usize = 65_536;
 /// Maximum number of blocks whose bodies are held in memory and whose
-/// `prepare_block_for` row-build work is fanned out across the rayon pool
+/// `prepare_block_with_spent_scripts` row-build work is fanned out across the rayon pool
 /// in one parallel prepare step. Bounds memory while keeping the CPU-bound
 /// decode/row-build off the single writer thread.
 const PREPARE_CHUNK_BLOCKS: usize = 128;
@@ -1265,24 +1265,13 @@ type ScriptLiveSeedProduce<'a> = dyn FnMut(&mut dyn FnMut(OutPoint, ScriptHash) 
     + 'a;
 
 /// Erased prepared-index writer used by the worker and stored in `NodeState`.
+///
+/// Prepare and rollback have one owner each: spent-script-aware
+/// [`Self::prepare_block_with_spent_scripts`] and
+/// [`Self::commit_rollback_one_for_with_cursor_with_spent_scripts`].
+/// Callers that are not rebuilding `ScriptLive` pass [`NoSpentScripts`].
 pub(crate) trait TxIndexWriter: Send + Sync {
     fn fenced_watermarks(&self) -> Result<(IndexWriteFence, IndexWatermarks), IndexError>;
-    fn prepare_block(
-        &self,
-        height: u32,
-        hash: [u8; 32],
-        body: &[u8],
-    ) -> Result<PreparedBlock, IndexError>;
-    fn prepare_block_for(
-        &self,
-        capabilities: IndexCapabilities,
-        height: u32,
-        hash: [u8; 32],
-        body: &[u8],
-    ) -> Result<PreparedBlock, IndexError> {
-        let _ = capabilities;
-        self.prepare_block(height, hash, body)
-    }
     fn prepare_block_with_spent_scripts(
         &self,
         capabilities: IndexCapabilities,
@@ -1290,10 +1279,7 @@ pub(crate) trait TxIndexWriter: Send + Sync {
         hash: [u8; 32],
         body: &[u8],
         spent_scripts: &dyn bitcoin_rs_index::SpentCoinScripts,
-    ) -> Result<PreparedBlock, IndexError> {
-        let _ = spent_scripts;
-        self.prepare_block_for(capabilities, height, hash, body)
-    }
+    ) -> Result<PreparedBlock, IndexError>;
     fn seed_script_live_stream(
         &self,
         produce: &mut ScriptLiveSeedProduce<'_>,
@@ -1308,14 +1294,6 @@ pub(crate) trait TxIndexWriter: Send + Sync {
         batch: PreparedBatch,
         cursor: ConsumerCursorUpdate<'_>,
     ) -> Result<IndexWatermark, IndexError>;
-    fn commit_rollback_one_for_with_cursor(
-        &self,
-        fence: IndexWriteFence,
-        capabilities: IndexCapabilities,
-        prev: Option<IndexWatermark>,
-        body: &[u8],
-        cursor: ConsumerCursorUpdate<'_>,
-    ) -> Result<(), IndexError>;
     fn commit_rollback_one_for_with_cursor_with_spent_scripts(
         &self,
         fence: IndexWriteFence,
@@ -1324,10 +1302,7 @@ pub(crate) trait TxIndexWriter: Send + Sync {
         body: &[u8],
         cursor: ConsumerCursorUpdate<'_>,
         spent_scripts: &dyn bitcoin_rs_index::SpentCoinScripts,
-    ) -> Result<(), IndexError> {
-        let _ = spent_scripts;
-        self.commit_rollback_one_for_with_cursor(fence, capabilities, prev, body, cursor)
-    }
+    ) -> Result<(), IndexError>;
 
     fn reset_capabilities(&self, capabilities: IndexCapabilities) -> Result<(), IndexError> {
         let _ = capabilities;
@@ -1341,148 +1316,17 @@ pub(crate) trait TxIndexWriter: Send + Sync {
     ) -> Result<(), IndexError>;
 }
 
-impl<S> TxIndexWriter for Mutex<IndexWriter<S>>
-where
-    S: bitcoin_rs_storage::KvStore + Send + Sync + 'static,
-{
-    fn fenced_watermarks(&self) -> Result<(IndexWriteFence, IndexWatermarks), IndexError> {
-        self.lock().fenced_watermarks()
-    }
-
-    fn prepare_block(
-        &self,
-        height: u32,
-        hash: [u8; 32],
-        body: &[u8],
-    ) -> Result<PreparedBlock, IndexError> {
-        self.lock().prepare_block(height, hash, body)
-    }
-
-    fn prepare_block_for(
-        &self,
-        capabilities: IndexCapabilities,
-        height: u32,
-        hash: [u8; 32],
-        body: &[u8],
-    ) -> Result<PreparedBlock, IndexError> {
-        self.lock()
-            .prepare_block_for(capabilities, height, hash, body)
-    }
-
-    fn prepare_block_with_spent_scripts(
-        &self,
-        capabilities: IndexCapabilities,
-        height: u32,
-        hash: [u8; 32],
-        body: &[u8],
-        spent_scripts: &dyn bitcoin_rs_index::SpentCoinScripts,
-    ) -> Result<PreparedBlock, IndexError> {
-        self.lock().prepare_block_with_spent_scripts(
-            capabilities,
-            height,
-            hash,
-            body,
-            spent_scripts,
-        )
-    }
-
-    fn commit_forward_with_cursor(
-        &self,
-        fence: IndexWriteFence,
-        batch: PreparedBatch,
-        cursor: ConsumerCursorUpdate<'_>,
-    ) -> Result<IndexWatermark, IndexError> {
-        self.lock().commit_forward_with_cursor(fence, batch, cursor)
-    }
-
-    fn seed_script_live_stream(
-        &self,
-        produce: &mut ScriptLiveSeedProduce<'_>,
-        tip: IndexWatermark,
-    ) -> Result<usize, IndexError> {
-        self.lock().seed_script_live_stream(produce, tip)
-    }
-
-    fn commit_rollback_one_for_with_cursor(
-        &self,
-        fence: IndexWriteFence,
-        capabilities: IndexCapabilities,
-        prev: Option<IndexWatermark>,
-        body: &[u8],
-        cursor: ConsumerCursorUpdate<'_>,
-    ) -> Result<(), IndexError> {
-        self.lock()
-            .commit_rollback_one_for_with_cursor(fence, capabilities, prev, body, cursor)
-    }
-
-    fn commit_rollback_one_for_with_cursor_with_spent_scripts(
-        &self,
-        fence: IndexWriteFence,
-        capabilities: IndexCapabilities,
-        prev: Option<IndexWatermark>,
-        body: &[u8],
-        cursor: ConsumerCursorUpdate<'_>,
-        spent_scripts: &dyn bitcoin_rs_index::SpentCoinScripts,
-    ) -> Result<(), IndexError> {
-        self.lock()
-            .commit_rollback_one_for_with_cursor_with_spent_scripts(
-                fence,
-                capabilities,
-                prev,
-                body,
-                cursor,
-                spent_scripts,
-            )
-    }
-
-    fn reset_capabilities(&self, capabilities: IndexCapabilities) -> Result<(), IndexError> {
-        self.lock().reset_capabilities(capabilities)
-    }
-
-    fn consumer_cursor(&self) -> Result<Option<Vec<u8>>, IndexError> {
-        self.lock().consumer_cursor()
-    }
-
-    fn commit_consumer_cursor(
-        &self,
-        fence: IndexWriteFence,
-        cursor: &[u8],
-    ) -> Result<(), IndexError> {
-        self.lock().commit_consumer_cursor(fence, cursor)
-    }
-}
-
-/// `RwLock`-backed writer: `prepare_block_for` and `consumer_cursor` take a
-/// shared read lock so the CPU-bound decode/row-build can run concurrently
-/// across the rayon pool, while `commit_*`, `fenced_watermarks`, and
-/// `reset_capabilities` take an exclusive write lock to preserve the
-/// single-writer atomic commit and watermark semantics.
+/// `RwLock`-backed writer: `prepare_block_with_spent_scripts` and
+/// `consumer_cursor` take a shared read lock so the CPU-bound decode/row-build
+/// can run concurrently across the rayon pool, while `commit_*`,
+/// `fenced_watermarks`, and `reset_capabilities` take an exclusive write lock
+/// to preserve the single-writer atomic commit and watermark semantics.
 impl<S> TxIndexWriter for RwLock<IndexWriter<S>>
 where
     S: bitcoin_rs_storage::KvStore + Send + Sync + 'static,
 {
     fn fenced_watermarks(&self) -> Result<(IndexWriteFence, IndexWatermarks), IndexError> {
         self.write().fenced_watermarks()
-    }
-
-    fn prepare_block(
-        &self,
-        height: u32,
-        hash: [u8; 32],
-        body: &[u8],
-    ) -> Result<PreparedBlock, IndexError> {
-        self.read().prepare_block(height, hash, body)
-    }
-
-    fn prepare_block_for(
-        &self,
-        capabilities: IndexCapabilities,
-        height: u32,
-        hash: [u8; 32],
-        body: &[u8],
-    ) -> Result<PreparedBlock, IndexError> {
-        self.read()
-            .prepare_block_for(capabilities, height, hash, body)
     }
 
     fn prepare_block_with_spent_scripts(
@@ -1518,18 +1362,6 @@ where
         tip: IndexWatermark,
     ) -> Result<usize, IndexError> {
         self.write().seed_script_live_stream(produce, tip)
-    }
-
-    fn commit_rollback_one_for_with_cursor(
-        &self,
-        fence: IndexWriteFence,
-        capabilities: IndexCapabilities,
-        prev: Option<IndexWatermark>,
-        body: &[u8],
-        cursor: ConsumerCursorUpdate<'_>,
-    ) -> Result<(), IndexError> {
-        self.write()
-            .commit_rollback_one_for_with_cursor(fence, capabilities, prev, body, cursor)
     }
 
     fn commit_rollback_one_for_with_cursor_with_spent_scripts(
@@ -2536,22 +2368,17 @@ impl Worker {
             .zip(bodies.par_iter())
             .enumerate()
             .map(|(index, (identity, body))| {
-                if let Some(anchors) = anchors.as_ref() {
-                    self.writer.prepare_block_with_spent_scripts(
-                        capabilities,
-                        identity.height,
-                        identity.hash,
-                        body.as_slice(),
-                        &anchors[index],
-                    )
-                } else {
-                    self.writer.prepare_block_for(
-                        capabilities,
-                        identity.height,
-                        identity.hash,
-                        body.as_slice(),
-                    )
-                }
+                let spent: &dyn bitcoin_rs_index::SpentCoinScripts = match anchors.as_ref() {
+                    Some(anchors) => &anchors[index],
+                    None => &NoSpentScripts,
+                };
+                self.writer.prepare_block_with_spent_scripts(
+                    capabilities,
+                    identity.height,
+                    identity.hash,
+                    body.as_slice(),
+                    spent,
+                )
             })
             .collect();
         drop(bodies);
@@ -2657,22 +2484,22 @@ impl Worker {
             .then(|| self.live_anchor(watermark.height, watermark.hash))
             .transpose()?;
 
+        let spent: &dyn bitcoin_rs_index::SpentCoinScripts =
+            anchor.as_ref().map_or(&NoSpentScripts, |anchor| anchor);
+
         let prev = if watermark.height == 0 {
             None
         } else {
-            let prepared = if let Some(anchor) = anchor.as_ref() {
-                self.writer.prepare_block_with_spent_scripts(
+            let prepared = self
+                .writer
+                .prepare_block_with_spent_scripts(
                     capabilities,
                     watermark.height,
                     watermark.hash,
                     &body,
-                    anchor,
+                    spent,
                 )
-            } else {
-                self.writer
-                    .prepare_block_for(capabilities, watermark.height, watermark.hash, &body)
-            }
-            .map_err(TxIndexWorkerError::Index)?;
+                .map_err(TxIndexWorkerError::Index)?;
             Some(IndexWatermark {
                 height: watermark.height.saturating_sub(1),
                 hash: prepared.parent_hash,
@@ -2688,26 +2515,16 @@ impl Worker {
             .map_or(ConsumerCursorUpdate::Clear, |bytes| {
                 ConsumerCursorUpdate::Set(bytes.as_slice())
             });
-        if let Some(anchor) = anchor.as_ref() {
-            self.writer
-                .commit_rollback_one_for_with_cursor_with_spent_scripts(
-                    fence,
-                    capabilities,
-                    prev,
-                    &body,
-                    cursor,
-                    anchor,
-                )
-        } else {
-            self.writer.commit_rollback_one_for_with_cursor(
+        self.writer
+            .commit_rollback_one_for_with_cursor_with_spent_scripts(
                 fence,
                 capabilities,
                 prev,
                 &body,
                 cursor,
+                spent,
             )
-        }
-        .map_err(TxIndexWorkerError::Index)?;
+            .map_err(TxIndexWorkerError::Index)?;
         Ok(prev)
     }
 
@@ -4016,7 +3833,7 @@ mod body_reader_tests {
         let runtime = Arc::new(TxIndexRuntime::new(wake_tx));
         let data_dir = tempfile::tempdir()?;
         let index_store = Arc::new(bitcoin_rs_storage::FjallStore::open(data_dir.path())?);
-        let writer: Arc<dyn TxIndexWriter> = Arc::new(parking_lot::Mutex::new(
+        let writer: Arc<dyn TxIndexWriter> = Arc::new(parking_lot::RwLock::new(
             bitcoin_rs_index::IndexWriter::open(index_store, 1)?,
         ));
         let body_store = Arc::new(SessionBodyStore {

--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -1270,6 +1270,9 @@ type ScriptLiveSeedProduce<'a> = dyn FnMut(&mut dyn FnMut(OutPoint, ScriptHash) 
 /// [`Self::prepare_block_with_spent_scripts`] and
 /// [`Self::commit_rollback_one_for_with_cursor_with_spent_scripts`].
 /// Callers that are not rebuilding `ScriptLive` pass [`NoSpentScripts`].
+/// Durability, crash visibility, and failure classification for rollback are
+/// owned by [`IndexWriter::commit_rollback_one_for_with_cursor_with_spent_scripts`]
+/// (`IDX-06` / `IDX-07`).
 pub(crate) trait TxIndexWriter: Send + Sync {
     fn fenced_watermarks(&self) -> Result<(IndexWriteFence, IndexWatermarks), IndexError>;
     fn prepare_block_with_spent_scripts(

--- a/crates/node/src/txindex_worker_recovery_tests.rs
+++ b/crates/node/src/txindex_worker_recovery_tests.rs
@@ -184,7 +184,7 @@ impl Harness {
         let index_dir = tempfile::tempdir().expect("index dir");
         let evidence_dir = tempfile::tempdir().expect("evidence dir");
         let store = Arc::new(FjallStore::open(index_dir.path()).expect("fjall open"));
-        let writer: Arc<dyn TxIndexWriter> = Arc::new(parking_lot::Mutex::new(
+        let writer: Arc<dyn TxIndexWriter> = Arc::new(parking_lot::RwLock::new(
             bitcoin_rs_index::IndexWriter::open(store, 1).expect("index writer open"),
         ));
         let applied_tip = Arc::new(ArcSwapOption::empty());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follows merged #563 (`IndexWriter` sole mutation owner). Next PR in the sync/index stack for #494.

**Stack:** #532 (merged) → #563 (merged) → **this PR** → #571 (count-and-byte prepare chunks)

## What changed

`TxIndexWriter` now has one prepare and one rollback: `prepare_block_with_spent_scripts` and `commit_rollback_one_for_with_cursor_with_spent_scripts`. The HISTORICAL-only defaults that ignored spent scripts are gone. Callers that are not rebuilding `ScriptLive` pass `NoSpentScripts`.

The `Mutex<IndexWriter>` impl is deleted. Production already used `RwLock`; tests now wrap the same way so prepare can share a read lock across the rayon pool.

## Review follow-up (#577)

Evaluated closed fix PR #577; did not cherry-pick it wholesale.

- **Taken (rewritten):** rollback durability lives on `IndexWriter::commit_rollback_one_for_with_cursor_with_spent_scripts` (`IDX-06` / `IDX-07`), matching `commit_forward`. The trait cites that owner.
- **Rejected:** restating the contract on the trait, and the claim that the worker retries storage errors (storage failures fail the worker per `IDX-07`).

## Verification

- `cargo fmt --all`
- `cargo clippy -p bitcoin-rs-node --no-default-features --features fjall --lib --tests -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38dcd083-f48e-4d38-a071-a4689f747d56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38dcd083-f48e-4d38-a071-a4689f747d56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

