### PR TITLE
Hash apply-path txids from preserved wire bytes

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -133,7 +133,7 @@ Bitcoin Core's C++ consensus engine (`libbitcoinkernel`). The `kernel` feature c
 The production script path (`crates/script`). It executes legacy, P2SH, SegWit v0, and Taproot key-path and script-path spends through the opcode evaluator. Core's `script_tests`, `tx_valid`, and `tx_invalid` vectors currently pin zero native mismatches. Signature checks reuse the process-wide `secp256k1::SECP256K1` context. Apply-path verification precomputes BIP143/BIP341 sighash midstates once per transaction (`SighashCache::precompute`) and clones that cache into each input.
 
 ### One-shot native block identities
-Apply hashes each already-decoded transaction once (`block_txids`) and reuses those txids for merkle, BIP30/BIP34, overlay, and script preparation. `KernelBlock` remains available under `--features kernel` so the Core parse can be compared, not substituted.
+Apply hashes each already-decoded transaction once (`block_txids`) when it has no preserved wire bytes, and hashes txids from those bytes (`txids_from_serialized_block`) when it does: a legacy transaction is one contiguous double-SHA256, a BIP144 transaction hashes the non-witness layout and skips marker/flag/witness. That avoids re-encoding the decoded `Tx` graph. `KernelBlock` remains available under `--features kernel` so the Core parse can be compared, not substituted.
 
 ### Runtime-dispatched AVX2 Merkle
 Parent hashing of Merkle pairs uses Bitcoin Core's 8-way AVX2 SHA-256d kernel on x86-64 hosts that advertise AVX2, selected at runtime. Hosts without AVX2, and trees too small to fill one 8-pair batch, use the allocation-free scalar spine. Both paths implement Bitcoin's odd-leaf duplication and mutated-tree rule.

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -2484,9 +2484,15 @@ fn parse_block_for_apply(
             ),
         ));
     }
+    if let Some(raw) = provided_serialized {
+        return bitcoin_rs_primitives::txids_from_serialized_block(raw).map_err(|error| {
+            ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Encoding(
+                error.to_string(),
+            ))
+        });
+    }
     // Hash each transaction of the already-decoded block exactly once.
-    // Re-decoding preserved bytes here would make apply pay two full
-    // decodes plus one consensus re-serialization per block.
+    // Used when apply has no preserved wire bytes to hash in place.
     Ok(block_txids(block))
 }
 

--- a/crates/primitives/src/encode.rs
+++ b/crates/primitives/src/encode.rs
@@ -389,6 +389,136 @@ impl ConsensusDecode for Block {
     }
 }
 
+const SERIALIZED_BLOCK_HEADER_LEN: usize = 80;
+
+/// Transaction ids of a serialized block, hashed from the wire bytes.
+///
+/// A legacy transaction is hashed as one contiguous slice. A BIP144 transaction
+/// hashes version, vin, vout, and locktime and skips the marker, flag, and
+/// witness. That is the same digest [`Tx::txid`] computes by re-encoding.
+pub fn txids_from_serialized_block(raw: &[u8]) -> Result<Vec<Txid>, DecodeError> {
+    let mut reader = raw;
+    let _header = take(&mut reader, SERIALIZED_BLOCK_HEADER_LEN)?;
+    let tx_count = read_compact(&mut reader)?;
+    let mut txids = Vec::new();
+    for _ in 0..tx_count {
+        txids.push(hash_txid_from_reader(&mut reader)?);
+    }
+    if !reader.is_empty() {
+        return Err(DecodeError::TrailingBytes {
+            remaining: reader.len(),
+        });
+    }
+    Ok(txids)
+}
+
+/// Double-SHA256 of one transaction's non-witness serialization, consumed from `reader`.
+fn hash_txid_from_reader(reader: &mut &[u8]) -> Result<Txid, DecodeError> {
+    let tx_start = *reader;
+    let _version = take(reader, 4)?;
+    let mut input_count = read_compact(reader)?;
+    if input_count != 0 {
+        skip_vin(reader, input_count)?;
+        let output_count = read_compact(reader)?;
+        skip_vout(reader, output_count)?;
+        let _lock_time = take(reader, 4)?;
+        let consumed = tx_start.len() - reader.len();
+        return Ok(Txid(double_sha256(&tx_start[..consumed])));
+    }
+
+    let flag = read_u8(reader)?;
+    if flag != 0x01 {
+        return Err(DecodeError::InvalidSegwitFlag { got: flag });
+    }
+    let mut engine = Sha256::new();
+    Digest::update(&mut engine, &tx_start[..4]);
+    input_count = read_compact_into(&mut engine, reader)?;
+    skip_vin_into(&mut engine, reader, input_count)?;
+    let output_count = read_compact_into(&mut engine, reader)?;
+    skip_vout_into(&mut engine, reader, output_count)?;
+    if !skip_witness(reader, input_count)? {
+        return Err(DecodeError::SuperfluousWitness);
+    }
+    take_into(&mut engine, reader, 4)?;
+    Ok(Txid(finalize_double_sha256(engine)))
+}
+
+fn read_compact_into(hasher: &mut Sha256, reader: &mut &[u8]) -> Result<u64, DecodeError> {
+    let (value, consumed) = varint::decode(reader)?;
+    Digest::update(hasher, &reader[..consumed]);
+    *reader = &reader[consumed..];
+    Ok(value)
+}
+
+fn take_into(hasher: &mut Sha256, reader: &mut &[u8], n: usize) -> Result<(), DecodeError> {
+    let bytes = take(reader, n)?;
+    Digest::update(hasher, bytes);
+    Ok(())
+}
+
+fn skip_prefixed_bytes(reader: &mut &[u8]) -> Result<(), DecodeError> {
+    let len = read_compact(reader)?;
+    let needed = usize::try_from(len).unwrap_or(usize::MAX);
+    let _ = take(reader, needed)?;
+    Ok(())
+}
+
+fn skip_vin(reader: &mut &[u8], count: u64) -> Result<(), DecodeError> {
+    for _ in 0..count {
+        let _ = take(reader, 36)?;
+        skip_prefixed_bytes(reader)?;
+        let _ = take(reader, 4)?;
+    }
+    Ok(())
+}
+
+fn skip_vout(reader: &mut &[u8], count: u64) -> Result<(), DecodeError> {
+    for _ in 0..count {
+        let _ = take(reader, 8)?;
+        skip_prefixed_bytes(reader)?;
+    }
+    Ok(())
+}
+
+fn skip_vin_into(hasher: &mut Sha256, reader: &mut &[u8], count: u64) -> Result<(), DecodeError> {
+    for _ in 0..count {
+        take_into(hasher, reader, 36)?;
+        skip_script_into(hasher, reader)?;
+        take_into(hasher, reader, 4)?;
+    }
+    Ok(())
+}
+
+fn skip_vout_into(hasher: &mut Sha256, reader: &mut &[u8], count: u64) -> Result<(), DecodeError> {
+    for _ in 0..count {
+        take_into(hasher, reader, 8)?;
+        skip_script_into(hasher, reader)?;
+    }
+    Ok(())
+}
+
+fn skip_script_into(hasher: &mut Sha256, reader: &mut &[u8]) -> Result<(), DecodeError> {
+    let len = read_compact_into(hasher, reader)?;
+    let needed = usize::try_from(len).unwrap_or(usize::MAX);
+    take_into(hasher, reader, needed)
+}
+
+fn skip_witness(reader: &mut &[u8], input_count: u64) -> Result<bool, DecodeError> {
+    let mut any = false;
+    for _ in 0..input_count {
+        let item_count = read_compact(reader)?;
+        if item_count > 0 {
+            any = true;
+        }
+        for _ in 0..item_count {
+            let len = read_compact(reader)?;
+            let needed = usize::try_from(len).unwrap_or(usize::MAX);
+            let _ = take(reader, needed)?;
+        }
+    }
+    Ok(any)
+}
+
 #[cfg(test)]
 mod tests {
     #![expect(clippy::expect_used, reason = "test assertions")]
@@ -554,6 +684,68 @@ mod tests {
             Err(DecodeError::SuperfluousWitness)
         );
         assert!(bitcoin_deserialize::<Transaction>(&zero_input).is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn wire_txid_matches_reencoded_txid_for_legacy_and_segwit() -> Result<()> {
+        use crate::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+
+        let legacy = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid::default(), 0),
+                script_sig: vec![0x51],
+                sequence: 0xffff_fffe,
+                witness: Vec::new(),
+            }],
+            outputs: vec![TxOut {
+                value: 50_000,
+                script_pubkey: vec![0x51],
+            }],
+            lock_time: 7,
+        };
+        let legacy_bytes = crate::encode::consensus_bytes(&legacy);
+        let mut legacy_reader = legacy_bytes.as_slice();
+        let legacy_wire = super::hash_txid_from_reader(&mut legacy_reader)?;
+        assert_eq!(legacy_wire, legacy.txid());
+        assert!(legacy_reader.is_empty());
+
+        let segwit = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid(Hash256::default()), 3),
+                script_sig: Vec::new(),
+                sequence: 0xffff_fffe,
+                witness: vec![vec![0xaa; 40]],
+            }],
+            outputs: vec![TxOut {
+                value: 50_000,
+                script_pubkey: vec![0x00, 0x14, 0xab],
+            }],
+            lock_time: 42,
+        };
+        let segwit_bytes = crate::encode::consensus_bytes(&segwit);
+        let mut segwit_reader = segwit_bytes.as_slice();
+        let segwit_wire = super::hash_txid_from_reader(&mut segwit_reader)?;
+        assert_eq!(segwit_wire, segwit.txid());
+        assert!(segwit_reader.is_empty());
+
+        let block = Block {
+            header: Header {
+                version: 1,
+                prev_blockhash: BlockHash::default(),
+                merkle_root: Hash256::default(),
+                time: 0,
+                bits: 0,
+                nonce: 0,
+            },
+            txs: vec![legacy, segwit],
+        };
+        let raw = crate::encode::consensus_bytes(&block);
+        let from_wire = super::txids_from_serialized_block(&raw)?;
+        let from_structs: Vec<Txid> = block.txs.iter().map(Tx::txid).collect();
+        assert_eq!(from_wire, from_structs);
         Ok(())
     }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -29,6 +29,7 @@ pub mod version;
 pub use block::Block;
 pub use encode::{
     ConsensusDecode, ConsensusEncode, DecodeError, consensus_bytes, consensus_len, deserialize,
+    txids_from_serialized_block,
 };
 pub use hash::{Hash256, HashError};
 pub use header::Header;

--- a/crates/primitives/tests/golden.rs
+++ b/crates/primitives/tests/golden.rs
@@ -95,6 +95,11 @@ fn golden_blocks_decode_and_hash_to_blockstream_txids() -> Result<(), Box<dyn st
             );
         }
         assert_eq!(
+            bitcoin_rs_primitives::txids_from_serialized_block(&block_bytes)?,
+            expected_txids,
+            "height {height} wire txids"
+        );
+        assert_eq!(
             bitcoin_rs_primitives::consensus_bytes(&block),
             block_bytes,
             "height {height} re-encode"

--- a/docs/contracts/validation-default.md
+++ b/docs/contracts/validation-default.md
@@ -16,8 +16,9 @@ Owners:
 - `bitcoin-rs-consensus` and `bitcoin-rs-node` default features do not
   include `kernel` while the recorded verdict in `g19_validation_default.rs`
   is `PromoteNative`.
-- Production apply is always the native Rust path: decode once, hash native
-  `Tx` values once, verify scripts through `Interpreter` with a shared
+- Production apply is always the native Rust path: decode once, hash each
+  transaction once (from preserved wire bytes when present, otherwise from
+  the decoded `Tx`), verify scripts through `Interpreter` with a shared
   `SighashCache`. Enabling `--features kernel` compiles `libbitcoinkernel`;
   it does not replace that path or feed kernel-owned data into apply.
 - The verdict may move back to `KeepKernel` only together with those two


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Stacked on #562. Native apply already decoded the block and, on the production path, still holds the preserved wire bytes. Hashing txids by re-encoding each `Tx` into SHA-256 was paying a second walk of the same data. Core's kernel hashed during deserialize; this PR hashes the same non-witness layout from the bytes we already checked.

```text
preserved bytes --(already proven equal to the decoded block)--> contiguous SHA-256d
legacy tx:  one digest over the wire slice
BIP144 tx:  version + vin + vout + locktime; skip marker/flag/witness
```

`Tx::txid` stays the owner of the decoded-struct digest. `txids_from_serialized_block` is the wire owner. Tests pin them equal.

Kernel types still never enter apply. `--verify-kernel` continues to compare these native txids against `KernelBlock`.

## What changed

- `bitcoin_rs_primitives::txids_from_serialized_block`
- `parse_block_for_apply` uses it when serialized bytes are present; `block_txids` remains the no-bytes path
- Golden fixture test also pins wire txids against the blockstream-recorded list

## Test plan

- [x] `cargo test -p bitcoin-rs-primitives --lib encode::`
- [x] `cargo clippy -p bitcoin-rs-primitives --all-targets -- -D warnings`
- [x] `cargo test -p bitcoin-rs-node --no-default-features --features fjall --lib verify_kernel`
- [x] `cargo clippy -p bitcoin-rs-node --no-default-features --features fjall --lib -- -D warnings`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-996af3b4-a8cd-45bf-aad7-e32419922de0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-996af3b4-a8cd-45bf-aad7-e32419922de0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

