### PR TITLE
Give Tx and Header native field newtypes

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -128,9 +128,12 @@ retained Criterion benchmark targets are compiled in the `bench-smoke` CI lane
 
 ### Native protocol primitives
 The owned Bitcoin protocol vocabulary in `crates/primitives`: `Tx`, `Block`,
-`Header`, `OutPoint`, hashes, sighash, compact-size encoding, and network
+`Header`, `OutPoint`, `Amount`, `Sequence`, `LockTime`, `CompactTarget`,
+`Script`, `Witness`, hashes, sighash, compact-size encoding, and network
 constants. These types are implemented here; they are not `rust-bitcoin`
-aliases, wrappers, or conversion shims. Durable tests pin Core vectors,
+aliases, wrappers, or conversion shims. Field types on `Tx`/`Header` are the
+same native newtypes — satoshis, nBits, scripts, and locktime are not raw
+integers at the protocol boundary. Durable tests pin Core vectors,
 published genesis hashes, and golden fixtures. RPC address/`asm` rendering
 may still use `rust-bitcoin` at the RPC boundary only.
 

--- a/bin/bitcoin-rs/tests/wallet_facing.rs
+++ b/bin/bitcoin-rs/tests/wallet_facing.rs
@@ -732,7 +732,7 @@ fn spend_first_anyone_can_spend(client: &Client, payout: &ScriptBuf) -> TestResu
         }],
         output: vec![TxOut {
             value: Amount::from_sat(REGTEST_SUBSIDY_SATS.saturating_sub(FEE_SATS)),
-            script_pubkey: payout.clone(),
+            script_pubkey: payout.clone().into(),
         }],
     };
     Ok(serialize_hex(&spend))
@@ -763,18 +763,18 @@ fn assemble_from_template(template: &Value, coinbase: Coinbase<'_>) -> TestResul
         lock_time: LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint::null(),
-            script_sig: coinbase_script_sig(height),
+            script_sig: coinbase_script_sig(height).into(),
             sequence: Sequence::MAX,
             witness: Witness::from_slice(&[&WITNESS_RESERVED]),
         }],
         output: vec![
             TxOut {
                 value: Amount::from_sat(coinbase_value),
-                script_pubkey: coinbase.script_pubkey(),
+                script_pubkey: coinbase.script_pubkey().into(),
             },
             TxOut {
                 value: Amount::from_sat(0),
-                script_pubkey: commitment,
+                script_pubkey: commitment.into(),
             },
         ],
     };

--- a/bin/bitcoin-rs/tests/wallet_facing.rs
+++ b/bin/bitcoin-rs/tests/wallet_facing.rs
@@ -732,7 +732,7 @@ fn spend_first_anyone_can_spend(client: &Client, payout: &ScriptBuf) -> TestResu
         }],
         output: vec![TxOut {
             value: Amount::from_sat(REGTEST_SUBSIDY_SATS.saturating_sub(FEE_SATS)),
-            script_pubkey: payout.clone().into(),
+            script_pubkey: payout.clone(),
         }],
     };
     Ok(serialize_hex(&spend))
@@ -763,18 +763,18 @@ fn assemble_from_template(template: &Value, coinbase: Coinbase<'_>) -> TestResul
         lock_time: LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint::null(),
-            script_sig: coinbase_script_sig(height).into(),
+            script_sig: coinbase_script_sig(height),
             sequence: Sequence::MAX,
             witness: Witness::from_slice(&[&WITNESS_RESERVED]),
         }],
         output: vec![
             TxOut {
                 value: Amount::from_sat(coinbase_value),
-                script_pubkey: coinbase.script_pubkey().into(),
+                script_pubkey: coinbase.script_pubkey(),
             },
             TxOut {
                 value: Amount::from_sat(0),
-                script_pubkey: commitment.into(),
+                script_pubkey: commitment,
             },
         ],
     };

--- a/crates/chain/src/deployment.rs
+++ b/crates/chain/src/deployment.rs
@@ -188,7 +188,7 @@ fn cached_deployment_state(
 mod tests {
     use crate::node::NodeStatus;
     use bitcoin_rs_consensus::DeploymentContext;
-    use bitcoin_rs_primitives::{BlockHash, Hash256, Header, Network};
+    use bitcoin_rs_primitives::{BlockHash, CompactTarget, Hash256, Header, Network};
 
     use super::{DeploymentView, softfork_state};
     use crate::BlockTree;
@@ -203,7 +203,7 @@ mod tests {
             prev_blockhash,
             merkle_root: Hash256::default(),
             time,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         }
     }

--- a/crates/chain/src/header_sync.rs
+++ b/crates/chain/src/header_sync.rs
@@ -1,5 +1,5 @@
 use bitcoin_rs_consensus::MEDIAN_TIME_PAST_WINDOW;
-use bitcoin_rs_primitives::{Hash256, Network};
+use bitcoin_rs_primitives::{CompactTarget, Hash256, Network};
 
 pub use pow::compact_is_met_by;
 use pow::{compact_to_target, target_to_compact};
@@ -153,7 +153,7 @@ pub fn next_work_required(
     parent_id: NodeId,
     candidate_time: u32,
     network: Network,
-) -> Result<u32, ChainError> {
+) -> Result<CompactTarget, ChainError> {
     let parent = tree.node(parent_id)?;
     let height = parent
         .height
@@ -231,7 +231,7 @@ fn expected_non_retarget_bits(
     parent_id: NodeId,
     candidate_time: u32,
     retarget_interval: u32,
-) -> Result<u32, ChainError> {
+) -> Result<CompactTarget, ChainError> {
     let parent = tree.node(parent_id)?;
     if !network.allow_min_difficulty_blocks() {
         return Ok(parent.header.bits);
@@ -267,7 +267,7 @@ fn expected_retarget_bits(
     parent_id: NodeId,
     height: u32,
     retarget_interval: u32,
-) -> Result<u32, ChainError> {
+) -> Result<CompactTarget, ChainError> {
     let prev_node = tree.node(parent_id)?;
     if network.pow_no_retargeting() {
         return Ok(prev_node.header.bits);
@@ -317,20 +317,20 @@ fn expected_retarget_bits(
 fn compare_expected_bits(
     header: &BlockHeader,
     height: u32,
-    expected: u32,
+    expected: CompactTarget,
 ) -> Result<(), ChainError> {
     let actual = header.bits;
     if actual != expected {
         return Err(ChainError::NbitsMismatch {
-            actual,
-            expected,
+            actual: actual.to_consensus(),
+            expected: expected.to_consensus(),
             height,
         });
     }
     Ok(())
 }
 
-fn pow_limit_bits(network: Network) -> u32 {
+fn pow_limit_bits(network: Network) -> CompactTarget {
     target_to_compact(network.max_target())
 }
 
@@ -339,7 +339,7 @@ fn pow_limit_bits(network: Network) -> u32 {
 /// These mirror Bitcoin Core's `arith_uint256::SetCompact`/`GetCompact`
 /// exactly, including sign-bit normalization and overflow classification.
 pub(crate) mod pow {
-    use bitcoin_rs_primitives::Hash256;
+    use bitcoin_rs_primitives::{CompactTarget, Hash256};
 
     use crate::node::{BlockHeader, ChainWork};
 
@@ -369,8 +369,8 @@ pub(crate) mod pow {
 
     /// Decodes a compact target, returning zero for negative encodings.
     #[must_use]
-    pub(crate) fn compact_to_target(bits: u32) -> ChainWork {
-        let decoded = decode_compact(bits);
+    pub(crate) fn compact_to_target(bits: CompactTarget) -> ChainWork {
+        let decoded = decode_compact(bits.to_consensus());
         if decoded.negative {
             ChainWork::ZERO
         } else {
@@ -381,7 +381,7 @@ pub(crate) mod pow {
     /// Returns `true` when a valid nonzero compact target is met by `hash`.
     /// The consensus hash bytes are interpreted as a little-endian integer.
     #[must_use]
-    pub fn compact_is_met_by(bits: u32, hash: Hash256) -> bool {
+    pub fn compact_is_met_by(bits: CompactTarget, hash: Hash256) -> bool {
         let target = compact_to_target(bits);
         target != ChainWork::ZERO && ChainWork::from_le_bytes(hash.to_le_bytes()) <= target
     }
@@ -398,8 +398,8 @@ pub(crate) mod pow {
 
     /// Encodes a non-negative 256-bit target into compact consensus form.
     #[must_use]
-    pub(crate) fn target_to_compact(target: ChainWork) -> u32 {
-        get_compact(target, false)
+    pub(crate) fn target_to_compact(target: ChainWork) -> CompactTarget {
+        CompactTarget::from_consensus(get_compact(target, false))
     }
 
     fn get_compact(target: ChainWork, negative: bool) -> u32 {
@@ -439,7 +439,7 @@ mod timestamp_tests {
         node::{BlockHeader, NodeStatus},
         tree::{BlockTree, hash_from_header},
     };
-    use bitcoin_rs_primitives::{BlockHash, Hash256};
+    use bitcoin_rs_primitives::{BlockHash, CompactTarget, Hash256};
 
     const REGTEST_BITS: u32 = 0x207f_ffff;
 
@@ -451,7 +451,7 @@ mod timestamp_tests {
             prev_blockhash,
             merkle_root: Hash256::from_le_bytes(&merkle),
             time,
-            bits: REGTEST_BITS,
+            bits: CompactTarget::from_consensus(REGTEST_BITS),
             nonce: 0,
         };
         while !compact_is_met_by(header.bits, header.compute_hash().0) {

--- a/crates/chain/src/tree.rs
+++ b/crates/chain/src/tree.rs
@@ -906,7 +906,7 @@ fn work_from_header(header: &BlockHeader) -> ChainWork {
 }
 #[cfg(test)]
 mod tests {
-    use bitcoin_rs_primitives::BlockHash;
+    use bitcoin_rs_primitives::{BlockHash, CompactTarget};
 
     use std::sync::Arc;
 
@@ -1245,7 +1245,7 @@ mod tests {
                 prev_blockhash: prev_hash,
                 merkle_root: Hash256::default(),
                 time: 1_000_000 + i * 600,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             };
             prev_hash = header.compute_hash();
@@ -1277,7 +1277,7 @@ mod tests {
                 prev_blockhash: prev_hash,
                 merkle_root: Hash256::default(),
                 time: 1_000_000 + i * 600,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             };
             prev_hash = header.compute_hash();
@@ -1534,7 +1534,7 @@ mod tests {
                 prev_blockhash: prev_hash,
                 merkle_root: Hash256::default(),
                 time: 1_000_000 + height * 600,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: height,
             };
             prev_hash = header.compute_hash();
@@ -1857,7 +1857,7 @@ mod tests {
             prev_blockhash,
             merkle_root: Hash256::from_le_bytes(&merkle),
             time: height,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: height,
         }
     }

--- a/crates/chain/tests/header_sync_roundtrip.rs
+++ b/crates/chain/tests/header_sync_roundtrip.rs
@@ -3,7 +3,7 @@ use bitcoin_rs_chain::header_sync::{next_work_required, validate_header_nbits};
 use bitcoin_rs_chain::{
     BlockHeader, BlockTree, ChainError, Network, NodeStatus, accept_headers, current_unix_seconds,
 };
-use bitcoin_rs_primitives::{BlockHash, Hash256};
+use bitcoin_rs_primitives::{BlockHash, CompactTarget, Hash256};
 
 #[test]
 fn accepts_valid_headers_across_batches_and_rejects_bad_bits()
@@ -34,7 +34,7 @@ fn accepts_valid_headers_across_batches_and_rejects_bad_bits()
     );
 
     let mut tampered = headers[0];
-    tampered.bits = 0x2200_ffff;
+    tampered.bits = CompactTarget::from_consensus(0x2200_ffff);
     let err = match accept_headers(
         &mut BlockTree::new(),
         &[tampered],
@@ -368,7 +368,7 @@ fn invalid_unknown_suffix_after_duplicate_inputs_propagates_consensus_error_with
     assert_eq!(tip_before.height, 1);
 
     let mut invalid_unknown = headers[2];
-    invalid_unknown.bits = 0x2200_ffff;
+    invalid_unknown.bits = CompactTarget::from_consensus(0x2200_ffff);
 
     let batch = [headers[0], headers[1], invalid_unknown];
     let err = match accept_headers(&mut tree, &batch, Network::Regtest, current_unix_seconds()) {
@@ -428,14 +428,21 @@ fn mine_header(prev_blockhash: BlockHash, height: u32) -> BlockHeader {
 
 /// Differential proof-of-work oracle: checks that the header hash satisfies
 /// the compact target, using bitcoin's compact-target decode and comparison.
-fn pow_is_met(bits: u32, hash: &BlockHash) -> bool {
+fn pow_is_met(bits: CompactTarget, hash: &BlockHash) -> bool {
     use bitcoin::hashes::Hash as _;
-    let target =
-        bitcoin::pow::Target::from_compact(bitcoin::pow::CompactTarget::from_consensus(bits));
+    let target = bitcoin::pow::Target::from_compact(bitcoin::pow::CompactTarget::from_consensus(
+        bits.to_consensus(),
+    ));
     target.is_met_by(bitcoin::BlockHash::from_byte_array(*hash.as_bytes()))
 }
 
-fn mine_header_with(prev_blockhash: BlockHash, height: u32, time: u32, bits: u32) -> BlockHeader {
+fn mine_header_with(
+    prev_blockhash: BlockHash,
+    height: u32,
+    time: u32,
+    bits: impl Into<CompactTarget>,
+) -> BlockHeader {
+    let bits = bits.into();
     let mut merkle = [0_u8; 32];
     merkle[..4].copy_from_slice(&height.to_le_bytes());
     let mut header = BlockHeader {
@@ -452,7 +459,13 @@ fn mine_header_with(prev_blockhash: BlockHash, height: u32, time: u32, bits: u32
     header
 }
 
-fn raw_header_with(prev_blockhash: BlockHash, height: u32, time: u32, bits: u32) -> BlockHeader {
+fn raw_header_with(
+    prev_blockhash: BlockHash,
+    height: u32,
+    time: u32,
+    bits: impl Into<CompactTarget>,
+) -> BlockHeader {
+    let bits = bits.into();
     let mut merkle = [0_u8; 32];
     merkle[..4].copy_from_slice(&height.to_le_bytes());
     BlockHeader {

--- a/crates/chain/tests/reorg_deep.rs
+++ b/crates/chain/tests/reorg_deep.rs
@@ -1,6 +1,6 @@
 //! Deep reorganization planner integration tests.
 use bitcoin_rs_chain::{BlockHeader, BlockTree, NodeId, NodeStatus, plan_reorg};
-use bitcoin_rs_primitives::{BlockHash, Hash256};
+use bitcoin_rs_primitives::{BlockHash, CompactTarget, Hash256};
 
 #[test]
 fn plans_deep_reorg_to_common_fork() -> Result<(), Box<dyn std::error::Error>> {
@@ -53,10 +53,11 @@ fn mine_child(
 
 /// Differential proof-of-work oracle: checks that the header hash satisfies
 /// the compact target, using bitcoin's compact-target decode and comparison.
-fn pow_is_met(bits: u32, hash: &BlockHash) -> bool {
+fn pow_is_met(bits: CompactTarget, hash: &BlockHash) -> bool {
     use bitcoin::hashes::Hash as _;
-    let target =
-        bitcoin::pow::Target::from_compact(bitcoin::pow::CompactTarget::from_consensus(bits));
+    let target = bitcoin::pow::Target::from_compact(bitcoin::pow::CompactTarget::from_consensus(
+        bits.to_consensus(),
+    ));
     target.is_met_by(bitcoin::BlockHash::from_byte_array(*hash.as_bytes()))
 }
 
@@ -69,7 +70,7 @@ fn mine_header(prev_blockhash: BlockHash, height: u32, branch: u8) -> BlockHeade
         prev_blockhash,
         merkle_root: Hash256::from_le_bytes(&merkle),
         time: height,
-        bits: 0x207f_ffff,
+        bits: CompactTarget::from_consensus(0x207f_ffff),
         nonce: 0,
     };
     while !pow_is_met(header.bits, &header.compute_hash()) {

--- a/crates/consensus/benches/merkle.rs
+++ b/crates/consensus/benches/merkle.rs
@@ -5,7 +5,7 @@
 use std::hint::black_box;
 
 use bitcoin_rs_consensus::verify_block::block_merkle_root_matches_txids;
-use bitcoin_rs_primitives::{Block, Hash256, Header, Txid, encode::double_sha256};
+use bitcoin_rs_primitives::{Block, CompactTarget, Hash256, Header, Txid, encode::double_sha256};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 fn make_txids(count: usize) -> Vec<Txid> {
@@ -64,7 +64,7 @@ fn benchmark_block(merkle_root: Hash256) -> Block {
             prev_blockhash: bitcoin_rs_primitives::BlockHash::default(),
             merkle_root,
             time: 0,
-            bits: 0,
+            bits: CompactTarget::from_consensus(0),
             nonce: 0,
         },
         txs: Vec::new(),

--- a/crates/consensus/src/bip141.rs
+++ b/crates/consensus/src/bip141.rs
@@ -24,9 +24,7 @@ pub fn check_bip141(tx: &Tx) -> Result<(), ConsensusError> {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin_rs_primitives::{
-        Amount, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Witness,
-    };
+    use bitcoin_rs_primitives::{Amount, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut};
 
     use super::check_bip141;
 

--- a/crates/consensus/src/bip141.rs
+++ b/crates/consensus/src/bip141.rs
@@ -24,7 +24,9 @@ pub fn check_bip141(tx: &Tx) -> Result<(), ConsensusError> {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin_rs_primitives::{OutPoint, Tx, TxIn, TxOut};
+    use bitcoin_rs_primitives::{
+        Amount, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Witness,
+    };
 
     use super::check_bip141;
 
@@ -43,16 +45,16 @@ mod tests {
     fn transaction_with_witness(witness: Vec<Vec<u8>>) -> Tx {
         Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::default(),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness,
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: witness.into(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
         }
     }

--- a/crates/consensus/src/bip143.rs
+++ b/crates/consensus/src/bip143.rs
@@ -1,4 +1,4 @@
-use bitcoin_rs_primitives::{Sighash, Tx};
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Sighash, Tx, Witness};
 
 use crate::ConsensusError;
 
@@ -7,7 +7,7 @@ pub fn check_bip143(
     tx: &Tx,
     input_idx: usize,
     script_code: &[u8],
-    value: u64,
+    value: Amount,
     sighash_type: Sighash,
 ) -> Result<(), ConsensusError> {
     Sighash::compute_bip143(tx, input_idx, script_code, value, sighash_type)
@@ -20,35 +20,40 @@ pub fn check_bip143(
 
 #[cfg(test)]
 mod tests {
-    use bitcoin_rs_primitives::{OutPoint, Sighash, Tx, TxIn, TxOut};
+    use bitcoin_rs_primitives::{
+        Amount, LockTime, OutPoint, Script, Sequence, Sighash, Tx, TxIn, TxOut, Witness,
+    };
 
     use super::check_bip143;
 
     #[test]
     fn valid_input_index_computes() {
         let tx = transaction();
-        assert_eq!(check_bip143(&tx, 0, &[0x51], 1, Sighash::All), Ok(()));
+        assert_eq!(
+            check_bip143(&tx, 0, &[0x51], Amount::SAT, Sighash::All),
+            Ok(())
+        );
     }
 
     #[test]
     fn out_of_range_input_fails() {
         let tx = transaction();
-        assert!(check_bip143(&tx, 1, &[0x51], 1, Sighash::All).is_err());
+        assert!(check_bip143(&tx, 1, &[0x51], Amount::SAT, Sighash::All).is_err());
     }
 
     fn transaction() -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::default(),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::SAT,
+                script_pubkey: Script::new(),
             }],
         }
     }

--- a/crates/consensus/src/bip143.rs
+++ b/crates/consensus/src/bip143.rs
@@ -1,4 +1,4 @@
-use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Sighash, Tx, Witness};
+use bitcoin_rs_primitives::{Amount, Sighash, Tx};
 
 use crate::ConsensusError;
 

--- a/crates/consensus/src/kernel.rs
+++ b/crates/consensus/src/kernel.rs
@@ -132,7 +132,7 @@ mod enabled {
     ) -> Result<(), ConsensusError> {
         let script = bitcoinkernel::ScriptPubkey::new(&prevout.script_pubkey)
             .map_err(|error| ConsensusError::Kernel(error.to_string()))?;
-        let amount = i64::try_from(prevout.value)
+        let amount = i64::try_from(prevout.value.to_sat())
             .map_err(|error| ConsensusError::Kernel(error.to_string()))?;
         bitcoinkernel::verify(
             &script,
@@ -204,7 +204,7 @@ mod enabled {
     fn kernel_txout(prevout: &TxOut) -> Result<bitcoinkernel::TxOut, ConsensusError> {
         let script = bitcoinkernel::ScriptPubkey::new(&prevout.script_pubkey)
             .map_err(|error| ConsensusError::Kernel(error.to_string()))?;
-        let amount = i64::try_from(prevout.value)
+        let amount = i64::try_from(prevout.value.to_sat())
             .map_err(|error| ConsensusError::Kernel(error.to_string()))?;
         Ok(bitcoinkernel::TxOut::new(&script, amount))
     }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -199,7 +199,11 @@ pub enum ConsensusError {
 }
 
 /// Maximum valid money supply in satoshis.
-pub const MAX_MONEY: u64 = 21_000_000 * 100_000_000;
+///
+/// The 21-million-BTC rule is owned by
+/// [`bitcoin_rs_primitives::Amount::MAX_MONEY`]; consensus checks use this
+/// satoshi view of that constant.
+pub const MAX_MONEY: u64 = bitcoin_rs_primitives::Amount::MAX_MONEY.to_sat();
 
 /// Coinbase subsidy at `height`, in satoshis.
 ///

--- a/crates/consensus/src/verify_block.rs
+++ b/crates/consensus/src/verify_block.rs
@@ -1,4 +1,7 @@
-use bitcoin_rs_primitives::{Block, Hash256, Tx, Txid, Wtxid, encode::double_sha256};
+use bitcoin_rs_primitives::{
+    Amount, Block, CompactTarget, Hash256, LockTime, Script, Sequence, Tx, Txid, Witness, Wtxid,
+    encode::double_sha256,
+};
 
 use crate::ConsensusError;
 use crate::sha256d64::{self, Avx2Sha256d64, detect_avx2};
@@ -414,7 +417,8 @@ fn next_merkle_level_scalar(level: &mut Vec<Txid>) {
 #[cfg(test)]
 mod tests {
     use bitcoin_rs_primitives::{
-        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, Wtxid,
+        Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script,
+        Sequence, Tx, TxIn, TxOut, Txid, Witness, Wtxid,
     };
 
     use super::{
@@ -434,7 +438,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0,
+                bits: CompactTarget::from_consensus(0),
                 nonce: 0,
             },
             txs: vec![coinbase_tx()],
@@ -453,15 +457,15 @@ mod tests {
             version: 1,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[1; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let block = Block {
             header: Header {
@@ -469,7 +473,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0,
+                bits: CompactTarget::from_consensus(0),
                 nonce: 0,
             },
             txs: vec![tx],
@@ -513,7 +517,7 @@ mod tests {
     #[test]
     fn contextual_rules_always_enforce_block_weight_limit() {
         let mut coinbase = coinbase_tx();
-        coinbase.inputs[0].script_sig = vec![1; 1_000_001];
+        coinbase.inputs[0].script_sig = vec![1; 1_000_001].into();
         let block = block_with_transactions(vec![coinbase]);
 
         assert!(matches!(
@@ -580,14 +584,14 @@ mod tests {
         let valid = compute_witness_commitment(&[coinbase_tx(), spend.clone()], &reserved);
 
         let mut coinbase = coinbase_tx();
-        coinbase.inputs[0].witness = vec![reserved];
+        coinbase.inputs[0].witness = vec![reserved].into();
         coinbase.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: commitment_script(&valid),
+            value: Amount::from_sat(0),
+            script_pubkey: commitment_script(&valid).into(),
         });
         coinbase.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: commitment_script(&[0xff; 32]),
+            value: Amount::from_sat(0),
+            script_pubkey: commitment_script(&[0xff; 32]).into(),
         });
 
         let block = block_with_transactions(vec![coinbase, spend]);
@@ -611,14 +615,14 @@ mod tests {
         let valid = compute_witness_commitment(&[coinbase_tx(), spend.clone()], &reserved);
 
         let mut coinbase = coinbase_tx();
-        coinbase.inputs[0].witness = vec![reserved];
+        coinbase.inputs[0].witness = vec![reserved].into();
         coinbase.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: commitment_script(&[0xff; 32]),
+            value: Amount::from_sat(0),
+            script_pubkey: commitment_script(&[0xff; 32]).into(),
         });
         coinbase.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: commitment_script(&valid),
+            value: Amount::from_sat(0),
+            script_pubkey: commitment_script(&valid).into(),
         });
 
         let block = block_with_transactions(vec![coinbase, spend]);
@@ -640,10 +644,10 @@ mod tests {
 
         let make_block = |witness: Vec<Vec<u8>>| -> Block {
             let mut coinbase = coinbase_tx();
-            coinbase.inputs[0].witness = witness;
+            coinbase.inputs[0].witness = witness.into();
             coinbase.outputs.push(TxOut {
-                value: 0,
-                script_pubkey: commitment_script(&commitment),
+                value: Amount::from_sat(0),
+                script_pubkey: commitment_script(&commitment).into(),
             });
             block_with_transactions(vec![coinbase, spend.clone()])
         };
@@ -692,10 +696,10 @@ mod tests {
         let commitment = compute_witness_commitment(&[coinbase_tx(), spend.clone()], &reserved);
 
         let mut coinbase = coinbase_tx();
-        coinbase.inputs[0].witness = vec![reserved];
+        coinbase.inputs[0].witness = vec![reserved].into();
         coinbase.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: commitment_script(&commitment),
+            value: Amount::from_sat(0),
+            script_pubkey: commitment_script(&commitment).into(),
         });
 
         let block = block_with_transactions(vec![coinbase, spend]);
@@ -822,7 +826,7 @@ mod tests {
             prev_blockhash: BlockHash::default(),
             merkle_root,
             time: 0,
-            bits: 0,
+            bits: CompactTarget::from_consensus(0),
             nonce: 0,
         };
         // Empty input is a MerkleRoot error regardless of the header.
@@ -963,7 +967,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: wrong_root,
                 time: 0,
-                bits: 0,
+                bits: CompactTarget::from_consensus(0),
                 nonce: 0,
             },
             txs: Vec::new(),
@@ -1015,15 +1019,15 @@ mod tests {
             version: 1,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: vec![1, 1],
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: vec![1, 1].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -1032,15 +1036,15 @@ mod tests {
             version: 1,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[2; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: vec![vec![1; 32]],
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: vec![vec![1; 32]].into(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -1049,15 +1053,15 @@ mod tests {
             version: 1,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[seed; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -1068,7 +1072,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0,
+                bits: CompactTarget::from_consensus(0),
                 nonce: 0,
             },
             txs,

--- a/crates/consensus/src/verify_block.rs
+++ b/crates/consensus/src/verify_block.rs
@@ -1,7 +1,4 @@
-use bitcoin_rs_primitives::{
-    Amount, Block, CompactTarget, Hash256, LockTime, Script, Sequence, Tx, Txid, Witness, Wtxid,
-    encode::double_sha256,
-};
+use bitcoin_rs_primitives::{Block, Hash256, Tx, Txid, Wtxid, encode::double_sha256};
 
 use crate::ConsensusError;
 use crate::sha256d64::{self, Avx2Sha256d64, detect_avx2};

--- a/crates/consensus/src/verify_tx.rs
+++ b/crates/consensus/src/verify_tx.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 use std::time::Instant;
 
-use bitcoin_rs_primitives::{OutPoint, Tx, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, CompactTarget, LockTime, OutPoint, Script, Sequence, Tx, TxOut, Txid, Witness,
+};
 
 use crate::block_view::BlockView;
 #[cfg(not(feature = "kernel"))]
@@ -113,7 +115,7 @@ fn is_null_outpoint(outpoint: &OutPoint) -> bool {
 /// Callers choose the timestamp cutoff: block header time before BIP113, previous-tip MTP after.
 #[must_use]
 fn is_final_tx_with_locktime_cutoff(tx: &Tx, block_height: u32, locktime_cutoff: u32) -> bool {
-    let lock_time = tx.lock_time;
+    let lock_time = tx.lock_time.to_consensus();
     if lock_time == 0 {
         return true;
     }
@@ -129,7 +131,7 @@ fn is_final_tx_with_locktime_cutoff(tx: &Tx, block_height: u32, locktime_cutoff:
 
     tx.inputs
         .iter()
-        .all(|input| input.sequence == SEQUENCE_FINAL)
+        .all(|input| input.sequence == Sequence::from_consensus(SEQUENCE_FINAL))
 }
 
 /// Verifies non-contextual and input-script transaction rules for a transaction.
@@ -268,7 +270,7 @@ fn prepare_tx_checks(
         let prevout = lookup(input_index, &input.previous_output)
             .ok_or(ConsensusError::MissingPrevout { input_index })?;
         input_value = input_value
-            .checked_add(prevout.value)
+            .checked_add(prevout.value.to_sat())
             .ok_or(ConsensusError::OutputValueOverflow)?;
         prevouts.push((input.previous_output, prevout));
     }
@@ -787,7 +789,7 @@ fn cached_prevout_lookup(
 fn total_output_value(tx: &Tx) -> Result<u64, ConsensusError> {
     tx.outputs.iter().try_fold(0u64, |sum, output| {
         let next = sum
-            .checked_add(output.value)
+            .checked_add(output.value.to_sat())
             .ok_or(ConsensusError::OutputValueOverflow)?;
         if next > MAX_MONEY {
             Err(ConsensusError::OutputValueOverflow)
@@ -862,8 +864,8 @@ mod tests {
     #[cfg(feature = "kernel")]
     use bitcoin::hashes::Hash as _;
     use bitcoin_rs_primitives::{
-        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-        deserialize,
+        Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script,
+        Sequence, Tx, TxIn, TxOut, Txid, Witness, consensus_bytes, deserialize,
     };
     #[cfg(not(feature = "kernel"))]
     use bitcoin_rs_primitives::{Sighash, SighashCache};
@@ -887,7 +889,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0x2000_ffff,
+                bits: CompactTarget::from_consensus(0x2000_ffff),
                 nonce: 0,
             },
             txs: txs.to_vec(),
@@ -919,16 +921,16 @@ mod tests {
     fn coinbase_transaction_skips_prevout_lookup() {
         let tx = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: vec![1, 1],
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: vec![1, 1].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50),
+                script_pubkey: Script::new(),
             }],
         };
         let utxos = hashbrown::HashMap::new();
@@ -975,19 +977,19 @@ mod tests {
         };
         let tx = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![spending_input(outpoint), spending_input(outpoint)],
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50),
+                script_pubkey: Script::new(),
             }],
         };
         let mut utxos = hashbrown::HashMap::new();
         utxos.insert(
             outpoint,
             TxOut {
-                value: 100,
-                script_pubkey: push_int(1),
+                value: Amount::from_sat(100),
+                script_pubkey: push_int(1).into(),
             },
         );
         assert_eq!(
@@ -1008,26 +1010,26 @@ mod tests {
         };
         let tx = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![true_spending_input(first), true_spending_input(second)],
             outputs: vec![TxOut {
-                value: 75,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(75),
+                script_pubkey: Script::new(),
             }],
         };
         let mut utxos = hashbrown::HashMap::new();
         utxos.insert(
             first,
             TxOut {
-                value: 50,
-                script_pubkey: push_int(1),
+                value: Amount::from_sat(50),
+                script_pubkey: push_int(1).into(),
             },
         );
         utxos.insert(
             second,
             TxOut {
-                value: 50,
-                script_pubkey: push_int(1),
+                value: Amount::from_sat(50),
+                script_pubkey: push_int(1).into(),
             },
         );
 
@@ -1049,26 +1051,26 @@ mod tests {
         };
         let tx = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![true_spending_input(first), true_spending_input(second)],
             outputs: vec![TxOut {
-                value: 75,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(75),
+                script_pubkey: Script::new(),
             }],
         };
         let mut utxos = hashbrown::HashMap::new();
         utxos.insert(
             first,
             TxOut {
-                value: 50,
-                script_pubkey: push_int(1),
+                value: Amount::from_sat(50),
+                script_pubkey: push_int(1).into(),
             },
         );
         utxos.insert(
             second,
             TxOut {
-                value: 50,
-                script_pubkey: push_int(1),
+                value: Amount::from_sat(50),
+                script_pubkey: push_int(1).into(),
             },
         );
         let view = CountingUtxoView::new(utxos);
@@ -1093,26 +1095,26 @@ mod tests {
         };
         let tx = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![true_spending_input(first), true_spending_input(second)],
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50),
+                script_pubkey: Script::new(),
             }],
         };
         let mut utxos = hashbrown::HashMap::new();
         utxos.insert(
             first,
             TxOut {
-                value: 50,
-                script_pubkey: p2tr_script_pubkey(),
+                value: Amount::from_sat(50),
+                script_pubkey: p2tr_script_pubkey().into(),
             },
         );
         utxos.insert(
             second,
             TxOut {
-                value: 50,
-                script_pubkey: push_int(1),
+                value: Amount::from_sat(50),
+                script_pubkey: push_int(1).into(),
             },
         );
 
@@ -1170,28 +1172,28 @@ mod tests {
             script_pubkey.push(0x20); // push 32 bytes
             script_pubkey.extend_from_slice(&output_key.serialize());
             prevouts.push(TxOut {
-                value: 50_000,
-                script_pubkey,
+                value: Amount::from_sat(50_000),
+                script_pubkey: script_pubkey.into(),
             });
             keypairs.push(tweaked_keypair);
         }
 
         let mut tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: outpoints
                 .iter()
                 .copied()
                 .map(|previous_output| TxIn {
                     previous_output,
-                    script_sig: Vec::new(),
-                    sequence: 0xffff_ffff,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 })
                 .collect(),
             outputs: vec![TxOut {
-                value: 99_000,
-                script_pubkey: push_int(1),
+                value: Amount::from_sat(99_000),
+                script_pubkey: push_int(1).into(),
             }],
         };
 
@@ -1202,7 +1204,7 @@ mod tests {
                 .unwrap_or_else(|_| panic!("taproot sighash"));
             let message = Message::from_digest(sighash.to_le_bytes());
             let signature = secp.sign_schnorr(&message, keypair);
-            tx.inputs[input_idx].witness = vec![signature.serialize().to_vec()];
+            tx.inputs[input_idx].witness = vec![signature.serialize().to_vec()].into();
         }
 
         let mut utxos = hashbrown::HashMap::new();
@@ -1225,24 +1227,24 @@ mod tests {
         };
         let tx = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: outpoint,
-                script_sig: [push_int(7), push_int(7)].concat(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: [push_int(7), push_int(7)].concat().into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50),
+                script_pubkey: Script::new(),
             }],
         };
         let mut utxos = hashbrown::HashMap::new();
         utxos.insert(
             outpoint,
             TxOut {
-                value: 100,
-                script_pubkey: vec![OP_EQUAL],
+                value: Amount::from_sat(100),
+                script_pubkey: vec![OP_EQUAL].into(),
             },
         );
 
@@ -1264,24 +1266,24 @@ mod tests {
         };
         let tx = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: outpoint,
-                script_sig: [push_int(7), push_int(8)].concat(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: [push_int(7), push_int(8)].concat().into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50),
+                script_pubkey: Script::new(),
             }],
         };
         let mut utxos = hashbrown::HashMap::new();
         utxos.insert(
             outpoint,
             TxOut {
-                value: 100,
-                script_pubkey: vec![OP_EQUAL],
+                value: Amount::from_sat(100),
+                script_pubkey: vec![OP_EQUAL].into(),
             },
         );
 
@@ -1308,24 +1310,24 @@ mod tests {
         };
         let tx = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: outpoint,
-                script_sig: [push_int(7), push_int(8)].concat(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: [push_int(7), push_int(8)].concat().into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50),
+                script_pubkey: Script::new(),
             }],
         };
         let mut utxos = hashbrown::HashMap::new();
         utxos.insert(
             outpoint,
             TxOut {
-                value: 100,
-                script_pubkey: vec![OP_EQUAL],
+                value: Amount::from_sat(100),
+                script_pubkey: vec![OP_EQUAL].into(),
             },
         );
 
@@ -1343,16 +1345,16 @@ mod tests {
     fn verify_transaction_rejects_non_final_height_lock() {
         let tx = Tx {
             version: 1,
-            lock_time: 200,
+            lock_time: LockTime::from_consensus(200),
             inputs: vec![TxIn {
                 previous_output: OutPoint::default(),
-                script_sig: Vec::new(),
-                sequence: 0,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(0),
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1_000),
+                script_pubkey: Script::new(),
             }],
         };
         let utxos = hashbrown::HashMap::new();
@@ -1369,16 +1371,16 @@ mod tests {
     fn timestamp_locktime_uses_caller_supplied_cutoff() {
         let tx = Tx {
             version: 1,
-            lock_time: 500_000_100,
+            lock_time: LockTime::from_consensus(500_000_100),
             inputs: vec![TxIn {
                 previous_output: OutPoint::default(),
-                script_sig: Vec::new(),
-                sequence: 0,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(0),
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1_000),
+                script_pubkey: Script::new(),
             }],
         };
 
@@ -1398,16 +1400,16 @@ mod tests {
 
         let non_final = Tx {
             version: 1,
-            lock_time: 500_000_100,
+            lock_time: LockTime::from_consensus(500_000_100),
             inputs: vec![TxIn {
                 previous_output: OutPoint::default(),
-                script_sig: Vec::new(),
-                sequence: 0,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(0),
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1_000),
+                script_pubkey: Script::new(),
             }],
         };
 
@@ -1420,9 +1422,9 @@ mod tests {
     fn spending_input(outpoint: OutPoint) -> TxIn {
         TxIn {
             previous_output: outpoint,
-            script_sig: push_int(1),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: push_int(1).into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }
     }
 
@@ -1574,22 +1576,24 @@ mod tests {
         let redeem_script = [0_u8];
         let redeem_hash = bitcoin::hashes::hash160::Hash::hash(&redeem_script);
         let p2sh_output = TxOut {
-            value: 50,
+            value: Amount::from_sat(50),
             script_pubkey: [
                 vec![OP_HASH160],
                 push_data(&redeem_hash.to_byte_array()),
                 vec![OP_EQUAL],
             ]
-            .concat(),
+            .into()
+            .concat()
+            .into(),
         };
         let second_txs = vec![
             coinbase_transaction_with_script_sig_len(2),
             spend_tx(
                 vec![TxIn {
                     previous_output: outpoint(10),
-                    script_sig: push_data(&redeem_script),
-                    sequence: 0xffff_ffff,
-                    witness: Vec::new(),
+                    script_sig: push_data(&redeem_script).into(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 }],
                 50,
             ),
@@ -1628,9 +1632,9 @@ mod tests {
     fn true_spending_input(outpoint: OutPoint) -> TxIn {
         TxIn {
             previous_output: outpoint,
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }
     }
 
@@ -1671,16 +1675,16 @@ mod tests {
     fn coinbase_transaction_with_script_sig_len(len: usize) -> Tx {
         Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: vec![1; len],
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: vec![1; len].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50),
+                script_pubkey: Script::new(),
             }],
         }
     }
@@ -1688,16 +1692,16 @@ mod tests {
     #[cfg(feature = "kernel")]
     fn op1_txout(value: u64) -> TxOut {
         TxOut {
-            value,
-            script_pubkey: push_int(1),
+            value: Amount::from_sat(value),
+            script_pubkey: push_int(1).into(),
         }
     }
 
     #[cfg(feature = "kernel")]
     fn op_equal_txout(value: u64) -> TxOut {
         TxOut {
-            value,
-            script_pubkey: vec![OP_EQUAL],
+            value: Amount::from_sat(value),
+            script_pubkey: vec![OP_EQUAL].into(),
         }
     }
 
@@ -1707,9 +1711,9 @@ mod tests {
     fn mismatch_input(outpoint: OutPoint) -> TxIn {
         TxIn {
             previous_output: outpoint,
-            script_sig: [push_int(7), push_int(8)].concat(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: [push_int(7), push_int(8)].concat().into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }
     }
 
@@ -1717,11 +1721,11 @@ mod tests {
     fn spend_tx(inputs: Vec<TxIn>, output_value: u64) -> Tx {
         Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs,
             outputs: vec![TxOut {
-                value: output_value,
-                script_pubkey: push_int(1),
+                value: Amount::from_sat(output_value),
+                script_pubkey: push_int(1).into(),
             }],
         }
     }
@@ -1989,8 +1993,8 @@ mod tests {
             .prevouts
             .iter()
             .map(|prevout| TxOut {
-                value: prevout.amount_sat,
-                script_pubkey: decode_hex(&prevout.script_hex),
+                value: Amount::from_sat(prevout.amount_sat),
+                script_pubkey: decode_hex(&prevout.script_hex).into(),
             })
             .collect::<Vec<_>>();
         let flags = VerifyFlags::from_core_names(&file.flags)

--- a/crates/consensus/src/verify_tx.rs
+++ b/crates/consensus/src/verify_tx.rs
@@ -2,9 +2,7 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 use std::time::Instant;
 
-use bitcoin_rs_primitives::{
-    Amount, CompactTarget, LockTime, OutPoint, Script, Sequence, Tx, TxOut, Txid, Witness,
-};
+use bitcoin_rs_primitives::{Amount, OutPoint, Sequence, Tx, TxOut, Txid};
 
 use crate::block_view::BlockView;
 #[cfg(not(feature = "kernel"))]
@@ -16,7 +14,7 @@ use bitcoin_rs_script::{
 use rayon::prelude::*;
 
 use crate::rust_path::UtxoView;
-use crate::{ConsensusError, MAX_BLOCK_SIGOPS_COST, MAX_MONEY};
+use crate::{ConsensusError, MAX_BLOCK_SIGOPS_COST};
 
 const LOCKTIME_THRESHOLD: u32 = 500_000_000;
 const SEQUENCE_FINAL: u32 = 0xffff_ffff;
@@ -791,7 +789,7 @@ fn total_output_value(tx: &Tx) -> Result<u64, ConsensusError> {
         let next = sum
             .checked_add(output.value.to_sat())
             .ok_or(ConsensusError::OutputValueOverflow)?;
-        if next > MAX_MONEY {
+        if Amount::from_sat(next) > Amount::MAX_MONEY {
             Err(ConsensusError::OutputValueOverflow)
         } else {
             Ok(next)

--- a/crates/consensus/tests/kernel_block_parity.rs
+++ b/crates/consensus/tests/kernel_block_parity.rs
@@ -80,7 +80,9 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 
 use bitcoin_rs_consensus::ConsensusError;
-use bitcoin_rs_primitives::{OutPoint, Tx, TxOut, consensus_bytes, deserialize};
+use bitcoin_rs_primitives::{
+    Amount, LockTime, OutPoint, Script, Sequence, Tx, TxOut, Witness, consensus_bytes, deserialize,
+};
 use bitcoin_rs_script::{Interpreter, VerifyFlags};
 use serde::Deserialize;
 
@@ -517,8 +519,8 @@ fn validate_fixture(file: FixtureFile, path: &Path) -> Result<Fixture, Box<dyn E
         .iter()
         .map(|prevout| {
             Ok(TxOut {
-                value: prevout.amount_sat,
-                script_pubkey: decode_hex(&prevout.script_hex)?,
+                value: bitcoin_rs_primitives::Amount::from_sat(prevout.amount_sat),
+                script_pubkey: decode_hex(&prevout.script_hex)?.into(),
             })
         })
         .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
@@ -724,16 +726,16 @@ fn op_true_spend_with_push_script_sig() -> Tx {
 
     Tx {
         version: 1,
-        lock_time: 0,
+        lock_time: bitcoin_rs_primitives::LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::default(),
-            script_sig: vec![0x51],
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: vec![0x51].into(),
+            sequence: bitcoin_rs_primitives::Sequence::MAX,
+            witness: bitcoin_rs_primitives::Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 40_000,
-            script_pubkey: Vec::new(),
+            value: bitcoin_rs_primitives::Amount::from_sat(40_000),
+            script_pubkey: bitcoin_rs_primitives::Script::new(),
         }],
     }
 }

--- a/crates/consensus/tests/kernel_vector_parity.rs
+++ b/crates/consensus/tests/kernel_vector_parity.rs
@@ -47,7 +47,7 @@ use std::error::Error;
 use std::path::Path;
 use std::str::FromStr;
 
-use bitcoin_rs_primitives::{OutPoint, Tx, TxOut, Txid, deserialize};
+use bitcoin_rs_primitives::{Amount, OutPoint, Tx, TxOut, Txid, deserialize};
 use bitcoin_rs_script::VerifyFlags;
 use sonic_rs::{JsonContainerTrait as _, JsonValueTrait as _, Value};
 
@@ -361,8 +361,8 @@ fn load_vectors(name: &str, expected: Verdict) -> Result<Vec<VectorRow>, Box<dyn
             prevouts.push((
                 outpoint,
                 TxOut {
-                    value: amount,
-                    script_pubkey,
+                    value: bitcoin_rs_primitives::Amount::from_sat(amount),
+                    script_pubkey: script_pubkey.into(),
                 },
             ));
         }

--- a/crates/index/benches/history_resolve.rs
+++ b/crates/index/benches/history_resolve.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 
 use bitcoin_rs_index::{BlockSource, Indexer, ScriptHash};
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-    deserialize,
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, Witness, consensus_bytes, deserialize,
 };
 use bitcoin_rs_storage::RocksDbStore;
 use bitcoin_rs_storage::block_file::{BlockFilePosition, FlatFileBlockStore};
@@ -118,24 +118,24 @@ fn filler_tx(seed: u64) -> Tx {
     fill_bytes(seed, &mut txid_bytes);
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint {
                 txid: Txid(Hash256::from_le_bytes(&txid_bytes)),
                 vout: u32::try_from(seed & 0x3).unwrap_or(0),
             },
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![
             TxOut {
-                value: 5_000,
-                script_pubkey: witness_script(seed ^ 0xa5a5_a5a5),
+                value: Amount::from_sat(5_000),
+                script_pubkey: witness_script(seed ^ 0xa5a5_a5a5).into(),
             },
             TxOut {
-                value: 7_000,
-                script_pubkey: witness_script(seed ^ 0x5a5a_5a5a),
+                value: Amount::from_sat(7_000),
+                script_pubkey: witness_script(seed ^ 0x5a5a_5a5a).into(),
             },
         ],
     }
@@ -151,19 +151,19 @@ fn target_tx(height: u32, target_script: &[u8]) -> Tx {
     );
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint {
                 txid: Txid(Hash256::from_le_bytes(&txid_bytes)),
                 vout: 0,
             },
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 11_000,
-            script_pubkey: target_script.to_vec(),
+            value: Amount::from_sat(11_000),
+            script_pubkey: target_script.to_vec().into(),
         }],
     }
 }
@@ -174,7 +174,7 @@ fn empty_header() -> Header {
         prev_blockhash: BlockHash::default(),
         merkle_root: Hash256::default(),
         time: 0,
-        bits: 0,
+        bits: CompactTarget::from_consensus(0),
         nonce: 0,
     }
 }

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -1,9 +1,6 @@
 use std::ops::ControlFlow;
 
-use bitcoin_rs_primitives::{
-    Amount, Block, CompactTarget, Hash256, LockTime, OutPoint, Script, Sequence, Tx, Txid, Witness,
-    encode, varint,
-};
+use bitcoin_rs_primitives::{Block, Hash256, OutPoint, Tx, Txid, encode, varint};
 use bitcoin_rs_storage::{
     ColumnFamily, KvSnapshot, KvStore, PrefixScanLimit, StorageError, WriteBatch, WriteCondition,
 };

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -1,6 +1,9 @@
 use std::ops::ControlFlow;
 
-use bitcoin_rs_primitives::{Block, Hash256, OutPoint, Tx, Txid, encode, varint};
+use bitcoin_rs_primitives::{
+    Amount, Block, CompactTarget, Hash256, LockTime, OutPoint, Script, Sequence, Tx, Txid, Witness,
+    encode, varint,
+};
 use bitcoin_rs_storage::{
     ColumnFamily, KvSnapshot, KvStore, PrefixScanLimit, StorageError, WriteBatch, WriteCondition,
 };
@@ -1554,7 +1557,7 @@ impl<S: KvStore> Indexer<S> {
                     let Ok(vout) = u32::try_from(vout_idx) else {
                         continue;
                     };
-                    outputs.push((txid, vout, output.value, height));
+                    outputs.push((txid, vout, output.value.to_sat(), height));
                 }
             }
         }
@@ -1689,7 +1692,7 @@ impl<S: KvStore> Indexer<S> {
         let Ok(vout_idx) = usize::try_from(outpoint.vout) else {
             return Ok(None);
         };
-        Ok(tx.outputs.get(vout_idx).map(|output| output.value))
+        Ok(tx.outputs.get(vout_idx).map(|output| output.value.to_sat()))
     }
 
     /// Resolves a transaction by txid and returns it alongside the block
@@ -2841,7 +2844,7 @@ fn append_matching_outputs(
             continue;
         };
         let txid = *computed_txid.get_or_insert_with(|| tx.txid());
-        outputs.push((txid, vout, output.value, height));
+        outputs.push((txid, vout, output.value.to_sat(), height));
     }
 }
 
@@ -4114,21 +4117,21 @@ mod tests {
         let coinbase = tx(OutPoint::new(Txid::default(), u32::MAX), vec![0x51, 0x04]);
         let spender = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: spent_outpoint(9, 1),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![
                 TxOut {
-                    value: 5_000,
-                    script_pubkey: vec![0x51, 0x05],
+                    value: Amount::from_sat(5_000),
+                    script_pubkey: vec![0x51, 0x05].into(),
                 },
                 TxOut {
-                    value: 0,
-                    script_pubkey: vec![0x6a, 0x01, 0x00],
+                    value: Amount::from_sat(0),
+                    script_pubkey: vec![0x6a, 0x01, 0x00].into(),
                 },
             ],
         };
@@ -4223,7 +4226,7 @@ mod tests {
         };
         let scripthash = ScriptHash::from_script_bytes(&output.script_pubkey);
         let txid = tx.txid();
-        let value = output.value;
+        let value = output.value.to_sat();
         let (_dir, mut indexer) = indexer()?;
 
         indexer.ingest_block(&consensus_bytes(&block), 0)?;
@@ -4419,7 +4422,7 @@ mod tests {
         };
         let scripthash = ScriptHash::from_script_bytes(&output.script_pubkey);
         let txid = tx.txid();
-        let value = output.value;
+        let value = output.value.to_sat();
         let (_dir, mut indexer) = indexer()?;
 
         indexer.ingest_block(&consensus_bytes(&block), 0)?;
@@ -4797,7 +4800,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0,
+                bits: CompactTarget::from_consensus(0),
                 nonce: 0,
             },
             txs,
@@ -4807,16 +4810,16 @@ mod tests {
     fn tx(previous_output: OutPoint, script_pubkey: Vec<u8>) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output,
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 5_000,
-                script_pubkey,
+                value: Amount::from_sat(5_000),
+                script_pubkey: script_pubkey.into(),
             }],
         }
     }

--- a/crates/index/tests/index_roundtrip.rs
+++ b/crates/index/tests/index_roundtrip.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use bitcoin_rs_primitives::{
-    Block, Hash256, Network, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-    encode::double_sha256,
+    Block, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    consensus_bytes, encode::double_sha256,
 };
 use parking_lot::{Mutex, RwLock};
 
@@ -928,19 +928,19 @@ fn spending_rows_carry_transaction_positions() -> Result<(), Box<dyn std::error:
     let funding_txid = block.txs[0].txid();
     let spending_tx = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint {
                 txid: funding_txid,
                 vout: 0,
             },
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
             value: block.txs[0].outputs[0].value,
-            script_pubkey: Vec::new(),
+            script_pubkey: Script::new(),
         }],
     };
     block.txs.push(spending_tx.clone());

--- a/crates/index/tests/le_order.rs
+++ b/crates/index/tests/le_order.rs
@@ -13,7 +13,8 @@ use std::sync::Arc;
 
 use bitcoin_rs_index::{BlockSource, Indexer, ScriptHash};
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, Witness, consensus_bytes,
 };
 
 use common::MemoryStore;
@@ -35,7 +36,7 @@ fn header() -> Header {
         prev_blockhash: BlockHash::default(),
         merkle_root: Hash256::default(),
         time: 0,
-        bits: 0,
+        bits: CompactTarget::from_consensus(0),
         nonce: 0,
     }
 }
@@ -43,16 +44,16 @@ fn header() -> Header {
 fn tx_with_script(previous_output: OutPoint, script_pubkey: Vec<u8>) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output,
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 5_000,
-            script_pubkey,
+            value: Amount::from_sat(5_000),
+            script_pubkey: script_pubkey.into(),
         }],
     }
 }

--- a/crates/index/tests/resolver_fallback.rs
+++ b/crates/index/tests/resolver_fallback.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 use bitcoin_rs_index::types::{TxPosition, TxPositionValue};
 use bitcoin_rs_index::{BlockSource, Indexer, ScriptHash, ScriptHashRow, ScriptHistoryEntry};
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes, varint,
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, Witness, consensus_bytes, varint,
 };
 use bitcoin_rs_storage::{ColumnFamily, KvStore as _, WriteBatch as _};
 
@@ -40,7 +41,7 @@ fn header() -> Header {
         prev_blockhash: BlockHash::default(),
         merkle_root: Hash256::default(),
         time: 0,
-        bits: 0,
+        bits: CompactTarget::from_consensus(0),
         nonce: 0,
     }
 }
@@ -48,19 +49,19 @@ fn header() -> Header {
 fn tx(seed: u8, script_pubkey: Vec<u8>, value: u64) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint {
                 txid: Txid(Hash256::from_le_bytes(&[seed; 32])),
                 vout: u32::from(seed),
             },
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value,
-            script_pubkey,
+            value: Amount::from_sat(value),
+            script_pubkey: script_pubkey.into(),
         }],
     }
 }

--- a/crates/index/tests/script_live.rs
+++ b/crates/index/tests/script_live.rs
@@ -220,7 +220,7 @@ fn coinbase(tag: u8) -> Transaction {
         }],
         output: vec![TxOut {
             value: Amount::from_sat(50),
-            script_pubkey: script(0xc0 ^ tag).into(),
+            script_pubkey: script(0xc0 ^ tag),
         }],
     }
 }
@@ -246,7 +246,7 @@ fn spend(inputs: &[OutPoint], outputs: &[ScriptBuf]) -> Transaction {
             .iter()
             .map(|script_pubkey| TxOut {
                 value: Amount::from_sat(10),
-                script_pubkey: script_pubkey.clone().into(),
+                script_pubkey: script_pubkey.clone(),
             })
             .collect(),
     }

--- a/crates/index/tests/script_live.rs
+++ b/crates/index/tests/script_live.rs
@@ -220,7 +220,7 @@ fn coinbase(tag: u8) -> Transaction {
         }],
         output: vec![TxOut {
             value: Amount::from_sat(50),
-            script_pubkey: script(0xc0 ^ tag),
+            script_pubkey: script(0xc0 ^ tag).into(),
         }],
     }
 }
@@ -246,7 +246,7 @@ fn spend(inputs: &[OutPoint], outputs: &[ScriptBuf]) -> Transaction {
             .iter()
             .map(|script_pubkey| TxOut {
                 value: Amount::from_sat(10),
-                script_pubkey: script_pubkey.clone(),
+                script_pubkey: script_pubkey.clone().into(),
             })
             .collect(),
     }

--- a/crates/index/tests/tx_positions.rs
+++ b/crates/index/tests/tx_positions.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 use bitcoin_rs_index::types::{TxPosition, TxPositionValue};
 use bitcoin_rs_index::{Indexer, ScriptHash};
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-    deserialize,
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, consensus_bytes, deserialize,
 };
 use bitcoin_rs_storage::{ColumnFamily, KvStore};
 use proptest::prelude::*;
@@ -30,7 +30,7 @@ fn header() -> Header {
         prev_blockhash: BlockHash::default(),
         merkle_root: Hash256::default(),
         time: 7,
-        bits: 0,
+        bits: CompactTarget::from_consensus(0),
         nonce: 42,
     }
 }
@@ -44,14 +44,14 @@ fn script(tag: u8) -> Vec<u8> {
 fn tx(seed: u8, outputs: Vec<TxOut>, witness: bool) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint {
                 txid: Txid(Hash256::from_le_bytes(&[seed; 32])),
                 vout: u32::from(seed),
             },
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
             // A segwit transaction serializes with a marker, a flag and a
             // witness. If `total_size()` and the zero-copy measurement disagree
             // anywhere, it is here.
@@ -59,7 +59,8 @@ fn tx(seed: u8, outputs: Vec<TxOut>, witness: bool) -> Tx {
                 vec![vec![0xab; 71], vec![0xcd; 33]]
             } else {
                 Vec::new()
-            },
+            }
+            .into(),
         }],
         outputs,
     }
@@ -67,8 +68,8 @@ fn tx(seed: u8, outputs: Vec<TxOut>, witness: bool) -> Tx {
 
 fn out(script_pubkey: Vec<u8>, sats: u64) -> TxOut {
     TxOut {
-        value: sats,
-        script_pubkey,
+        value: Amount::from_sat(sats),
+        script_pubkey: script_pubkey.into(),
     }
 }
 

--- a/crates/mempool/benches/pareto.rs
+++ b/crates/mempool/benches/pareto.rs
@@ -13,7 +13,9 @@ use std::hint::black_box;
 use std::sync::Arc;
 
 use bitcoin_rs_mempool::{Mempool, MempoolEntry, MempoolLimits};
-use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+};
 use criterion::{Criterion, criterion_group, criterion_main};
 
 /// Pool sizes large enough to cover admission from a small node to a mature
@@ -31,18 +33,18 @@ fn distinct_tx(seed: u64) -> Tx {
     previous[..8].copy_from_slice(&seed.to_le_bytes());
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             // Distinct prevouts: entries that conflict would be rejected rather
             // than accepted, and the fill would measure the rejection path.
             previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&previous)), 0),
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFF,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 10_000,
-            script_pubkey: seed.to_le_bytes().to_vec(),
+            value: Amount::from_sat(10_000),
+            script_pubkey: seed.to_le_bytes().to_vec().into(),
         }],
     }
 }

--- a/crates/mempool/src/accept.rs
+++ b/crates/mempool/src/accept.rs
@@ -22,7 +22,9 @@ use alloc::vec::Vec;
 
 use bitcoin_rs_consensus::rust_path::UtxoView;
 use bitcoin_rs_consensus::{ConsensusError, verify_transaction};
-use bitcoin_rs_primitives::{OutPoint, Tx, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, LockTime, OutPoint, Script, Sequence, Tx, TxOut, Txid, Witness,
+};
 use bitcoin_rs_script::VerifyFlags;
 use bitcoin_rs_script::script::{Instruction, instructions, is_p2sh, is_witness_program, opcode};
 use bitcoin_rs_script::sigops::{count_segwit, count_tx_legacy};
@@ -238,7 +240,7 @@ where
         match view.lookup(&input.previous_output) {
             Some(prevout) => {
                 value_in = value_in
-                    .checked_add(prevout.value)
+                    .checked_add(prevout.value.to_sat())
                     .ok_or(AcceptError::InputValueOverflow)?;
                 prevouts.push((input.previous_output, prevout));
             }
@@ -275,7 +277,7 @@ where
     let mut value_out = 0_u64;
     for output in &tx.outputs {
         value_out = value_out
-            .checked_add(output.value)
+            .checked_add(output.value.to_sat())
             .ok_or(AcceptError::OutputValueOverflow)?;
     }
     // Verification already rejected `value_out > value_in`; saturating rather
@@ -511,19 +513,19 @@ mod tests {
     fn spending_tx(inputs: &[OutPoint], output_value: u64, tag: u8) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: inputs
                 .iter()
                 .map(|previous_output| TxIn {
                     previous_output: *previous_output,
-                    script_sig: Vec::new(),
-                    sequence: 0xffff_ffff,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 })
                 .collect(),
             outputs: vec![TxOut {
-                value: output_value,
-                script_pubkey: p2pkh(tag),
+                value: Amount::from_sat(output_value),
+                script_pubkey: p2pkh(tag).into(),
             }],
         }
     }
@@ -536,8 +538,8 @@ mod tests {
                     (
                         outpoint_key(outpoint),
                         TxOut {
-                            value: *value,
-                            script_pubkey: anyone_can_spend(),
+                            value: Amount::from_sat(*value),
+                            script_pubkey: anyone_can_spend().into(),
                         },
                     )
                 })
@@ -625,7 +627,7 @@ mod tests {
             ..context()
         };
         let mut parent = spending_tx(&[outpoint(1, 0)], 90_000, 7);
-        parent.outputs[0].script_pubkey = anyone_can_spend();
+        parent.outputs[0].script_pubkey = anyone_can_spend().into();
         let parent_txid = parent.txid();
         let Ok(_parent) = accept_to_mempool(&mut pool, parent, &chain, &relaxed) else {
             panic!("parent must be accepted or the child case is untested");
@@ -664,7 +666,7 @@ mod tests {
         let mut pool = pool();
         let chain = chain_with(&[]);
         let mut tx = spending_tx(&[OutPoint::new(Txid::default(), u32::MAX)], 90_000, 7);
-        tx.inputs[0].script_sig = push_int(800_001);
+        tx.inputs[0].script_sig = push_int(800_001).into();
         assert!(is_coinbase(&tx), "the fixture must be a coinbase");
 
         assert_eq!(
@@ -739,7 +741,7 @@ mod tests {
         let mut pool = pool();
         let chain = chain_with(&[(outpoint(1, 0), 100_000)]);
         let mut original = spending_tx(&[outpoint(1, 0)], 90_000, 7);
-        original.inputs[0].sequence = 0xffff_fffd;
+        original.inputs[0].sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
         let original_txid = original.txid();
         let Ok(_first) = accept_to_mempool(&mut pool, original, &chain, &context()) else {
             panic!("the original must be accepted");
@@ -747,7 +749,7 @@ mod tests {
 
         // Same input, higher fee, different output so it is a distinct txid.
         let mut replacement = spending_tx(&[outpoint(1, 0)], 50_000, 8);
-        replacement.inputs[0].sequence = 0xffff_fffd;
+        replacement.inputs[0].sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
         let Ok(result) = accept_to_mempool(&mut pool, replacement, &chain, &context()) else {
             panic!("a higher-feerate replacement must be accepted");
         };
@@ -829,8 +831,8 @@ mod tests {
                     (
                         outpoint_key(outpoint),
                         TxOut {
-                            value: 1_000,
-                            script_pubkey: script_pubkey.clone(),
+                            value: Amount::from_sat(1_000),
+                            script_pubkey: script_pubkey.clone().into(),
                         },
                     )
                 })
@@ -839,7 +841,7 @@ mod tests {
 
         let mut tx = spending_tx(&inputs, 190_000, 7);
         for input in &mut tx.inputs {
-            input.script_sig = script_sig.clone();
+            input.script_sig = script_sig.clone().into();
         }
 
         let blind = count_tx_legacy(&tx).saturating_mul(4);

--- a/crates/mempool/src/accept.rs
+++ b/crates/mempool/src/accept.rs
@@ -22,9 +22,10 @@ use alloc::vec::Vec;
 
 use bitcoin_rs_consensus::rust_path::UtxoView;
 use bitcoin_rs_consensus::{ConsensusError, verify_transaction};
-use bitcoin_rs_primitives::{
-    Amount, LockTime, OutPoint, Script, Sequence, Tx, TxOut, Txid, Witness,
-};
+use bitcoin_rs_primitives::{OutPoint, Tx, TxOut, Txid};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Witness};
 use bitcoin_rs_script::VerifyFlags;
 use bitcoin_rs_script::script::{Instruction, instructions, is_p2sh, is_witness_program, opcode};
 use bitcoin_rs_script::sigops::{count_segwit, count_tx_legacy};

--- a/crates/mempool/src/entry.rs
+++ b/crates/mempool/src/entry.rs
@@ -1,6 +1,9 @@
 use alloc::sync::Arc;
 
-use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Tx, Txid, Witness, Wtxid};
+use bitcoin_rs_primitives::{Tx, Txid, Wtxid};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Witness};
 use bitcoin_rs_script::count_tx_legacy;
 
 /// Stable mempool entry identifier.

--- a/crates/mempool/src/entry.rs
+++ b/crates/mempool/src/entry.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-use bitcoin_rs_primitives::{Tx, Txid, Wtxid};
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Tx, Txid, Witness, Wtxid};
 use bitcoin_rs_script::count_tx_legacy;
 
 /// Stable mempool entry identifier.
@@ -149,7 +149,7 @@ impl MempoolEntry {
         self.tx
             .inputs
             .iter()
-            .any(|input| input.sequence < RBF_FLAG_THRESHOLD)
+            .any(|input| input.sequence.to_consensus() < RBF_FLAG_THRESHOLD)
     }
 }
 
@@ -169,18 +169,18 @@ fn signed_fee_rate(fee: i128, vsize: u64) -> i128 {
 #[cfg(test)]
 mod is_replaceable_tests {
     use super::*;
-    use bitcoin_rs_primitives::{OutPoint, Tx, TxIn};
+    use bitcoin_rs_primitives::{OutPoint, Sequence, Tx, TxIn};
     use std::sync::Arc;
 
     fn entry_with_sequence(sequence: u32) -> MempoolEntry {
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::default(),
-                script_sig: Vec::new(),
-                sequence,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(sequence),
+                witness: Witness::new(),
             }],
             outputs: vec![],
         };
@@ -209,7 +209,7 @@ mod is_replaceable_tests {
     fn is_replaceable_false_for_no_inputs() {
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![],
             outputs: vec![],
         };
@@ -227,7 +227,7 @@ mod mining_metadata_tests {
     fn bare_entry() -> MempoolEntry {
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![],
             outputs: vec![],
         };
@@ -244,13 +244,13 @@ mod mining_metadata_tests {
 
         let mut tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![],
             outputs: vec![],
         };
         tx.outputs.push(TxOut {
-            value: 1_000,
-            script_pubkey: alloc::vec![0xac],
+            value: Amount::from_sat(1_000),
+            script_pubkey: alloc::vec![0xac].into(),
         });
         let counted = MempoolEntry::new(Arc::new(tx), 100, 1_000, 1, 7);
         assert_eq!(counted.sigop_cost, count_tx_legacy(&counted.tx));

--- a/crates/mempool/src/eviction.rs
+++ b/crates/mempool/src/eviction.rs
@@ -64,7 +64,9 @@ pub fn mempool_min_fee_sat_per_kvb(pool: &Mempool, incremental_relay_fee_sat_per
 #[allow(clippy::expect_used)]
 mod tests {
     use alloc::sync::Arc;
-    use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    };
 
     use super::{evict_lowest_fee_packages, mempool_min_fee_sat_per_kvb};
     use crate::mutation::{MutationChange, MutationOutcome, RemovalReason};
@@ -141,16 +143,16 @@ mod tests {
     fn tx(label: u8) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[label; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51, label],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51, label].into(),
             }],
         }
     }

--- a/crates/mempool/src/gateway.rs
+++ b/crates/mempool/src/gateway.rs
@@ -19,7 +19,9 @@ use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 
 use bitcoin_rs_consensus::{UtxoView, verify_transaction};
-use bitcoin_rs_primitives::{OutPoint, Tx, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, LockTime, OutPoint, Script, Sequence, Tx, TxOut, Txid, Witness,
+};
 use bitcoin_rs_script::VerifyFlags;
 use hashbrown::HashSet;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};
@@ -1004,7 +1006,9 @@ mod tests {
     use crate::{Mempool, MempoolEntry, MempoolLimits};
     use alloc::sync::Arc;
     use alloc::vec::Vec;
-    use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    };
     use core::sync::atomic::Ordering;
     use parking_lot::{Mutex, RwLock};
     use std::sync::mpsc;
@@ -1012,16 +1016,16 @@ mod tests {
     fn tx(label: u8) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[label; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFF,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51, label],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51, label].into(),
             }],
         }
     }
@@ -1085,16 +1089,16 @@ mod tests {
         script.push(0xac); // OP_CHECKSIG
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[label; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFF,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 10_000,
-                script_pubkey: script,
+                value: Amount::from_sat(10_000),
+                script_pubkey: script.into(),
             }],
         }
     }
@@ -1104,16 +1108,16 @@ mod tests {
     fn prevout_spend(prev: OutPoint, value: u64, script: u8) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: prev,
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFD, // RBF signal
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME, // RBF signal
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value,
-                script_pubkey: vec![script],
+                value: Amount::from_sat(value),
+                script_pubkey: vec![script].into(),
             }],
         }
     }
@@ -1138,10 +1142,10 @@ mod tests {
             prevouts: vec![(
                 tx.inputs[0].previous_output,
                 TxOut {
-                    value: 11_000,
+                    value: Amount::from_sat(11_000),
                     // OP_TRUE: an anyone-can-spend prevout, the same shape the
                     // RPC fixtures use, so script verification passes.
-                    script_pubkey: vec![0x51],
+                    script_pubkey: vec![0x51].into(),
                 },
             )],
             locktime_cutoff: 0,
@@ -1277,14 +1281,14 @@ mod tests {
             .expect("parent in");
         let mut child = tx(7);
         child.inputs[0].previous_output = OutPoint::new(parent_txid, 0);
-        child.inputs[0].sequence = 0xFFFF_FFFD;
+        child.inputs[0].sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
         let child_txid = child.txid();
         gateway
             .insert_entry(AdmissionOrigin::Rpc, entry(&child))
             .expect("child in");
         let mut grandchild = tx(8);
         grandchild.inputs[0].previous_output = OutPoint::new(child_txid, 0);
-        grandchild.inputs[0].sequence = 0xFFFF_FFFD;
+        grandchild.inputs[0].sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
         let grandchild_txid = grandchild.txid();
         gateway
             .insert_entry(AdmissionOrigin::Rpc, entry(&grandchild))
@@ -1296,7 +1300,7 @@ mod tests {
         // (Descendant). The parent survives.
         let mut replacement = tx(9);
         replacement.inputs[0].previous_output = OutPoint::new(parent_txid, 0);
-        replacement.inputs[0].sequence = 0xFFFF_FFFD;
+        replacement.inputs[0].sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
         let replacement_txid = replacement.txid();
         let result = gateway
             .replace_transaction(
@@ -2157,8 +2161,8 @@ mod tests {
     fn admit_transaction_accepts_locktime_equal_to_tip_at_next_height() {
         let gateway = gateway_with(None);
         let mut tx = standard_tx(0x80);
-        tx.lock_time = 100;
-        tx.inputs[0].sequence = 0xFFFF_FFFE; // non-final
+        tx.lock_time = LockTime::from_consensus(100);
+        tx.inputs[0].sequence = Sequence::from_consensus(0xFFFF_FFFE); // non-final
 
         let mut request = admit_request(&gateway, &tx, AdmissionOrigin::Rpc);
         request.height = 100;
@@ -2176,8 +2180,8 @@ mod tests {
     fn admit_transaction_rejects_locktime_one_past_tip() {
         let gateway = gateway_with(None);
         let mut tx = standard_tx(0x81);
-        tx.lock_time = 101;
-        tx.inputs[0].sequence = 0xFFFF_FFFE; // non-final
+        tx.lock_time = LockTime::from_consensus(101);
+        tx.inputs[0].sequence = Sequence::from_consensus(0xFFFF_FFFE); // non-final
 
         let mut request = admit_request(&gateway, &tx, AdmissionOrigin::Rpc);
         request.height = 100;
@@ -2197,8 +2201,8 @@ mod tests {
         let gateway = gateway_with(None);
         let mut tx = standard_tx(0x82);
         // Timestamp-based lock time, above the threshold.
-        tx.lock_time = 1_800_000_000;
-        tx.inputs[0].sequence = 0xFFFF_FFFE; // non-final
+        tx.lock_time = LockTime::from_consensus(1_800_000_000);
+        tx.inputs[0].sequence = Sequence::from_consensus(0xFFFF_FFFE); // non-final
 
         let mut request = admit_request(&gateway, &tx, AdmissionOrigin::Rpc);
         // The applied-tip MTP is lower than the header-tip MTP; a tx with
@@ -2227,7 +2231,7 @@ mod tests {
         let mut request = admit_request(&gateway, &tx, AdmissionOrigin::Rpc);
         // OP_FALSE: the input script evaluates to false, so the spend is
         // invalid under any verify flags.
-        request.prevouts[0].1.script_pubkey = vec![0x00];
+        request.prevouts[0].1.script_pubkey = vec![0x00].into();
 
         let result = gateway.admit_transaction(request);
         assert!(
@@ -2361,16 +2365,16 @@ mod tests {
 
         // Set up a conflict: insert a tx, then admit a replacement.
         let mut original = standard_tx(44);
-        original.inputs[0].sequence = 0xFFFF_FFFD; // RBF signal (< 0xFFFF_FFFE)
+        original.inputs[0].sequence = Sequence::ENABLE_RBF_NO_LOCKTIME; // RBF signal (< 0xFFFF_FFFE)
         let original_txid = original.txid();
         // The replacement spends the same input as the original but
         // signals RBF (sequence < 0xFFFF_FFFF) and pays a higher fee.
         let mut replacement = standard_tx(45);
         replacement.inputs[0].previous_output = original.inputs[0].previous_output;
-        replacement.inputs[0].sequence = 0xFFFF_FFFE; // RBF signal
+        replacement.inputs[0].sequence = Sequence::from_consensus(0xFFFF_FFFE); // RBF signal
         // Higher fee to pass BIP125 (original output is 10 000, replacement
         // output is 5 000, so fee = 5 000 > original fee = 0).
-        replacement.outputs[0].value = 5_000;
+        replacement.outputs[0].value = Amount::from_sat(5_000);
         let replacement_txid = replacement.txid();
 
         // Fund the original's output in the UTXO set so the replacement
@@ -2398,10 +2402,10 @@ mod tests {
             prevouts: vec![(
                 replacement.inputs[0].previous_output,
                 TxOut {
-                    value: 10_000,
+                    value: Amount::from_sat(10_000),
                     // OP_TRUE: anyone-can-spend, so script verification passes
                     // and only the RBF rules are under test.
-                    script_pubkey: vec![0x51],
+                    script_pubkey: vec![0x51].into(),
                 },
             )],
             locktime_cutoff: 0,
@@ -2717,9 +2721,9 @@ mod tests {
         let mut double_spend = tx(13);
         double_spend.inputs[0] = TxIn {
             previous_output: spent_outpoint,
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFF,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         };
         let double_spend_txid = double_spend.txid();
 
@@ -2819,8 +2823,8 @@ mod tests {
             prevouts: vec![(
                 tx.inputs[0].previous_output,
                 TxOut {
-                    value: 11_000,
-                    script_pubkey: Vec::new(),
+                    value: Amount::from_sat(11_000),
+                    script_pubkey: Script::new(),
                 },
             )],
             locktime_cutoff: 0,

--- a/crates/mempool/src/gateway.rs
+++ b/crates/mempool/src/gateway.rs
@@ -19,9 +19,7 @@ use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 
 use bitcoin_rs_consensus::{UtxoView, verify_transaction};
-use bitcoin_rs_primitives::{
-    Amount, LockTime, OutPoint, Script, Sequence, Tx, TxOut, Txid, Witness,
-};
+use bitcoin_rs_primitives::{OutPoint, Tx, TxOut, Txid};
 use bitcoin_rs_script::VerifyFlags;
 use hashbrown::HashSet;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};

--- a/crates/mempool/src/orphan.rs
+++ b/crates/mempool/src/orphan.rs
@@ -13,7 +13,10 @@
 use alloc::vec::Vec;
 use core::time::Duration;
 
-use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Tx, Txid, Witness};
+use bitcoin_rs_primitives::{Tx, Txid};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Witness};
 use hashbrown::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::time::Instant;

--- a/crates/mempool/src/orphan.rs
+++ b/crates/mempool/src/orphan.rs
@@ -13,7 +13,7 @@
 use alloc::vec::Vec;
 use core::time::Duration;
 
-use bitcoin_rs_primitives::{Tx, Txid};
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Tx, Txid, Witness};
 use hashbrown::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::time::Instant;
@@ -416,19 +416,19 @@ mod tests {
     fn orphan_tx(label: u8, prevouts: Vec<OutPoint>) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: prevouts
                 .into_iter()
                 .map(|previous_output| TxIn {
                     previous_output,
-                    script_sig: Vec::new(),
-                    sequence: 0xFFFF_FFFF,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 })
                 .collect(),
             outputs: vec![TxOut {
-                value: 5_000 + u64::from(label),
-                script_pubkey: vec![label],
+                value: Amount::from_sat(5_000 + u64::from(label)),
+                script_pubkey: vec![label].into(),
             }],
         }
     }
@@ -436,17 +436,17 @@ mod tests {
     /// Builds a large transaction (many outputs) to exceed weight limits.
     fn large_tx(label: u8) -> Tx {
         let output = TxOut {
-            value: 1_000,
-            script_pubkey: vec![0x51; 200],
+            value: Amount::from_sat(1_000),
+            script_pubkey: vec![0x51; 200].into(),
         };
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[label; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFF,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![output; 50],
         }

--- a/crates/mempool/src/pareto.rs
+++ b/crates/mempool/src/pareto.rs
@@ -158,23 +158,25 @@ mod memory_usage_tests {
     use alloc::sync::Arc;
     use core::mem::size_of;
 
-    use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    };
 
     use super::*;
 
     fn entry(tag: u8) -> MempoolEntry {
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: alloc::vec![TxIn {
                 previous_output: OutPoint::new(Txid::from(Hash256::from_le_bytes(&[tag; 32])), 0,),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: alloc::vec![TxOut {
-                value: 10_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(10_000),
+                script_pubkey: Script::new(),
             }],
         };
         MempoolEntry::new(Arc::new(tx), 100, 10_000, u64::from(tag), 7)

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -2,9 +2,10 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::ops::{Bound, RangeInclusive};
 
-use bitcoin_rs_primitives::{
-    Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness, Wtxid,
-};
+use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid, Wtxid};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Witness};
 use hashbrown::{HashMap, HashSet};
 use sha2::{Digest, Sha256};
 use slab::Slab;

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -2,7 +2,9 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::ops::{Bound, RangeInclusive};
 
-use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid, Wtxid};
+use bitcoin_rs_primitives::{
+    Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness, Wtxid,
+};
 use hashbrown::{HashMap, HashSet};
 use sha2::{Digest, Sha256};
 use slab::Slab;
@@ -1789,7 +1791,7 @@ impl Mempool {
                 .tx
                 .inputs
                 .iter()
-                .any(|input| input.sequence < 0xFFFF_FFFE)
+                .any(|input| input.sequence.to_consensus() < 0xFFFF_FFFE)
         })
     }
 }
@@ -1917,11 +1919,11 @@ mod tests {
         let mut pool = Mempool::new(limits);
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let entry = MempoolEntry::new(Arc::new(tx), 100, 100, 1, 7);
@@ -1946,7 +1948,7 @@ mod tests {
 
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: Vec::new(),
         };
@@ -1978,7 +1980,7 @@ mod tests {
         });
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![],
             outputs: vec![],
         };
@@ -2043,11 +2045,11 @@ mod tests {
         let mut pool = Mempool::new(MempoolLimits::default());
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 99_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(99_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let txid = tx.txid();
@@ -2065,7 +2067,7 @@ mod tests {
         });
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![],
             outputs: vec![],
         };
@@ -2093,7 +2095,7 @@ mod tests {
         });
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![],
             outputs: vec![],
         };
@@ -2130,21 +2132,21 @@ mod tests {
         });
         let tx_a = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![],
             outputs: vec![TxOut {
-                value: 100,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(100),
+                script_pubkey: Script::new(),
             }],
         };
         let txid_a = tx_a.txid();
         let tx_b = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![],
             outputs: vec![TxOut {
-                value: 200,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(200),
+                script_pubkey: Script::new(),
             }],
         };
         let txid_b = tx_b.txid();
@@ -2163,22 +2165,22 @@ mod tests {
         // Two distinct txs with different fee rates.
         let low_tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let low_txid = low_tx.txid();
         let _ = pool.insert_entry(MempoolEntry::new(Arc::new(low_tx), 100, 1_000, 1, 7));
         let high_tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 99_000,
-                script_pubkey: vec![0x52],
+                value: Amount::from_sat(99_000),
+                script_pubkey: vec![0x52].into(),
             }],
         };
         let high_txid = high_tx.txid();
@@ -2328,16 +2330,16 @@ mod tests {
         };
         let original = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: prev,
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFD,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         pool.insert_entry(MempoolEntry::new(Arc::new(original), 1_000, 2_000, 1, 7))?;
@@ -2352,16 +2354,16 @@ mod tests {
 
         let replacement = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: prev,
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFD,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 900,
-                script_pubkey: vec![0x52],
+                value: Amount::from_sat(900),
+                script_pubkey: vec![0x52].into(),
             }],
         };
         pool.replace_transaction(
@@ -2384,21 +2386,21 @@ mod tests {
         let mut pool = Mempool::new(MempoolLimits::default());
         let low_tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let _ = pool.insert_entry(MempoolEntry::new(Arc::new(low_tx), 100, 1_000, 1, 7)); // fee_rate = 1000
         let high_tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 99_000,
-                script_pubkey: vec![0x52],
+                value: Amount::from_sat(99_000),
+                script_pubkey: vec![0x52].into(),
             }],
         };
         let _ = pool.insert_entry(MempoolEntry::new(Arc::new(high_tx), 100, 10_000, 1, 7)); // fee_rate = 100_000
@@ -2416,15 +2418,15 @@ mod tests {
         // RBF-signalled tx (sequence < 0xFFFFFFFE).
         let rbf_tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint {
                     txid: txid_of([0xaa; 32]),
                     vout: 0,
                 },
-                script_sig: Vec::new(),
-                sequence: 0x0000_0001,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(0x0000_0001),
+                witness: Witness::new(),
             }],
             outputs: Vec::new(),
         };
@@ -2433,15 +2435,15 @@ mod tests {
         // Non-RBF tx (sequence = MAX = 0xFFFFFFFF).
         let non_rbf_tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint {
                     txid: txid_of([0xbb; 32]),
                     vout: 0,
                 },
-                script_sig: Vec::new(),
-                sequence: 0xFF_FF_FF_FF,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: Vec::new(),
         };
@@ -2459,7 +2461,7 @@ mod tests {
         let before = pool.sequence_number();
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: Vec::new(),
         };
@@ -2475,11 +2477,11 @@ mod tests {
         let mut pool = Mempool::new(MempoolLimits::default());
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 99_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(99_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let _id = pool.insert_entry(MempoolEntry::new(Arc::new(tx), 100, 10_000, 1, 7))?;
@@ -2515,24 +2517,24 @@ mod tests {
         };
         let spending = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![
                 TxIn {
                     previous_output: decoy,
-                    script_sig: Vec::new(),
-                    sequence: 0xFF_FF_FF_FF,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 },
                 TxIn {
                     previous_output: outpoint,
-                    script_sig: Vec::new(),
-                    sequence: 0xFF_FF_FF_FF,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 },
             ],
             outputs: vec![TxOut {
-                value: 99_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(99_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let spending_txid = spending.txid();
@@ -2565,19 +2567,19 @@ mod tests {
         let other = vec![0x52];
         let funder = |script: Vec<u8>, tag: u8| Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint {
                     txid: txid_of([tag; 32]),
                     vout: 0,
                 },
-                script_sig: Vec::new(),
-                sequence: 0xFF_FF_FF_FF,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50_000,
-                script_pubkey: script,
+                value: Amount::from_sat(50_000),
+                script_pubkey: script.into(),
             }],
         };
         let matching_tx = funder(matching.clone(), 0xaa);
@@ -2638,16 +2640,16 @@ mod tests {
         };
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: unrelated,
-                script_sig: Vec::new(),
-                sequence: 0xFF_FF_FF_FF,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 99_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(99_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let entry_txid = tx.txid();
@@ -2676,16 +2678,16 @@ mod tests {
         };
         let spender_tx = |fee: u64| Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: outpoint,
-                script_sig: Vec::new(),
-                sequence: 0xFF_FF_FF_FF,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: fee,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(fee),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let first = spender_tx(99_000);
@@ -2721,12 +2723,12 @@ mod tests {
         };
         let spending = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: outpoint,
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFF,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![],
         };
@@ -3296,11 +3298,11 @@ mod tests {
         });
         let low = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let low_txid = low.txid();
@@ -3308,11 +3310,11 @@ mod tests {
 
         let high = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 99_000,
-                script_pubkey: vec![0x52],
+                value: Amount::from_sat(99_000),
+                script_pubkey: vec![0x52].into(),
             }],
         };
         let high_txid = high.txid();
@@ -3335,11 +3337,11 @@ mod tests {
 
         let low = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let low_txid = low.txid();
@@ -3347,11 +3349,11 @@ mod tests {
 
         let high = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 99_000,
-                script_pubkey: vec![0x52],
+                value: Amount::from_sat(99_000),
+                script_pubkey: vec![0x52].into(),
             }],
         };
         let high_txid = high.txid();
@@ -3378,11 +3380,11 @@ mod tests {
         for nonce in 0..2_u32 {
             let tx = Tx {
                 version: 2,
-                lock_time: 0,
+                lock_time: LockTime::ZERO,
                 inputs: Vec::new(),
                 outputs: vec![TxOut {
-                    value: 1_000 + u64::from(nonce),
-                    script_pubkey: vec![0x51, u8::try_from(nonce).unwrap_or(0)],
+                    value: Amount::from_sat(1_000 + u64::from(nonce)),
+                    script_pubkey: vec![0x51, u8::try_from(nonce).unwrap_or(0)].into(),
                 }],
             };
             let fee = 100_u64.saturating_add(u64::from(nonce).saturating_mul(50));
@@ -3411,11 +3413,11 @@ mod tests {
         fn tx_paying(nonce: u8) -> Arc<Tx> {
             Arc::new(Tx {
                 version: 2,
-                lock_time: 0,
+                lock_time: LockTime::ZERO,
                 inputs: Vec::new(),
                 outputs: vec![TxOut {
-                    value: 1_000 + u64::from(nonce),
-                    script_pubkey: vec![0x51, nonce],
+                    value: Amount::from_sat(1_000 + u64::from(nonce)),
+                    script_pubkey: vec![0x51, nonce].into(),
                 }],
             })
         }
@@ -3493,16 +3495,16 @@ mod tests {
         // Original: 100 vbytes, low fee rate (100 sat/vbyte).
         let original = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: prev,
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFD,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let original_txid = original.txid();
@@ -3525,16 +3527,16 @@ mod tests {
         // lowest-fee-rate entry — the replacement itself.
         let replacement = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: prev,
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFD,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 100,
-                script_pubkey: vec![0x52],
+                value: Amount::from_sat(100),
+                script_pubkey: vec![0x52].into(),
             }],
         };
         let replacement_txid = replacement.txid();
@@ -3887,19 +3889,19 @@ mod tests {
     fn tx(label: u8, previous_outputs: Vec<OutPoint>) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: previous_outputs
                 .into_iter()
                 .map(|previous_output| TxIn {
                     previous_output,
-                    script_sig: Vec::new(),
-                    sequence: 0xFF_FF_FF_FF,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 })
                 .collect(),
             outputs: vec![TxOut {
-                value: 5_000 + u64::from(label),
-                script_pubkey: vec![label],
+                value: Amount::from_sat(5_000 + u64::from(label)),
+                script_pubkey: vec![label].into(),
             }],
         }
     }
@@ -3923,22 +3925,24 @@ mod spend_index_tests {
     fn tx_with(inputs: &[OutPoint], outputs: u32, tag: u64) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: inputs
                 .iter()
                 .map(|previous_output| TxIn {
                     previous_output: *previous_output,
-                    script_sig: Vec::new(),
-                    sequence: 0xFF_FF_FF_FF,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 })
                 .collect(),
             outputs: (0..outputs)
                 .map(|vout| TxOut {
-                    value: 10_000_u64
-                        .saturating_add(u64::from(vout))
-                        .saturating_add(tag.saturating_mul(1_000)),
-                    script_pubkey: alloc::vec![0x51],
+                    value: Amount::from_sat(
+                        10_000_u64
+                            .saturating_add(u64::from(vout))
+                            .saturating_add(tag.saturating_mul(1_000)),
+                    ),
+                    script_pubkey: alloc::vec![0x51].into(),
                 })
                 .collect(),
         }
@@ -4227,7 +4231,7 @@ mod spend_index_tests {
         let root = tx_with(&[confirmed], 2, 1);
         let root_txid = root.txid();
         let mut a = tx_with(&[OutPoint::new(root_txid, 0)], 1, 2);
-        a.inputs[0].sequence = 0xFFFF_FFFD;
+        a.inputs[0].sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
         let a_txid = a.txid();
         let b = tx_with(&[OutPoint::new(root_txid, 1)], 1, 3);
 
@@ -4319,7 +4323,7 @@ mod spend_index_tests {
         let root = tx_with(&[confirmed], 2, 1);
         let root_txid = root.txid();
         let mut a = tx_with(&[OutPoint::new(root_txid, 0)], 1, 2);
-        a.inputs[0].sequence = 0xFFFF_FFFD;
+        a.inputs[0].sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
         let a_txid = a.txid();
         let b = tx_with(&[OutPoint::new(root_txid, 1)], 1, 3);
 
@@ -4479,16 +4483,16 @@ mod dynamic_memory_usage_tests {
     fn tx_with(script_len: usize, tag: u8) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: alloc::vec![TxIn {
                 previous_output: OutPoint::new(Txid::from(Hash256::from_le_bytes(&[tag; 32])), 0,),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: alloc::vec![TxOut {
-                value: 10_000,
-                script_pubkey: alloc::vec![0x51; script_len],
+                value: Amount::from_sat(10_000),
+                script_pubkey: alloc::vec![0x51; script_len].into(),
             }],
         }
     }
@@ -4667,7 +4671,7 @@ mod entry_overhead_tests {
         Tx {
             version: 2,
             // The only thing distinguishing them, so they get distinct txids.
-            lock_time: tag,
+            lock_time: LockTime::from_consensus(tag),
             inputs: alloc::vec::Vec::new(),
             outputs: alloc::vec::Vec::new(),
         }

--- a/crates/mempool/src/standardness.rs
+++ b/crates/mempool/src/standardness.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 
 use hashbrown::HashSet;
 
-use bitcoin_rs_primitives::{Tx, TxOut, Txid, Wtxid};
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Tx, TxOut, Txid, Witness, Wtxid};
 use bitcoin_rs_script::{
     Instruction, is_multisig, is_op_return, is_p2a, is_p2pk, is_p2pkh, is_p2sh, is_p2tr, is_p2wpkh,
     is_p2wsh, is_push_only, minimal_non_dust, opcode, script::instructions,
@@ -526,7 +526,7 @@ fn multisig_key_count(script: &[u8]) -> Option<u8> {
 
 /// Returns `true` if a non-`OP_RETURN` output is dust.
 fn is_dust(output: &TxOut, dust_relay_fee: u64) -> bool {
-    output.value < minimal_non_dust(&output.script_pubkey, dust_relay_fee)
+    output.value.to_sat() < minimal_non_dust(&output.script_pubkey, dust_relay_fee)
 }
 
 #[inline]
@@ -598,16 +598,16 @@ mod tests {
     fn standard_tx(version: i32) -> Tx {
         Tx {
             version,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::default(),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 100_000,
-                script_pubkey: p2pkh(&[7_u8; 20]),
+                value: Amount::from_sat(100_000),
+                script_pubkey: p2pkh(&[7_u8; 20]).into(),
             }],
         }
     }
@@ -669,12 +669,12 @@ mod tests {
     #[test]
     fn accepts_op_return_followed_by_a_numeric_push() {
         let mut tx = standard_tx(1);
-        tx.outputs[0].value = 0;
-        tx.outputs[0].script_pubkey = vec![opcode::OP_RETURN, opcode::OP_PUSHNUM_1];
+        tx.outputs[0].value = Amount::ZERO;
+        tx.outputs[0].script_pubkey = vec![opcode::OP_RETURN, opcode::OP_PUSHNUM_1].into();
         // Padded to clear the relay minimum, which is a different rule.
         tx.outputs.push(TxOut {
-            value: 50_000,
-            script_pubkey: p2pkh(&[9_u8; 20]),
+            value: Amount::from_sat(50_000),
+            script_pubkey: p2pkh(&[9_u8; 20]).into(),
         });
         assert_eq!(is_standard_tx(&tx, &policy()), Ok(()));
     }
@@ -683,8 +683,8 @@ mod tests {
     #[test]
     fn rejects_op_return_followed_by_an_opcode() {
         let mut tx = standard_tx(1);
-        tx.outputs[0].value = 0;
-        tx.outputs[0].script_pubkey = vec![opcode::OP_RETURN, opcode::OP_DUP];
+        tx.outputs[0].value = Amount::ZERO;
+        tx.outputs[0].script_pubkey = vec![opcode::OP_RETURN, opcode::OP_DUP].into();
         assert_eq!(
             is_standard_tx(&tx, &policy()),
             Err(StandardnessError::NonStandardOutput)
@@ -708,7 +708,7 @@ mod tests {
         );
 
         let mut tx = standard_tx(1);
-        tx.outputs[0].script_pubkey = script;
+        tx.outputs[0].script_pubkey = script.into();
         assert_eq!(
             is_standard_tx(&tx, &policy()),
             Err(StandardnessError::NonStandardOutput)
@@ -724,7 +724,7 @@ mod tests {
         script.extend([opcode::OP_PUSHNUM_1, opcode::OP_CHECKMULTISIG]);
 
         let mut tx = standard_tx(1);
-        tx.outputs[0].script_pubkey = script;
+        tx.outputs[0].script_pubkey = script.into();
         assert_eq!(is_standard_tx(&tx, &policy()), Ok(()));
     }
 
@@ -741,7 +741,7 @@ mod tests {
         ]);
 
         let mut tx = standard_tx(1);
-        tx.outputs[0].script_pubkey = script;
+        tx.outputs[0].script_pubkey = script.into();
         assert_eq!(is_standard_tx(&tx, &policy()), Ok(()));
     }
 
@@ -758,7 +758,7 @@ mod tests {
         ]);
 
         let mut tx = standard_tx(1);
-        tx.outputs[0].script_pubkey = script;
+        tx.outputs[0].script_pubkey = script.into();
         assert_eq!(
             is_standard_tx(&tx, &policy()),
             Err(StandardnessError::NonStandardOutput)
@@ -774,8 +774,8 @@ mod tests {
     fn accepts_a_pay_to_anchor_output() {
         let mut tx = standard_tx(1);
         tx.outputs.push(TxOut {
-            value: 240,
-            script_pubkey: vec![0x51, 0x02, 0x4e, 0x73],
+            value: Amount::from_sat(240),
+            script_pubkey: vec![0x51, 0x02, 0x4e, 0x73].into(),
         });
         assert_eq!(is_standard_tx(&tx, &policy()), Ok(()));
     }
@@ -786,8 +786,8 @@ mod tests {
     #[test]
     fn rejects_a_transaction_below_the_non_witness_minimum() {
         let mut tx = standard_tx(1);
-        tx.outputs[0].value = 0;
-        tx.outputs[0].script_pubkey = vec![opcode::OP_RETURN];
+        tx.outputs[0].value = Amount::ZERO;
+        tx.outputs[0].script_pubkey = vec![opcode::OP_RETURN].into();
         assert!(
             tx.base_size() < super::MIN_NON_WITNESS_TX_SIZE,
             "the fixture must be undersized or this test proves nothing"
@@ -802,7 +802,7 @@ mod tests {
     fn rejects_non_pushonly_scriptsig() {
         let mut tx = standard_tx(1);
         // OP_DUP is not a push opcode.
-        tx.inputs[0].script_sig = vec![opcode::OP_DUP];
+        tx.inputs[0].script_sig = vec![opcode::OP_DUP].into();
         assert_eq!(
             is_standard_tx(&tx, &policy()),
             Err(StandardnessError::ScriptSigNotPushOnly)
@@ -814,7 +814,7 @@ mod tests {
         let mut tx = standard_tx(1);
         // Build a push-only scriptSig that exceeds 1650 bytes.
         let big = vec![0_u8; super::MAX_STANDARD_SCRIPTSIG_SIZE];
-        tx.inputs[0].script_sig = push_data(&big);
+        tx.inputs[0].script_sig = push_data(&big).into();
         assert_eq!(
             is_standard_tx(&tx, &policy()),
             Err(StandardnessError::ScriptSigTooLarge)
@@ -833,12 +833,12 @@ mod tests {
             });
         tx.outputs = vec![
             TxOut {
-                value: 0,
-                script_pubkey: first,
+                value: Amount::from_sat(0),
+                script_pubkey: first.into(),
             },
             TxOut {
-                value: 0,
-                script_pubkey: second,
+                value: Amount::from_sat(0),
+                script_pubkey: second.into(),
             },
         ];
         let aggregate = StandardnessPolicy {
@@ -869,7 +869,7 @@ mod tests {
     fn dust_relay_fee_changes_the_boundary() {
         let mut tx = standard_tx(1);
         let threshold = minimal_non_dust(&tx.outputs[0].script_pubkey, DUST_RELAY_FEE_SAT_PER_KVB);
-        tx.outputs[0].value = threshold - 1;
+        tx.outputs[0].value = Amount::from_sat(threshold - 1);
 
         assert_eq!(
             is_standard_tx(&tx, &policy()),
@@ -887,8 +887,8 @@ mod tests {
         let mut tx = standard_tx(1);
         let script = [vec![opcode::OP_RETURN], push_data(b"ok")].concat();
         tx.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: script,
+            value: Amount::from_sat(0),
+            script_pubkey: script.into(),
         });
         assert_eq!(is_standard_tx(&tx, &policy()), Ok(()));
     }
@@ -897,7 +897,7 @@ mod tests {
     fn rejects_dust_output() {
         let mut tx = standard_tx(1);
         // 1 sat to a P2PKH output is dust.
-        tx.outputs[0].value = 1;
+        tx.outputs[0].value = Amount::from_sat(1);
         assert_eq!(
             is_standard_tx(&tx, &policy()),
             Err(StandardnessError::DustOutput)
@@ -908,7 +908,7 @@ mod tests {
     fn rejects_non_standard_output_script() {
         let mut tx = standard_tx(1);
         // A random non-standard script.
-        tx.outputs[0].script_pubkey = vec![0x74]; // OP_DEPTH
+        tx.outputs[0].script_pubkey = vec![0x74].into(); // OP_DEPTH
         assert_eq!(
             is_standard_tx(&tx, &policy()),
             Err(StandardnessError::NonStandardOutput)
@@ -937,7 +937,7 @@ mod tests {
             .map(|i| {
                 let mut tx = standard_tx(1);
                 tx.outputs[0].script_pubkey =
-                    vec![0x51, u8::try_from(i).expect("package index fits u8")];
+                    vec![0x51, u8::try_from(i).expect("package index fits u8")].into();
                 tx
             })
             .collect();
@@ -979,7 +979,7 @@ mod tests {
         let pool = crate::Mempool::new(crate::MempoolLimits::default());
         let first = standard_tx(1);
         let mut second = standard_tx(1);
-        second.outputs[0].script_pubkey = vec![0x51, 0x99];
+        second.outputs[0].script_pubkey = vec![0x51, 0x99].into();
         let facts = evaluate_package_acceptance(
             &pool,
             &policy(),
@@ -1048,15 +1048,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: vec![0x51],
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: vec![0x51].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50 * 100_000_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(50 * 100_000_000),
+                script_pubkey: vec![0x51].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let facts = evaluate_package_acceptance(
             &pool,

--- a/crates/mempool/src/standardness.rs
+++ b/crates/mempool/src/standardness.rs
@@ -9,7 +9,10 @@ use alloc::vec::Vec;
 
 use hashbrown::HashSet;
 
-use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Tx, TxOut, Txid, Witness, Wtxid};
+use bitcoin_rs_primitives::{Tx, TxOut, Txid, Wtxid};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Witness};
 use bitcoin_rs_script::{
     Instruction, is_multisig, is_op_return, is_p2a, is_p2pk, is_p2pkh, is_p2sh, is_p2tr, is_p2wpkh,
     is_p2wsh, is_push_only, minimal_non_dust, opcode, script::instructions,

--- a/crates/mempool/tests/ancestor_limits.rs
+++ b/crates/mempool/tests/ancestor_limits.rs
@@ -9,7 +9,9 @@ use alloc::sync::Arc;
 use std::error::Error;
 
 use bitcoin_rs_mempool::{Mempool, MempoolEntry, MempoolError, MempoolLimits, PolicyError};
-use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+};
 
 #[test]
 fn chain_of_twenty_six_unconfirmed_transactions_rejects_twenty_sixth() -> Result<(), Box<dyn Error>>
@@ -187,21 +189,22 @@ fn fee_estimate_access_reuses_pool_owned_estimator() -> Result<(), Box<dyn Error
 fn multi_output_tx(label: u8, outputs: u32) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: outpoint(label, 0),
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFF,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: (0..outputs)
             .map(|vout| TxOut {
-                value: 1_000,
+                value: Amount::from_sat(1_000),
                 script_pubkey: vec![
                     0x51,
                     label,
                     u8::try_from(vout).expect("fixture vout fits u8"),
-                ],
+                ]
+                .into(),
             })
             .collect(),
     }
@@ -210,16 +213,16 @@ fn multi_output_tx(label: u8, outputs: u32) -> Tx {
 fn chained_tx(label: u8, previous_output: OutPoint) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output,
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFF,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 1_000,
-            script_pubkey: vec![0x51, label],
+            value: Amount::from_sat(1_000),
+            script_pubkey: vec![0x51, label].into(),
         }],
     }
 }

--- a/crates/mempool/tests/policy_contract.rs
+++ b/crates/mempool/tests/policy_contract.rs
@@ -21,7 +21,9 @@ use bitcoin_rs_mempool::{
     Mempool, MempoolEntry, MempoolError, MempoolLimits, MutationOutcome, PolicyError, RbfError,
     RemovalReason, ReplacementCandidate,
 };
-use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+};
 use bitcoin_rs_script::opcode;
 
 /// Node default: Bitcoin Core incremental relay fee, 1000 sat/kvB.
@@ -62,19 +64,19 @@ fn tx(prevout: OutPoint, output_value: u64, sequence: u32) -> Tx {
 fn tx_multi(inputs: &[(OutPoint, u32)], output_value: u64, script_pubkey: Vec<u8>) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: inputs
             .iter()
             .map(|(prevout, sequence)| TxIn {
                 previous_output: *prevout,
-                script_sig: Vec::new(),
-                sequence: *sequence,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(*sequence),
+                witness: Witness::new(),
             })
             .collect(),
         outputs: vec![TxOut {
-            value: output_value,
-            script_pubkey,
+            value: Amount::from_sat(output_value),
+            script_pubkey: script_pubkey.into(),
         }],
     }
 }
@@ -472,17 +474,19 @@ fn acceptance_preview_surfaces_ancestor_limits() -> Result<(), Box<dyn Error>> {
 fn fanout_root(label: u8, output_count: usize) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: outpoint(label, 0),
-            script_sig: Vec::new(),
-            sequence: 0xFF_FF_FF_FF,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: (0..output_count)
             .map(|index| TxOut {
-                value: 1_000_u64.saturating_add(u64::try_from(index).unwrap_or(u64::MAX)),
-                script_pubkey: p2wpkh_script(),
+                value: Amount::from_sat(
+                    1_000_u64.saturating_add(u64::try_from(index).unwrap_or(u64::MAX)),
+                ),
+                script_pubkey: p2wpkh_script().into(),
             })
             .collect(),
     }
@@ -591,8 +595,8 @@ fn oversized_weight_is_not_standard_on_both_surfaces() {
     let mut oversized = tx(outpoint(1, 0), 1_000, 0xFF_FF_FF_FF);
     oversized.outputs = (0..3_400)
         .map(|_| TxOut {
-            value: 1_000,
-            script_pubkey: p2wpkh_script(),
+            value: Amount::from_sat(1_000),
+            script_pubkey: p2wpkh_script().into(),
         })
         .collect();
 

--- a/crates/mempool/tests/rbf_bip125.rs
+++ b/crates/mempool/tests/rbf_bip125.rs
@@ -15,7 +15,9 @@ use bitcoin_rs_mempool::{
     Mempool, MempoolEntry, MempoolError, MempoolLimits, MempoolStats, PolicyError, RbfError,
     ReplacementCandidate,
 };
-use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+};
 
 #[derive(Clone, Copy)]
 struct OriginalSpec {
@@ -255,7 +257,7 @@ fn package_acceptance_surfaces_bip125_replacement_boundaries() -> Result<(), Box
         // P2WPKH scriptPubKey: OP_0 PUSHBYTES_20 <20-byte hash>
         let mut script = vec![0x00, 0x14];
         script.extend([0x02; 20]);
-        script
+        script.into()
     };
 
     let policy = StandardnessPolicy {
@@ -350,20 +352,20 @@ fn pool_with_conflict(
 fn tx_from_inputs(label: u8, inputs: &[(OutPoint, u32)], outputs: usize) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: inputs
             .iter()
             .map(|(previous_output, sequence)| TxIn {
                 previous_output: *previous_output,
-                script_sig: Vec::new(),
-                sequence: *sequence,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(*sequence),
+                witness: Witness::new(),
             })
             .collect(),
         outputs: (0..outputs)
             .map(|i| TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51, label, u8::try_from(i).unwrap_or(0)],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51, label, u8::try_from(i).unwrap_or(0)].into(),
             })
             .collect(),
     }

--- a/crates/mining/src/coinbase.rs
+++ b/crates/mining/src/coinbase.rs
@@ -1,4 +1,6 @@
-use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Hash256, LockTime, OutPoint, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+};
 use bitcoin_rs_script::push_int;
 use thiserror::Error;
 
@@ -72,17 +74,17 @@ pub(crate) fn build_coinbase(
         .checked_add(fees)
         .ok_or(MiningError::CoinbaseValueOverflow)?;
 
-    let mut witness = Vec::new();
+    let mut witness = Witness::new();
     let mut outputs = vec![TxOut {
-        value,
-        script_pubkey: payout,
+        value: Amount::from_sat(value),
+        script_pubkey: payout.into(),
     }];
 
     if let Some(commitment) = witness_commitment {
         witness.push(WITNESS_RESERVED_VALUE.to_vec());
         outputs.push(TxOut {
-            value: 0,
-            script_pubkey: witness_commitment_script(commitment),
+            value: Amount::ZERO,
+            script_pubkey: witness_commitment_script(commitment).into(),
         });
     }
 
@@ -90,12 +92,12 @@ pub(crate) fn build_coinbase(
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0; 32])), 0xffff_ffff),
-            script_sig: coinbase_script_sig(height)?,
-            sequence: 0xffff_ffff,
+            script_sig: coinbase_script_sig(height)?.into(),
+            sequence: Sequence::MAX,
             witness,
         }],
         outputs,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     })
 }
 

--- a/crates/mining/src/context.rs
+++ b/crates/mining/src/context.rs
@@ -11,7 +11,7 @@ use bitcoin_rs_chain::{
     softfork_state,
 };
 use bitcoin_rs_consensus::{MEDIAN_TIME_PAST_WINDOW, locktime_cutoff};
-use bitcoin_rs_primitives::{Hash256, Network};
+use bitcoin_rs_primitives::{CompactTarget, Hash256, Network};
 
 /// Contextual facts for the block that would extend `previous_tip_id`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -24,7 +24,7 @@ pub struct MiningChainContext {
     /// `LockedIn` deployment bit.
     pub version: i32,
     /// Compact target the candidate's nBits must equal.
-    pub bits: u32,
+    pub bits: CompactTarget,
     /// Earliest timestamp the candidate may carry: previous-tip MTP + 1.
     pub min_time: u32,
     /// Median time past of the previous tip over the BIP113 window.
@@ -110,7 +110,7 @@ pub fn check_candidate_header(
 #[cfg(test)]
 mod tests {
     use bitcoin_rs_chain::{BlockTree, ChainError, node::NodeStatus};
-    use bitcoin_rs_primitives::{BlockHash, Hash256, Header, Network};
+    use bitcoin_rs_primitives::{BlockHash, CompactTarget, Hash256, Header, Network};
 
     use super::{MiningChainContext, check_candidate_header};
 
@@ -120,7 +120,7 @@ mod tests {
             prev_blockhash,
             merkle_root: Hash256::default(),
             time,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         }
     }
@@ -140,7 +140,7 @@ mod tests {
             u32::from_ne_bytes(context.version.to_ne_bytes()),
             0x2000_0000
         );
-        assert_eq!(context.bits, chain_bits);
+        assert_eq!(context.bits, CompactTarget::from_consensus(chain_bits));
         assert_eq!(context.prev_median_time_past, 1_000_000 + 6 * 600);
         assert_eq!(context.min_time, 1_000_000 + 6 * 600 + 1);
         assert!(!context.csv_active);
@@ -148,7 +148,7 @@ mod tests {
         assert_eq!(context.locktime_cutoff(tip_time + 600), tip_time + 600);
 
         let recovered = MiningChainContext::resolve(&tree, Network::Regtest, tip, tip_time + 1201)?;
-        assert_eq!(recovered.bits, 0x207f_ffff);
+        assert_eq!(recovered.bits, CompactTarget::from_consensus(0x207f_ffff));
 
         let unknown = bitcoin_rs_chain::node::NodeId::new(u32::MAX);
         assert_eq!(
@@ -213,7 +213,11 @@ mod tests {
         let hash = candidate.compute_hash().0;
         check_candidate_header(&tree, Network::Regtest, tip, &candidate, hash, u32::MAX)?;
 
-        let bad_bits = candidate_header(tip_blockhash, context.min_time, 0x207f_fffd);
+        let bad_bits = candidate_header(
+            tip_blockhash,
+            context.min_time,
+            CompactTarget::from_consensus(0x207f_fffd),
+        );
         let hash = bad_bits.compute_hash().0;
         assert!(matches!(
             check_candidate_header(&tree, Network::Regtest, tip, &bad_bits, hash, u32::MAX),
@@ -229,7 +233,7 @@ mod tests {
         Ok(())
     }
 
-    fn candidate_header(prev_blockhash: BlockHash, time: u32, bits: u32) -> Header {
+    fn candidate_header(prev_blockhash: BlockHash, time: u32, bits: CompactTarget) -> Header {
         Header {
             version: 0x2000_0000,
             prev_blockhash,
@@ -264,7 +268,7 @@ mod tests {
                 start_time.saturating_add(height.saturating_mul(600)),
                 version_at(height),
             );
-            header.bits = bits;
+            header.bits = CompactTarget::from_consensus(bits);
             prev = header.compute_hash();
             tip = Some(tree.insert_header(header, NodeStatus::HeaderValid)?);
         }

--- a/crates/mining/src/control.rs
+++ b/crates/mining/src/control.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 use std::vec::Vec;
 
-use bitcoin_rs_primitives::{Block, BlockHash, Network, Tx, Txid};
+use bitcoin_rs_primitives::{Block, BlockHash, CompactTarget, Network, Tx, Txid};
 use compact_str::CompactString;
 
 use crate::Candidate;
@@ -160,7 +160,7 @@ pub struct MiningInfo {
     /// Most recently assembled candidate facts.
     pub last_candidate: Option<LastCandidateInfo>,
     /// Compact target bits of the applied tip.
-    pub bits: u32,
+    pub bits: CompactTarget,
     /// Difficulty represented by `bits`.
     pub difficulty: f64,
     /// Estimated network hashes per second.
@@ -170,7 +170,7 @@ pub struct MiningInfo {
     /// Active consensus network.
     pub network: Network,
     /// Compact target bits for the next candidate.
-    pub next_bits: u32,
+    pub next_bits: CompactTarget,
     /// Difficulty represented by `next_bits`.
     pub next_difficulty: f64,
     /// Configured minimum mining feerate in satoshis per kvB.
@@ -285,7 +285,8 @@ pub trait MiningControl: Send + Sync {
 
 /// Returns the f64 difficulty for `bits` using Bitcoin Core's calculation.
 #[must_use]
-pub fn difficulty_for_bits(consensus_bits: u32) -> f64 {
+pub fn difficulty_for_bits(consensus_bits: CompactTarget) -> f64 {
+    let consensus_bits = consensus_bits.to_consensus();
     let mantissa = consensus_bits & 0x00ff_ffff;
     if mantissa == 0 {
         return 0.0;
@@ -309,7 +310,9 @@ mod tests {
 
     #[test]
     fn difficulty_one_is_the_difficulty_1_target() {
-        let difficulty = difficulty_for_bits(0x1d00_ffff);
+        let difficulty = difficulty_for_bits(bitcoin_rs_primitives::CompactTarget::from_consensus(
+            0x1d00_ffff,
+        ));
         assert!(
             (difficulty - 1.0).abs() < f64::EPSILON,
             "0x1d00ffff must be difficulty 1, got {difficulty}"

--- a/crates/mining/src/policy.rs
+++ b/crates/mining/src/policy.rs
@@ -228,20 +228,21 @@ fn package_is_final(
 /// - locktime >= `LOCKTIME_THRESHOLD`: timestamp-based; final iff locktime < `locktime_cutoff`.
 /// - all inputs sequence == `SEQUENCE_FINAL`: final regardless of locktime.
 fn is_final_tx(tx: &Tx, block_height: u32, locktime_cutoff: u32) -> bool {
-    if tx.lock_time == 0 {
+    let lock_time = tx.lock_time.to_consensus();
+    if lock_time == 0 {
         return true;
     }
-    let threshold = if tx.lock_time < LOCKTIME_THRESHOLD {
+    let threshold = if lock_time < LOCKTIME_THRESHOLD {
         block_height
     } else {
         locktime_cutoff
     };
-    if tx.lock_time < threshold {
+    if lock_time < threshold {
         return true;
     }
     tx.inputs
         .iter()
-        .all(|input| input.sequence == SEQUENCE_FINAL)
+        .all(|input| input.sequence.to_consensus() == SEQUENCE_FINAL)
 }
 
 fn next_block_sequence_locks_final(
@@ -266,7 +267,7 @@ fn next_block_sequence_locks_final(
         }
         bitcoin_rs_consensus::bip68::sequence_lock_satisfied(
             tx.version,
-            sequence,
+            sequence.to_consensus(),
             context.height,
             context.locktime_cutoff,
             context.height,
@@ -288,7 +289,10 @@ mod tests {
     use std::sync::Arc;
 
     use bitcoin_rs_mempool::{MempoolMiningSnapshot, SnapshotEntry};
-    use bitcoin_rs_primitives::{Hash256, Network, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, CompactTarget, Hash256, LockTime, Network, OutPoint, Sequence, Tx, TxIn, TxOut,
+        Txid, Witness,
+    };
 
     use super::{RESIDUAL_PACKAGE_CONSTRUCTIONS, select_packages};
     use crate::template::CandidateContext;
@@ -335,7 +339,7 @@ mod tests {
             previous_block_hash: Hash256::from_le_bytes(&[0xcd; 32]),
             height: 100,
             version: 0x2000_0000,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             min_time: 1,
             current_time: 2,
             locktime_cutoff: 1,
@@ -377,15 +381,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::from(Hash256::from_le_bytes(&bytes)), 0),
-                script_sig: vec![],
-                sequence: u32::MAX,
-                witness: vec![],
+                script_sig: vec![].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51, label],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51, label].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 }

--- a/crates/mining/src/template.rs
+++ b/crates/mining/src/template.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use bitcoin_rs_chain::compact_is_met_by;
 use bitcoin_rs_mempool::MempoolMiningSnapshot;
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, Network, Tx, Txid, Wtxid, encode::double_sha256,
+    Block, BlockHash, CompactTarget, Hash256, Header, Network, Tx, Txid, Wtxid,
+    encode::double_sha256,
 };
 
 use crate::MiningError;
@@ -24,7 +25,7 @@ pub struct CandidateContext {
     /// Versionbits candidate version.
     pub version: i32,
     /// Compact target the candidate header must carry (`nBits`).
-    pub bits: u32,
+    pub bits: CompactTarget,
     /// Earliest legal timestamp (previous MTP + 1).
     pub min_time: u32,
     /// Candidate header time used for the template clock.
@@ -118,7 +119,7 @@ pub struct Candidate {
     /// Candidate version.
     pub version: i32,
     /// Compact target bits.
-    pub bits: u32,
+    pub bits: CompactTarget,
     /// Minimum legal timestamp.
     pub min_time: u32,
     /// Candidate creation time.
@@ -361,7 +362,7 @@ fn finish_candidate(
     let coinbase_value = coinbase
         .outputs
         .first()
-        .map(|output| output.value)
+        .map(|output| output.value.to_sat())
         .ok_or(MiningError::CoinbaseValueOverflow)?;
     // Fees change a fixed-width amount and the witness commitment replaces a
     // fixed-width hash, so the reservation and final coinbase have the same

--- a/crates/mining/tests/coinbase_template.rs
+++ b/crates/mining/tests/coinbase_template.rs
@@ -12,7 +12,10 @@ use bitcoin_rs_mempool::{MempoolMiningSnapshot, SnapshotEntry};
 use bitcoin_rs_mining::{
     CandidateContext, MiningError, TemplateId, WITNESS_RESERVED_VALUE, assemble_candidate,
 };
-use bitcoin_rs_primitives::{Hash256, Network, OutPoint, Tx, TxIn, TxOut, Txid, Wtxid};
+use bitcoin_rs_primitives::{
+    Amount, CompactTarget, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+    Txid, Wtxid,
+};
 
 #[test]
 fn empty_candidate_encodes_bip34_and_exact_subsidy() -> Result<(), Box<dyn Error>> {
@@ -146,7 +149,7 @@ fn context(height: u32, segwit_active: bool) -> CandidateContext {
         previous_block_hash: Hash256::from_le_bytes(&[0xab; 32]),
         height,
         version: 0x2000_0000,
-        bits: 0x207f_ffff,
+        bits: CompactTarget::from_consensus(0x207f_ffff),
         min_time: 1_700_000_001,
         current_time: 1_700_000_600,
         locktime_cutoff: 1_700_000_000,
@@ -219,14 +222,14 @@ fn tx_with_witness(label: u8, value: u64, parent: Option<Txid>) -> Tx {
                 parent.unwrap_or_else(|| Txid(Hash256::from_le_bytes(&bytes))),
                 0,
             ),
-            script_sig: vec![],
-            sequence: u32::MAX,
-            witness: vec![vec![label; 32]],
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: vec![vec![label; 32]].into(),
         }],
         outputs: vec![TxOut {
-            value,
-            script_pubkey: vec![0x51, label],
+            value: Amount::from_sat(value),
+            script_pubkey: vec![0x51, label].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }

--- a/crates/mining/tests/policy_pareto.rs
+++ b/crates/mining/tests/policy_pareto.rs
@@ -8,7 +8,10 @@ use bitcoin_rs_mempool::{
     Mempool, MempoolEntry, MempoolLimits, MempoolMiningSnapshot, SnapshotEntry,
 };
 use bitcoin_rs_mining::{CandidateContext, MiningError, assemble_candidate};
-use bitcoin_rs_primitives::{Hash256, Network, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, CompactTarget, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+    Txid, Witness,
+};
 use proptest::prelude::*;
 
 #[test]
@@ -180,7 +183,7 @@ fn weight_size_and_sigop_limits_are_independent() -> Result<(), Box<dyn Error>> 
 fn bip68_unmet_unconfirmed_parent_package_is_skipped() -> Result<(), Box<dyn Error>> {
     let parent = snapshot_entry(Arc::new(independent_tx(1)), 1_000, 0, 400, 100, 0, vec![]);
     let mut child_tx = chained_tx(2, 1_000, Some(parent.txid));
-    child_tx.inputs[0].sequence = 1;
+    child_tx.inputs[0].sequence = Sequence::from_consensus(1);
     let child = snapshot_entry(Arc::new(child_tx), 10_000, 0, 400, 100, 0, vec![1]);
     let snapshot = MempoolMiningSnapshot {
         sequence: 12,
@@ -196,7 +199,7 @@ fn bip68_unmet_unconfirmed_parent_package_is_skipped() -> Result<(), Box<dyn Err
 fn bip68_unmet_lock_is_ignored_when_csv_is_inactive() -> Result<(), Box<dyn Error>> {
     let parent = snapshot_entry(Arc::new(independent_tx(1)), 1_000, 0, 400, 100, 0, vec![]);
     let mut child_tx = chained_tx(2, 1_000, Some(parent.txid));
-    child_tx.inputs[0].sequence = 1;
+    child_tx.inputs[0].sequence = Sequence::from_consensus(1);
     let child = snapshot_entry(Arc::new(child_tx), 10_000, 0, 400, 100, 0, vec![1]);
     let snapshot = MempoolMiningSnapshot {
         sequence: 13,
@@ -374,11 +377,11 @@ fn coinbase_reservation_accepts_exact_limits_and_rejects_one_over() -> Result<()
 #[test]
 fn non_final_packages_are_skipped() -> Result<(), Box<dyn Error>> {
     let mut final_tx = independent_tx(1);
-    final_tx.lock_time = 0;
+    final_tx.lock_time = LockTime::ZERO;
     let mut non_final = independent_tx(2);
-    non_final.lock_time = 500_000_100;
+    non_final.lock_time = LockTime::from_consensus(500_000_100);
     for input in &mut non_final.inputs {
-        input.sequence = 0;
+        input.sequence = Sequence::ZERO;
     }
 
     let snapshot = MempoolMiningSnapshot {
@@ -434,7 +437,7 @@ fn oversized_residual_package_is_skipped_atomically() -> Result<(), Box<dyn Erro
     // limits so parent alone and parent+child both overflow, while `other` fits.
     let parent = snapshot_entry(Arc::new(independent_tx(1)), 100, 0, 99_600, 100, 0, vec![]);
     let mut child_tx = chained_tx(2, 1_000, Some(parent.txid));
-    child_tx.lock_time = 0;
+    child_tx.lock_time = LockTime::ZERO;
     let child = snapshot_entry(Arc::new(child_tx), 10_000, 0, 20_000, 100, 0, vec![1]);
     let other = snapshot_entry(Arc::new(independent_tx(3)), 1_000, 0, 400, 100, 0, vec![]);
 
@@ -501,7 +504,7 @@ fn context(max_weight: u64, max_size: u64, max_sigops: u64) -> CandidateContext 
         previous_block_hash: Hash256::from_le_bytes(&[0xcd; 32]),
         height: 100,
         version: 0x2000_0000,
-        bits: 0x207f_ffff,
+        bits: CompactTarget::from_consensus(0x207f_ffff),
         min_time: 1,
         current_time: 2,
         locktime_cutoff: 1,
@@ -548,15 +551,15 @@ fn independent_tx(label: u8) -> Tx {
         version: 2,
         inputs: vec![TxIn {
             previous_output: outpoint(label),
-            script_sig: vec![],
-            sequence: u32::MAX,
-            witness: vec![],
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 1_000,
-            script_pubkey: vec![0x51, label],
+            value: Amount::from_sat(1_000),
+            script_pubkey: vec![0x51, label].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 
@@ -565,15 +568,15 @@ fn chained_tx(label: u8, value: u64, parent: Option<Txid>) -> Tx {
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(parent.unwrap_or_else(|| outpoint(label).txid), 0),
-            script_sig: vec![],
-            sequence: u32::MAX,
-            witness: vec![],
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value,
-            script_pubkey: vec![0x51, label],
+            value: Amount::from_sat(value),
+            script_pubkey: vec![0x51, label].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 

--- a/crates/mining/tests/template_shape.rs
+++ b/crates/mining/tests/template_shape.rs
@@ -12,7 +12,10 @@ use bitcoin_rs_mining::{
     CandidateContext, TemplateId, WITNESS_RESERVED_VALUE, assemble_candidate,
     assemble_ordered_candidate,
 };
-use bitcoin_rs_primitives::{Hash256, Network, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, CompactTarget, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+    Txid, Witness,
+};
 
 #[test]
 #[allow(clippy::too_many_lines)]
@@ -46,7 +49,7 @@ fn candidate_scalars_and_depends_match_selected_transactions() -> Result<(), Box
         previous_block_hash: Hash256::from_le_bytes(&[0x11; 32]),
         height: 250,
         version: 0x2000_0001,
-        bits: 0x1d00_ffff,
+        bits: CompactTarget::from_consensus(0x1d00_ffff),
         min_time: 10,
         current_time: 20,
         locktime_cutoff: 10,
@@ -168,7 +171,7 @@ fn equal_fee_ties_follow_snapshot_order_deterministically() -> Result<(), Box<dy
             previous_block_hash: Hash256::from_le_bytes(&[0x22; 32]),
             height: 10,
             version: 1,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             min_time: 1,
             current_time: 2,
             locktime_cutoff: 1,
@@ -187,7 +190,7 @@ fn equal_fee_ties_follow_snapshot_order_deterministically() -> Result<(), Box<dy
             previous_block_hash: Hash256::from_le_bytes(&[0x22; 32]),
             height: 10,
             version: 1,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             min_time: 1,
             current_time: 2,
             locktime_cutoff: 1,
@@ -239,15 +242,15 @@ fn tx(label: u8, value: u64, parent: Option<Txid>) -> Tx {
                 parent.unwrap_or_else(|| Txid(Hash256::from_le_bytes(&bytes))),
                 0,
             ),
-            script_sig: vec![],
-            sequence: u32::MAX,
-            witness: vec![],
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value,
-            script_pubkey: vec![0x51, label],
+            value: Amount::from_sat(value),
+            script_pubkey: vec![0x51, label].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 
@@ -263,7 +266,7 @@ fn currentblocktx_counts_exclude_the_coinbase() -> Result<(), Box<dyn Error>> {
             previous_block_hash: Hash256::from_le_bytes(&[0x44; 32]),
             height: 100,
             version: 1,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             min_time: 1,
             current_time: 2,
             locktime_cutoff: 1,
@@ -299,7 +302,7 @@ fn currentblocktx_counts_exclude_the_coinbase() -> Result<(), Box<dyn Error>> {
             previous_block_hash: Hash256::from_le_bytes(&[0x44; 32]),
             height: 100,
             version: 1,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             min_time: 1,
             current_time: 2,
             locktime_cutoff: 1,
@@ -332,7 +335,7 @@ fn assembly_copies_deployment_boundary_flags() -> Result<(), Box<dyn Error>> {
                 previous_block_hash: Hash256::from_le_bytes(&[0x55; 32]),
                 height: 432,
                 version: 1,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 min_time: 1,
                 current_time: 2,
                 locktime_cutoff: 1,
@@ -364,7 +367,7 @@ fn candidate_solves_an_unsolved_regtest_header() -> Result<(), Box<dyn Error>> {
         previous_block_hash: Hash256::from_le_bytes(&[0x11; 32]),
         height: 1,
         version: 1,
-        bits: 0x207f_ffff,
+        bits: CompactTarget::from_consensus(0x207f_ffff),
         min_time: 1,
         current_time: 2,
         locktime_cutoff: 1,
@@ -412,7 +415,7 @@ fn ordered_assembly_keeps_snapshot_order() -> Result<(), Box<dyn Error>> {
         previous_block_hash: Hash256::from_le_bytes(&[0x11; 32]),
         height: 1,
         version: 1,
-        bits: 0x207f_ffff,
+        bits: CompactTarget::from_consensus(0x207f_ffff),
         min_time: 1,
         current_time: 2,
         locktime_cutoff: 1,

--- a/crates/mining/tests/witness_commitment_vector.rs
+++ b/crates/mining/tests/witness_commitment_vector.rs
@@ -18,7 +18,10 @@ use bitcoin_rs_mempool::{MempoolMiningSnapshot, SnapshotEntry};
 use bitcoin_rs_mining::{
     CandidateContext, WITNESS_RESERVED_VALUE, assemble_candidate, witness_commitment_script,
 };
-use bitcoin_rs_primitives::{Hash256, Network, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes};
+use bitcoin_rs_primitives::{
+    Amount, CompactTarget, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+    Txid, consensus_bytes,
+};
 use bitcoin_rs_script::count_tx_legacy;
 
 /// Pinned commitment bytes for the vector below, derived by piping
@@ -102,7 +105,7 @@ fn witness_commitment_matches_pinned_vector_and_rust_bitcoin_root() -> Result<()
         .iter()
         .find(|output| output.script_pubkey == script)
         .ok_or("coinbase must carry the commitment output script")?;
-    assert_eq!(commitment_output.value, 0);
+    assert_eq!(commitment_output.value, Amount::ZERO);
     assert_eq!(
         candidate.coinbase.inputs[0].witness,
         vec![WITNESS_RESERVED_VALUE.to_vec()],
@@ -134,7 +137,7 @@ fn vector_context(segwit_active: bool) -> CandidateContext {
         previous_block_hash: Hash256::from_le_bytes(&[0xab; 32]),
         height: 1,
         version: 0x2000_0000,
-        bits: 0x207f_ffff,
+        bits: CompactTarget::from_consensus(0x207f_ffff),
         min_time: 1_700_000_001,
         current_time: 1_700_000_600,
         locktime_cutoff: 1_700_000_000,
@@ -163,15 +166,15 @@ fn witnessed_tx(label: u8, value: u64, parent: Option<Txid>) -> Tx {
                 }),
                 0,
             ),
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: vec![vec![label; 32]],
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: vec![vec![label; 32]].into(),
         }],
         outputs: vec![TxOut {
-            value,
-            script_pubkey: vec![0x51, label],
+            value: Amount::from_sat(value),
+            script_pubkey: vec![0x51, label].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 

--- a/crates/node/benches/chainstate_journal.rs
+++ b/crates/node/benches/chainstate_journal.rs
@@ -7,7 +7,10 @@ use std::time::{Duration, Instant};
 use anyhow::{Context as _, Result, bail};
 use bitcoin_rs_consensus::block_subsidy;
 use bitcoin_rs_node::{Network, NodeConfig, state::NodeState};
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, Witness,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -136,16 +139,19 @@ fn test_config(data_dir: PathBuf) -> NodeConfig {
 fn mined_regtest_child_at(prev_blockhash: BlockHash, height: u32) -> Result<Block> {
     let coinbase = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid::default(), u32::MAX),
-            script_sig: bip34_height_script(height),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: bip34_height_script(height).into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: block_subsidy(height, Network::Regtest.subsidy_halving_interval()),
-            script_pubkey: Vec::new(),
+            value: Amount::from_sat(block_subsidy(
+                height,
+                Network::Regtest.subsidy_halving_interval(),
+            )),
+            script_pubkey: Script::new(),
         }],
     };
     let mut block = Block {
@@ -154,7 +160,7 @@ fn mined_regtest_child_at(prev_blockhash: BlockHash, height: u32) -> Result<Bloc
             prev_blockhash,
             merkle_root: Hash256::default(),
             time: Network::Regtest.genesis_block().header.time + height,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         },
         txs: vec![coinbase],
@@ -213,7 +219,8 @@ fn double_sha256(bytes: &[u8]) -> [u8; 32] {
     Sha256::digest(first).into()
 }
 
-fn pow_met(bits: u32, hash: Hash256) -> bool {
+fn pow_met(bits: CompactTarget, hash: Hash256) -> bool {
+    let bits = bits.to_consensus();
     let exponent = u8::try_from(bits >> 24).unwrap_or(0);
     let mantissa = bits & 0x007f_ffff;
     if exponent <= 3 || exponent > 32 || mantissa > 0x00ff_ffff {

--- a/crates/node/benches/sync_pipeline.rs
+++ b/crates/node/benches/sync_pipeline.rs
@@ -40,7 +40,10 @@ use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwapOption;
 use bitcoin_rs_primitives::encode::double_sha256;
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, Witness,
+};
 use bitcoin_rs_script::script::push_int;
 // seam: getdata inventory items stay rust-bitcoin at the p2p wire boundary.
 use bitcoin::hashes::Hash as _;
@@ -48,9 +51,10 @@ use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin::secp256k1::{All, Message as SecpMessage, Secp256k1, SecretKey};
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};
 use bitcoin::{
-    Amount, OutPoint as OracleOutPoint, ScriptBuf as OracleScriptBuf, Sequence as OracleSequence,
-    Transaction as OracleTx, TxIn as OracleTxIn, TxOut as OracleTxOut, Txid as OracleTxid, Witness,
-    absolute, opcodes, script::Builder as OracleBuilder, transaction,
+    Amount as OracleAmount, OutPoint as OracleOutPoint, ScriptBuf as OracleScriptBuf,
+    Sequence as OracleSequence, Transaction as OracleTx, TxIn as OracleTxIn, TxOut as OracleTxOut,
+    Txid as OracleTxid, Witness as OracleWitness, absolute, opcodes,
+    script::Builder as OracleBuilder, transaction,
 };
 use bitcoin_rs_chain::{BlockTree, NodeStatus, TipSnapshot};
 use bitcoin_rs_index::BlockSource;
@@ -1194,7 +1198,7 @@ fn child_coinbase_block(parent: &Block, height: u32) -> Block {
             prev_blockhash: parent.block_hash(),
             merkle_root: Hash256::default(),
             time: parent.header.time.saturating_add(1),
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         },
         txs: vec![coinbase_transaction(height)],
@@ -1211,7 +1215,7 @@ fn child_fanout_coinbase_block(parent: &Block, height: u32) -> Block {
             prev_blockhash: parent.block_hash(),
             merkle_root: Hash256::default(),
             time: parent.header.time.saturating_add(1),
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         },
         txs: vec![fanout_coinbase_transaction(height)],
@@ -1241,7 +1245,7 @@ fn child_spend_fanout_block(parent: &Block, height: u32, source_block: &Block) -
             prev_blockhash: parent.block_hash(),
             merkle_root: Hash256::default(),
             time: parent.header.time.saturating_add(1),
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         },
         txs,
@@ -1257,7 +1261,7 @@ fn child_header(prev_blockhash: BlockHash, time: u32) -> Header {
         prev_blockhash,
         merkle_root: Hash256::default(),
         time,
-        bits: 0x207f_ffff,
+        bits: CompactTarget::from_consensus(0x207f_ffff),
         nonce: 0,
     }
 }
@@ -1265,16 +1269,16 @@ fn child_header(prev_blockhash: BlockHash, time: u32) -> Header {
 fn coinbase_transaction(height: u32) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid::default(), u32::MAX),
-            script_sig: coinbase_script_sig(height),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: coinbase_script_sig(height).into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 50_0000_0000,
-            script_pubkey: Vec::new(),
+            value: Amount::from_sat(50_0000_0000),
+            script_pubkey: Script::new(),
         }],
     }
 }
@@ -1282,18 +1286,18 @@ fn coinbase_transaction(height: u32) -> Tx {
 fn fanout_coinbase_transaction(height: u32) -> Tx {
     let outputs = (0..SPEND_PROXY_FANOUT)
         .map(|_| TxOut {
-            value: SPEND_PROXY_COINBASE_OUTPUT_VALUE,
-            script_pubkey: push_int(1),
+            value: Amount::from_sat(SPEND_PROXY_COINBASE_OUTPUT_VALUE),
+            script_pubkey: push_int(1).into(),
         })
         .collect();
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid::default(), u32::MAX),
-            script_sig: coinbase_script_sig(height),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: coinbase_script_sig(height).into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs,
     }
@@ -1302,16 +1306,16 @@ fn fanout_coinbase_transaction(height: u32) -> Tx {
 fn spend_proxy_transaction(prev_txid: Txid, vout: u32) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(prev_txid, vout),
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: SPEND_PROXY_SPEND_OUTPUT_VALUE,
-            script_pubkey: push_int(1),
+            value: Amount::from_sat(SPEND_PROXY_SPEND_OUTPUT_VALUE),
+            script_pubkey: push_int(1).into(),
         }],
     }
 }
@@ -1355,7 +1359,8 @@ fn block_merkle_root(block: &Block) -> Hash256 {
 
 /// Decodes a 256-bit compact target into little-endian bytes. Negative,
 /// overflowed, and zero-mantissa encodings decode to an unreachable zero.
-fn compact_to_target(bits: u32) -> [u8; 32] {
+fn compact_to_target(bits: CompactTarget) -> [u8; 32] {
+    let bits = bits.to_consensus();
     let exponent = usize::from(u8::try_from(bits >> 24).unwrap_or(0));
     let mantissa = u64::from(bits & 0x007f_ffff);
     let mut target = [0_u8; 32];
@@ -1379,7 +1384,7 @@ fn compact_to_target(bits: u32) -> [u8; 32] {
 
 /// Returns true when `hash` is at or below the compact target, comparing the
 /// little-endian byte arrays from the most significant end.
-fn pow_met(bits: u32, hash: &BlockHash) -> bool {
+fn pow_met(bits: CompactTarget, hash: &BlockHash) -> bool {
     let target = compact_to_target(bits);
     let hash_le = hash.as_bytes();
     for index in (0..32).rev() {
@@ -1490,7 +1495,7 @@ fn child_signed_fanout_coinbase_block(parent: &Block, height: u32, keys: &Signin
             prev_blockhash: parent.block_hash(),
             merkle_root: Hash256::default(),
             time: parent.header.time.saturating_add(1),
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         },
         txs: vec![coinbase],
@@ -1507,8 +1512,8 @@ fn signed_fanout_coinbase_transaction(height: u32, keys: &SigningKeys) -> Tx {
         let pkh = keys.p2pkh[usize::try_from(i).unwrap()].pubkey_hash();
         let script = OracleScriptBuf::new_p2pkh(&pkh);
         outputs.push(TxOut {
-            value: SPEND_PROXY_COINBASE_OUTPUT_VALUE,
-            script_pubkey: script.as_bytes().to_vec(),
+            value: Amount::from_sat(SPEND_PROXY_COINBASE_OUTPUT_VALUE),
+            script_pubkey: script.as_bytes().to_vec().into(),
         });
     }
     // P2WPKH outputs (indices 22..44).
@@ -1518,8 +1523,8 @@ fn signed_fanout_coinbase_transaction(height: u32, keys: &SigningKeys) -> Tx {
             .unwrap();
         let script = OracleScriptBuf::new_p2wpkh(&pkh);
         outputs.push(TxOut {
-            value: SPEND_PROXY_COINBASE_OUTPUT_VALUE,
-            script_pubkey: script.as_bytes().to_vec(),
+            value: Amount::from_sat(SPEND_PROXY_COINBASE_OUTPUT_VALUE),
+            script_pubkey: script.as_bytes().to_vec().into(),
         });
     }
     // P2WSH 2-of-3 outputs (indices 44..64).
@@ -1528,25 +1533,25 @@ fn signed_fanout_coinbase_transaction(height: u32, keys: &SigningKeys) -> Tx {
         let script_hash = redeem.wscript_hash();
         let script = OracleScriptBuf::new_p2wsh(&script_hash);
         outputs.push(TxOut {
-            value: SPEND_PROXY_COINBASE_OUTPUT_VALUE,
-            script_pubkey: script.as_bytes().to_vec(),
+            value: Amount::from_sat(SPEND_PROXY_COINBASE_OUTPUT_VALUE),
+            script_pubkey: script.as_bytes().to_vec().into(),
         });
     }
     // BIP141 witness commitment output.
     let commitment = witness_commitment_for_coinbase(&outputs);
     outputs.push(TxOut {
-        value: 0,
-        script_pubkey: witness_commitment_script_pubkey(&commitment),
+        value: Amount::from_sat(0),
+        script_pubkey: witness_commitment_script_pubkey(&commitment).into(),
     });
 
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid::default(), u32::MAX),
-            script_sig: coinbase_script_sig(height),
-            sequence: u32::MAX,
-            witness: vec![WITNESS_RESERVED_VALUE.to_vec()],
+            script_sig: coinbase_script_sig(height).into(),
+            sequence: Sequence::MAX,
+            witness: vec![WITNESS_RESERVED_VALUE.to_vec()].into(),
         }],
         outputs,
     }
@@ -1616,7 +1621,7 @@ fn child_signed_spend_fanout_block(
             prev_blockhash: parent.block_hash(),
             merkle_root: Hash256::default(),
             time: parent.header.time.saturating_add(1),
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         },
         txs,
@@ -1630,7 +1635,7 @@ fn child_signed_spend_fanout_block(
         .outputs
         .last_mut()
         .unwrap_or_else(|| panic!("coinbase missing commitment output"));
-    last.script_pubkey = witness_commitment_script_pubkey(&commitment);
+    last.script_pubkey = witness_commitment_script_pubkey(&commitment).into();
     // Recompute merkle root after updating the commitment.
     block.header.merkle_root = block_merkle_root(&block);
     mine_block_to_declared_target(&mut block);
@@ -1731,10 +1736,10 @@ fn build_signed_p2pkh_spend(
             },
             script_sig: OracleScriptBuf::new(),
             sequence: OracleSequence::MAX,
-            witness: Witness::new(),
+            witness: OracleWitness::new(),
         }],
         output: vec![OracleTxOut {
-            value: Amount::from_sat(SPEND_PROXY_SPEND_OUTPUT_VALUE),
+            value: OracleAmount::from_sat(SPEND_PROXY_SPEND_OUTPUT_VALUE),
             script_pubkey: OracleBuilder::new().push_int(1).into_script(),
         }],
     };
@@ -1779,10 +1784,10 @@ fn build_signed_p2wpkh_spend(
             },
             script_sig: OracleScriptBuf::new(),
             sequence: OracleSequence::MAX,
-            witness: Witness::new(),
+            witness: OracleWitness::new(),
         }],
         output: vec![OracleTxOut {
-            value: Amount::from_sat(SPEND_PROXY_SPEND_OUTPUT_VALUE),
+            value: OracleAmount::from_sat(SPEND_PROXY_SPEND_OUTPUT_VALUE),
             script_pubkey: OracleBuilder::new().push_int(1).into_script(),
         }],
     };
@@ -1791,7 +1796,7 @@ fn build_signed_p2wpkh_spend(
         .p2wpkh_signature_hash(
             0,
             &script_pubkey,
-            Amount::from_sat(prevout_value),
+            OracleAmount::from_sat(prevout_value),
             EcdsaSighashType::All,
         )
         .unwrap_or_else(|e| panic!("p2wpkh sighash: {e}"));
@@ -1801,7 +1806,8 @@ fn build_signed_p2wpkh_spend(
     sig.normalize_s();
     let mut sig_bytes = sig.serialize_der().as_ref().to_vec();
     sig_bytes.push(EcdsaSighashType::All as u8);
-    tx.input[0].witness = Witness::from_slice(&[sig_bytes, pubkey.inner.serialize().to_vec()]);
+    tx.input[0].witness =
+        OracleWitness::from_slice(&[sig_bytes, pubkey.inner.serialize().to_vec()]);
     to_native_tx(&tx)
 }
 
@@ -1826,10 +1832,10 @@ fn build_signed_p2wsh_spend(
             },
             script_sig: OracleScriptBuf::new(),
             sequence: OracleSequence::MAX,
-            witness: Witness::new(),
+            witness: OracleWitness::new(),
         }],
         output: vec![OracleTxOut {
-            value: Amount::from_sat(SPEND_PROXY_SPEND_OUTPUT_VALUE),
+            value: OracleAmount::from_sat(SPEND_PROXY_SPEND_OUTPUT_VALUE),
             script_pubkey: OracleBuilder::new().push_int(1).into_script(),
         }],
     };
@@ -1838,7 +1844,7 @@ fn build_signed_p2wsh_spend(
         .p2wsh_signature_hash(
             0,
             &redeem,
-            Amount::from_sat(prevout_value),
+            OracleAmount::from_sat(prevout_value),
             EcdsaSighashType::All,
         )
         .unwrap_or_else(|e| panic!("p2wsh sighash: {e}"));
@@ -1860,7 +1866,7 @@ fn build_signed_p2wsh_spend(
         sigs[1].clone(),
         redeem.as_bytes().to_vec(),
     ];
-    tx.input[0].witness = Witness::from_slice(&witness_items);
+    tx.input[0].witness = OracleWitness::from_slice(&witness_items);
     to_native_tx(&tx)
 }
 

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -14,8 +14,8 @@ use bitcoin_rs_chain::{BlockTree, ChainWork, NodeId, TipSnapshot};
 use bitcoin_rs_consensus::{MAX_SCRIPT_SIZE, MEDIAN_TIME_PAST_WINDOW, rust_path::UtxoView};
 use bitcoin_rs_mempool::{AdmissionOrigin, ChainChangeGuard, Mempool, MempoolGateway};
 use bitcoin_rs_primitives::{
-    Block, ConsensusEncode as _, Hash256, Network, OutPoint, Tx, TxOut, Txid, consensus_bytes,
-    varint,
+    Amount, Block, CompactTarget, ConsensusEncode as _, Hash256, LockTime, Network, OutPoint,
+    Script, Sequence, Tx, TxOut, Txid, Witness, consensus_bytes, varint,
 };
 use bitcoin_rs_utxo::{
     LiveOutput, LiveOutputMeta, UtxoSet,
@@ -3061,7 +3061,8 @@ fn apply_block_admitted<'b>(
 /// `arith_uint256::SetCompact` semantics; the sign bit decodes to zero.
 /// Node-local port: `bitcoin_rs_chain::header_sync` keeps its `pow` module
 /// crate-private, and the header `PoW` gate here must match it exactly.
-fn compact_to_target(bits: u32) -> ChainWork {
+fn compact_to_target(bits: CompactTarget) -> ChainWork {
+    let bits = bits.to_consensus();
     let exponent = usize::from(u8::try_from(bits >> 24).unwrap_or(0));
     let mut mantissa = u64::from(bits & 0x007f_ffff);
     let target = if exponent <= 3 {
@@ -3084,7 +3085,7 @@ fn compact_to_target(bits: u32) -> ChainWork {
 
 /// Returns `true` when `hash`, read as a 256-bit little-endian integer, does
 /// not exceed the decoded compact target.
-fn compact_is_met_by(bits: u32, hash: Hash256) -> bool {
+fn compact_is_met_by(bits: CompactTarget, hash: Hash256) -> bool {
     let target = compact_to_target(bits);
     target != ChainWork::ZERO && ChainWork::from_le_bytes(hash.to_le_bytes()) <= target
 }
@@ -4375,15 +4376,15 @@ mod consensus_rule_tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: funding_outpoint,
-                script_sig,
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: script_sig.into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: op_true_script(),
+                value: Amount::from_sat(1),
+                script_pubkey: op_true_script().into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let block = block_with_transactions(vec![funding_tx, bad_same_block_spend]);
         let plan = tx_plan(&block);
@@ -4432,8 +4433,8 @@ mod consensus_rule_tests {
         changes.add(UtxoAdd::new(
             base_prevout,
             TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x87],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x87].into(),
             },
             false,
             1,
@@ -4448,15 +4449,15 @@ mod consensus_rule_tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: base_prevout,
-                script_sig,
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: script_sig.into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: op_true_script(),
+                value: Amount::from_sat(1),
+                script_pubkey: op_true_script().into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let funding_outpoint = OutPoint::new(funding_tx.txid(), 0);
         // tx1 spends tx0's output inside the block, forcing the overlay walk.
@@ -4537,7 +4538,7 @@ mod consensus_rule_tests {
     #[test]
     fn verify_block_transactions_rejects_bad_coinbase_script_sig() {
         let mut coinbase = coinbase_transaction(0x63);
-        coinbase.inputs[0].script_sig = vec![0x63];
+        coinbase.inputs[0].script_sig = vec![0x63].into();
         let block = block_with_transaction(coinbase);
         let handles = empty_apply_handles();
 
@@ -4888,7 +4889,7 @@ mod consensus_rule_tests {
     #[test]
     fn verify_block_transactions_still_checks_coinbase_script_sig_under_assume_valid_height() {
         let mut coinbase = coinbase_transaction(0x63);
-        coinbase.inputs[0].script_sig = vec![0x63];
+        coinbase.inputs[0].script_sig = vec![0x63].into();
         let block = block_with_transaction(coinbase);
         let mut handles = empty_apply_handles();
         handles.assume_valid_height = 100;
@@ -4939,8 +4940,8 @@ mod consensus_rule_tests {
     fn build_utxo_changes_excludes_op_return_outputs() -> Result<(), Box<dyn std::error::Error>> {
         let mut coinbase = coinbase_transaction(0x6f);
         coinbase.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: op_return_script(b"not a coin"),
+            value: Amount::from_sat(0),
+            script_pubkey: op_return_script(b"not a coin").into(),
         });
         let txid = coinbase.txid();
         let block = block_with_transaction(coinbase);
@@ -4970,12 +4971,12 @@ mod consensus_rule_tests {
     fn build_utxo_changes_excludes_oversized_scripts() -> Result<(), Box<dyn std::error::Error>> {
         let mut coinbase = coinbase_transaction(0x70);
         coinbase.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: vec![0x51; MAX_SCRIPT_SIZE],
+            value: Amount::from_sat(0),
+            script_pubkey: vec![0x51; MAX_SCRIPT_SIZE].into(),
         });
         coinbase.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: vec![0x51; MAX_SCRIPT_SIZE + 1],
+            value: Amount::from_sat(0),
+            script_pubkey: vec![0x51; MAX_SCRIPT_SIZE + 1].into(),
         });
         let txid = coinbase.txid();
         let block = block_with_transaction(coinbase);
@@ -5098,7 +5099,7 @@ mod consensus_rule_tests {
     #[test]
     fn verify_block_transactions_defers_same_block_coinbase_spend_to_maturity() {
         let mut coinbase = coinbase_transaction(0x65);
-        coinbase.outputs[0].script_pubkey = op_true_script();
+        coinbase.outputs[0].script_pubkey = op_true_script().into();
         let coinbase_outpoint = OutPoint::new(coinbase.txid(), 0);
         let spend = spending_transaction_to_script(coinbase_outpoint, u32::MAX, op_true_script());
         let block = block_with_transactions(vec![coinbase, spend]);
@@ -5709,8 +5710,8 @@ mod consensus_rule_tests {
         changes.add(UtxoAdd::new(
             OutPoint::new(duplicate_txid, 1),
             TxOut {
-                value: 1_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1_000),
+                script_pubkey: Script::new(),
             },
             false,
             0,
@@ -5724,7 +5725,7 @@ mod consensus_rule_tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0,
+                bits: CompactTarget::from_consensus(0),
                 nonce: 0,
             },
             txs: vec![duplicate_tx],
@@ -5757,8 +5758,8 @@ mod consensus_rule_tests {
         changes.add(UtxoAdd::new(
             OutPoint::new(duplicate_txid, 0),
             TxOut {
-                value: 1_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1_000),
+                script_pubkey: Script::new(),
             },
             false,
             0,
@@ -5789,8 +5790,8 @@ mod consensus_rule_tests {
         changes.add(UtxoAdd::new(
             OutPoint::new(duplicate_txid, 0),
             TxOut {
-                value: 1_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1_000),
+                script_pubkey: Script::new(),
             },
             false,
             0,
@@ -5822,8 +5823,8 @@ mod consensus_rule_tests {
         changes.add(UtxoAdd::new(
             OutPoint::new(duplicate_txid, 0),
             TxOut {
-                value: 1_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1_000),
+                script_pubkey: Script::new(),
             },
             false,
             0,
@@ -6155,8 +6156,8 @@ mod consensus_rule_tests {
         let outpoint = OutPoint::new(fixture_txid(0x2c), 7);
         let removed = OutPoint::new(fixture_txid(0x3d), 1);
         let txout = TxOut {
-            value: 123_456,
-            script_pubkey: op_true_script(),
+            value: Amount::from_sat(123_456),
+            script_pubkey: op_true_script().into(),
         };
 
         let mut batch = UndoBatch::default();
@@ -6312,10 +6313,10 @@ mod consensus_rule_tests {
         // coinbase scriptSig of at least two.
         let mut script_sig = push_int(1);
         script_sig.extend_from_slice(&push_data(&[0_u8; 4]));
-        coinbase.inputs[0].script_sig = script_sig;
+        coinbase.inputs[0].script_sig = script_sig.into();
         coinbase.outputs = vec![TxOut {
-            value: coinbase_value,
-            script_pubkey: op_true_script(),
+            value: Amount::from_sat(coinbase_value),
+            script_pubkey: op_true_script().into(),
         }];
         let mut txdata = vec![coinbase];
         txdata.extend(extra);
@@ -6685,7 +6686,7 @@ mod consensus_rule_tests {
             let txdata = match case {
                 Case::CoinbaseScriptSigLength => {
                     let mut coinbase = coinbase_transaction(1);
-                    coinbase.inputs[0].script_sig = vec![1];
+                    coinbase.inputs[0].script_sig = vec![1].into();
                     vec![coinbase]
                 }
                 Case::SigopOverflow => {
@@ -6708,11 +6709,11 @@ mod consensus_rule_tests {
                         Case::DuplicateInput => spend.inputs.push(spend.inputs[0].clone()),
                         Case::MissingPrevout => {}
                         Case::NonFinalLocktime => {
-                            spend.lock_time = 2;
-                            spend.inputs[0].sequence = 0;
+                            spend.lock_time = LockTime::from_consensus(2);
+                            spend.inputs[0].sequence = Sequence::ZERO;
                         }
                         Case::OutputsGreaterThanInputs => {
-                            spend.outputs[0].value = 2_000;
+                            spend.outputs[0].value = Amount::from_sat(2_000);
                         }
                         Case::CoinbaseScriptSigLength | Case::SigopOverflow => unreachable!(),
                     }
@@ -6752,8 +6753,8 @@ mod consensus_rule_tests {
             changes.add(UtxoAdd::new(
                 prevout,
                 TxOut {
-                    value: 1_000,
-                    script_pubkey: vec![0x87],
+                    value: Amount::from_sat(1_000),
+                    script_pubkey: vec![0x87].into(),
                 },
                 false,
                 0,
@@ -6901,8 +6902,8 @@ mod consensus_rule_tests {
         // The older coin at the very same outpoint, with values the new one does
         // not share, so a restore that invents a coin cannot pass.
         let older = TxOut {
-            value: 4_242,
-            script_pubkey: op_true_script(),
+            value: Amount::from_sat(4_242),
+            script_pubkey: op_true_script().into(),
         };
         let mut seed = bitcoin_rs_utxo::BlockChanges::default();
         seed.add(bitcoin_rs_utxo::UtxoAdd::new(
@@ -7221,8 +7222,8 @@ mod consensus_rule_tests {
         seed.restore(bitcoin_rs_utxo::UtxoAdd::new(
             funded,
             TxOut {
-                value: funded_value,
-                script_pubkey: op_true_script(),
+                value: Amount::from_sat(funded_value),
+                script_pubkey: op_true_script().into(),
             },
             false,
             0,
@@ -8004,7 +8005,7 @@ mod consensus_rule_tests {
         handles.applied_tip.store(Some(Arc::new(genesis_tip)));
 
         let mut coinbase = coinbase_transaction(0x94);
-        coinbase.outputs[0].script_pubkey = op_true_script();
+        coinbase.outputs[0].script_pubkey = op_true_script().into();
         let coinbase_outpoint = OutPoint::new(coinbase.txid(), 0);
         let spend = spending_transaction_to_script(coinbase_outpoint, u32::MAX, op_true_script());
         let block = mined_block_with_prev_hash_and_transactions(
@@ -8060,15 +8061,15 @@ mod consensus_rule_tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(fixture_txid(seed), u32::from(seed)),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -8077,15 +8078,15 @@ mod consensus_rule_tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: vec![seed, seed],
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: vec![seed, seed].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -8094,15 +8095,15 @@ mod consensus_rule_tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: push_int(i64::from(height)),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: push_int(i64::from(height)).into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -8125,8 +8126,8 @@ mod consensus_rule_tests {
             changes.add(UtxoAdd::new(
                 *previous_output,
                 TxOut {
-                    value: 1_000,
-                    script_pubkey: op_true_script(),
+                    value: Amount::from_sat(1_000),
+                    script_pubkey: op_true_script().into(),
                 },
                 false,
                 height,
@@ -8143,7 +8144,7 @@ mod consensus_rule_tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0,
+                bits: CompactTarget::from_consensus(0),
                 nonce: 0,
             },
             txs: vec![tx],
@@ -8157,7 +8158,7 @@ mod consensus_rule_tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0,
+                bits: CompactTarget::from_consensus(0),
                 nonce: 0,
             },
             txs: txdata,
@@ -8171,7 +8172,7 @@ mod consensus_rule_tests {
                 prev_blockhash,
                 merkle_root: Hash256::default(),
                 time: next_fixture_time(),
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             },
             txs: txdata,
@@ -8226,7 +8227,7 @@ mod consensus_rule_tests {
             prev_blockhash,
             merkle_root: Hash256::default(),
             time,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce,
         }
     }
@@ -8383,7 +8384,7 @@ mod consensus_rule_tests {
         let min_timespan = expected_timespan / 4;
         let max_timespan = expected_timespan * 4;
         let actual_clamped = actual_timespan.clamp(min_timespan, max_timespan);
-        let previous_target = compact_to_target(previous_bits);
+        let previous_target = compact_to_target(CompactTarget::from_consensus(previous_bits));
         let actual = ChainWork::from(actual_clamped);
         let expected = ChainWork::from(expected_timespan);
         let target = ((previous_target / expected) * actual)
@@ -8426,15 +8427,15 @@ mod consensus_rule_tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output,
-                script_sig: Vec::new(),
-                sequence,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(sequence),
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey,
+                value: Amount::from_sat(1),
+                script_pubkey: script_pubkey.into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -8470,7 +8471,7 @@ mod consensus_rule_tests {
                     .unwrap_or_else(BlockHash::default),
                 merkle_root: Hash256::default(),
                 time: BIP68_TEST_PREVOUT_MTP,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: height,
             };
             let id = tree.insert_node(parent, header, NodeStatus::Active)?;
@@ -8498,7 +8499,7 @@ mod consensus_rule_tests {
                     .unwrap_or_else(BlockHash::default),
                 merkle_root: Hash256::default(),
                 time,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: u32::try_from(height).map_err(|_| ApplyError::HeightOverflow(u32::MAX))?,
             };
             let id = tree.insert_node(parent, header, NodeStatus::Active)?;
@@ -8685,8 +8686,8 @@ mod consensus_rule_tests {
         changes.add(UtxoAdd::new(
             base_prevout,
             TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x87],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x87].into(),
             },
             false,
             1,
@@ -8699,15 +8700,15 @@ mod consensus_rule_tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: base_prevout,
-                script_sig,
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: script_sig.into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: op_true_script(),
+                value: Amount::from_sat(1),
+                script_pubkey: op_true_script().into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let block = block_with_transaction(spend);
         let plan = tx_plan(&block);
@@ -8750,8 +8751,8 @@ mod consensus_rule_tests {
         changes.add(UtxoAdd::new(
             base_prevout,
             TxOut {
-                value: 1_000,
-                script_pubkey: p2sh_output_script,
+                value: Amount::from_sat(1_000),
+                script_pubkey: p2sh_output_script.into(),
             },
             false,
             1,
@@ -8762,15 +8763,15 @@ mod consensus_rule_tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: base_prevout,
-                script_sig: push_data(&redeem),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: push_data(&redeem).into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: op_true_script(),
+                value: Amount::from_sat(1),
+                script_pubkey: op_true_script().into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let block = block_with_transaction(spend);
         let plan = tx_plan(&block);
@@ -8868,15 +8869,15 @@ mod consensus_rule_tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: base_prevout,
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 2_000,
-                script_pubkey: op_true_script(),
+                value: Amount::from_sat(2_000),
+                script_pubkey: op_true_script().into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let block = block_with_transaction(spend);
         let plan = tx_plan(&block);
@@ -10450,7 +10451,7 @@ mod consensus_rule_tests {
         // header merkle root no longer matches and block rules reject the
         // block with a permanent consensus error before any write.
         let mut bad_body = bad.clone();
-        bad_body.txs[0].outputs[0].value = 2;
+        bad_body.txs[0].outputs[0].value = Amount::from_sat(2);
         let descendant = mined_block_with_prev_hash_and_transactions(
             bad.block_hash(),
             vec![coinbase_transaction(3)],
@@ -10856,7 +10857,10 @@ mod chain_generation_tests {
     use std::sync::atomic::Ordering;
 
     use bitcoin_rs_mempool::{MempoolObserver, MutationEnvelope};
-    use bitcoin_rs_primitives::{BlockHash, Hash256, Network, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, BlockHash, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+        Txid, Witness,
+    };
     use bitcoin_rs_utxo::UtxoSet;
     use parking_lot::Mutex;
 
@@ -11157,7 +11161,7 @@ mod chain_generation_tests {
         for height in 1..=101_u32 {
             let mut coinbase = coinbase_transaction(u8::try_from(height).unwrap_or(0xFF));
             if height == 1 {
-                coinbase.outputs[0].value = subsidy;
+                coinbase.outputs[0].value = Amount::from_sat(subsidy);
             }
             let mut txs = vec![coinbase];
             if height == 101 {
@@ -11168,15 +11172,15 @@ mod chain_generation_tests {
                     version: 2,
                     inputs: vec![TxIn {
                         previous_output: OutPoint::new(first, 0),
-                        script_sig: push_int(1),
-                        sequence: 0xffff_ffff,
-                        witness: Vec::new(),
+                        script_sig: push_int(1).into(),
+                        sequence: Sequence::MAX,
+                        witness: Witness::new(),
                     }],
                     outputs: vec![TxOut {
-                        value: subsidy - 100_000,
-                        script_pubkey: Vec::new(),
+                        value: Amount::from_sat(subsidy - 100_000),
+                        script_pubkey: Script::new(),
                     }],
-                    lock_time: 0,
+                    lock_time: LockTime::ZERO,
                 });
             }
             let block = mined_block_with_prev_hash_and_transactions(prev_hash, txs)
@@ -11261,15 +11265,15 @@ mod chain_generation_tests {
                     Txid::from(bitcoin_rs_primitives::Hash256::from_le_bytes(&[0xAA; 32])),
                     0,
                 ),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let _ = &mut bad_tx;
 

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -14,9 +14,12 @@ use bitcoin_rs_chain::{BlockTree, ChainWork, NodeId, TipSnapshot};
 use bitcoin_rs_consensus::{MAX_SCRIPT_SIZE, MEDIAN_TIME_PAST_WINDOW, rust_path::UtxoView};
 use bitcoin_rs_mempool::{AdmissionOrigin, ChainChangeGuard, Mempool, MempoolGateway};
 use bitcoin_rs_primitives::{
-    Amount, Block, CompactTarget, ConsensusEncode as _, Hash256, LockTime, Network, OutPoint,
-    Script, Sequence, Tx, TxOut, Txid, Witness, consensus_bytes, varint,
+    Block, CompactTarget, ConsensusEncode as _, Hash256, Network, OutPoint, Tx, TxOut, Txid,
+    consensus_bytes, varint,
 };
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Witness};
 use bitcoin_rs_utxo::{
     LiveOutput, LiveOutputMeta, UtxoSet,
     connect::{BlockChangeError, SpentOutputLookup, build_block_changes},

--- a/crates/node/src/chainstate_journal/delta.rs
+++ b/crates/node/src/chainstate_journal/delta.rs
@@ -129,7 +129,7 @@ pub(crate) fn mutations_for_block(
 
 #[cfg(test)]
 mod tests {
-    use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut, Txid};
+    use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, TxOut, Txid};
     use bitcoin_rs_utxo::{BorrowedBlockChanges, BorrowedUtxoAdd};
 
     use super::{Coin, Mutation, mutations_for_block};
@@ -138,8 +138,8 @@ mod tests {
         Coin {
             outpoint: OutPoint::new(Txid(Hash256::from_le_bytes(&[marker; 32])), 0),
             txout: TxOut {
-                value,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(value),
+                script_pubkey: vec![0x51].into(),
             },
             height,
             coinbase: true,
@@ -152,7 +152,7 @@ mod tests {
         let old = coin(1, 10, 50);
         let mut new = old.clone();
         new.height = 100;
-        new.txout.value = 25;
+        new.txout.value = Amount::from_sat(25);
         let spent = coin(2, 20, 12);
         let mut changes = BorrowedBlockChanges::with_capacity(1, 1);
         changes.add(BorrowedUtxoAdd::new(

--- a/crates/node/src/chainstate_journal/record.rs
+++ b/crates/node/src/chainstate_journal/record.rs
@@ -1,6 +1,6 @@
 //! Framed, checksummed chainstate journal records.
 
-use bitcoin_rs_primitives::{ConsensusDecode, ConsensusEncode, Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{Amount, ConsensusDecode, ConsensusEncode, Hash256, OutPoint, TxOut};
 use thiserror::Error;
 
 const MAGIC: [u8; 4] = *b"JRNL";
@@ -365,15 +365,15 @@ mod tests {
     use super::{
         BlockMeta, Coin, JournalRecord, JournalRecordError, Mutation, decode_record, encode_record,
     };
-    use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut, Txid};
+    use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, TxOut, Txid};
     use proptest::prelude::*;
 
     fn coin(seed: u8, height: u32, coinbase: bool) -> Coin {
         Coin {
             outpoint: OutPoint::new(Txid(Hash256::from_le_bytes(&[seed; 32])), u32::from(seed)),
             txout: TxOut {
-                value: u64::from(seed) * 1_000,
-                script_pubkey: vec![0x51, seed],
+                value: Amount::from_sat(u64::from(seed) * 1_000),
+                script_pubkey: vec![0x51, seed].into(),
             },
             height,
             coinbase,
@@ -485,8 +485,8 @@ mod tests {
             |(seed, height, coinbase, script_len)| Coin {
                 outpoint: OutPoint::new(Txid(Hash256::from_le_bytes(&[seed; 32])), u32::from(seed)),
                 txout: TxOut {
-                    value: u64::from(seed),
-                    script_pubkey: vec![seed; script_len],
+                    value: Amount::from_sat(u64::from(seed)),
+                    script_pubkey: vec![seed; script_len].into(),
                 },
                 height,
                 coinbase,

--- a/crates/node/src/chainstate_journal/record.rs
+++ b/crates/node/src/chainstate_journal/record.rs
@@ -1,6 +1,6 @@
 //! Framed, checksummed chainstate journal records.
 
-use bitcoin_rs_primitives::{Amount, ConsensusDecode, ConsensusEncode, Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{ConsensusDecode, ConsensusEncode, Hash256, OutPoint, TxOut};
 use thiserror::Error;
 
 const MAGIC: [u8; 4] = *b"JRNL";

--- a/crates/node/src/chainstate_journal/replay.rs
+++ b/crates/node/src/chainstate_journal/replay.rs
@@ -640,7 +640,7 @@ fn block_hash_of(record: &JournalRecord) -> Hash256 {
 mod tests {
     use bitcoin_rs_chain::{BlockTree, NodeStatus, TipSnapshot};
     use bitcoin_rs_primitives::{
-        BlockHash, Hash256, Header, OutPoint, TxOut, Txid, consensus_bytes,
+        Amount, BlockHash, CompactTarget, Hash256, Header, OutPoint, TxOut, Txid, consensus_bytes,
     };
     use bitcoin_rs_utxo::stats::{CoinStats, CoinStatsListener};
     use bitcoin_rs_utxo::{BorrowedBlockChanges, BorrowedUtxoAdd, UtxoSet};
@@ -664,7 +664,7 @@ mod tests {
             prev_blockhash,
             merkle_root: Hash256::from_le_bytes(&merkle),
             time,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: u32::from(marker),
         }
     }
@@ -681,8 +681,8 @@ mod tests {
         Coin {
             outpoint: OutPoint::new(Txid(Hash256::from_le_bytes(&[marker; 32])), 0),
             txout: TxOut {
-                value,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(value),
+                script_pubkey: vec![0x51].into(),
             },
             height,
             coinbase: true,

--- a/crates/node/src/chainstate_journal/writer.rs
+++ b/crates/node/src/chainstate_journal/writer.rs
@@ -1435,7 +1435,7 @@ mod tests {
     use parking_lot::Mutex;
 
     use super::*;
-    use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut, Txid};
+    use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, TxOut, Txid};
 
     use crate::chainstate_journal::record::{Coin, Mutation};
 
@@ -1585,8 +1585,8 @@ mod tests {
                             height,
                         ),
                         txout: TxOut {
-                            value: u64::from(height),
-                            script_pubkey: vec![0x51],
+                            value: Amount::from_sat(u64::from(height)),
+                            script_pubkey: vec![0x51].into(),
                         },
                         height,
                         coinbase: true,
@@ -1601,8 +1601,8 @@ mod tests {
                             height.wrapping_sub(1),
                         ),
                         txout: TxOut {
-                            value: u64::from(height),
-                            script_pubkey: vec![0x51],
+                            value: Amount::from_sat(u64::from(height)),
+                            script_pubkey: vec![0x51].into(),
                         },
                         height: height.wrapping_sub(1),
                         coinbase: false,

--- a/crates/node/src/checkpoint.rs
+++ b/crates/node/src/checkpoint.rs
@@ -2,8 +2,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use bitcoin_rs_chain::{BlockTree, ChainWork, NodeId, TipSnapshot, accept_headers};
-use bitcoin_rs_primitives::{Hash256, Network};
-use bitcoin_rs_primitives::{Header, deserialize};
+use bitcoin_rs_primitives::{Amount, CompactTarget, Hash256, Header, Network, deserialize};
 use bitcoin_rs_utxo::stats::{
     CoinStats, CoinStatsAccumulator, CoinStatsListener, coin_stats::COIN_STATS_ENCODED_LEN,
 };
@@ -1745,7 +1744,8 @@ mod tests {
 
     use bitcoin_rs_chain::{BlockTree, ChainWork, NodeId, TipSnapshot, accept_headers};
     use bitcoin_rs_primitives::{
-        BlockHash, Hash256, Header, Network, OutPoint, TxOut, Txid, deserialize,
+        Amount, BlockHash, CompactTarget, Hash256, Header, Network, OutPoint, TxOut, Txid,
+        deserialize,
     };
     use bitcoin_rs_utxo::stats::{CoinStats, CoinStatsListener, scan_coin_stats};
     use bitcoin_rs_utxo::{BlockChanges, UtxoAdd, UtxoSet};
@@ -1890,7 +1890,7 @@ mod tests {
         let mut bad_nbits = bytes;
         let previous = header_from_row(&bad_nbits[header_offset..header_offset + 80])?;
         let mut nbits_mismatch = Header {
-            bits: 0x207f_fffe,
+            bits: CompactTarget::from_consensus(0x207f_fffe),
             ..previous
         };
         mine_header_to_declared_target(&mut nbits_mismatch)?;
@@ -2527,8 +2527,8 @@ mod tests {
             changes.add(UtxoAdd::new(
                 OutPoint::new(record_txid, vout),
                 TxOut {
-                    value: u64::from(vout) + 1,
-                    script_pubkey: vec![0x51],
+                    value: Amount::from_sat(u64::from(vout) + 1),
+                    script_pubkey: vec![0x51].into(),
                 },
                 false,
                 0,
@@ -2596,8 +2596,8 @@ mod tests {
         changes.add(UtxoAdd::new(
             OutPoint::new(Txid(Hash256::from_le_bytes(&[0x5a; 32])), 42),
             TxOut {
-                value: 123_456,
-                script_pubkey: vec![0x51, 0xac],
+                value: Amount::from_sat(123_456),
+                script_pubkey: vec![0x51, 0xac].into(),
             },
             false,
             restored.applied_tip.height,
@@ -2821,7 +2821,7 @@ mod tests {
             prev_blockhash,
             merkle_root: Hash256::default(),
             time: 1_296_688_602_u32.saturating_add(height),
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         }
     }
@@ -2838,7 +2838,8 @@ mod tests {
 
     /// Decodes a compact target and checks whether `hash` meets it, mirroring
     /// the chain crate's private `compact_is_met_by`.
-    fn pow_meets_target(bits: u32, hash: Hash256) -> bool {
+    fn pow_meets_target(bits: CompactTarget, hash: Hash256) -> bool {
+        let bits = bits.to_consensus();
         let exponent = usize::from(u8::try_from(bits >> 24).unwrap_or(0));
         let mantissa = u64::from(bits & 0x007f_ffff);
         let negative = mantissa != 0 && bits & 0x0080_0000 != 0;
@@ -2874,8 +2875,8 @@ mod tests {
         changes.add(UtxoAdd::new(
             OutPoint::new(Txid(Hash256::from_le_bytes(&[7_u8; 32])), 3),
             TxOut {
-                value: 50_000,
-                script_pubkey: vec![0x51, 0x21],
+                value: Amount::from_sat(50_000),
+                script_pubkey: vec![0x51, 0x21].into(),
             },
             true,
             0,

--- a/crates/node/src/checkpoint.rs
+++ b/crates/node/src/checkpoint.rs
@@ -2,7 +2,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use bitcoin_rs_chain::{BlockTree, ChainWork, NodeId, TipSnapshot, accept_headers};
-use bitcoin_rs_primitives::{Amount, CompactTarget, Hash256, Header, Network, deserialize};
+use bitcoin_rs_primitives::{Hash256, Header, Network, deserialize};
 use bitcoin_rs_utxo::stats::{
     CoinStats, CoinStatsAccumulator, CoinStatsListener, coin_stats::COIN_STATS_ENCODED_LEN,
 };
@@ -215,7 +215,7 @@ fn write_headers_inner<W: Write>(
         if node.height != height {
             return Err(HeaderCheckpointError::MalformedAncestry { height });
         }
-        let encoded = encode_header(&node.header)?;
+        let encoded = encode_header(&node.header);
         writer.write_all(&encoded)?;
         best_hasher.update(encoded);
         if node.height <= applied.height {
@@ -412,8 +412,8 @@ fn tip_from_node(
     })
 }
 
-fn encode_header(header: &Header) -> Result<[u8; HEADER_LEN], HeaderCheckpointError> {
-    Ok(header.to_bytes())
+fn encode_header(header: &Header) -> [u8; HEADER_LEN] {
+    header.to_bytes()
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1884,7 +1884,7 @@ mod tests {
         while pow_meets_target(invalid.bits, invalid.compute_hash().0) {
             invalid.nonce = invalid.nonce.checked_add(1).ok_or("nonce exhausted")?;
         }
-        bad_pow[header_offset..header_offset + 80].copy_from_slice(&encode_header(&invalid)?);
+        bad_pow[header_offset..header_offset + 80].copy_from_slice(&encode_header(&invalid));
         assert!(read_headers(&mut Cursor::new(bad_pow), config(), written.metadata).is_err());
 
         let mut bad_nbits = bytes;
@@ -1895,7 +1895,7 @@ mod tests {
         };
         mine_header_to_declared_target(&mut nbits_mismatch)?;
         bad_nbits[header_offset..header_offset + 80]
-            .copy_from_slice(&encode_header(&nbits_mismatch)?);
+            .copy_from_slice(&encode_header(&nbits_mismatch));
         assert!(read_headers(&mut Cursor::new(bad_nbits), config(), written.metadata).is_err());
         Ok(())
     }

--- a/crates/node/src/checkpoint_worker.rs
+++ b/crates/node/src/checkpoint_worker.rs
@@ -50,7 +50,6 @@ use crate::apply::{ApplyAdmission, PruneBodyStore, UndoStore};
 use crate::checkpoint::{self, CheckpointError, CheckpointWrite};
 use crate::recovery_evidence;
 use crate::state::ChainEventPublisher;
-use bitcoin_rs_primitives::Witness;
 
 fn retire_full_revalidation_marker(data_dir: &std::path::Path) -> Result<(), CheckpointError> {
     crate::chainstate_journal::clear_full_revalidation_marker_at(data_dir).map_err(|error| {

--- a/crates/node/src/checkpoint_worker.rs
+++ b/crates/node/src/checkpoint_worker.rs
@@ -50,6 +50,7 @@ use crate::apply::{ApplyAdmission, PruneBodyStore, UndoStore};
 use crate::checkpoint::{self, CheckpointError, CheckpointWrite};
 use crate::recovery_evidence;
 use crate::state::ChainEventPublisher;
+use bitcoin_rs_primitives::Witness;
 
 fn retire_full_revalidation_marker(data_dir: &std::path::Path) -> Result<(), CheckpointError> {
     crate::chainstate_journal::clear_full_revalidation_marker_at(data_dir).map_err(|error| {

--- a/crates/node/src/embed.rs
+++ b/crates/node/src/embed.rs
@@ -28,9 +28,10 @@
 //! only when no existing public type fits, and both fit.
 
 use bitcoin_rs_mempool::{FeeRate, MempoolStats, MutationResult};
-use bitcoin_rs_primitives::{
-    Amount, Block, BlockHash, Hash256, LockTime, Network, Script, Sequence, Tx, Txid, deserialize,
-};
+use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Network, Tx, Txid, deserialize};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence};
 use bitcoin_rs_rpc::capabilities::CapabilitySnapshot;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/node/src/embed.rs
+++ b/crates/node/src/embed.rs
@@ -28,7 +28,9 @@
 //! only when no existing public type fits, and both fit.
 
 use bitcoin_rs_mempool::{FeeRate, MempoolStats, MutationResult};
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Network, Tx, Txid, deserialize};
+use bitcoin_rs_primitives::{
+    Amount, Block, BlockHash, Hash256, LockTime, Network, Script, Sequence, Tx, Txid, deserialize,
+};
 use bitcoin_rs_rpc::capabilities::CapabilitySnapshot;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -568,16 +570,16 @@ mod tests {
     fn spending_tx(previous_output: OutPoint) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output,
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: vec![vec![0x51]],
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: vec![vec![0x51]].into(),
             }],
             outputs: vec![TxOut {
-                value: 92_000,
-                script_pubkey: spendable_script(),
+                value: Amount::from_sat(92_000),
+                script_pubkey: spendable_script().into(),
             }],
         }
     }
@@ -608,8 +610,8 @@ mod tests {
             changes.add(UtxoAdd::new(
                 prevout,
                 TxOut {
-                    value: 100_000,
-                    script_pubkey: spendable_script(),
+                    value: Amount::from_sat(100_000),
+                    script_pubkey: spendable_script().into(),
                 },
                 false,
                 1,

--- a/crates/node/src/import.rs
+++ b/crates/node/src/import.rs
@@ -6,7 +6,7 @@
 //! file declares the contract those commits fill in.
 
 use anyhow::{Context as _, Result};
-use bitcoin_rs_primitives::{Block, Hash256};
+use bitcoin_rs_primitives::{Block, CompactTarget, Hash256};
 
 use crate::state::NodeState;
 
@@ -46,7 +46,8 @@ mod tests {
     use super::*;
     use bitcoin_rs_primitives::encode::double_sha256;
     use bitcoin_rs_primitives::{
-        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
+        Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script,
+        Sequence, Tx, TxIn, TxOut, Txid, Witness, consensus_bytes,
     };
     use std::time::{Duration, Instant};
     use tempfile::tempdir;
@@ -147,7 +148,7 @@ mod tests {
         Some(Hash256::from_le_bytes(&leaves[0]))
     }
 
-    fn pow_met(bits: u32, hash: Hash256) -> bool {
+    fn pow_met(bits: CompactTarget, hash: Hash256) -> bool {
         // Interpret the hash as a little-endian 256-bit integer and compare it
         // against the decoded compact target. Regtest bits 0x207f_ffff is the
         // easiest target (about half of all hashes pass); lower targets reject
@@ -160,7 +161,8 @@ mod tests {
         uint_be(&hash.to_le_bytes()) <= target
     }
 
-    fn compact_to_target(bits: u32) -> [u8; 32] {
+    fn compact_to_target(bits: CompactTarget) -> [u8; 32] {
+        let bits = bits.to_consensus();
         let exponent = usize::from(u8::try_from(bits >> 24).unwrap_or(0));
         let mantissa = u64::from(bits & 0x007f_ffff);
         let mut target = [0_u8; 32];
@@ -227,7 +229,7 @@ mod tests {
         let mut block = Block::consensus_decode(&genesis_bytes)?;
         block.header.prev_blockhash = block.block_hash();
         block.header.time = block.header.time.saturating_add(1);
-        block.header.bits = 0x0010_0001;
+        block.header.bits = CompactTarget::from_consensus(0x0010_0001);
 
         let block_bytes = consensus_bytes(&block);
 
@@ -271,8 +273,8 @@ mod tests {
         let mut block = genesis_block.clone();
         block.header.prev_blockhash = genesis_block.block_hash();
         block.header.time = block.header.time.saturating_add(1);
-        block.header.bits = 0x207f_ffff;
-        block.txs[0].inputs[0].script_sig = vec![1, 1];
+        block.header.bits = CompactTarget::from_consensus(0x207f_ffff);
+        block.txs[0].inputs[0].script_sig = vec![1, 1].into();
         block.header.merkle_root = compute_merkle_root(&block)
             .ok_or_else(|| anyhow::anyhow!("mutated block should have merkle root"))?;
         mine_block_to_declared_target(&mut block)?;
@@ -316,8 +318,8 @@ mod tests {
         let mut block = Block::consensus_decode(&genesis_bytes)?;
         block.header.prev_blockhash = block.block_hash();
         block.header.time = block.header.time.saturating_add(1);
-        block.header.bits = 0x207e_ffff;
-        block.txs[0].inputs[0].script_sig = vec![1, 1];
+        block.header.bits = CompactTarget::from_consensus(0x207e_ffff);
+        block.txs[0].inputs[0].script_sig = vec![1, 1].into();
         block.header.merkle_root = compute_merkle_root(&block)
             .ok_or_else(|| anyhow::anyhow!("mutated block should have merkle root"))?;
         mine_block_to_declared_target(&mut block)?;
@@ -365,7 +367,7 @@ mod tests {
         let mut follow_up = Block::consensus_decode(&genesis_bytes)?;
         follow_up.header.prev_blockhash = follow_up.block_hash();
         follow_up.header.time = follow_up.header.time.saturating_add(1);
-        follow_up.txs[0].inputs[0].script_sig = vec![1, 1];
+        follow_up.txs[0].inputs[0].script_sig = vec![1, 1].into();
         follow_up.header.merkle_root = compute_merkle_root(&follow_up)
             .ok_or_else(|| anyhow::anyhow!("follow-up block should have merkle root"))?;
         mine_block_to_declared_target(&mut follow_up)?;
@@ -395,7 +397,7 @@ mod tests {
         let mut follow_up = Block::consensus_decode(&genesis_bytes)?;
         follow_up.header.prev_blockhash = follow_up.block_hash();
         follow_up.header.time = follow_up.header.time.saturating_add(1);
-        follow_up.txs[0].inputs[0].script_sig = vec![1, 1];
+        follow_up.txs[0].inputs[0].script_sig = vec![1, 1].into();
         follow_up.header.merkle_root = compute_merkle_root(&follow_up)
             .ok_or_else(|| anyhow::anyhow!("follow-up block should have merkle root"))?;
         mine_block_to_declared_target(&mut follow_up)?;
@@ -421,20 +423,20 @@ mod tests {
         let mut block = Block::consensus_decode(&genesis_bytes)?;
         block.header.prev_blockhash = block.block_hash();
         block.header.time = block.header.time.saturating_add(1);
-        block.txs[0].inputs[0].script_sig = vec![1, 1];
+        block.txs[0].inputs[0].script_sig = vec![1, 1].into();
         block.txs.push(Tx {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0_u8; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         });
         block.header.merkle_root = compute_merkle_root(&block)
             .ok_or_else(|| anyhow::anyhow!("mutated block should have merkle root"))?;
@@ -486,7 +488,7 @@ mod tests {
         let mut coinbase_block = genesis_block.clone();
         coinbase_block.header.prev_blockhash = genesis_block.block_hash();
         coinbase_block.header.time = coinbase_block.header.time.saturating_add(1);
-        coinbase_block.txs[0].inputs[0].script_sig = vec![1, 1];
+        coinbase_block.txs[0].inputs[0].script_sig = vec![1, 1].into();
         coinbase_block.header.merkle_root = compute_merkle_root(&coinbase_block)
             .ok_or_else(|| anyhow::anyhow!("height-1 block should have merkle root"))?;
         mine_block_to_declared_target(&mut coinbase_block)?;
@@ -497,20 +499,20 @@ mod tests {
         let mut block = coinbase_block;
         block.header.prev_blockhash = block.block_hash();
         block.header.time = block.header.time.saturating_add(1);
-        block.txs[0].inputs[0].script_sig = vec![1, 2];
+        block.txs[0].inputs[0].script_sig = vec![1, 2].into();
         block.txs.push(Tx {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(immature_coinbase_txid, 0),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         });
 
         let Err(error) = state.check_coinbase_maturity(&block, 2) else {
@@ -597,7 +599,7 @@ mod tests {
         let synthetic_tip = seed_synthetic_header_tip(&state, 499)?;
 
         block.header.prev_blockhash = BlockHash(synthetic_tip.hash);
-        block.txs[0].inputs[0].script_sig = Vec::new();
+        block.txs[0].inputs[0].script_sig = Vec::new().into();
         block.header.merkle_root = compute_merkle_root(&block)
             .ok_or_else(|| anyhow::anyhow!("mutated block should have merkle root"))?;
         mine_block_to_declared_target(&mut block)?;
@@ -649,7 +651,7 @@ mod tests {
                 prev_blockhash,
                 merkle_root: Hash256::from_le_bytes(&merkle),
                 time: current_height,
-                bits,
+                bits: CompactTarget::from_consensus(bits),
                 nonce: 0,
             };
             mine_header_to_declared_target(&mut header)?;

--- a/crates/node/src/import.rs
+++ b/crates/node/src/import.rs
@@ -6,7 +6,7 @@
 //! file declares the contract those commits fill in.
 
 use anyhow::{Context as _, Result};
-use bitcoin_rs_primitives::{Block, CompactTarget, Hash256};
+use bitcoin_rs_primitives::{Block, Hash256};
 
 use crate::state::NodeState;
 

--- a/crates/node/src/mining.rs
+++ b/crates/node/src/mining.rs
@@ -25,9 +25,7 @@ use bitcoin_rs_mining::{
     SignetMiningInfo, TemplateId, TemplateMutation, assemble_candidate, assemble_ordered_candidate,
     difficulty_for_bits,
 };
-use bitcoin_rs_primitives::{
-    Amount, Block, CompactTarget, Hash256, LockTime, Network, Script, Tx, consensus_bytes,
-};
+use bitcoin_rs_primitives::{Block, CompactTarget, Hash256, Network, Tx, consensus_bytes};
 use compact_str::CompactString;
 use hashbrown::HashMap;
 use parking_lot::{Condvar, Mutex, RwLock};

--- a/crates/node/src/mining.rs
+++ b/crates/node/src/mining.rs
@@ -25,7 +25,9 @@ use bitcoin_rs_mining::{
     SignetMiningInfo, TemplateId, TemplateMutation, assemble_candidate, assemble_ordered_candidate,
     difficulty_for_bits,
 };
-use bitcoin_rs_primitives::{Block, Hash256, Network, Tx, consensus_bytes};
+use bitcoin_rs_primitives::{
+    Amount, Block, CompactTarget, Hash256, LockTime, Network, Script, Tx, consensus_bytes,
+};
 use compact_str::CompactString;
 use hashbrown::HashMap;
 use parking_lot::{Condvar, Mutex, RwLock};
@@ -790,7 +792,12 @@ impl MiningCoordinator {
                     difficulty_for_bits(next.bits),
                 )
             }
-            None => (0, 0.0, 0, 0.0),
+            None => (
+                CompactTarget::from_consensus(0),
+                0.0,
+                CompactTarget::from_consensus(0),
+                0.0,
+            ),
         };
         let pooled_transactions = u64::try_from(self.mempool.read().len()).unwrap_or(u64::MAX);
         let minimum_fee_rate = self.mempool.read().min_relay_fee_sat_per_kvb();
@@ -1275,7 +1282,7 @@ mod network_hashps_oracle_tests {
     use super::{estimate_network_hashps, hash_ps_at};
     use bitcoin_rs_chain::{BlockTree, NodeId, NodeStatus, TipSnapshot};
     use bitcoin_rs_mining::MiningControlError;
-    use bitcoin_rs_primitives::{BlockHash, Hash256, Header, Network};
+    use bitcoin_rs_primitives::{BlockHash, CompactTarget, Hash256, Header, Network};
 
     const BITS: u32 = 0x207f_ffff;
 
@@ -1285,7 +1292,7 @@ mod network_hashps_oracle_tests {
             prev_blockhash: prev,
             merkle_root: Hash256::default(),
             time,
-            bits: BITS,
+            bits: CompactTarget::from_consensus(BITS),
             nonce: 0,
         }
     }
@@ -1449,7 +1456,9 @@ mod network_hashps_oracle_tests {
 mod candidate_template_tests {
     use alloc::sync::Arc;
     use bitcoin_rs_mining::{Candidate, TemplateId};
-    use bitcoin_rs_primitives::{Hash256, Network, Tx, TxOut};
+    use bitcoin_rs_primitives::{
+        Amount, CompactTarget, Hash256, LockTime, Network, Script, Tx, TxOut,
+    };
 
     #[test]
     fn candidate_cache_evicts_the_oldest_entry_at_the_bound() {
@@ -1459,11 +1468,11 @@ mod candidate_template_tests {
         let mut state = super::CoordinatorState::new();
         let coinbase = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50),
+                script_pubkey: Script::new(),
             }],
         };
         let mut first_id = None;
@@ -1479,7 +1488,7 @@ mod candidate_template_tests {
                 previous_block_hash: hash,
                 height: 1,
                 version: 1,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 min_time: 1,
                 current_time: 1,
                 csv_active: false,
@@ -1516,7 +1525,7 @@ mod candidate_template_tests {
             previous_block_hash: previous,
             height: 1,
             version: 1,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             min_time: 1,
             current_time: 1,
             csv_active,
@@ -1527,11 +1536,11 @@ mod candidate_template_tests {
             mempool_sequence: 1,
             coinbase: Tx {
                 version: 2,
-                lock_time: 0,
+                lock_time: LockTime::ZERO,
                 inputs: Vec::new(),
                 outputs: vec![TxOut {
-                    value: 50,
-                    script_pubkey: Vec::new(),
+                    value: Amount::from_sat(50),
+                    script_pubkey: Script::new(),
                 }],
             },
             coinbase_value: 50,

--- a/crates/node/src/recovery_evidence.rs
+++ b/crates/node/src/recovery_evidence.rs
@@ -24,7 +24,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use bitcoin_rs_primitives::Witness;
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------

--- a/crates/node/src/recovery_evidence.rs
+++ b/crates/node/src/recovery_evidence.rs
@@ -24,6 +24,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
+use bitcoin_rs_primitives::Witness;
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------

--- a/crates/node/src/reorg.rs
+++ b/crates/node/src/reorg.rs
@@ -661,7 +661,7 @@ fn reconsider_entry(
     for input in &tx.inputs {
         let outpoint = input.previous_output;
         if let Some(output) = utxo.get(&outpoint) {
-            input_total = input_total.saturating_add(output.value);
+            input_total = input_total.saturating_add(output.value.to_sat());
             continue;
         }
         let values = offered.get(&input.previous_output.txid)?;
@@ -670,7 +670,11 @@ fn reconsider_entry(
             .copied()?;
         input_total = input_total.saturating_add(value);
     }
-    let output_values: Vec<u64> = tx.outputs.iter().map(|output| output.value).collect();
+    let output_values: Vec<u64> = tx
+        .outputs
+        .iter()
+        .map(|output| output.value.to_sat())
+        .collect();
     let output_total = output_values
         .iter()
         .fold(0_u64, |total, value| total.saturating_add(*value));

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -8,9 +8,10 @@
 use arc_swap::ArcSwapOption;
 use bitcoin_rs_chain::{BlockBodyMetadata, BlockBodySource, TipSnapshot};
 use bitcoin_rs_primitives::Hash256;
-use bitcoin_rs_primitives::{
-    Amount, Block, CompactTarget, LockTime, Script, Sequence, Tx, Txid, Witness, deserialize,
-};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::LockTime;
+use bitcoin_rs_primitives::{Block, Tx, Txid, deserialize};
 use bitcoin_rs_rpc::context::{
     BlockLog, NetworkState, PruneResult, PruneService, PruneServiceError, PruneStatus,
     ZmqNotification,

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -8,7 +8,9 @@
 use arc_swap::ArcSwapOption;
 use bitcoin_rs_chain::{BlockBodyMetadata, BlockBodySource, TipSnapshot};
 use bitcoin_rs_primitives::Hash256;
-use bitcoin_rs_primitives::{Block, Tx, Txid, deserialize};
+use bitcoin_rs_primitives::{
+    Amount, Block, CompactTarget, LockTime, Script, Sequence, Tx, Txid, Witness, deserialize,
+};
 use bitcoin_rs_rpc::context::{
     BlockLog, NetworkState, PruneResult, PruneService, PruneServiceError, PruneStatus,
     ZmqNotification,
@@ -2546,7 +2548,8 @@ mod tests {
     use bitcoin_rs_index::IndexCapabilities;
     use bitcoin_rs_primitives::encode::double_sha256;
     use bitcoin_rs_primitives::{
-        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, consensus_bytes,
+        Amount, Block, BlockHash, CompactTarget, Hash256, Header, OutPoint, Script, Sequence, Tx,
+        TxIn, TxOut, Txid, Witness, consensus_bytes,
     };
     use bitcoin_rs_rpc::context::BlockRecord;
 
@@ -3120,7 +3123,7 @@ mod tests {
             version: 1,
             inputs: Vec::new(),
             outputs: Vec::new(),
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         for _ in 0..super::INBOUND_TX_CHANNEL_LIMIT {
             sender
@@ -3749,7 +3752,7 @@ mod tests {
         let pruned_txid = pruned_tx.txid();
         let unrelated_tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: Vec::new(),
         };
@@ -4970,16 +4973,16 @@ mod tests {
         script_sig.extend_from_slice(&time.to_le_bytes());
         let coinbase = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig,
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: script_sig.into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
         };
         let mut block = Block {
@@ -4988,7 +4991,7 @@ mod tests {
                 prev_blockhash,
                 merkle_root: Hash256::default(),
                 time,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             },
             txs: vec![coinbase],
@@ -5032,7 +5035,8 @@ mod tests {
     /// Regtest-easy compact-target `PoW` check over the hash as a 256-bit
     /// little-endian integer (mirrors `chain::pow::compact_is_met_by` for the
     /// >3-exponent, 3-byte-mantissa forms these fixtures mine).
-    fn pow_met(bits: u32, hash: Hash256) -> bool {
+    fn pow_met(bits: CompactTarget, hash: Hash256) -> bool {
+        let bits = bits.to_consensus();
         let exponent = u8::try_from(bits >> 24).unwrap_or(0);
         let mantissa = bits & 0x007f_ffff;
         if exponent <= 3 || exponent > 32 || mantissa > 0x00ff_ffff {

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -17,7 +17,7 @@ use bitcoin::hashes::Hash as _;
 use bitcoin::p2p::message_blockdata::{GetHeadersMessage, Inventory};
 use bitcoin_rs_chain::{BlockTree, ChainError, NodeId, TipSnapshot, plan_reorg};
 use bitcoin_rs_p2p::{InboundBlock, InboundHeaders, Message, PeerTable};
-use bitcoin_rs_primitives::{Block, Hash256};
+use bitcoin_rs_primitives::{Block, CompactTarget, Hash256};
 use crossbeam_channel::Receiver;
 use hashbrown::HashMap;
 use parking_lot::Mutex;
@@ -1611,8 +1611,8 @@ mod tests {
     use bitcoin_rs_p2p::{PeerInfo, PeerLease, PeerSource, PeerTable};
     use bitcoin_rs_primitives::encode::double_sha256;
     use bitcoin_rs_primitives::{
-        Block, BlockHash, Hash256, Header, Network, OutPoint, Tx, TxIn, TxOut, Txid,
-        consensus_bytes,
+        Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Network, OutPoint,
+        Script, Sequence, Tx, TxIn, TxOut, Txid, Witness, consensus_bytes,
     };
     use bitcoin_rs_script::push_int;
     use bitcoin_rs_storage::StorageError;
@@ -1894,7 +1894,7 @@ mod tests {
         };
 
         let mut high_work = test_header(genesis.compute_hash(), 101);
-        high_work.bits = 0x2000_ffff;
+        high_work.bits = CompactTarget::from_consensus(0x2000_ffff);
         high_work.nonce = 0;
         while !pow_met(high_work.bits, Hash256::from(high_work.compute_hash())) {
             high_work.nonce = high_work.nonce.wrapping_add(1);
@@ -1965,7 +1965,7 @@ mod tests {
         let mut fork = Vec::new();
         for height in 1..=3_u32 {
             let mut coinbase = coinbase_transaction(height);
-            coinbase.outputs[0].script_pubkey = push_int(2);
+            coinbase.outputs[0].script_pubkey = push_int(2).into();
             let block = mined_block_with_prev_hash(fork_prev, height, vec![coinbase]);
             fork_parent = sync.handles.block_tree.write().insert_node(
                 Some(fork_parent),
@@ -2109,7 +2109,7 @@ mod tests {
         let mut fork = Vec::new();
         for height in 1..=3_u32 {
             let mut coinbase = coinbase_transaction(height);
-            coinbase.outputs[0].script_pubkey = push_int(2);
+            coinbase.outputs[0].script_pubkey = push_int(2).into();
             let block = mined_block_with_prev_hash(fork_prev, height, vec![coinbase]);
             fork_parent = sync.handles.block_tree.write().insert_node(
                 Some(fork_parent),
@@ -2128,7 +2128,7 @@ mod tests {
             .lookup(Hash256::from_le_bytes(main[1].block_hash().as_bytes()))
             .ok_or_else(|| std::io::Error::other("missing main branch tip"))?;
         let mut racing_coinbase = coinbase_transaction(3);
-        racing_coinbase.outputs[0].script_pubkey = push_int(3);
+        racing_coinbase.outputs[0].script_pubkey = push_int(3).into();
         let racing = mined_block_with_prev_hash(main[1].block_hash(), 3, vec![racing_coinbase]);
         stage_body(&sync, &racing);
         sync.handles.block_tree.write().insert_node(
@@ -2204,7 +2204,7 @@ mod tests {
         let mut fork = Vec::new();
         for height in 1..=2_u32 {
             let mut coinbase = coinbase_transaction(height);
-            coinbase.outputs[0].script_pubkey = push_int(2);
+            coinbase.outputs[0].script_pubkey = push_int(2).into();
             let mut block = mined_block_with_prev_hash(fork_prev, height, vec![coinbase]);
             fork_parent = sync.handles.block_tree.write().insert_node(
                 Some(fork_parent),
@@ -2213,7 +2213,7 @@ mod tests {
             )?;
             fork_prev = block.block_hash();
             if height == 2 {
-                block.txs[0].outputs[0].value = 2;
+                block.txs[0].outputs[0].value = Amount::from_sat(2);
             }
             let hash = Hash256::from_le_bytes(block.block_hash().as_bytes());
             let bytes = consensus_bytes(&block).len();
@@ -2339,7 +2339,7 @@ mod tests {
             .lookup(Hash256::from_le_bytes(genesis.block_hash().as_bytes()))
             .ok_or_else(|| std::io::Error::other("missing genesis node"))?;
         let mut fork_coinbase = coinbase_transaction(1);
-        fork_coinbase.outputs[0].script_pubkey = push_int(2);
+        fork_coinbase.outputs[0].script_pubkey = push_int(2).into();
         let fork = mined_block_with_prev_hash(genesis.block_hash(), 1, vec![fork_coinbase]);
         let fork_id = sync.handles.block_tree.write().insert_node(
             Some(genesis_id),
@@ -2400,7 +2400,7 @@ mod tests {
             .lookup(Hash256::from_le_bytes(genesis.block_hash().as_bytes()))
             .ok_or_else(|| std::io::Error::other("missing genesis node"))?;
         let mut target_coinbase = coinbase_transaction(1);
-        target_coinbase.outputs[0].script_pubkey = push_int(2);
+        target_coinbase.outputs[0].script_pubkey = push_int(2).into();
         let target = mined_block_with_prev_hash(genesis.block_hash(), 1, vec![target_coinbase]);
         let target_id = sync.handles.block_tree.write().insert_node(
             Some(genesis_id),
@@ -2408,7 +2408,7 @@ mod tests {
             NodeStatus::HeaderValid,
         )?;
         let mut wrong_coinbase = coinbase_transaction(1);
-        wrong_coinbase.outputs[0].script_pubkey = push_int(3);
+        wrong_coinbase.outputs[0].script_pubkey = push_int(3).into();
         let wrong = mined_block_with_prev_hash(genesis.block_hash(), 1, vec![wrong_coinbase]);
         let target_hash = Hash256::from_le_bytes(target.block_hash().as_bytes());
         let wrong_hash = Hash256::from_le_bytes(wrong.block_hash().as_bytes());
@@ -2471,7 +2471,7 @@ mod tests {
             .lookup(Hash256::from_le_bytes(genesis.block_hash().as_bytes()))
             .ok_or_else(|| std::io::Error::other("missing genesis node"))?;
         let mut target_coinbase = coinbase_transaction(1);
-        target_coinbase.outputs[0].script_pubkey = push_int(2);
+        target_coinbase.outputs[0].script_pubkey = push_int(2).into();
         let target = mined_block_with_prev_hash(genesis.block_hash(), 1, vec![target_coinbase]);
         let target_id = sync.handles.block_tree.write().insert_node(
             Some(genesis_id),
@@ -2479,7 +2479,7 @@ mod tests {
             NodeStatus::HeaderValid,
         )?;
         let mut wrong_coinbase = coinbase_transaction(1);
-        wrong_coinbase.outputs[0].script_pubkey = push_int(3);
+        wrong_coinbase.outputs[0].script_pubkey = push_int(3).into();
         let wrong = mined_block_with_prev_hash(genesis.block_hash(), 1, vec![wrong_coinbase]);
         let target_hash = Hash256::from_le_bytes(target.block_hash().as_bytes());
         let wrong_bytes = bytes::Bytes::from(consensus_bytes(&wrong));
@@ -6551,7 +6551,7 @@ mod tests {
             prev_blockhash,
             merkle_root: Hash256::from_le_bytes(&merkle),
             time: GENESIS_TIME.saturating_add(height),
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: height,
         };
         // Mine rather than hope: the fixture previously relied on nonce=height
@@ -6565,7 +6565,7 @@ mod tests {
 
     fn nbits_mismatch_header(prev_blockhash: BlockHash, height: u32) -> Header {
         let mut header = test_header(prev_blockhash, height);
-        header.bits = 0x207f_fffe;
+        header.bits = CompactTarget::from_consensus(0x207f_fffe);
         for nonce in 0..=u32::MAX {
             header.nonce = nonce;
             if pow_met(header.bits, Hash256::from(header.compute_hash())) {
@@ -6593,7 +6593,8 @@ mod tests {
     /// Regtest-easy compact-target `PoW` check over the hash as a 256-bit
     /// little-endian integer (mirrors `chain::pow::compact_is_met_by` for the
     /// >3-exponent, 3-byte-mantissa forms these fixtures mine).
-    fn pow_met(bits: u32, hash: Hash256) -> bool {
+    fn pow_met(bits: CompactTarget, hash: Hash256) -> bool {
+        let bits = bits.to_consensus();
         let exponent = bits >> 24;
         let mantissa = bits & 0x007f_ffff;
         if exponent <= 3 || exponent > 32 || mantissa > 0x00ff_ffff {
@@ -6705,15 +6706,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig,
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: script_sig.into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -6725,15 +6726,15 @@ mod tests {
                     Txid(Hash256::from_le_bytes(&[seed; 32])),
                     u32::from(seed),
                 ),
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -6748,7 +6749,7 @@ mod tests {
                 prev_blockhash,
                 merkle_root: Hash256::default(),
                 time: GENESIS_TIME.saturating_add(height),
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             },
             txs: txdata,
@@ -7304,7 +7305,7 @@ mod tests {
         for height in 1..=depth {
             let mut coinbase = coinbase_transaction(height);
             if height == 1 {
-                coinbase.outputs[0].value = subsidy;
+                coinbase.outputs[0].value = Amount::from_sat(subsidy);
             }
             let mut txs = vec![coinbase];
             if height == depth {
@@ -7313,15 +7314,15 @@ mod tests {
                     version: 2,
                     inputs: vec![TxIn {
                         previous_output: OutPoint::new(first_txid, 0),
-                        script_sig: push_int(1),
-                        sequence: 0xffff_ffff,
-                        witness: Vec::new(),
+                        script_sig: push_int(1).into(),
+                        sequence: Sequence::MAX,
+                        witness: Witness::new(),
                     }],
                     outputs: vec![TxOut {
-                        value: subsidy - 100_000,
-                        script_pubkey: Vec::new(),
+                        value: Amount::from_sat(subsidy - 100_000),
+                        script_pubkey: Script::new(),
                     }],
-                    lock_time: 0,
+                    lock_time: LockTime::ZERO,
                 });
             }
             let block = mined_block_with_prev_hash(prev_hash, height, txs);
@@ -7361,7 +7362,7 @@ mod tests {
         // The value change alters the txid, so the staged body contradicts the
         // header's merkle root: a permanent consensus failure.
         let mut bad_body = bad.clone();
-        bad_body.txs[0].outputs[0].value = 2;
+        bad_body.txs[0].outputs[0].value = Amount::from_sat(2);
         let descendant =
             mined_block_with_prev_hash(bad.block_hash(), 3, vec![coinbase_transaction(3)]);
         {
@@ -7421,7 +7422,7 @@ mod tests {
             let mut coinbase = coinbase_transaction(height);
             // Distinguish the branch: same-height coinbases on both chains
             // must not carry identical txids, or the fork headers collide.
-            coinbase.outputs[0].script_pubkey = push_int(2);
+            coinbase.outputs[0].script_pubkey = push_int(2).into();
             let block = mined_block_with_prev_hash(fork_prev, height, vec![coinbase]);
             fork_parent =
                 tree.insert_node(Some(fork_parent), block.header, NodeStatus::HeaderValid)?;
@@ -7431,7 +7432,7 @@ mod tests {
         let fork_target = fork_parent;
         drop(tree);
         let mut corrupt = fork_blocks[fork_blocks.len() - 1].clone();
-        corrupt.txs[0].outputs[0].value = 2;
+        corrupt.txs[0].outputs[0].value = Amount::from_sat(2);
         let last = fork_blocks.len() - 1;
         fork_blocks[last] = corrupt;
         for block in &fork_blocks {
@@ -7518,7 +7519,7 @@ mod tests {
         let mut fork_blocks = Vec::new();
         for height in 51..=52_u32 {
             let mut coinbase = coinbase_transaction(height);
-            coinbase.outputs[0].script_pubkey = push_int(2);
+            coinbase.outputs[0].script_pubkey = push_int(2).into();
             let block = mined_block_with_prev_hash(fork_prev, height, vec![coinbase]);
             fork_parent =
                 tree.insert_node(Some(fork_parent), block.header, NodeStatus::HeaderValid)?;
@@ -7577,7 +7578,7 @@ mod tests {
         let mut fork_blocks = Vec::new();
         for height in 51..=52_u32 {
             let mut coinbase = coinbase_transaction(height);
-            coinbase.outputs[0].script_pubkey = push_int(2);
+            coinbase.outputs[0].script_pubkey = push_int(2).into();
             let block = mined_block_with_prev_hash(fork_prev, height, vec![coinbase]);
             fork_parent =
                 tree.insert_node(Some(fork_parent), block.header, NodeStatus::HeaderValid)?;
@@ -7602,7 +7603,7 @@ mod tests {
         // permanent consensus failure (MerkleRoot), which the classifier
         // marks as permanent and invalidates the subtree.
         let mut corrupt = fork_blocks[0].clone();
-        corrupt.txs[0].outputs[0].value = 2;
+        corrupt.txs[0].outputs[0].value = Amount::from_sat(2);
         fork_blocks[0] = corrupt;
         for block in &fork_blocks {
             bodies.insert(

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -17,7 +17,7 @@ use bitcoin::hashes::Hash as _;
 use bitcoin::p2p::message_blockdata::{GetHeadersMessage, Inventory};
 use bitcoin_rs_chain::{BlockTree, ChainError, NodeId, TipSnapshot, plan_reorg};
 use bitcoin_rs_p2p::{InboundBlock, InboundHeaders, Message, PeerTable};
-use bitcoin_rs_primitives::{Block, CompactTarget, Hash256};
+use bitcoin_rs_primitives::{Block, Hash256};
 use crossbeam_channel::Receiver;
 use hashbrown::HashMap;
 use parking_lot::Mutex;

--- a/crates/node/src/sync/stage.rs
+++ b/crates/node/src/sync/stage.rs
@@ -375,7 +375,8 @@ fn block_size(block: &Block) -> usize {
 #[cfg(test)]
 mod tests {
     use bitcoin_rs_primitives::{
-        Block, Hash256, Network, OutPoint, Tx, TxIn, TxOut, consensus_bytes,
+        Amount, Block, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+        Witness, consensus_bytes,
     };
     use std::time::{Duration, Instant};
 
@@ -730,15 +731,15 @@ mod tests {
                 version: 2,
                 inputs: vec![TxIn {
                     previous_output: OutPoint::default(),
-                    script_sig: vec![0_u8; script_len],
-                    sequence: 0xffff_ffff,
-                    witness: Vec::new(),
+                    script_sig: vec![0_u8; script_len].into(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 }],
                 outputs: vec![TxOut {
-                    value: 0,
-                    script_pubkey: Vec::new(),
+                    value: Amount::from_sat(0),
+                    script_pubkey: Script::new(),
                 }],
-                lock_time: 0,
+                lock_time: LockTime::ZERO,
             }],
         }
     }

--- a/crates/node/src/tx_admission.rs
+++ b/crates/node/src/tx_admission.rs
@@ -23,7 +23,10 @@ use std::sync::Arc;
 
 use bitcoin_rs_mempool::{MempoolGateway, MempoolObserver, MutationEnvelope, MutationOutcome};
 use bitcoin_rs_p2p::{InboundTx, PeerSource, TxInventory};
-use bitcoin_rs_primitives::{Amount, Hash256, LockTime, Sequence, Tx, Txid, Witness, Wtxid};
+use bitcoin_rs_primitives::{Hash256, Tx, Txid, Wtxid};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Sequence, Witness};
 use crossbeam_channel::Sender;
 use parking_lot::Mutex;
 

--- a/crates/node/src/tx_admission.rs
+++ b/crates/node/src/tx_admission.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use bitcoin_rs_mempool::{MempoolGateway, MempoolObserver, MutationEnvelope, MutationOutcome};
 use bitcoin_rs_p2p::{InboundTx, PeerSource, TxInventory};
-use bitcoin_rs_primitives::{Hash256, Tx, Txid, Wtxid};
+use bitcoin_rs_primitives::{Amount, Hash256, LockTime, Sequence, Tx, Txid, Witness, Wtxid};
 use crossbeam_channel::Sender;
 use parking_lot::Mutex;
 
@@ -458,15 +458,15 @@ mod tests {
                     txid: Txid::from(Hash256::from_le_bytes(&[byte; 32])),
                     vout: 0,
                 },
-                script_sig: vec![byte],
-                sequence: 0xFFFF_FFFF,
-                witness: Vec::new(),
+                script_sig: vec![byte].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x6A],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x6A].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 

--- a/crates/node/src/tx_ingress.rs
+++ b/crates/node/src/tx_ingress.rs
@@ -25,9 +25,10 @@ use bitcoin_rs_mempool::{
     standardness::{PackageTxContext, is_standard_tx},
 };
 use bitcoin_rs_mining::MiningControl;
-use bitcoin_rs_primitives::{
-    Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxOut, Txid, Witness,
-};
+use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxOut, Txid};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Witness};
 use bitcoin_rs_utxo::UtxoSet;
 use crossbeam_channel::Receiver;
 use hashbrown::HashMap;

--- a/crates/node/src/tx_ingress.rs
+++ b/crates/node/src/tx_ingress.rs
@@ -25,7 +25,9 @@ use bitcoin_rs_mempool::{
     standardness::{PackageTxContext, is_standard_tx},
 };
 use bitcoin_rs_mining::MiningControl;
-use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxOut, Txid, Witness,
+};
 use bitcoin_rs_utxo::UtxoSet;
 use crossbeam_channel::Receiver;
 use hashbrown::HashMap;
@@ -333,22 +335,21 @@ impl TxIngressConsumer {
                 continue;
             }
             if let Some(output) = mempool_prevouts.get(&input.previous_output) {
-                input_value = input_value.saturating_add(output.value);
+                input_value = input_value.saturating_add(output.value.to_sat());
                 prevouts.push((input.previous_output, output.clone()));
                 continue;
             }
             if let Some(live) = self.utxo.get_entry(&input.previous_output) {
-                input_value = input_value.saturating_add(live.txout.value);
+                input_value = input_value.saturating_add(live.txout.value.to_sat());
                 prevouts.push((input.previous_output, live.txout.clone()));
                 continue;
             }
             missing_inputs = true;
         }
 
-        let output_value = tx
-            .outputs
-            .iter()
-            .fold(0_u64, |sum, output| sum.saturating_add(output.value));
+        let output_value = tx.outputs.iter().fold(0_u64, |sum, output| {
+            sum.saturating_add(output.value.to_sat())
+        });
         let fee = input_value.saturating_sub(output_value);
         let vsize = u32::try_from(tx.vsize()).unwrap_or(u32::MAX);
         let sigop_cost = bitcoin_rs_script::count_tx_legacy(tx);
@@ -545,15 +546,15 @@ mod tests {
             version: 1,
             inputs: vec![TxIn {
                 previous_output: OutPoint::default(),
-                script_sig: vec![0x51],
-                sequence: 0xFFFF_FFFF,
-                witness: Vec::new(),
+                script_sig: vec![0x51].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value,
-                script_pubkey: vec![0x6A],
+                value: Amount::from_sat(value),
+                script_pubkey: vec![0x6A].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -570,15 +571,15 @@ mod tests {
                     txid: parent_txid,
                     vout: 0,
                 },
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFF,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 49_000,
-                script_pubkey: vec![0x6A, 0x04, 0xAA, 0xBB, 0xCC, 0xDD],
+                value: Amount::from_sat(49_000),
+                script_pubkey: vec![0x6A, 0x04, 0xAA, 0xBB, 0xCC, 0xDD].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -598,8 +599,8 @@ mod tests {
                 vout: 0,
             },
             TxOut {
-                value: 50_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(50_000),
+                script_pubkey: vec![0x51].into(),
             },
             false,
             100,
@@ -805,15 +806,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: vec![0x00],
-                sequence: 0xFFFF_FFFF,
-                witness: Vec::new(),
+                script_sig: vec![0x00].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50_000,
-                script_pubkey: vec![0x6A],
+                value: Amount::from_sat(50_000),
+                script_pubkey: vec![0x6A].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let txid = coinbase.txid();
         consumer.process_one(bitcoin_rs_p2p::InboundTx::new(coinbase, test_source()));
@@ -838,8 +839,8 @@ mod tests {
         let mining = Arc::new(RecordingMining::new());
         let consumer = make_consumer_with_utxo(&gateway, mining);
         let mut tx = spending_tx();
-        tx.lock_time = 100;
-        tx.inputs[0].sequence = 0xFFFF_FFFE;
+        tx.lock_time = LockTime::from_consensus(100);
+        tx.inputs[0].sequence = Sequence::from_consensus(0xFFFF_FFFE);
         let txid = tx.txid();
         consumer.process_one(bitcoin_rs_p2p::InboundTx::new(tx, test_source()));
         assert!(
@@ -866,15 +867,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(parent, 0),
-                script_sig: Vec::new(),
-                sequence: 0xFFFF_FFFF,
-                witness: vec![vec![0; 400_000]],
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: vec![vec![0; 400_000]].into(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x6A, 0x04, 0xAA, 0xBB, 0xCC, 0xDD],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x6A, 0x04, 0xAA, 0xBB, 0xCC, 0xDD].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         assert!(
             tx.weight() > 400_000,

--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -1247,7 +1247,7 @@ impl UndoScripts {
         for add in batch.restores() {
             scripts.insert(
                 (add.outpoint.txid.0.to_le_bytes(), add.outpoint.vout),
-                add.txout.script_pubkey.clone(),
+                add.txout.script_pubkey.as_bytes().to_vec(),
             );
         }
         Ok(Self { scripts })
@@ -3315,7 +3315,7 @@ impl TxIndexQueryEngine {
         };
         let vout = usize::try_from(outpoint.vout)
             .map_err(|_| TxQueryError::Storage("outpoint vout overflow".into()))?;
-        Ok(tx.outputs.get(vout).map(|o| o.value))
+        Ok(tx.outputs.get(vout).map(|o| o.value.to_sat()))
     }
 
     fn scan_funding_rows(
@@ -3380,7 +3380,7 @@ impl TxIndexQueryEngine {
             }
             let vout = u32::try_from(vout_idx)
                 .map_err(|_| TxQueryError::Storage("vout overflow".into()))?;
-            outputs.push((txid, vout, output.value, height));
+            outputs.push((txid, vout, output.value.to_sat(), height));
         }
         Ok(outputs.len() != before)
     }
@@ -3565,7 +3565,7 @@ impl TxIndexQueryEngine {
                 records.push(ScriptIndexRecord {
                     txid: outpoint.txid,
                     height: entry.height,
-                    value: entry.txout.value,
+                    value: entry.txout.value.to_sat(),
                     vout: outpoint.vout,
                 });
             }

--- a/crates/node/src/txindex_worker_query_tests.rs
+++ b/crates/node/src/txindex_worker_query_tests.rs
@@ -7,8 +7,8 @@ use bitcoin_rs_index::{
     HashPrefixRow, IndexCapabilities, ScriptHashRow, ScriptLiveRow, SpendingPrefixRow, TxidRow,
 };
 use bitcoin_rs_primitives::{
-    Amount, Block, BlockHash, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn,
-    TxOut, Txid, Witness, consensus_bytes, encode::double_sha256,
+    Block, BlockHash, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+    Txid, Witness, consensus_bytes, encode::double_sha256,
 };
 use bitcoin_rs_rpc::context::{BlockRecord, ScriptHistoryRecord};
 use bitcoin_rs_storage::{ColumnFamily, PrefixScan, PrefixScanLimit};

--- a/crates/node/src/txindex_worker_query_tests.rs
+++ b/crates/node/src/txindex_worker_query_tests.rs
@@ -7,8 +7,8 @@ use bitcoin_rs_index::{
     HashPrefixRow, IndexCapabilities, ScriptHashRow, ScriptLiveRow, SpendingPrefixRow, TxidRow,
 };
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Network, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-    encode::double_sha256,
+    Amount, Block, BlockHash, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn,
+    TxOut, Txid, Witness, consensus_bytes, encode::double_sha256,
 };
 use bitcoin_rs_rpc::context::{BlockRecord, ScriptHistoryRecord};
 use bitcoin_rs_storage::{ColumnFamily, PrefixScan, PrefixScanLimit};
@@ -507,16 +507,16 @@ fn block_with_spending_transaction() -> Result<(Block, OutPoint, ScriptHash, Txi
     };
     block.txs.push(Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: outpoint,
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
             value,
-            script_pubkey: Vec::new(),
+            script_pubkey: Script::new(),
         }],
     });
     block.header.merkle_root = compute_merkle_root(&block)
@@ -838,16 +838,16 @@ fn confirmed_history_snapshot_includes_the_spending_transaction_from_legacy_empt
 
     let spend_tx = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint { txid, vout: 0 },
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
             value,
-            script_pubkey: Vec::new(),
+            script_pubkey: Script::new(),
         }],
     };
     block.txs.push(spend_tx);
@@ -1047,16 +1047,16 @@ fn confirmed_history_snapshot_retries_after_aba_on_spending_scan()
 
     let spend_tx = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint { txid, vout: 0 },
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
             value,
-            script_pubkey: Vec::new(),
+            script_pubkey: Script::new(),
         }],
     };
     block.txs.push(spend_tx);

--- a/crates/node/src/window_overlay.rs
+++ b/crates/node/src/window_overlay.rs
@@ -5,7 +5,9 @@
 //! committed UTXO set. This module supplies exactly that view and nothing else:
 //! it answers lookups and it is advanced one block at a time.
 
-use bitcoin_rs_primitives::{Block, OutPoint, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Block, CompactTarget, LockTime, OutPoint, Script, Sequence, Txid, Witness,
+};
 use bitcoin_rs_utxo::{UtxoSet, shard::LiveOutput};
 use hashbrown::HashMap;
 
@@ -159,7 +161,10 @@ fn is_op_return(script: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin_rs_primitives::{Block, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, Block, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence, Tx,
+        TxIn, TxOut, Txid, Witness,
+    };
     use bitcoin_rs_utxo::{UndoBatch, UtxoAdd, UtxoSet};
 
     use super::{OutputSource, WindowOverlay};
@@ -188,7 +193,7 @@ mod tests {
         let found = overlay.get_entry(&OutPoint::new(txid, 0));
         assert_eq!(
             found.map(|entry| (entry.height, entry.coinbase, entry.txout.value)),
-            Some((HEIGHT, true, 500)),
+            Some((HEIGHT, true, Amount::from_sat(500))),
             "the created output must carry the height and coinbase flag the committed set would record"
         );
         Ok(())
@@ -380,8 +385,8 @@ mod tests {
         batch.restore(UtxoAdd::new(
             outpoint,
             TxOut {
-                value,
-                script_pubkey: op_true(),
+                value: Amount::from_sat(value),
+                script_pubkey: op_true().into(),
             },
             false,
             1,
@@ -400,16 +405,16 @@ mod tests {
     fn coinbase() -> Tx {
         Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: vec![0x00, 0x01],
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: vec![0x00, 0x01].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: op_true(),
+                value: Amount::from_sat(1),
+                script_pubkey: op_true().into(),
             }],
         }
     }
@@ -418,8 +423,8 @@ mod tests {
     fn paying_tx(script_pubkey: Vec<u8>, value: u64) -> Tx {
         let mut tx = coinbase();
         tx.outputs = vec![TxOut {
-            value,
-            script_pubkey,
+            value: Amount::from_sat(value),
+            script_pubkey: script_pubkey.into(),
         }];
         tx
     }
@@ -427,16 +432,16 @@ mod tests {
     fn spending_tx(previous_output: OutPoint) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output,
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: op_true(),
+                value: Amount::from_sat(1),
+                script_pubkey: op_true().into(),
             }],
         }
     }
@@ -448,7 +453,7 @@ mod tests {
                 prev_blockhash: bitcoin_rs_primitives::BlockHash(Hash256::from_le_bytes(&[0; 32])),
                 merkle_root: Hash256::from_le_bytes(&[0; 32]),
                 time: 0,
-                bits: 0x2100_ffff,
+                bits: CompactTarget::from_consensus(0x2100_ffff),
                 nonce: 0,
             },
             txs,

--- a/crates/node/src/window_overlay.rs
+++ b/crates/node/src/window_overlay.rs
@@ -5,9 +5,7 @@
 //! committed UTXO set. This module supplies exactly that view and nothing else:
 //! it answers lookups and it is advanced one block at a time.
 
-use bitcoin_rs_primitives::{
-    Amount, Block, CompactTarget, LockTime, OutPoint, Script, Sequence, Txid, Witness,
-};
+use bitcoin_rs_primitives::{Block, OutPoint, Txid};
 use bitcoin_rs_utxo::{UtxoSet, shard::LiveOutput};
 use hashbrown::HashMap;
 

--- a/crates/node/src/zmq_publisher.rs
+++ b/crates/node/src/zmq_publisher.rs
@@ -8,7 +8,7 @@
 #[cfg(feature = "zmq")]
 use anyhow::{Context as _, bail};
 use anyhow::{Result, ensure};
-use bitcoin_rs_primitives::{Hash256, Txid};
+use bitcoin_rs_primitives::{Amount, Hash256, LockTime, Script, Sequence, Txid, Witness};
 #[cfg(feature = "zmq")]
 use core::fmt;
 #[cfg(feature = "zmq")]
@@ -1066,16 +1066,16 @@ mod compat_manifest_tests {
         use bitcoin_rs_primitives::{OutPoint, Tx, TxIn, TxOut};
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[label; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51, label],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51, label].into(),
             }],
         }
     }
@@ -1366,16 +1366,16 @@ mod sequence_observer_tests {
     fn sequence_tx(label: u8) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[label; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51, label],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51, label].into(),
             }],
         }
     }

--- a/crates/node/src/zmq_publisher.rs
+++ b/crates/node/src/zmq_publisher.rs
@@ -8,7 +8,10 @@
 #[cfg(feature = "zmq")]
 use anyhow::{Context as _, bail};
 use anyhow::{Result, ensure};
-use bitcoin_rs_primitives::{Amount, Hash256, LockTime, Script, Sequence, Txid, Witness};
+use bitcoin_rs_primitives::{Hash256, Txid};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Witness};
 #[cfg(feature = "zmq")]
 use core::fmt;
 #[cfg(feature = "zmq")]

--- a/crates/node/tests/chainstate_journal.rs
+++ b/crates/node/tests/chainstate_journal.rs
@@ -8,7 +8,10 @@ use bitcoin_rs_node::{
     Network, NodeConfig,
     state::{ApplyError, NodeState},
 };
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, Witness,
+};
 use sha2::{Digest, Sha256};
 
 fn stable_utxo_hash(
@@ -294,16 +297,16 @@ fn mined_regtest_child(prev_blockhash: BlockHash) -> Result<Block> {
 fn mined_regtest_child_at(prev_blockhash: BlockHash, height: u32) -> Result<Block> {
     let coinbase = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid::default(), u32::MAX),
-            script_sig: vec![1, u8::try_from(height)?],
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: vec![1, u8::try_from(height)?].into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 1,
-            script_pubkey: Vec::new(),
+            value: Amount::from_sat(1),
+            script_pubkey: Script::new(),
         }],
     };
     let mut block = Block {
@@ -312,7 +315,7 @@ fn mined_regtest_child_at(prev_blockhash: BlockHash, height: u32) -> Result<Bloc
             prev_blockhash,
             merkle_root: Hash256::default(),
             time: Network::Regtest.genesis_block().header.time + height,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         },
         txs: vec![coinbase],
@@ -355,7 +358,8 @@ fn double_sha256(bytes: &[u8]) -> [u8; 32] {
     Sha256::digest(first).into()
 }
 
-fn pow_met(bits: u32, hash: Hash256) -> bool {
+fn pow_met(bits: CompactTarget, hash: Hash256) -> bool {
+    let bits = bits.to_consensus();
     let exponent = u8::try_from(bits >> 24).unwrap_or(0);
     let mantissa = bits & 0x007f_ffff;
     if exponent <= 3 || exponent > 32 || mantissa > 0x00ff_ffff {

--- a/crates/node/tests/crash_recovery.rs
+++ b/crates/node/tests/crash_recovery.rs
@@ -6,7 +6,10 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result, bail};
 use bitcoin_rs_node::{Network, NodeConfig, state::NodeState};
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, Witness,
+};
 use sha2::{Digest, Sha256};
 
 const CHILD_ENV: &str = "BITCOIN_RS_CRASH_TEST_CHILD";
@@ -198,16 +201,16 @@ fn assert_tip(state: &NodeState, expected: &bitcoin_rs_chain::TipSnapshot) -> Re
 fn mined_regtest_child_at(prev_blockhash: BlockHash, height: u32) -> Result<Block> {
     let coinbase = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid::default(), u32::MAX),
-            script_sig: vec![1, u8::try_from(height)?],
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: vec![1, u8::try_from(height)?].into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 1,
-            script_pubkey: Vec::new(),
+            value: Amount::from_sat(1),
+            script_pubkey: Script::new(),
         }],
     };
     let mut block = Block {
@@ -216,7 +219,7 @@ fn mined_regtest_child_at(prev_blockhash: BlockHash, height: u32) -> Result<Bloc
             prev_blockhash,
             merkle_root: Hash256::default(),
             time: Network::Regtest.genesis_block().header.time + height,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         },
         txs: vec![coinbase],
@@ -259,7 +262,8 @@ fn double_sha256(bytes: &[u8]) -> [u8; 32] {
     Sha256::digest(first).into()
 }
 
-fn pow_met(bits: u32, hash: Hash256) -> bool {
+fn pow_met(bits: CompactTarget, hash: Hash256) -> bool {
+    let bits = bits.to_consensus();
     let exponent = u8::try_from(bits >> 24).unwrap_or(0);
     let mantissa = bits & 0x007f_ffff;
     if exponent <= 3 || exponent > 32 || mantissa > 0x00ff_ffff {

--- a/crates/node/tests/embed.rs
+++ b/crates/node/tests/embed.rs
@@ -13,7 +13,8 @@ use bitcoin_rs_node::state::NodeState;
 use bitcoin_rs_node::{Network, Node, NodeConfig, NodeError};
 use bitcoin_rs_primitives::encode::double_sha256;
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
+    Amount, Block, BlockHash, CompactTarget, Hash256, LockTime, OutPoint, Script, Sequence, Tx,
+    TxIn, TxOut, Txid, Witness, consensus_bytes,
 };
 
 const SEED_BLOCKS: u32 = 100;
@@ -244,7 +245,7 @@ fn seed_chain(state: &NodeState, count: u32) -> Result<(Hash256, Hash256, Vec<u8
                 prev_blockhash: BlockHash::from(tip.hash),
                 merkle_root: Hash256::from_le_bytes(&[0_u8; 32]),
                 time: SEED_BASE_TIME.saturating_add(SEED_BLOCK_INTERVAL.saturating_mul(height)),
-                bits: REGTEST_BITS,
+                bits: CompactTarget::from_consensus(REGTEST_BITS),
                 nonce: 0,
             },
             txs: vec![coinbase],
@@ -274,15 +275,17 @@ fn seed_coinbase(height: u32) -> Tx {
             previous_output: null_prevout(),
             // BIP34 height push plus one pad byte: consensus requires a
             // 2..=100 byte coinbase scriptSig (Core bad-cb-length).
-            script_sig: [script_push_int(i64::from(height)), script_push_int(0)].concat(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: [script_push_int(i64::from(height)), script_push_int(0)]
+                .concat()
+                .into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REGTEST_SUBSIDY_SATS,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(REGTEST_SUBSIDY_SATS),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 
@@ -294,17 +297,17 @@ fn seed_coinbase_spend() -> Tx {
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(seed_coinbase.txid(), 0),
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REGTEST_SUBSIDY_SATS - MEMPOOL_TX_FEE_SATS,
+            value: Amount::from_sat(REGTEST_SUBSIDY_SATS - MEMPOOL_TX_FEE_SATS),
             // P2WPKH. The prevout is anyone-can-spend, but the mempool also
             // enforces output standardness, which a bare OP_TRUE output fails.
-            script_pubkey: [vec![0x00, 0x14], vec![0x11; 20]].concat(),
+            script_pubkey: [vec![0x00, 0x14], vec![0x11; 20]].concat().into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 
@@ -353,7 +356,8 @@ fn grind_pow(block: &mut Block) -> Result<()> {
 
 /// Returns true when the header hash, read as a little-endian integer, meets
 /// the compact bits target (Core `CheckProofOfWork` shape).
-fn pow_is_met(bits: u32, hash: &Hash256) -> bool {
+fn pow_is_met(bits: CompactTarget, hash: &Hash256) -> bool {
+    let bits = bits.to_consensus();
     let exponent = usize::try_from(bits >> 24).unwrap_or(usize::MAX);
     let mantissa = bits & 0x00ff_ffff;
     if mantissa == 0 || mantissa & 0x0080_0000 != 0 || exponent > 32 {

--- a/crates/node/tests/mining.rs
+++ b/crates/node/tests/mining.rs
@@ -1118,7 +1118,12 @@ fn generate_mines_coinbase_only_blocks_to_the_tip() -> anyhow::Result<()> {
     assert_eq!(tip.height, 2);
     assert_eq!(
         tip.hash,
-        Hash256::from(hashes.last().expect("two hashes").hash)
+        Hash256::from(
+            hashes
+                .last()
+                .unwrap_or_else(|| panic!("generate returned two hashes"))
+                .hash,
+        )
     );
     Ok(())
 }
@@ -1130,15 +1135,16 @@ fn generateblock_rejects_unknown_mempool_txid() -> anyhow::Result<()> {
     apply_genesis(&state)?;
     let mining = coordinator(&state);
     let missing = Txid::from(Hash256::from_le_bytes(&[0xcd; 32]));
-    let error = mining
-        .generate(GenerateRequest {
-            payout: vec![0x51],
-            count: 1,
-            max_tries: 16,
-            selection: GenerateSelection::Ordered(vec![GenerateTx::Mempool(missing)]),
-            submit: true,
-        })
-        .expect_err("missing mempool txid must fail");
+    let error = match mining.generate(GenerateRequest {
+        payout: vec![0x51],
+        count: 1,
+        max_tries: 16,
+        selection: GenerateSelection::Ordered(vec![GenerateTx::Mempool(missing)]),
+        submit: true,
+    }) {
+        Err(error) => error,
+        Ok(_) => panic!("missing mempool txid must fail"),
+    };
     assert!(matches!(error, MiningControlError::InvalidRequest(_)));
     Ok(())
 }
@@ -1165,15 +1171,16 @@ fn generateblock_raw_tx_does_not_require_mempool_admission() -> anyhow::Result<(
         }],
         lock_time: LockTime::ZERO,
     };
-    let error = mining
-        .generate(GenerateRequest {
-            payout: vec![0x51],
-            count: 1,
-            max_tries: 16,
-            selection: GenerateSelection::Ordered(vec![GenerateTx::Raw(raw)]),
-            submit: false,
-        })
-        .expect_err("invalid raw spend must fail validation, not mempool lookup");
+    let error = match mining.generate(GenerateRequest {
+        payout: vec![0x51],
+        count: 1,
+        max_tries: 16,
+        selection: GenerateSelection::Ordered(vec![GenerateTx::Raw(raw)]),
+        submit: false,
+    }) {
+        Err(error) => error,
+        Ok(_) => panic!("invalid raw spend must fail validation, not mempool lookup"),
+    };
     assert!(
         matches!(error, MiningControlError::Failed(_)),
         "raw generateblock txs skip mempool membership: {error:?}"
@@ -1188,7 +1195,7 @@ fn network_hash_ps_matches_mining_info_default_window() -> anyhow::Result<()> {
     let mining = coordinator(&state);
     let info = mining.mining_info()?;
     let rate = mining.network_hash_ps(120, -1)?;
-    assert_eq!(rate, info.network_hashes_per_second);
+    assert_eq!(rate.to_bits(), info.network_hashes_per_second.to_bits());
     Ok(())
 }
 

--- a/crates/node/tests/mining.rs
+++ b/crates/node/tests/mining.rs
@@ -15,7 +15,10 @@ use bitcoin_rs_node::{
     state::NodeState,
 };
 use bitcoin_rs_primitives::encode::double_sha256;
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, Witness,
+};
 use compact_str::CompactString;
 use crossbeam_channel::bounded;
 use parking_lot::Mutex;
@@ -121,16 +124,16 @@ fn mined_child_labeled(prev: BlockHash, label: i64) -> anyhow::Result<Block> {
     let script_opcode = u8::try_from(label + 0x50)?;
     let coinbase = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid::default(), u32::MAX),
-            script_sig: vec![script_opcode, 0x51],
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: vec![script_opcode, 0x51].into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 50 * 100_000_000,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(50 * 100_000_000),
+            script_pubkey: vec![0x51].into(),
         }],
     };
     let mut block = Block {
@@ -139,7 +142,7 @@ fn mined_child_labeled(prev: BlockHash, label: i64) -> anyhow::Result<Block> {
             prev_blockhash: prev,
             merkle_root: Hash256::default(),
             time: 1_296_688_603 + 600,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         },
         txs: vec![coinbase],
@@ -154,7 +157,7 @@ fn excess_coinbase_child(prev: BlockHash) -> anyhow::Result<Block> {
     let Some(output) = block.txs.first_mut().and_then(|tx| tx.outputs.first_mut()) else {
         panic!("coinbase has no output");
     };
-    output.value = output.value.saturating_add(1);
+    output.value = output.value.saturating_add(Amount::from_sat(1));
     block.header.merkle_root = block_merkle_root(&block);
     mine_block_to_regtest_target(&mut block)?;
     Ok(block)
@@ -193,7 +196,8 @@ fn block_merkle_root(block: &Block) -> Hash256 {
 
 /// Decodes a 256-bit compact target into little-endian bytes. Negative,
 /// overflowed, and zero-mantissa encodings decode to an unreachable zero.
-fn compact_to_target(bits: u32) -> [u8; 32] {
+fn compact_to_target(bits: CompactTarget) -> [u8; 32] {
+    let bits = bits.to_consensus();
     let exponent = usize::from(u8::try_from(bits >> 24).unwrap_or(0));
     let mantissa = u64::from(bits & 0x007f_ffff);
     let mut target = [0_u8; 32];
@@ -217,7 +221,7 @@ fn compact_to_target(bits: u32) -> [u8; 32] {
 
 /// Returns true when `hash` is at or below the compact target, comparing the
 /// little-endian byte arrays from the most significant end.
-fn pow_met(bits: u32, hash: &BlockHash) -> bool {
+fn pow_met(bits: CompactTarget, hash: &BlockHash) -> bool {
     let target = compact_to_target(bits);
     let hash_le = hash.as_bytes();
     for index in (0..32).rev() {
@@ -235,16 +239,16 @@ fn pow_met(bits: u32, hash: &BlockHash) -> bool {
 fn mempool_sequence_tx() -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0x42; 32])), 0),
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 1_000,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(1_000),
+            script_pubkey: vec![0x51].into(),
         }],
     }
 }
@@ -837,16 +841,16 @@ fn last_candidate_counts_include_the_coinbase() -> anyhow::Result<()> {
 
     let tx = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0x42; 32])), 0),
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 1_000,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(1_000),
+            script_pubkey: vec![0x51].into(),
         }],
     };
     {
@@ -1151,15 +1155,15 @@ fn generateblock_raw_tx_does_not_require_mempool_admission() -> anyhow::Result<(
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid::from(Hash256::from_le_bytes(&[0x11; 32])), 0),
-            script_sig: vec![],
-            sequence: u32::MAX,
-            witness: vec![],
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 50_000,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(50_000),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     };
     let error = mining
         .generate(GenerateRequest {

--- a/crates/node/tests/mining_e2e.rs
+++ b/crates/node/tests/mining_e2e.rs
@@ -13,8 +13,8 @@ use bitcoin_rs_mining::MiningControl;
 use bitcoin_rs_node::{MiningCoordinator, Network, NodeConfig, state::NodeState};
 use bitcoin_rs_primitives::encode::double_sha256;
 use bitcoin_rs_primitives::{
-    Block, Hash256, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-    deserialize as native_deserialize,
+    Amount, Block, CompactTarget, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+    Txid, Witness, consensus_bytes, deserialize as native_deserialize,
 };
 use bitcoin_rs_rpc::Handler;
 use bitcoin_rs_rpc::context::{
@@ -162,15 +162,17 @@ fn seed_chain(state: &NodeState, count: u32) -> Result<Hash256> {
                 previous_output: null_prevout(),
                 // BIP34 height push plus one pad byte: consensus requires a
                 // 2..=100 byte coinbase scriptSig (Core bad-cb-length).
-                script_sig: [script_push_int(i64::from(height)), script_push_int(0)].concat(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: [script_push_int(i64::from(height)), script_push_int(0)]
+                    .concat()
+                    .into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: REGTEST_SUBSIDY_SATS,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(REGTEST_SUBSIDY_SATS),
+                script_pubkey: vec![0x51].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let mut block = Block {
             header: bitcoin_rs_primitives::Header {
@@ -178,7 +180,7 @@ fn seed_chain(state: &NodeState, count: u32) -> Result<Hash256> {
                 prev_blockhash: bitcoin_rs_primitives::BlockHash::from(tip.hash),
                 merkle_root: Hash256::from_le_bytes(&[0_u8; 32]),
                 time: SEED_BASE_TIME.saturating_add(SEED_BLOCK_INTERVAL.saturating_mul(height)),
-                bits: REGTEST_BITS,
+                bits: CompactTarget::from_consensus(REGTEST_BITS),
                 nonce: 0,
             },
             txs: vec![coinbase],
@@ -215,7 +217,8 @@ fn grind_pow(block: &mut Block) -> Result<()> {
 
 /// Returns true when the header hash, read as a little-endian integer, meets
 /// the compact bits target (Core `CheckProofOfWork` shape).
-fn pow_is_met(bits: u32, hash: &Hash256) -> bool {
+fn pow_is_met(bits: CompactTarget, hash: &Hash256) -> bool {
+    let bits = bits.to_consensus();
     let exponent = usize::try_from(bits >> 24).unwrap_or(usize::MAX);
     let mantissa = bits & 0x00ff_ffff;
     if mantissa == 0 || mantissa & 0x0080_0000 != 0 || exponent > 32 {
@@ -301,29 +304,29 @@ fn seed_coinbase_spend_with_fee(fee_sats: u64) -> Tx {
             previous_output: null_prevout(),
             // Must mirror the height-1 seed coinbase exactly (txid anchors
             // the mempool spend).
-            script_sig: [script_push_int(1), script_push_int(0)].concat(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: [script_push_int(1), script_push_int(0)].concat().into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REGTEST_SUBSIDY_SATS,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(REGTEST_SUBSIDY_SATS),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     };
     Tx {
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(seed_coinbase.txid(), 0),
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REGTEST_SUBSIDY_SATS - fee_sats,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(REGTEST_SUBSIDY_SATS - fee_sats),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 
@@ -341,15 +344,17 @@ fn mine_regtest_block(
             previous_output: null_prevout(),
             // BIP34 height push plus one pad byte: consensus requires a
             // 2..=100 byte coinbase scriptSig (Core bad-cb-length).
-            script_sig: [script_push_int(i64::from(height)), script_push_int(0)].concat(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: [script_push_int(i64::from(height)), script_push_int(0)]
+                .concat()
+                .into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REGTEST_SUBSIDY_SATS,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(REGTEST_SUBSIDY_SATS),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     };
     let mut block = Block {
         header: bitcoin_rs_primitives::Header {
@@ -357,7 +362,7 @@ fn mine_regtest_block(
             prev_blockhash: bitcoin_rs_primitives::BlockHash::from(prev),
             merkle_root: Hash256::from_le_bytes(&[0_u8; 32]),
             time: SEED_BASE_TIME.saturating_add(SEED_BLOCK_INTERVAL.saturating_mul(height)),
-            bits: REGTEST_BITS,
+            bits: CompactTarget::from_consensus(REGTEST_BITS),
             nonce: 0,
         },
         txs: std::iter::once(coinbase).chain(txs).collect(),
@@ -433,21 +438,21 @@ fn assemble_block(
         inputs: vec![TxIn {
             previous_output: null_prevout(),
             // BIP34: the coinbase scriptSig begins with the serialized height.
-            script_sig: script_push_int(i64::from(height)),
-            sequence: 0xffff_ffff,
-            witness: vec![WITNESS_RESERVED.to_vec()],
+            script_sig: script_push_int(i64::from(height)).into(),
+            sequence: Sequence::MAX,
+            witness: vec![WITNESS_RESERVED.to_vec()].into(),
         }],
         outputs: vec![
             TxOut {
-                value: coinbase_value,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(coinbase_value),
+                script_pubkey: vec![0x51].into(),
             },
             TxOut {
-                value: 0,
-                script_pubkey: commitment_script,
+                value: Amount::from_sat(0),
+                script_pubkey: commitment_script.into(),
             },
         ],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     };
 
     let mut block_txs = Vec::with_capacity(txs.len() + 1);
@@ -462,7 +467,7 @@ fn assemble_block(
                 .map_err(|err| anyhow::anyhow!("invalid previousblockhash: {err}"))?,
             merkle_root: Hash256::from_le_bytes(&[0_u8; 32]),
             time: curtime,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 0,
         },
         txs: block_txs,
@@ -590,15 +595,15 @@ fn invalidateblock_readmits_parent_before_child_in_dependency_order() -> Result<
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(parent_txid, 0),
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REGTEST_SUBSIDY_SATS - 2 * MEMPOOL_TX_FEE_SATS,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(REGTEST_SUBSIDY_SATS - 2 * MEMPOOL_TX_FEE_SATS),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     };
     let child_txid = child.txid();
 
@@ -701,15 +706,15 @@ fn invalidateblock_readmission_publishes_a_events_through_shared_gateway() -> Re
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(parent_txid, 0),
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REGTEST_SUBSIDY_SATS - 2 * MEMPOOL_TX_FEE_SATS,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(REGTEST_SUBSIDY_SATS - 2 * MEMPOOL_TX_FEE_SATS),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     };
     let child_txid = child.txid();
 
@@ -751,15 +756,15 @@ fn invalidateblock_keeps_a_below_floor_parent_and_its_child_out_of_the_mempool()
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(parent_txid, 0),
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REGTEST_SUBSIDY_SATS - 1 - 5_000,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(REGTEST_SUBSIDY_SATS - 1 - 5_000),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     };
 
     let block = mine_regtest_block(&state, seed_tip_hash, SEED_BLOCKS + 1, vec![parent, child])?;

--- a/crates/node/tests/sync_smoke.rs
+++ b/crates/node/tests/sync_smoke.rs
@@ -7,7 +7,8 @@ use bitcoin_rs_chain::{BlockTree, TipSnapshot};
 use bitcoin_rs_mempool::{Mempool, MempoolGateway, MempoolLimits};
 use bitcoin_rs_node::{BlockSync, Network, apply::Chainstate};
 use bitcoin_rs_primitives::{
-    Block, Hash256, OutPoint, Tx, TxIn, TxOut, Txid, encode::double_sha256,
+    Amount, Block, CompactTarget, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+    Txid, Witness, encode::double_sha256,
 };
 use bitcoin_rs_utxo::UtxoSet;
 use bitcoin_rs_utxo::stats::{CoinStats, CoinStatsListener};
@@ -290,13 +291,13 @@ fn child_coinbase_block(parent: &Block, height: u8) -> Result<Block, Box<dyn std
 fn child_coinbase_block_with_script(
     parent: &Block,
     height: u8,
-    script_pubkey: Vec<u8>,
+    script_pubkey: Script,
 ) -> Result<Block, Box<dyn std::error::Error>> {
     let mut block = parent.clone();
     block.header.prev_blockhash = parent.block_hash();
     block.header.time = parent.header.time.saturating_add(1);
     block.txs.truncate(1);
-    block.txs[0].inputs[0].script_sig = vec![1, height];
+    block.txs[0].inputs[0].script_sig = vec![1, height].into();
     block.txs[0].outputs[0].script_pubkey = script_pubkey;
     block.header.merkle_root = compute_merkle_root(&block)
         .ok_or_else(|| std::io::Error::other("child block should have merkle root"))?;
@@ -319,30 +320,31 @@ fn child_block_with_transactions(
 
 fn spend_to_op_true(
     previous_output: OutPoint,
-    previous_value: u64,
+    previous_value: Amount,
     fee: u64,
 ) -> Result<Tx, Box<dyn std::error::Error>> {
     let value = previous_value
+        .to_sat()
         .checked_sub(fee)
         .ok_or_else(|| std::io::Error::other("spend fee exceeds previous output value"))?;
     Ok(Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output,
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value,
+            value: Amount::from_sat(value),
             script_pubkey: op_true_script(),
         }],
     })
 }
 
-fn op_true_script() -> Vec<u8> {
-    vec![0x51]
+fn op_true_script() -> Script {
+    vec![0x51].into()
 }
 
 fn primitive_outpoint(outpoint: OutPoint) -> OutPoint {
@@ -387,7 +389,7 @@ fn mine_block_to_declared_target(block: &mut Block) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
-fn pow_met(bits: u32, hash: Hash256) -> bool {
+fn pow_met(bits: CompactTarget, hash: Hash256) -> bool {
     let target = uint_be(&compact_to_target(bits));
     if target == [0_u8; 32] {
         return false;
@@ -395,7 +397,8 @@ fn pow_met(bits: u32, hash: Hash256) -> bool {
     uint_be(&hash.to_le_bytes()) <= target
 }
 
-fn compact_to_target(bits: u32) -> [u8; 32] {
+fn compact_to_target(bits: CompactTarget) -> [u8; 32] {
+    let bits = bits.to_consensus();
     let exponent = usize::from(u8::try_from(bits >> 24).unwrap_or(0));
     let mantissa = u64::from(bits & 0x007f_ffff);
     let mut target = [0_u8; 32];

--- a/crates/node/tests/tx_ingress_e2e.rs
+++ b/crates/node/tests/tx_ingress_e2e.rs
@@ -44,7 +44,9 @@ use bitcoin_rs_p2p::dispatch::dispatch_inbound_full;
 use bitcoin_rs_p2p::handshake::{run_inbound_handshake, version_message};
 use bitcoin_rs_p2p::wire::{PeerError, read_message, write_message};
 use bitcoin_rs_p2p::{InboundTx, Message, Peer, PeerLease};
-use bitcoin_rs_primitives::{Block, Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Block, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+};
 use bitcoin_rs_utxo::{BlockChanges, UtxoAdd};
 use crossbeam_channel::Sender;
 use parking_lot::Mutex;
@@ -95,8 +97,8 @@ fn fund_utxo(state: &NodeState, parent: Txid, value: u64) -> anyhow::Result<()> 
     changes.add(UtxoAdd::new(
         OutPoint::new(parent, 0),
         TxOut {
-            value,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(value),
+            script_pubkey: vec![0x51].into(),
         },
         false,
         100,
@@ -114,15 +116,15 @@ fn spending_tx(parent: Txid, output_value: u64) -> Tx {
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(parent, 0),
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: output_value,
-            script_pubkey: vec![0x6A, 0x04, 0xAA, 0xBB, 0xCC, 0xDD],
+            value: Amount::from_sat(output_value),
+            script_pubkey: vec![0x6A, 0x04, 0xAA, 0xBB, 0xCC, 0xDD].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 

--- a/crates/p2p/src/chain_query.rs
+++ b/crates/p2p/src/chain_query.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use bitcoin::hashes::Hash as _;
 use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin_rs_chain::{BlockBodySource, BlockTree};
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header};
+use bitcoin_rs_primitives::{Block, BlockHash, CompactTarget, Hash256, Header};
 use parking_lot::RwLock;
 
 use crate::dispatch::{ChainQuery, InventoryServing};
@@ -543,7 +543,7 @@ mod tests {
             prev_blockhash,
             merkle_root: Hash256::default(),
             time: nonce,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce,
         }
     }

--- a/crates/p2p/src/chain_query.rs
+++ b/crates/p2p/src/chain_query.rs
@@ -9,7 +9,10 @@ use std::sync::Arc;
 use bitcoin::hashes::Hash as _;
 use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin_rs_chain::{BlockBodySource, BlockTree};
-use bitcoin_rs_primitives::{Block, BlockHash, CompactTarget, Hash256, Header};
+use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::CompactTarget;
 use parking_lot::RwLock;
 
 use crate::dispatch::{ChainQuery, InventoryServing};

--- a/crates/p2p/src/dispatch.rs
+++ b/crates/p2p/src/dispatch.rs
@@ -2,7 +2,10 @@ use std::cell::RefCell;
 
 use bitcoin::hashes::Hash as _;
 use bitcoin::p2p::message_blockdata::{GetHeadersMessage, Inventory};
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, Tx, Txid, Wtxid};
+use bitcoin_rs_primitives::{
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Sequence, Tx, Txid,
+    Witness, Wtxid,
+};
 
 use crate::fsm::step;
 use crate::handshake::feature_messages;
@@ -340,7 +343,10 @@ mod tests {
     use bitcoin::hashes::Hash as _;
     use bitcoin::p2p::Magic;
     use bitcoin::p2p::message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory};
-    use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, Tx, Txid, Wtxid};
+    use bitcoin_rs_primitives::{
+        Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Script, Sequence, Tx,
+        Txid, Witness, Wtxid,
+    };
 
     use super::{
         ChainQuery, InventoryServing, MAX_HEADERS_RESPONSE, MAX_LOCATOR_HASHES, TxInventory,
@@ -927,15 +933,15 @@ mod tests {
                     txid: Txid::from(Hash256::from_le_bytes(&[byte; 32])),
                     vout: 0,
                 },
-                script_sig: vec![byte],
-                sequence: 0xFFFF_FFFF,
-                witness: Vec::new(),
+                script_sig: vec![byte].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x6A],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x6A].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -1124,7 +1130,7 @@ mod tests {
             prev_blockhash,
             merkle_root: Hash256::from_le_bytes(&[0; 32]),
             time: nonce,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce,
         }
     }

--- a/crates/p2p/src/dispatch.rs
+++ b/crates/p2p/src/dispatch.rs
@@ -2,10 +2,7 @@ use std::cell::RefCell;
 
 use bitcoin::hashes::Hash as _;
 use bitcoin::p2p::message_blockdata::{GetHeadersMessage, Inventory};
-use bitcoin_rs_primitives::{
-    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Sequence, Tx, Txid,
-    Witness, Wtxid,
-};
+use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, Tx, Txid, Wtxid};
 
 use crate::fsm::step;
 use crate::handshake::feature_messages;
@@ -344,8 +341,8 @@ mod tests {
     use bitcoin::p2p::Magic;
     use bitcoin::p2p::message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory};
     use bitcoin_rs_primitives::{
-        Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Script, Sequence, Tx,
-        Txid, Witness, Wtxid,
+        Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Sequence, Tx, Txid,
+        Witness, Wtxid,
     };
 
     use super::{

--- a/crates/p2p/tests/core_compat.rs
+++ b/crates/p2p/tests/core_compat.rs
@@ -38,7 +38,7 @@ use bitcoin_rs_p2p::{
     PINNED_CORE_VERSION, Peer, PeerState, PeerTable,
 };
 use bitcoin_rs_primitives::{
-    Block, BlockHash as NativeBlockHash, Hash256, Header, consensus_bytes,
+    Block, BlockHash as NativeBlockHash, CompactTarget, Hash256, Header, consensus_bytes,
 };
 use bitcoin_rs_primitives::{Network, USER_AGENT};
 use hashbrown::HashMap;
@@ -104,7 +104,7 @@ fn child_headers(parent: &Header, count: usize) -> Vec<Header> {
             prev_blockhash: current.compute_hash(),
             merkle_root: Hash256::default(),
             time: current.time + 1,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         };
         headers.push(next);

--- a/crates/primitives/README.md
+++ b/crates/primitives/README.md
@@ -1,8 +1,9 @@
 # bitcoin-rs-primitives
 
 The fixed-layout consensus primitives the rest of the workspace speaks in: the
-256-bit hash type, transaction outpoints, the compact-size varint codec, and the
-transaction, block, and header wrappers with their txid/wtxid and header-hash
+256-bit hash type, transaction outpoints, the compact-size varint codec, native
+amount/sequence/locktime/compact-target newtypes, script and witness stacks, and
+the transaction, block, and header types with their txid/wtxid and header-hash
 computation.
 
 This crate is self-contained with respect to Bitcoin protocol primitives. It
@@ -14,7 +15,9 @@ type vocabulary.
 `Tx`, `TxIn`, and `TxOut` wrap transactions and compute txid/wtxid; `Block` and
 `Header` do the same at block level with block-level hashing helpers; `OutPoint` is
 the fixed-layout transaction outpoint; and `Hash256` is the fixed-width 256-bit hash
-type the wrappers hash into. `encode` holds the consensus encoding and hashing helpers
+type the wrappers hash into. Output values are `Amount`, input sequences
+`Sequence`, locktime `LockTime`, nBits `CompactTarget`, and script/witness
+bytes `Script` / `Witness`. `encode` holds the consensus encoding and hashing helpers
 shared by the primitive wrappers (`Sink`, `ConsensusEncode`, analytic `consensus_size`),
 `varint` the Bitcoin compact-size integer codec,
 `sighash` the signature-hash mode wrappers (`Sighash`, `SighashError`), and `network`

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -133,19 +133,19 @@ mod tests {
         Ok(())
     }
 
-    fn witness_tx(witness: Vec<Vec<u8>>) -> Tx {
+    fn witness_tx(witness: crate::Witness) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: crate::LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::from(Hash256::from_le_bytes(&[0_u8; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
+                script_sig: crate::Script::new(),
+                sequence: crate::Sequence::MAX,
                 witness,
             }],
             outputs: vec![TxOut {
-                value: 50_000,
-                script_pubkey: vec![0x51],
+                value: crate::Amount::from_sat(50_000),
+                script_pubkey: vec![0x51].into(),
             }],
         }
     }
@@ -157,7 +157,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 1_700_000_000,
-                bits: 0x207f_ffff,
+                bits: crate::CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             },
             txs: vec![tx],
@@ -166,7 +166,9 @@ mod tests {
 
     #[test]
     fn stripped_size_drops_witness_and_matches_header_plus_base_transactions() {
-        let block = block_with_tx(witness_tx(vec![vec![0x21_u8; 64], vec![0x03_u8; 33]]));
+        let block = block_with_tx(witness_tx(
+            vec![vec![0x21_u8; 64], vec![0x03_u8; 33]].into(),
+        ));
         let total = crate::encode::consensus_bytes(&block).len();
         let stripped = block.stripped_size();
         assert!(
@@ -181,7 +183,7 @@ mod tests {
 
     #[test]
     fn stripped_size_equals_total_size_without_witness() {
-        let block = block_with_tx(witness_tx(Vec::new()));
+        let block = block_with_tx(witness_tx(crate::Witness::new()));
         assert_eq!(
             block.stripped_size(),
             crate::encode::consensus_bytes(&block).len()

--- a/crates/primitives/src/encode.rs
+++ b/crates/primitives/src/encode.rs
@@ -263,8 +263,8 @@ impl ConsensusEncode for TxOut {
 impl ConsensusDecode for TxOut {
     fn consensus_decode(reader: &mut &[u8]) -> Result<Self, DecodeError> {
         Ok(Self {
-            value: read_u64_le(reader)?,
-            script_pubkey: read_script(reader)?,
+            value: crate::Amount::from_sat(read_u64_le(reader)?),
+            script_pubkey: crate::Script::from_bytes(read_script(reader)?),
         })
     }
 }
@@ -287,9 +287,9 @@ impl ConsensusDecode for TxIn {
     fn consensus_decode(reader: &mut &[u8]) -> Result<Self, DecodeError> {
         Ok(Self {
             previous_output: OutPoint::consensus_decode(reader)?,
-            script_sig: read_script(reader)?,
-            sequence: read_u32_le(reader)?,
-            witness: Vec::new(),
+            script_sig: crate::Script::from_bytes(read_script(reader)?),
+            sequence: crate::Sequence::from_consensus(read_u32_le(reader)?),
+            witness: crate::Witness::new(),
         })
     }
 }
@@ -401,7 +401,7 @@ pub(crate) fn decode_tx(reader: &mut &[u8]) -> Result<Tx, DecodeError> {
                 let needed = usize::try_from(len).unwrap_or(usize::MAX);
                 witness.push(take(reader, needed)?.to_vec());
             }
-            input.witness = witness;
+            input.witness = crate::Witness::from_stack(witness);
         }
         // BIP144: the marker/flag exists only to carry witness data. Core rejects the
         // all-empty form ("Superfluous witness record") and rust-bitcoin rejects the
@@ -412,7 +412,7 @@ pub(crate) fn decode_tx(reader: &mut &[u8]) -> Result<Tx, DecodeError> {
             return Err(DecodeError::SuperfluousWitness);
         }
     }
-    let lock_time = read_u32_le(reader)?;
+    let lock_time = crate::LockTime::from_consensus(read_u32_le(reader)?);
 
     Ok(Tx {
         version,
@@ -540,12 +540,12 @@ mod tests {
             version: 1,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0),
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: crate::Script::new(),
+                sequence: crate::Sequence::MAX,
+                witness: crate::Witness::new(),
             }],
             outputs: Vec::new(),
-            lock_time: 0,
+            lock_time: crate::LockTime::ZERO,
         };
         let mut bytes = crate::encode::consensus_bytes(&tx);
         bytes.push(0xff);
@@ -564,12 +564,12 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0),
-                script_sig: vec![0x51],
-                sequence: 0xffff_fffe,
-                witness: Vec::new(),
+                script_sig: vec![0x51].into(),
+                sequence: crate::Sequence::from_consensus(0xffff_fffe),
+                witness: crate::Witness::new(),
             }],
             outputs: Vec::new(),
-            lock_time: 7,
+            lock_time: crate::LockTime::from_consensus(7),
         };
         let bytes = crate::encode::consensus_bytes(&tx);
         // No witness data: no marker/flag is emitted.
@@ -587,12 +587,12 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0),
-                script_sig: vec![0x51],
-                sequence: 0xffff_fffe,
-                witness: Vec::new(),
+                script_sig: vec![0x51].into(),
+                sequence: crate::Sequence::from_consensus(0xffff_fffe),
+                witness: crate::Witness::new(),
             }],
             outputs: Vec::new(),
-            lock_time: 7,
+            lock_time: crate::LockTime::from_consensus(7),
         };
         let stripped = crate::encode::consensus_bytes(&tx);
         assert_eq!(&stripped[4], &0x01, "witness-free tx carries no marker");
@@ -638,15 +638,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0),
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: vec![vec![0x21_u8; 64], vec![0x03_u8; 33]],
+                script_sig: crate::Script::new(),
+                sequence: crate::Sequence::MAX,
+                witness: vec![vec![0x21_u8; 64], vec![0x03_u8; 33]].into(),
             }],
             outputs: vec![TxOut {
-                value: 50_000,
-                script_pubkey: vec![0x51],
+                value: crate::Amount::from_sat(50_000),
+                script_pubkey: vec![0x51].into(),
             }],
-            lock_time: 0,
+            lock_time: crate::LockTime::ZERO,
         };
         let bytes = crate::encode::consensus_bytes(&tx);
         assert_eq!(tx.consensus_size(), bytes.len());

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -1,7 +1,7 @@
 //! Native block header type and header hash computation.
 
 use crate::{
-    BlockHash, Hash256,
+    BlockHash, CompactTarget, Hash256,
     encode::{DecodeError, deserialize, double_sha256},
 };
 
@@ -17,7 +17,7 @@ pub struct Header {
     /// Unix epoch seconds.
     pub time: u32,
     /// Compact proof-of-work target.
-    pub bits: u32,
+    pub bits: CompactTarget,
     /// Proof-of-work nonce.
     pub nonce: u32,
 }
@@ -34,7 +34,7 @@ impl Header {
         out[4..36].copy_from_slice(self.prev_blockhash.as_bytes());
         out[36..68].copy_from_slice(self.merkle_root.as_byte_array());
         out[68..72].copy_from_slice(&self.time.to_le_bytes());
-        out[72..76].copy_from_slice(&self.bits.to_le_bytes());
+        out[72..76].copy_from_slice(&self.bits.to_consensus().to_le_bytes());
         out[76..80].copy_from_slice(&self.nonce.to_le_bytes());
         out
     }
@@ -59,7 +59,7 @@ impl Header {
             prev_blockhash: BlockHash(Hash256::from_le_bytes(&prev)),
             merkle_root: Hash256::from_le_bytes(&merkle),
             time: u32::from_le_bytes(time),
-            bits: u32::from_le_bytes(bits),
+            bits: CompactTarget::from_consensus(u32::from_le_bytes(bits)),
             nonce: u32::from_le_bytes(nonce),
         }
     }
@@ -91,7 +91,7 @@ mod tests {
         assert_eq!(header.version, 1);
         assert_eq!(header.time, 1_231_006_505);
         assert_eq!(header.nonce, 2_083_236_893);
-        assert_eq!(header.bits, 0x1d00_ffff);
+        assert_eq!(header.bits.to_consensus(), 0x1d00_ffff);
         assert_eq!(
             header.compute_hash(),
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -17,10 +17,14 @@ pub mod ids;
 pub mod network;
 /// Fixed-layout transaction outpoint.
 pub mod outpoint;
+/// Native script and witness byte stacks.
+pub mod script;
 /// Native signature-hash computation for legacy, segwit v0, and taproot.
 pub mod sighash;
 /// Native transaction types and txid/wtxid computation.
 pub mod tx;
+/// Native protocol scalar newtypes: amount, sequence, locktime, compact target.
+pub mod units;
 /// Bitcoin compact-size integer codec.
 pub mod varint;
 /// Workspace release version constants for wire/RPC user-agent strings.
@@ -36,9 +40,11 @@ pub use header::Header;
 pub use ids::{BlockHash, Txid, Wtxid};
 pub use network::{ChainTxData, Network};
 pub use outpoint::OutPoint;
+pub use script::{Script, Witness};
 pub use sighash::{
     AnnexError, CODESEPARATOR_POSITION, Sighash, SighashCache, SighashError,
     TAPSCRIPT_LEAF_VERSION, tapleaf_hash,
 };
 pub use tx::{Tx, TxIn, TxOut};
+pub use units::{Amount, CompactTarget, LockTime, Sequence};
 pub use version::{PKG_VERSION, USER_AGENT, client_version};

--- a/crates/primitives/src/script.rs
+++ b/crates/primitives/src/script.rs
@@ -1,0 +1,269 @@
+//! Native script and witness byte stacks.
+
+use core::ops::{Deref, DerefMut};
+
+/// A Bitcoin script (`scriptSig` or `scriptPubKey`) as owned consensus bytes.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Script(Vec<u8>);
+
+impl Script {
+    /// An empty script.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Wraps already-decoded consensus script bytes.
+    #[must_use]
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the consensus script bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Unwraps the consensus script bytes.
+    #[must_use]
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    /// Returns true when the script is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the script length in bytes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl Deref for Script {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+impl DerefMut for Script {
+    fn deref_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.0
+    }
+}
+
+impl From<Vec<u8>> for Script {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<Script> for Vec<u8> {
+    fn from(script: Script) -> Self {
+        script.0
+    }
+}
+
+impl AsRef<[u8]> for Script {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl PartialEq<[u8]> for Script {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<Vec<u8>> for Script {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<Script> for [u8] {
+    fn eq(&self, other: &Script) -> bool {
+        self == other.0.as_slice()
+    }
+}
+
+impl PartialEq<Script> for Vec<u8> {
+    fn eq(&self, other: &Script) -> bool {
+        self == &other.0
+    }
+}
+
+impl IntoIterator for Script {
+    type Item = u8;
+    type IntoIter = std::vec::IntoIter<u8>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Script {
+    type Item = &'a u8;
+    type IntoIter = std::slice::Iter<'a, u8>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Script {
+    type Item = &'a mut u8;
+    type IntoIter = std::slice::IterMut<'a, u8>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
+
+/// A BIP144 witness stack.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Witness(Vec<Vec<u8>>);
+
+impl Witness {
+    /// An empty witness stack.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Wraps already-decoded witness stack items.
+    #[must_use]
+    pub fn from_stack(stack: Vec<Vec<u8>>) -> Self {
+        Self(stack)
+    }
+
+    /// Returns the witness items.
+    #[must_use]
+    pub fn as_stack(&self) -> &[Vec<u8>] {
+        &self.0
+    }
+
+    /// Unwraps the witness items.
+    #[must_use]
+    pub fn into_stack(self) -> Vec<Vec<u8>> {
+        self.0
+    }
+
+    /// Returns true when the stack is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the number of witness items.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl Deref for Witness {
+    type Target = Vec<Vec<u8>>;
+
+    fn deref(&self) -> &Vec<Vec<u8>> {
+        &self.0
+    }
+}
+
+impl DerefMut for Witness {
+    fn deref_mut(&mut self) -> &mut Vec<Vec<u8>> {
+        &mut self.0
+    }
+}
+
+impl From<Vec<Vec<u8>>> for Witness {
+    fn from(stack: Vec<Vec<u8>>) -> Self {
+        Self(stack)
+    }
+}
+
+impl From<Witness> for Vec<Vec<u8>> {
+    fn from(witness: Witness) -> Self {
+        witness.0
+    }
+}
+
+impl PartialEq<[Vec<u8>]> for Witness {
+    fn eq(&self, other: &[Vec<u8>]) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<Vec<Vec<u8>>> for Witness {
+    fn eq(&self, other: &Vec<Vec<u8>>) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<Witness> for [Vec<u8>] {
+    fn eq(&self, other: &Witness) -> bool {
+        self == other.0.as_slice()
+    }
+}
+
+impl PartialEq<Witness> for Vec<Vec<u8>> {
+    fn eq(&self, other: &Witness) -> bool {
+        self == &other.0
+    }
+}
+
+impl IntoIterator for Witness {
+    type Item = Vec<u8>;
+    type IntoIter = std::vec::IntoIter<Vec<u8>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Witness {
+    type Item = &'a Vec<u8>;
+    type IntoIter = std::slice::Iter<'a, Vec<u8>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Witness {
+    type Item = &'a mut Vec<u8>;
+    type IntoIter = std::slice::IterMut<'a, Vec<u8>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Script, Witness};
+
+    #[test]
+    fn script_deref_exposes_bytes() {
+        let script = Script::from_bytes(vec![0x51, 0x20]);
+        assert_eq!(script.as_bytes(), &[0x51, 0x20]);
+        assert_eq!(&script[..], &[0x51, 0x20]);
+        assert!(!script.is_empty());
+    }
+
+    #[test]
+    fn witness_deref_exposes_stack() {
+        let mut witness = Witness::from_stack(vec![vec![0xaa], vec![0xbb, 0xcc]]);
+        assert_eq!(witness.len(), 2);
+        assert_eq!(witness[0], vec![0xaa]);
+        witness.clear();
+        assert!(witness.is_empty());
+    }
+}

--- a/crates/primitives/src/sighash.rs
+++ b/crates/primitives/src/sighash.rs
@@ -225,7 +225,7 @@ impl<'t> SighashCache<'t> {
             write_compact(writer, compact_len(total));
             for (n, txin) in self.tx.inputs.iter().enumerate() {
                 let sequence = if n != input_index && (ty.is_single() || ty.is_none()) {
-                    0
+                    crate::Sequence::ZERO
                 } else {
                     txin.sequence
                 };
@@ -266,7 +266,7 @@ impl<'t> SighashCache<'t> {
         &mut self,
         input_index: usize,
         script_code: &[u8],
-        value: u64,
+        value: crate::Amount,
         sighash_type: Sighash,
     ) -> Result<Hash256, SighashError> {
         let ty = sighash_type.to_ecdsa()?;
@@ -524,7 +524,7 @@ impl Sighash {
         tx: &Tx,
         input_idx: usize,
         script_code: &[u8],
-        value: u64,
+        value: crate::Amount,
         sighash_type: Self,
     ) -> Result<Hash256, SighashError> {
         SighashCache::new(tx).segwit_v0_signature_hash(input_idx, script_code, value, sighash_type)
@@ -639,7 +639,7 @@ fn encode_legacy_input(
     writer: &mut Sha256Sink<'_>,
     input: &crate::TxIn,
     script: &[u8],
-    sequence: u32,
+    sequence: crate::Sequence,
 ) {
     input.previous_output.consensus_encode(writer);
     write_script(writer, script);
@@ -692,9 +692,6 @@ mod tests {
     };
     use crate::{Hash256, OutPoint, Tx, Txid};
 
-    /// BIP125 opt-in sequence (`ENABLE_RBF_NO_LOCKTIME`).
-    const RBF_SEQUENCE: u32 = 0xffff_fffd;
-
     fn pin(hex: &str) -> Hash256 {
         Hash256::from_str_be(hex).expect("pinned hash hex")
     }
@@ -702,22 +699,25 @@ mod tests {
     fn synthetic_tx(output_count: usize) -> Tx {
         let input = crate::TxIn {
             previous_output: OutPoint::new(Txid(Hash256::default()), 0xffff_ffff),
-            script_sig: Vec::new(),
-            sequence: RBF_SEQUENCE,
-            witness: Vec::new(),
+            script_sig: crate::Script::new(),
+            // BIP125 opt-in sequence (`ENABLE_RBF_NO_LOCKTIME`).
+            sequence: crate::Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: crate::Witness::new(),
         };
         let mut outputs = Vec::new();
         for value in 0..output_count {
             outputs.push(crate::TxOut {
-                value: 1_000 + u64::try_from(value).unwrap_or_else(|_| unreachable!("small count")),
-                script_pubkey: Vec::new(),
+                value: crate::Amount::from_sat(
+                    1_000 + u64::try_from(value).unwrap_or_else(|_| unreachable!("small count")),
+                ),
+                script_pubkey: crate::Script::new(),
             });
         }
         Tx {
             version: 2,
             inputs: vec![input],
             outputs,
-            lock_time: 0,
+            lock_time: crate::LockTime::ZERO,
         }
     }
 
@@ -764,7 +764,13 @@ mod tests {
         let tx = synthetic_tx(2);
         let script = vec![0x51_u8, 0x51];
         assert_eq!(
-            Sighash::compute_bip143(&tx, 0, &script, 50_000, Sighash::Single),
+            Sighash::compute_bip143(
+                &tx,
+                0,
+                &script,
+                crate::Amount::from_sat(50_000),
+                Sighash::Single
+            ),
             Ok(pin(
                 "c9bb107a16a13d1a8ad4ebc540978164a7d92b4a26d388d26fa8eed79e10ebec"
             ))
@@ -775,8 +781,8 @@ mod tests {
     fn bip341_key_path_and_bip342_script_path_pins() {
         let tx = synthetic_tx(2);
         let prevouts = vec![crate::TxOut {
-            value: 50_000,
-            script_pubkey: Vec::new(),
+            value: crate::Amount::from_sat(50_000),
+            script_pubkey: crate::Script::new(),
         }];
         assert_eq!(
             Sighash::compute_bip341(&tx, 0, &prevouts, Sighash::AllAnyoneCanPay, None, None),
@@ -816,7 +822,13 @@ mod tests {
         let tx = synthetic_tx(1);
 
         assert_eq!(
-            Sighash::compute_bip143(&tx, 0, &[], 50_000, Sighash::Default),
+            Sighash::compute_bip143(
+                &tx,
+                0,
+                &[],
+                crate::Amount::from_sat(50_000),
+                Sighash::Default
+            ),
             Err(SighashError::DefaultOnlyTaproot)
         );
     }
@@ -825,8 +837,8 @@ mod tests {
     fn taproot_sighash_reports_invalid_annex() {
         let tx = synthetic_tx(1);
         let prevouts = vec![crate::TxOut {
-            value: 50_000,
-            script_pubkey: Vec::new(),
+            value: crate::Amount::from_sat(50_000),
+            script_pubkey: crate::Script::new(),
         }];
 
         assert!(matches!(

--- a/crates/primitives/src/tx.rs
+++ b/crates/primitives/src/tx.rs
@@ -3,7 +3,7 @@
 use sha2::{Digest, Sha256};
 
 use crate::{
-    DecodeError, OutPoint, Txid, Wtxid,
+    Amount, DecodeError, LockTime, OutPoint, Script, Sequence, Txid, Witness, Wtxid,
     encode::{
         ConsensusEncode, Sha256Sink, deserialize, encode_tx, finalize_double_sha256, tx_base_size,
     },
@@ -15,20 +15,20 @@ pub struct TxIn {
     /// The outpoint being spent.
     pub previous_output: OutPoint,
     /// The input's scriptSig (empty for segwit spends).
-    pub script_sig: Vec<u8>,
+    pub script_sig: Script,
     /// The input sequence number.
-    pub sequence: u32,
+    pub sequence: Sequence,
     /// The BIP144 witness stack; empty when the input has no witness.
-    pub witness: Vec<Vec<u8>>,
+    pub witness: Witness,
 }
 
 /// A Bitcoin transaction output in native owned form.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TxOut {
     /// The output value in satoshis.
-    pub value: u64,
+    pub value: Amount,
     /// The output scriptPubKey.
-    pub script_pubkey: Vec<u8>,
+    pub script_pubkey: Script,
 }
 
 /// A Bitcoin transaction in native owned form.
@@ -41,7 +41,7 @@ pub struct Tx {
     /// Outputs in consensus order.
     pub outputs: Vec<TxOut>,
     /// Lock time.
-    pub lock_time: u32,
+    pub lock_time: LockTime,
 }
 
 impl Tx {
@@ -117,15 +117,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::default()), 3),
-                script_sig: vec![0x51],
-                sequence: 0xffff_fffe,
-                witness: vec![vec![0xaa; 40]],
+                script_sig: vec![0x51].into(),
+                sequence: crate::Sequence::from_consensus(0xffff_fffe),
+                witness: vec![vec![0xaa; 40]].into(),
             }],
             outputs: vec![TxOut {
-                value: 50_000,
-                script_pubkey: vec![0x00, 0x14, 0xab],
+                value: crate::Amount::from_sat(50_000),
+                script_pubkey: vec![0x00, 0x14, 0xab].into(),
             }],
-            lock_time: 42,
+            lock_time: crate::LockTime::from_consensus(42),
         }
     }
 

--- a/crates/primitives/src/units.rs
+++ b/crates/primitives/src/units.rs
@@ -1,0 +1,378 @@
+//! Native protocol scalar newtypes: amounts, sequences, locktime, compact targets.
+//!
+//! These are bitcoin-rs types, not `rust-bitcoin` aliases. Arithmetic and wire
+//! conversion live here so `Tx`, `TxIn`, `TxOut`, and `Header` do not restate
+//! satoshi, sequence, or nBits layout.
+
+use core::fmt;
+
+/// An amount in satoshis.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Amount(u64);
+
+impl Amount {
+    /// Zero satoshis.
+    pub const ZERO: Self = Self(0);
+    /// One satoshi.
+    pub const SAT: Self = Self(1);
+    /// One bitcoin in satoshis.
+    pub const COIN: Self = Self(100_000_000);
+    /// Consensus maximum money (21 million bitcoin).
+    pub const MAX_MONEY: Self = Self(21_000_000 * 100_000_000);
+
+    /// Constructs an amount from satoshis.
+    #[must_use]
+    pub const fn from_sat(sat: u64) -> Self {
+        Self(sat)
+    }
+
+    /// Returns the amount in satoshis.
+    #[must_use]
+    pub const fn to_sat(self) -> u64 {
+        self.0
+    }
+
+    /// Checked addition.
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        match self.0.checked_add(rhs.0) {
+            Some(sum) => Some(Self(sum)),
+            None => None,
+        }
+    }
+
+    /// Checked subtraction.
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        match self.0.checked_sub(rhs.0) {
+            Some(diff) => Some(Self(diff)),
+            None => None,
+        }
+    }
+
+    /// Saturating addition.
+    #[must_use]
+    pub const fn saturating_add(self, rhs: Self) -> Self {
+        Self(self.0.saturating_add(rhs.0))
+    }
+
+    /// Saturating subtraction.
+    #[must_use]
+    pub const fn saturating_sub(self, rhs: Self) -> Self {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+
+    /// Little-endian consensus encoding of the satoshi count.
+    #[must_use]
+    pub const fn to_le_bytes(self) -> [u8; 8] {
+        self.0.to_le_bytes()
+    }
+}
+
+impl fmt::Display for Amount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u64> for Amount {
+    fn from(sat: u64) -> Self {
+        Self::from_sat(sat)
+    }
+}
+
+impl PartialEq<u64> for Amount {
+    fn eq(&self, other: &u64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<Amount> for u64 {
+    fn eq(&self, other: &Amount) -> bool {
+        *self == other.0
+    }
+}
+
+impl PartialOrd<u64> for Amount {
+    fn partial_cmp(&self, other: &u64) -> Option<core::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl PartialOrd<Amount> for u64 {
+    fn partial_cmp(&self, other: &Amount) -> Option<core::cmp::Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+
+/// A transaction input sequence number.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Sequence(u32);
+
+impl Sequence {
+    /// Sequence zero.
+    pub const ZERO: Self = Self(0);
+    /// `0xffffffff` — final, disables relative locktime and RBF signaling.
+    pub const MAX: Self = Self(u32::MAX);
+    /// BIP125 opt-in RBF without locktime (`0xfffffffd`).
+    pub const ENABLE_RBF_NO_LOCKTIME: Self = Self(0xffff_fffd);
+
+    /// Constructs a sequence from its consensus `u32`.
+    #[must_use]
+    pub const fn from_consensus(n: u32) -> Self {
+        Self(n)
+    }
+
+    /// Returns the consensus `u32`.
+    #[must_use]
+    pub const fn to_consensus(self) -> u32 {
+        self.0
+    }
+
+    /// Little-endian consensus encoding.
+    #[must_use]
+    pub const fn to_le_bytes(self) -> [u8; 4] {
+        self.0.to_le_bytes()
+    }
+}
+
+impl fmt::Display for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u32> for Sequence {
+    fn from(n: u32) -> Self {
+        Self::from_consensus(n)
+    }
+}
+
+impl PartialEq<u32> for Sequence {
+    fn eq(&self, other: &u32) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<Sequence> for u32 {
+    fn eq(&self, other: &Sequence) -> bool {
+        *self == other.0
+    }
+}
+
+impl PartialOrd<u32> for Sequence {
+    fn partial_cmp(&self, other: &u32) -> Option<core::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl PartialOrd<Sequence> for u32 {
+    fn partial_cmp(&self, other: &Sequence) -> Option<core::cmp::Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+
+impl fmt::LowerHex for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::UpperHex for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+impl core::ops::BitAnd<u32> for Sequence {
+    type Output = u32;
+
+    fn bitand(self, rhs: u32) -> u32 {
+        self.0 & rhs
+    }
+}
+
+/// A transaction lock time (`nLockTime`).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LockTime(u32);
+
+impl LockTime {
+    /// Locktime zero — always final from the locktime field alone.
+    pub const ZERO: Self = Self(0);
+
+    /// Constructs a lock time from its consensus `u32`.
+    #[must_use]
+    pub const fn from_consensus(n: u32) -> Self {
+        Self(n)
+    }
+
+    /// Returns the consensus `u32`.
+    #[must_use]
+    pub const fn to_consensus(self) -> u32 {
+        self.0
+    }
+
+    /// Little-endian consensus encoding.
+    #[must_use]
+    pub const fn to_le_bytes(self) -> [u8; 4] {
+        self.0.to_le_bytes()
+    }
+}
+
+impl fmt::Display for LockTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u32> for LockTime {
+    fn from(n: u32) -> Self {
+        Self::from_consensus(n)
+    }
+}
+
+impl PartialEq<u32> for LockTime {
+    fn eq(&self, other: &u32) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<LockTime> for u32 {
+    fn eq(&self, other: &LockTime) -> bool {
+        *self == other.0
+    }
+}
+
+impl PartialOrd<u32> for LockTime {
+    fn partial_cmp(&self, other: &u32) -> Option<core::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl PartialOrd<LockTime> for u32 {
+    fn partial_cmp(&self, other: &LockTime) -> Option<core::cmp::Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+
+impl fmt::LowerHex for LockTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::UpperHex for LockTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+/// Compact proof-of-work target (`nBits`).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct CompactTarget(u32);
+
+impl CompactTarget {
+    /// Constructs a compact target from its consensus `u32`.
+    #[must_use]
+    pub const fn from_consensus(n: u32) -> Self {
+        Self(n)
+    }
+
+    /// Returns the consensus `u32`.
+    #[must_use]
+    pub const fn to_consensus(self) -> u32 {
+        self.0
+    }
+
+    /// Little-endian consensus encoding.
+    #[must_use]
+    pub const fn to_le_bytes(self) -> [u8; 4] {
+        self.0.to_le_bytes()
+    }
+}
+
+impl fmt::LowerHex for CompactTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::UpperHex for CompactTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for CompactTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#010x}", self.0)
+    }
+}
+
+impl From<u32> for CompactTarget {
+    fn from(n: u32) -> Self {
+        Self::from_consensus(n)
+    }
+}
+
+impl PartialEq<u32> for CompactTarget {
+    fn eq(&self, other: &u32) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<CompactTarget> for u32 {
+    fn eq(&self, other: &CompactTarget) -> bool {
+        *self == other.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Amount, CompactTarget, LockTime, Sequence};
+
+    #[test]
+    fn amount_sat_roundtrip_and_overflow() {
+        assert_eq!(Amount::from_sat(50_000).to_sat(), 50_000);
+        assert_eq!(Amount::COIN.to_sat(), 100_000_000);
+        assert_eq!(Amount::from_sat(u64::MAX).checked_add(Amount::SAT), None);
+        assert_eq!(
+            Amount::from_sat(2)
+                .saturating_add(Amount::from_sat(3))
+                .to_sat(),
+            5
+        );
+    }
+
+    #[test]
+    fn sequence_and_locktime_consensus_roundtrip() {
+        assert_eq!(Sequence::MAX.to_consensus(), u32::MAX);
+        assert_eq!(Sequence::ENABLE_RBF_NO_LOCKTIME.to_consensus(), 0xffff_fffd);
+        assert_eq!(Sequence::MAX & 0xffff_ffff, u32::MAX);
+        assert_eq!(LockTime::ZERO.to_consensus(), 0);
+        assert_eq!(
+            LockTime::from_consensus(500_000_000).to_consensus(),
+            500_000_000
+        );
+    }
+
+    #[test]
+    fn compact_target_consensus_roundtrip() {
+        let bits = CompactTarget::from_consensus(0x1d00_ffff);
+        assert_eq!(bits.to_consensus(), 0x1d00_ffff);
+        assert_eq!(bits, 0x1d00_ffff_u32);
+    }
+
+    #[test]
+    fn integer_comparisons_and_from() {
+        assert_eq!(Amount::from_sat(7), 7_u64);
+        assert!(Amount::from_sat(3) < 4_u64);
+        assert_eq!(
+            Sequence::from(0xffff_fffd),
+            Sequence::ENABLE_RBF_NO_LOCKTIME
+        );
+        assert!(Sequence::ENABLE_RBF_NO_LOCKTIME < 0xffff_fffe);
+        assert_eq!(LockTime::from(0_u32), LockTime::ZERO);
+        assert_eq!(CompactTarget::from(0x207f_ffff), 0x207f_ffff_u32);
+    }
+}

--- a/crates/primitives/src/units.rs
+++ b/crates/primitives/src/units.rs
@@ -18,7 +18,7 @@ impl Amount {
     /// One bitcoin in satoshis.
     pub const COIN: Self = Self(100_000_000);
     /// Consensus maximum money (21 million bitcoin).
-    pub const MAX_MONEY: Self = Self(21_000_000 * 100_000_000);
+    pub const MAX_MONEY: Self = Self(21_000_000 * Self::COIN.0);
 
     /// Constructs an amount from satoshis.
     #[must_use]
@@ -335,6 +335,10 @@ mod tests {
     fn amount_sat_roundtrip_and_overflow() {
         assert_eq!(Amount::from_sat(50_000).to_sat(), 50_000);
         assert_eq!(Amount::COIN.to_sat(), 100_000_000);
+        assert_eq!(
+            Amount::MAX_MONEY.to_sat(),
+            21_000_000 * Amount::COIN.to_sat()
+        );
         assert_eq!(Amount::from_sat(u64::MAX).checked_add(Amount::SAT), None);
         assert_eq!(
             Amount::from_sat(2)

--- a/crates/primitives/tests/differential.rs
+++ b/crates/primitives/tests/differential.rs
@@ -12,8 +12,8 @@
 use std::path::PathBuf;
 
 use bitcoin_rs_primitives::{
-    Block as NativeBlock, DecodeError, Sighash, SighashCache, Tx as NativeTx, TxOut,
-    consensus_bytes, deserialize,
+    Amount, Block as NativeBlock, DecodeError, LockTime, Script, Sequence, Sighash, SighashCache,
+    Tx as NativeTx, TxOut, Witness, consensus_bytes, deserialize,
 };
 
 type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
@@ -181,12 +181,12 @@ fn malformed_input_returns_typed_errors_without_panicking() {
         version: 1,
         inputs: vec![bitcoin_rs_primitives::TxIn {
             previous_output: bitcoin_rs_primitives::OutPoint::default(),
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: Vec::new(),
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     };
     let mut trailing = consensus_bytes(&tx);
     trailing.push(0xff);
@@ -326,21 +326,26 @@ fn sighash_cache_matches_one_shot_helpers_across_fixtures() {
                 .iter()
                 .enumerate()
                 .map(|(index, _)| TxOut {
-                    value: 1_000_u64
-                        + u64::try_from(index)
-                            .unwrap_or_else(|error| panic!("prevout index overflow: {error}")),
+                    value: Amount::from_sat(
+                        1_000_u64
+                            + u64::try_from(index)
+                                .unwrap_or_else(|error| panic!("prevout index overflow: {error}")),
+                    ),
                     script_pubkey: {
                         let mut bytes = vec![0x51, 0x20];
                         bytes.extend_from_slice(&[0x42_u8; 32]);
-                        bytes
+                        bytes.into()
                     },
                 })
                 .collect();
             for (input_index, native_input) in native_tx.inputs.iter().enumerate() {
                 let script_code = native_input.script_sig.clone();
-                let value = 1_000_u64
-                    + u64::try_from(input_index)
-                        .unwrap_or_else(|error| panic!("{context}: input index overflow: {error}"));
+                let value = Amount::from_sat(
+                    1_000_u64
+                        + u64::try_from(input_index).unwrap_or_else(|error| {
+                            panic!("{context}: input index overflow: {error}")
+                        }),
+                );
                 for ty in ecdsa_types {
                     let cached = cache
                         .legacy_signature_hash(input_index, &script_code, u32::from(ty.to_u8()))

--- a/crates/primitives/tests/genesis.rs
+++ b/crates/primitives/tests/genesis.rs
@@ -59,7 +59,8 @@ fn native_genesis_matches_published_hash_and_compiled_bytes() {
             "{network:?} genesis coinbase prevout is null"
         );
         assert_eq!(
-            native.txs[0].outputs[0].value, 5_000_000_000,
+            native.txs[0].outputs[0].value,
+            bitcoin_rs_primitives::Amount::from_sat(5_000_000_000),
             "{network:?} genesis subsidy is 50 BTC"
         );
         if has_times {

--- a/crates/rpc/src/compat/convert.rs
+++ b/crates/rpc/src/compat/convert.rs
@@ -13,7 +13,7 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use bitcoin_rs_primitives::{Network, Tx, TxIn, TxOut, consensus_bytes};
+use bitcoin_rs_primitives::{CompactTarget, Network, Tx, TxIn, TxOut, consensus_bytes};
 use sonic_rs::{JsonValueMutTrait as _, JsonValueTrait as _, Value};
 
 use crate::error::RpcError;
@@ -92,7 +92,8 @@ pub(crate) fn signed_sat_to_btc(sats: i128) -> f64 {
 /// the degenerate exponents that collapse to an all-zero target. The sign bit
 /// only negates in Core's arithmetic; the rendered magnitude is unaffected.
 #[must_use]
-pub(crate) fn compact_target_hex(bits: u32) -> String {
+pub(crate) fn compact_target_hex(bits: CompactTarget) -> String {
+    let bits = bits.to_consensus();
     let exponent = bits >> 24;
     let word = u64::from(bits & 0x007f_ffff);
     // Least-significant byte first; reversed for the wire's big-endian hex.
@@ -195,8 +196,8 @@ pub(crate) fn coinbase_transaction_typed(
     let input = tx.inputs.first()?;
     Some(corepc_types::v31::CoinbaseTransaction {
         version: tx.version,
-        locktime: tx.lock_time,
-        sequence: input.sequence,
+        locktime: tx.lock_time.to_consensus(),
+        sequence: input.sequence.to_consensus(),
         coinbase: hex_encode(&input.script_sig),
         witness: input.witness.first().map(|item| hex_encode(item)),
     })
@@ -254,7 +255,7 @@ pub(crate) fn raw_transaction_verbose(
         vsize: tx.vsize(),
         weight: tx.weight(),
         version: tx.version,
-        lock_time: tx.lock_time,
+        lock_time: tx.lock_time.to_consensus(),
         inputs,
         outputs,
         block_hash,
@@ -294,7 +295,7 @@ pub(crate) fn raw_transaction(
         vsize: tx.vsize(),
         weight: tx.weight(),
         version: tx.version,
-        lock_time: tx.lock_time,
+        lock_time: tx.lock_time.to_consensus(),
         inputs,
         outputs,
     })
@@ -316,7 +317,7 @@ fn raw_input_typed(input: &TxIn, coinbase: bool) -> corepc_types::v31::RawTransa
             vout: None,
             script_sig: None,
             txin_witness,
-            sequence: input.sequence,
+            sequence: input.sequence.to_consensus(),
         };
     }
     // Field copies come before any `&self` method: `OutPoint` is
@@ -329,7 +330,7 @@ fn raw_input_typed(input: &TxIn, coinbase: bool) -> corepc_types::v31::RawTransa
         vout: Some(prev_vout),
         script_sig: Some(script_sig_typed(&input.script_sig)),
         txin_witness,
-        sequence: input.sequence,
+        sequence: input.sequence.to_consensus(),
     }
 }
 
@@ -340,7 +341,7 @@ fn raw_output_typed(
     network: Network,
 ) -> Result<corepc_types::v31::RawTransactionOutput, RpcError> {
     Ok(corepc_types::v31::RawTransactionOutput {
-        value: sat_to_btc(output.value),
+        value: sat_to_btc(output.value.to_sat()),
         index: u64::try_from(index).unwrap_or(u64::MAX),
         script_pubkey: script_pub_key_typed(&output.script_pubkey, network)?,
     })
@@ -367,12 +368,18 @@ mod compact_target_tests {
         // Historical pow limit 0x1d00ffff: ffff lands at bytes 4-5.
         let mut expected = String::from("00000000ffff");
         expected.push_str(&"0".repeat(52));
-        assert_eq!(compact_target_hex(0x1d00_ffff), expected);
+        assert_eq!(
+            compact_target_hex(CompactTarget::from_consensus(0x1d00_ffff)),
+            expected
+        );
 
         // Regtest difficulty-one 0x207fffff: 7fffff at the very top.
         let mut expected = String::from("7fffff");
         expected.push_str(&"0".repeat(58));
-        assert_eq!(compact_target_hex(0x207f_ffff), expected);
+        assert_eq!(
+            compact_target_hex(CompactTarget::from_consensus(0x207f_ffff)),
+            expected
+        );
     }
 
     #[test]
@@ -381,23 +388,32 @@ mod compact_target_tests {
         let mut expected = String::new();
         expected.push_str(&"0".repeat(62));
         expected.push_str("ff");
-        assert_eq!(compact_target_hex(0x0200_ff00), expected);
+        assert_eq!(
+            compact_target_hex(CompactTarget::from_consensus(0x0200_ff00)),
+            expected
+        );
 
         // Exponent three keeps all three mantissa bytes in place.
         let mut expected = "0".repeat(58);
         expected.push_str("7fff80");
-        assert_eq!(compact_target_hex(0x03ff_ff80), expected);
+        assert_eq!(
+            compact_target_hex(CompactTarget::from_consensus(0x03ff_ff80)),
+            expected
+        );
     }
 
     #[test]
     fn compact_target_ignores_sign_and_drops_overflow_shifts() {
         // The sign bit negates; the rendered magnitude is unchanged.
         assert_eq!(
-            compact_target_hex(0x1d80_ffff),
-            compact_target_hex(0x1d00_ffff)
+            compact_target_hex(CompactTarget::from_consensus(0x1d80_ffff)),
+            compact_target_hex(CompactTarget::from_consensus(0x1d00_ffff))
         );
 
         // Exponent 35 shifts every mantissa byte past 256 bits: zero target.
-        assert_eq!(compact_target_hex(0x2300_ffff), "0".repeat(64));
+        assert_eq!(
+            compact_target_hex(CompactTarget::from_consensus(0x2300_ffff)),
+            "0".repeat(64)
+        );
     }
 }

--- a/crates/rpc/src/compat/schema.rs
+++ b/crates/rpc/src/compat/schema.rs
@@ -356,7 +356,7 @@ fn load_schemas_from(
 mod tests {
     use alloc::sync::Arc;
 
-    use bitcoin_rs_primitives::{Block, Network};
+    use bitcoin_rs_primitives::{Block, CompactTarget, Network};
     use sonic_rs::JsonValueTrait as _;
 
     use super::{diff_best, load_schemas};
@@ -386,12 +386,12 @@ mod tests {
             Ok(MiningInfo {
                 blocks: 0,
                 last_candidate: None,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 difficulty: 1.0,
                 network_hashes_per_second: 0.0,
                 pooled_transactions: 0,
                 network: Network::Regtest,
-                next_bits: 0x207f_ffff,
+                next_bits: CompactTarget::from_consensus(0x207f_ffff),
                 next_difficulty: 1.0,
                 minimum_fee_rate: 1_000,
                 signet: None,

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -5,9 +5,11 @@ use bitcoin_rs_index::ScriptHash;
 use bitcoin_rs_mempool::{Mempool, MempoolGateway, MempoolLimits, MempoolObserver, MutationResult};
 use bitcoin_rs_mining::MiningControl;
 use bitcoin_rs_primitives::{
-    Amount, Block, BlockHash, CompactTarget, Hash256, Network, OutPoint, Script, Tx, Txid,
-    consensus_bytes,
+    Block, BlockHash, CompactTarget, Hash256, Network, OutPoint, Tx, Txid, consensus_bytes,
 };
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, Script};
 use compact_str::CompactString;
 use core::fmt;
 use core::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -5,7 +5,8 @@ use bitcoin_rs_index::ScriptHash;
 use bitcoin_rs_mempool::{Mempool, MempoolGateway, MempoolLimits, MempoolObserver, MutationResult};
 use bitcoin_rs_mining::MiningControl;
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Network, OutPoint, Tx, Txid, consensus_bytes,
+    Amount, Block, BlockHash, CompactTarget, Hash256, Network, OutPoint, Script, Tx, Txid,
+    consensus_bytes,
 };
 use compact_str::CompactString;
 use core::fmt;
@@ -1121,7 +1122,7 @@ impl Context {
     /// changing the repeated 256 scaling into an equivalent exponentiation can
     /// change the final floating-point bit.
     #[must_use]
-    pub fn difficulty_for_bits(&self, bits: u32) -> f64 {
+    pub fn difficulty_for_bits(&self, bits: CompactTarget) -> f64 {
         bitcoin_rs_mining::difficulty_for_bits(bits)
     }
 
@@ -1744,8 +1745,8 @@ mod tests {
         let ctx = Context::new();
         let outpoint = OutPoint::new(Txid(Hash256::from_le_bytes(&[1_u8; 32])), 0);
         let txout = TxOut {
-            value: 125_000,
-            script_pubkey: Vec::new(),
+            value: Amount::from_sat(125_000),
+            script_pubkey: Script::new(),
         };
         let mut changes = BlockChanges::default();
         changes.add(UtxoAdd::new(outpoint, txout, true, 7));
@@ -1954,7 +1955,7 @@ mod tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1_000_000,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 7,
         };
         let hash = {
@@ -1998,7 +1999,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 1_000_000,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             };
             let genesis_id = tree.insert_node(None, genesis, NodeStatus::Active)?;
@@ -2007,7 +2008,7 @@ mod tests {
                 prev_blockhash: genesis.compute_hash(),
                 merkle_root: Hash256::default(),
                 time: 1_000_900,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             };
             child.nonce = 1;
@@ -2051,7 +2052,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 1_000_000,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             };
             let genesis_id = tree.insert_node(None, genesis, NodeStatus::Active)?;
@@ -2060,7 +2061,7 @@ mod tests {
                 prev_blockhash: genesis.compute_hash(),
                 merkle_root: Hash256::default(),
                 time: 1_000_900,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 1,
             };
             let applied_id = tree.insert_node(Some(genesis_id), applied, NodeStatus::Active)?;
@@ -2074,7 +2075,7 @@ mod tests {
                 prev_blockhash: genesis.compute_hash(),
                 merkle_root: Hash256::default(),
                 time: 1_000_901,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 2,
             };
             let fork_id = tree.insert_node(Some(genesis_id), fork, NodeStatus::HeaderValid)?;
@@ -2083,7 +2084,7 @@ mod tests {
                 prev_blockhash: fork.compute_hash(),
                 merkle_root: Hash256::default(),
                 time: 1_001_800,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 3,
             };
             let header_tip_id =

--- a/crates/rpc/src/esplora.rs
+++ b/crates/rpc/src/esplora.rs
@@ -120,7 +120,8 @@ mod tests {
     use bitcoin_rs_mempool::MempoolEntry;
     use bitcoin_rs_primitives::encode::double_sha256;
     use bitcoin_rs_primitives::{
-        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
+        Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script,
+        Sequence, Tx, TxIn, TxOut, Txid, Witness, consensus_bytes,
     };
     use bitcoin_rs_utxo::{BlockChanges, UtxoAdd};
     use serde_json::{Value, json};
@@ -185,13 +186,13 @@ mod tests {
                 .into_iter()
                 .map(|previous_output| TxIn {
                     previous_output,
-                    script_sig: Vec::new(),
-                    sequence: u32::MAX,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 })
                 .collect(),
             outputs: vec![output],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 
@@ -228,14 +229,14 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 1_700_000_000,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 1,
             },
             txs: vec![transaction(
                 Some(null_outpoint()),
                 TxOut {
-                    value: 5_000_000_000,
-                    script_pubkey: vec![0x51],
+                    value: Amount::from_sat(5_000_000_000),
+                    script_pubkey: vec![0x51].into(),
                 },
             )],
         };
@@ -252,8 +253,8 @@ mod tests {
         let funding = transaction(
             None,
             TxOut {
-                value: 10_000,
-                script_pubkey: spendable.clone(),
+                value: Amount::from_sat(10_000),
+                script_pubkey: spendable.clone().into(),
             },
         );
         let txid = ctx.add_transaction(funding);
@@ -261,8 +262,8 @@ mod tests {
         changes.add(UtxoAdd::new(
             OutPoint::new(txid, 0),
             TxOut {
-                value: 10_000,
-                script_pubkey: spendable,
+                value: Amount::from_sat(10_000),
+                script_pubkey: spendable.into(),
             },
             false,
             1,
@@ -273,8 +274,8 @@ mod tests {
         transaction(
             Some(OutPoint::new(txid, 0)),
             TxOut {
-                value: 9_000,
-                script_pubkey: script,
+                value: Amount::from_sat(9_000),
+                script_pubkey: script.into(),
             },
         )
     }
@@ -307,7 +308,7 @@ mod tests {
                         .get(usize::try_from(out_vout).unwrap_or(usize::MAX))
                 })
                 .flatten()
-                .map(|output| output.value))
+                .map(|output| output.value.to_sat()))
         }
 
         fn transaction_height(&self, txid: &Txid) -> Result<Option<u32>, TxQueryError> {
@@ -373,7 +374,7 @@ mod tests {
                         .outputs
                         .get(usize::try_from(out_vout).unwrap_or(usize::MAX))
                 })
-                .map(|output| output.value))
+                .map(|output| output.value.to_sat()))
         }
 
         fn transaction_height(&self, txid: &Txid) -> Result<Option<u32>, TxQueryError> {
@@ -504,15 +505,15 @@ mod tests {
         let mut transaction = transaction(
             None,
             TxOut {
-                value: 5_000_000_000,
-                script_pubkey: target,
+                value: Amount::from_sat(5_000_000_000),
+                script_pubkey: target.into(),
             },
         );
         transaction.inputs.push(TxIn {
             previous_output: null_outpoint(),
-            script_sig: vec![1, 1],
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: vec![1, 1].into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         });
         let mut block = Block {
             header: Header {
@@ -520,7 +521,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 1_700_000_000,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 1,
             },
             txs: vec![transaction.clone()],
@@ -1018,8 +1019,8 @@ mod tests {
         let transaction = transaction(
             None,
             TxOut {
-                value: 125,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(125),
+                script_pubkey: vec![0x51].into(),
             },
         );
         let txid = transaction.txid();
@@ -1104,8 +1105,8 @@ mod tests {
                 transaction(
                     None,
                     TxOut {
-                        value,
-                        script_pubkey: target.clone(),
+                        value: Amount::from_sat(value),
+                        script_pubkey: target.clone().into(),
                     },
                 )
             })
@@ -1152,8 +1153,8 @@ mod tests {
                 transaction(
                     None,
                     TxOut {
-                        value,
-                        script_pubkey: target.clone(),
+                        value: Amount::from_sat(value),
+                        script_pubkey: target.clone().into(),
                     },
                 )
             })
@@ -1229,8 +1230,8 @@ mod tests {
         let spending = transaction(
             Some(OutPoint::new(confirmed.txid, confirmed.vout)),
             TxOut {
-                value: 100,
-                script_pubkey: vec![0x52],
+                value: Amount::from_sat(100),
+                script_pubkey: vec![0x52].into(),
             },
         );
         let mut ctx = Context::new();
@@ -1310,15 +1311,15 @@ mod tests {
         let parent = transaction(
             None,
             TxOut {
-                value: 125,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(125),
+                script_pubkey: vec![0x51].into(),
             },
         );
         let child = transaction(
             Some(OutPoint::new(parent.txid(), 0)),
             TxOut {
-                value: 100,
-                script_pubkey: vec![0x52],
+                value: Amount::from_sat(100),
+                script_pubkey: vec![0x52].into(),
             },
         );
         let mut ctx = Context::new();
@@ -1347,8 +1348,8 @@ mod tests {
         let transaction = transaction(
             Some(null_outpoint()),
             TxOut {
-                value: 125,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(125),
+                script_pubkey: vec![0x51].into(),
             },
         );
         let genesis = Header {
@@ -1356,7 +1357,7 @@ mod tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1_000,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         };
         let stale_block = Block {
@@ -1365,7 +1366,7 @@ mod tests {
                 prev_blockhash: genesis.compute_hash(),
                 merkle_root: Hash256::default(),
                 time: 2_000,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 2,
             },
             txs: vec![transaction.clone()],
@@ -1395,7 +1396,7 @@ mod tests {
                 prev_blockhash: genesis.compute_hash(),
                 merkle_root: Hash256::default(),
                 time: 1_500,
-                bits: 0x1d00_ffff,
+                bits: CompactTarget::from_consensus(0x1d00_ffff),
                 nonce: 1,
             };
             tree.insert_node(Some(genesis_id), active, NodeStatus::Active)?;

--- a/crates/rpc/src/esplora/projection.rs
+++ b/crates/rpc/src/esplora/projection.rs
@@ -97,9 +97,9 @@ impl ScriptActivity {
                     continue;
                 }
                 stats.funded_txo_count = stats.funded_txo_count.saturating_add(1);
-                stats.funded_txo_sum = stats.funded_txo_sum.saturating_add(output.value);
+                stats.funded_txo_sum = stats.funded_txo_sum.saturating_add(output.value.to_sat());
                 if let Ok(vout) = u32::try_from(vout) {
-                    target_outputs.insert((txid, vout), output.value);
+                    target_outputs.insert((txid, vout), output.value.to_sat());
                 }
             }
         }
@@ -240,7 +240,7 @@ impl<'a> Projection<'a> {
                 let output = self
                     .prevout(&previous_output)?
                     .ok_or_else(|| unavailable("previous transaction unavailable"))?;
-                input_value = input_value.saturating_add(output.value);
+                input_value = input_value.saturating_add(output.value.to_sat());
                 Some(output)
             };
             let (redeem, witness_script) = inner_scripts(input, previous.as_ref());
@@ -261,7 +261,7 @@ impl<'a> Projection<'a> {
                         .collect()
                 }),
                 is_coinbase: coinbase,
-                sequence: input.sequence,
+                sequence: input.sequence.to_consensus(),
                 inner_redeemscript_asm: redeem.as_deref().map(script_asm),
                 inner_witnessscript_asm: witness_script.as_deref().map(script_asm),
             });
@@ -271,14 +271,13 @@ impl<'a> Projection<'a> {
             .iter()
             .map(|output| self.transaction_output(output))
             .collect();
-        let output_value = transaction
-            .outputs
-            .iter()
-            .fold(0_u64, |sum, output| sum.saturating_add(output.value));
+        let output_value = transaction.outputs.iter().fold(0_u64, |sum, output| {
+            sum.saturating_add(output.value.to_sat())
+        });
         Ok(TransactionValue {
             txid: transaction.txid().to_string(),
             version: transaction.version.cast_unsigned(),
-            locktime: transaction.lock_time,
+            locktime: transaction.lock_time.to_consensus(),
             vin: inputs,
             vout: outputs,
             size: u32::try_from(transaction.total_size()).unwrap_or(u32::MAX),
@@ -300,7 +299,7 @@ impl<'a> Projection<'a> {
             )
             .ok()
             .map(|address| address.to_string()),
-            value: output.value,
+            value: output.value.to_sat(),
         }
     }
 
@@ -361,7 +360,7 @@ impl<'a> Projection<'a> {
                 .median_time_past_for_hash(Hash256::from(record.hash))
                 .unwrap_or(header.time),
             nonce: header.nonce,
-            bits: header.bits,
+            bits: header.bits.to_consensus(),
             difficulty: self.ctx.difficulty_for_bits(header.bits),
         })
     }
@@ -469,7 +468,7 @@ impl<'a> Projection<'a> {
                         txid: entry.txid.to_string(),
                         vout,
                         status: TransactionStatus::unconfirmed(),
-                        value: output.value,
+                        value: output.value.to_sat(),
                     });
                 }
             }

--- a/crates/rpc/src/esplora/public.rs
+++ b/crates/rpc/src/esplora/public.rs
@@ -505,11 +505,9 @@ fn mempool_recent(ctx: &Context) -> Response {
                 txid: entry.txid.to_string(),
                 fee: entry.fee,
                 vsize: entry.vsize,
-                value: entry
-                    .tx
-                    .outputs
-                    .iter()
-                    .fold(0_u64, |sum, output| sum.saturating_add(output.value)),
+                value: entry.tx.outputs.iter().fold(0_u64, |sum, output| {
+                    sum.saturating_add(output.value.to_sat())
+                }),
             })
             .collect::<Vec<_>>(),
     )

--- a/crates/rpc/src/handlers/chain.rs
+++ b/crates/rpc/src/handlers/chain.rs
@@ -5,7 +5,8 @@ use core::{fmt, fmt::Write as _};
 use bitcoin_rs_chain::{NodeStatus, TipSnapshot};
 use bitcoin_rs_primitives::chain_constants::CORE_REORG_SAFETY_MARGIN;
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, Network, TxOut, consensus_bytes, deserialize,
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Network, Script, Sequence,
+    TxOut, Witness, consensus_bytes, deserialize,
 };
 use corepc_types::v31::{self, ChainTips, ChainTipsStatus};
 use hashbrown::HashMap;
@@ -27,12 +28,12 @@ pub(crate) fn getblockchaininfo(ctx: &Arc<Context>, params: &Value) -> Result<Va
     let applied_tip = ctx.applied_tip.load_full();
     let applied = applied_tip.as_ref().map_or(0, |tip| tip.height);
     let headers = ctx.height();
-    let (difficulty, time, mediantime, tip_bits) =
-        applied_tip
-            .as_ref()
-            .map_or((0.0, 0_u64, 0_u64, 0_u32), |tip| {
-                let tree = ctx.block_tree.read();
-                tree.node(tip.tip_id).map_or((0.0, 0, 0, 0), |node| {
+    let (difficulty, time, mediantime, tip_bits) = applied_tip.as_ref().map_or(
+        (0.0, 0_u64, 0_u64, CompactTarget::from_consensus(0)),
+        |tip| {
+            let tree = ctx.block_tree.read();
+            tree.node(tip.tip_id)
+                .map_or((0.0, 0, 0, CompactTarget::from_consensus(0)), |node| {
                     (
                         ctx.difficulty_for_bits(node.header.bits),
                         u64::from(node.header.time),
@@ -40,7 +41,8 @@ pub(crate) fn getblockchaininfo(ctx: &Arc<Context>, params: &Value) -> Result<Va
                         node.header.bits,
                     )
                 })
-            });
+        },
+    );
     // Core's estimate when this node knows how many transactions it has
     // verified, and the old height ratio when it does not.
     //
@@ -663,7 +665,7 @@ pub(crate) fn getblockstats(ctx: &Arc<Context>, params: &Value) -> Result<Value,
         }
         ins = ins.saturating_add(u64::try_from(tx.inputs.len()).unwrap_or(u64::MAX));
         for output in &tx.outputs {
-            total_out = total_out.saturating_add(output.value);
+            total_out = total_out.saturating_add(output.value.to_sat());
         }
         let tx_size = u64::try_from(tx.total_size()).unwrap_or(u64::MAX);
         let tx_weight = tx.weight();
@@ -760,10 +762,9 @@ fn resolve_per_tx_fees(ctx: &Context, block: &Block) -> Result<Vec<(u64, u64)>, 
                 Err(error) => return Err(error),
             }
         }
-        let total_out = tx
-            .outputs
-            .iter()
-            .fold(0_u64, |sum, output| sum.saturating_add(output.value));
+        let total_out = tx.outputs.iter().fold(0_u64, |sum, output| {
+            sum.saturating_add(output.value.to_sat())
+        });
         let Some(fee) = total_in.checked_sub(total_out) else {
             return Err(TxQueryError::Unavailable("negative fee".into()));
         };
@@ -1341,7 +1342,7 @@ fn scan_unspents(
         .unspents
         .iter()
         .map(|utxo| {
-            total_amount = total_amount.saturating_add(utxo.txout.value);
+            total_amount = total_amount.saturating_add(utxo.txout.value.to_sat());
             let desc = descs
                 .get(utxo.txout.script_pubkey.as_slice())
                 .copied()
@@ -1360,7 +1361,7 @@ fn scan_unspents(
                 vout,
                 script_pubkey: hex_encode(&utxo.txout.script_pubkey),
                 descriptor: desc.to_owned(),
-                amount: sat_to_btc(utxo.txout.value),
+                amount: sat_to_btc(utxo.txout.value.to_sat()),
                 coinbase: utxo.coinbase,
                 height: u64::from(utxo.height),
                 block_hash,
@@ -1555,7 +1556,8 @@ fn next_applied_block_hash(ctx: &Context, height: u32) -> Option<BlockHash> {
 /// needs the `PoW` self-consistency verdict the old `validate_pow` call made:
 /// decode `bits` into a 256-bit target and compare the header hash against it
 /// (both read as little-endian integers, as consensus does).
-fn compact_target_met_by(bits: u32, hash: Hash256) -> bool {
+fn compact_target_met_by(bits: CompactTarget, hash: Hash256) -> bool {
+    let bits = bits.to_consensus();
     let exponent = usize::from(u8::try_from(bits >> 24).unwrap_or(0));
     let mantissa = u64::from(bits & 0x007f_ffff);
     // A zero mantissa or a negative sign bit decodes to a zero target, and an
@@ -1670,7 +1672,7 @@ mod tests {
                     prev_blockhash: previous_hash,
                     merkle_root: Hash256::default(),
                     time,
-                    bits,
+                    bits: CompactTarget::from_consensus(bits),
                     nonce: u32::try_from(index).unwrap_or(u32::MAX),
                 };
                 previous_hash = header.compute_hash();
@@ -1716,15 +1718,15 @@ mod tests {
             version: 1,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 5_000_000_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(5_000_000_000),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         Block {
             header: Header {
@@ -1732,7 +1734,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: coinbase.txid().0,
                 time: 1_296_688_602,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             },
             txs: vec![coinbase],
@@ -2116,7 +2118,7 @@ mod tests {
             prev_blockhash: prev,
             merkle_root: Hash256::default(),
             time,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce,
         };
 
@@ -2287,16 +2289,16 @@ mod tests {
     fn coinbase_only_block(header: Header) -> Block {
         let coinbase = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: vec![0x51],
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: vec![0x51].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50 * 100_000_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(50 * 100_000_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         Block {
@@ -2640,9 +2642,9 @@ mod tests {
     #[test]
     fn difficulty_matches_core_for_mainnet_and_regtest_targets() {
         let ctx = Context::new();
-        let mainnet = ctx.difficulty_for_bits(0x1d00_ffff);
+        let mainnet = ctx.difficulty_for_bits(CompactTarget::from_consensus(0x1d00_ffff));
         assert_eq!(mainnet.to_bits(), 1.0_f64.to_bits());
-        let regtest = ctx.difficulty_for_bits(0x207f_ffff);
+        let regtest = ctx.difficulty_for_bits(CompactTarget::from_consensus(0x207f_ffff));
         let expected = 4.656_542_373_906_924_7e-10_f64;
         assert_eq!(regtest.to_bits(), expected.to_bits());
     }
@@ -3012,7 +3014,7 @@ mod tests {
                     prev_blockhash: prev,
                     merkle_root: Hash256::default(),
                     time: 1_000_u32.saturating_add(height.saturating_mul(10)),
-                    bits: 0x207f_ffff,
+                    bits: CompactTarget::from_consensus(0x207f_ffff),
                     nonce: height,
                 };
                 prev = header.compute_hash();
@@ -3079,7 +3081,7 @@ mod tests {
                     prev_blockhash: prev,
                     merkle_root: Hash256::default(),
                     time: 1_000_u32.saturating_add(height.saturating_mul(10)),
-                    bits: 0x207f_ffff,
+                    bits: CompactTarget::from_consensus(0x207f_ffff),
                     nonce: height,
                 };
                 prev = header.compute_hash();
@@ -3125,7 +3127,7 @@ mod tests {
                     prev_blockhash: prev,
                     merkle_root: Hash256::default(),
                     time,
-                    bits: 0x207f_ffff,
+                    bits: CompactTarget::from_consensus(0x207f_ffff),
                     nonce: height,
                 };
                 prev = header.compute_hash();
@@ -3285,7 +3287,7 @@ mod pruneblockchain_tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1_296_688_602,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         }
     }
@@ -3458,7 +3460,7 @@ mod getchaintips_tests {
             prev_blockhash,
             merkle_root: Hash256::default(),
             time,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         }
     }
@@ -4114,7 +4116,7 @@ mod chaintxstats_durability_tests {
                 prev_blockhash: prev,
                 merkle_root: Hash256::default(),
                 time,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: height,
             };
             prev = header.compute_hash();
@@ -4302,7 +4304,7 @@ mod chaintxstats_durability_tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1_000,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         };
         let genesis_id = tree
@@ -4315,7 +4317,7 @@ mod chaintxstats_durability_tests {
             prev_blockhash: genesis.compute_hash(),
             merkle_root: Hash256::default(),
             time: 1_100,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 1,
         };
         let lost_id = tree
@@ -4328,7 +4330,7 @@ mod chaintxstats_durability_tests {
             prev_blockhash: genesis.compute_hash(),
             merkle_root: Hash256::default(),
             time: 1_200,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 2,
         };
         let won_id = tree
@@ -4341,7 +4343,7 @@ mod chaintxstats_durability_tests {
             prev_blockhash: won.compute_hash(),
             merkle_root: Hash256::default(),
             time: 1_300,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 3,
         };
         let child_id = tree
@@ -4443,7 +4445,7 @@ mod chaintxstats_window_tests {
             prev_blockhash: previous,
             merkle_root: Hash256::default(),
             time,
-            bits: REGTEST_BITS,
+            bits: CompactTarget::from_consensus(REGTEST_BITS),
             nonce,
         }
     }
@@ -5043,7 +5045,7 @@ mod chaintxstats_window_tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1_000,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         };
         let genesis_id = tree
@@ -5056,7 +5058,7 @@ mod chaintxstats_window_tests {
             prev_blockhash: genesis.compute_hash(),
             merkle_root: Hash256::default(),
             time: 1_100,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 1,
         };
         let lost_id = tree
@@ -5069,7 +5071,7 @@ mod chaintxstats_window_tests {
             prev_blockhash: genesis.compute_hash(),
             merkle_root: Hash256::default(),
             time: 1_200,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 2,
         };
         let won_id = tree
@@ -5082,7 +5084,7 @@ mod chaintxstats_window_tests {
             prev_blockhash: won.compute_hash(),
             merkle_root: Hash256::default(),
             time: 1_300,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 3,
         };
         let child_id = tree
@@ -5163,7 +5165,7 @@ mod verification_progress_wiring_tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1_000,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             nonce: 0,
         };
         let id = {
@@ -5288,7 +5290,7 @@ mod initial_block_download_tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 1_000_000,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             };
             let Ok(genesis_id) = tree.insert_node(None, genesis, NodeStatus::Active) else {
@@ -5299,7 +5301,7 @@ mod initial_block_download_tests {
                 prev_blockhash: genesis.compute_hash(),
                 merkle_root: Hash256::default(),
                 time: tip_time,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 1,
             };
             let Ok(_child_id) = tree.insert_node(Some(genesis_id), child, NodeStatus::Active)
@@ -5458,8 +5460,8 @@ mod scantxoutset_tests {
         let address = "1111111111111111111114oLvT2";
         let script = burn_p2pkh_script();
         let txout = TxOut {
-            value: 12_345,
-            script_pubkey: script.clone(),
+            value: Amount::from_sat(12_345),
+            script_pubkey: script.clone().into(),
         };
         let outpoint = OutPoint::new(Txid::from(test_txid(11)), 0);
         commit_test_utxo(&ctx, outpoint, txout, true, 0);
@@ -5467,8 +5469,8 @@ mod scantxoutset_tests {
             &ctx,
             OutPoint::new(Txid::from(test_txid(12)), 0),
             TxOut {
-                value: 9_999,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(9_999),
+                script_pubkey: vec![0x51].into(),
             },
             false,
             0,
@@ -5531,8 +5533,8 @@ mod scantxoutset_tests {
             &ctx,
             OutPoint::new(Txid::from(test_txid(101)), 0),
             TxOut {
-                value: 10_000,
-                script_pubkey: script.clone(),
+                value: Amount::from_sat(10_000),
+                script_pubkey: script.clone().into(),
             },
             false,
             0,
@@ -5555,8 +5557,8 @@ mod scantxoutset_tests {
             &ctx,
             OutPoint::new(Txid::from(test_txid(102)), 0),
             TxOut {
-                value: 20_000,
-                script_pubkey: script,
+                value: Amount::from_sat(20_000),
+                script_pubkey: script.into(),
             },
             false,
             1,
@@ -5601,8 +5603,8 @@ mod scantxoutset_tests {
         let address = "1111111111111111111114oLvT2";
         let script = burn_p2pkh_script();
         let txout = TxOut {
-            value: 12_345,
-            script_pubkey: script,
+            value: Amount::from_sat(12_345),
+            script_pubkey: script.into(),
         };
         let outpoint = OutPoint::new(Txid::from(test_txid(13)), 0);
         commit_test_utxo(&ctx, outpoint, txout, true, 0);

--- a/crates/rpc/src/handlers/chain.rs
+++ b/crates/rpc/src/handlers/chain.rs
@@ -5,9 +5,11 @@ use core::{fmt, fmt::Write as _};
 use bitcoin_rs_chain::{NodeStatus, TipSnapshot};
 use bitcoin_rs_primitives::chain_constants::CORE_REORG_SAFETY_MARGIN;
 use bitcoin_rs_primitives::{
-    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Network, Script, Sequence,
-    TxOut, Witness, consensus_bytes, deserialize,
+    Block, BlockHash, CompactTarget, Hash256, Header, Network, TxOut, consensus_bytes, deserialize,
 };
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Witness};
 use corepc_types::v31::{self, ChainTips, ChainTipsStatus};
 use hashbrown::HashMap;
 use sonic_rs::{JsonContainerTrait as _, JsonValueMutTrait as _, JsonValueTrait, Value, json};

--- a/crates/rpc/src/handlers/mempool.rs
+++ b/crates/rpc/src/handlers/mempool.rs
@@ -265,7 +265,9 @@ mod tests {
     use alloc::vec::Vec;
 
     use bitcoin_rs_mempool::MempoolEntry;
-    use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    };
     use sonic_rs::{JsonContainerTrait, JsonValueTrait, json};
 
     use super::*;
@@ -617,25 +619,25 @@ mod tests {
         let handler = crate::Handler::new(Arc::clone(&ctx));
         let parent = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let parent_txid = parent.txid();
         let child = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint {
                     txid: parent_txid,
                     vout: 0,
                 },
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: Vec::new(),
         };
@@ -667,19 +669,19 @@ mod tests {
         let ctx = Arc::new(Context::new());
         let rbf_tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint {
                     txid: Txid(Hash256::from_le_bytes(&[0xaa; 32])),
                     vout: 0,
                 },
-                script_sig: Vec::new(),
-                sequence: 0x0000_0001,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(0x0000_0001),
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let rbf_txid = rbf_tx.txid();
@@ -705,19 +707,19 @@ mod tests {
     fn tx(label: u8, previous_outputs: Vec<OutPoint>) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: previous_outputs
                 .into_iter()
                 .map(|previous_output| TxIn {
                     previous_output,
-                    script_sig: Vec::new(),
-                    sequence: u32::MAX,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 })
                 .collect(),
             outputs: vec![TxOut {
-                value: 5_000 + u64::from(label),
-                script_pubkey: vec![label],
+                value: Amount::from_sat(5_000 + u64::from(label)),
+                script_pubkey: vec![label].into(),
             }],
         }
     }
@@ -729,7 +731,9 @@ mod usage_wiring_tests {
     use alloc::vec::Vec;
 
     use bitcoin_rs_mempool::MempoolEntry;
-    use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    };
     use sonic_rs::{JsonValueTrait, json};
 
     use super::*;
@@ -742,19 +746,19 @@ mod usage_wiring_tests {
             for tag in 0_u8..4 {
                 let tx = Tx {
                     version: 2,
-                    lock_time: 0,
+                    lock_time: LockTime::ZERO,
                     inputs: vec![TxIn {
                         previous_output: OutPoint::new(
                             Txid::from(Hash256::from_le_bytes(&[tag; 32])),
                             0,
                         ),
-                        script_sig: Vec::new(),
-                        sequence: u32::MAX,
-                        witness: Vec::new(),
+                        script_sig: Script::new(),
+                        sequence: Sequence::MAX,
+                        witness: Witness::new(),
                     }],
                     outputs: vec![TxOut {
-                        value: 10_000,
-                        script_pubkey: vec![0x51; 128],
+                        value: Amount::from_sat(10_000),
+                        script_pubkey: vec![0x51; 128].into(),
                     }],
                 };
                 let entry = MempoolEntry::new(Arc::new(tx), 100, 10_000, 1, 7);
@@ -788,7 +792,9 @@ mod spentby_tests {
     use alloc::vec::Vec;
 
     use bitcoin_rs_mempool::MempoolEntry;
-    use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    };
     use sonic_rs::json;
 
     use super::*;
@@ -796,22 +802,24 @@ mod spentby_tests {
     fn tx_with(inputs: &[OutPoint], outputs: u32, tag: u64) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: inputs
                 .iter()
                 .map(|previous_output| TxIn {
                     previous_output: *previous_output,
-                    script_sig: Vec::new(),
-                    sequence: 0xFFFF_FFFD,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                    witness: Witness::new(),
                 })
                 .collect(),
             outputs: (0..outputs)
                 .map(|vout| TxOut {
-                    value: 10_000_u64
-                        .saturating_add(u64::from(vout))
-                        .saturating_add(tag.saturating_mul(1_000)),
-                    script_pubkey: vec![0x51],
+                    value: Amount::from_sat(
+                        10_000_u64
+                            .saturating_add(u64::from(vout))
+                            .saturating_add(tag.saturating_mul(1_000)),
+                    ),
+                    script_pubkey: vec![0x51].into(),
                 })
                 .collect(),
         }

--- a/crates/rpc/src/handlers/mempool.rs
+++ b/crates/rpc/src/handlers/mempool.rs
@@ -728,7 +728,6 @@ mod tests {
 #[cfg(test)]
 mod usage_wiring_tests {
     use alloc::sync::Arc;
-    use alloc::vec::Vec;
 
     use bitcoin_rs_mempool::MempoolEntry;
     use bitcoin_rs_primitives::{

--- a/crates/rpc/src/handlers/mining.rs
+++ b/crates/rpc/src/handlers/mining.rs
@@ -7,10 +7,10 @@ use bitcoin_rs_mining::{
     MiningCapability, MiningControlError, MiningInfo, MiningRule, TemplateMutation,
     witness_commitment_script,
 };
-use bitcoin_rs_primitives::{
-    Amount, Block, CompactTarget, LockTime, Script, Sequence, Tx, Txid, Witness, consensus_bytes,
-    deserialize,
-};
+use bitcoin_rs_primitives::{Block, Tx, Txid, consensus_bytes, deserialize};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, CompactTarget, LockTime, Script, Sequence, Witness};
 use compact_str::CompactString;
 use sonic_rs::{JsonContainerTrait, JsonValueTrait, Value, json};
 
@@ -799,7 +799,7 @@ mod tests {
         }
     }
 
-    fn ctx_with_control(control: Arc<dyn MiningControl>) -> Arc<Context> {
+    fn ctx_with_control(control: Arc<impl MiningControl + 'static>) -> Arc<Context> {
         Arc::new(Context::new().with_mining_control(control))
     }
 
@@ -1463,7 +1463,7 @@ mod tests {
     #[test]
     fn generateblock_projects_hash_object() {
         let control = FakeMiningControl::with_template(sample_template());
-        let ctx = ctx_with_control(Arc::clone(&control) as Arc<dyn MiningControl>);
+        let ctx = ctx_with_control(Arc::clone(&control));
         let result = generateblock(&ctx, &json!([MAINNET_ADDRESS, []]))
             .unwrap_or_else(|err| panic!("generateblock failed: {err}"));
         assert!(
@@ -1482,11 +1482,11 @@ mod tests {
         assert!(request.submit);
     }
 
-    /// API-05: generateblock accepts addr() without a checksum.
+    /// API-05: generateblock accepts `addr()` without a checksum.
     #[test]
     fn generateblock_accepts_addr_descriptor() {
         let control = FakeMiningControl::with_template(sample_template());
-        let ctx = ctx_with_control(Arc::clone(&control) as Arc<dyn MiningControl>);
+        let ctx = ctx_with_control(Arc::clone(&control));
         let result = generateblock(&ctx, &json!([format!("addr({MAINNET_ADDRESS})"), []]))
             .unwrap_or_else(|err| panic!("addr() descriptor must be accepted: {err}"));
         assert!(
@@ -1515,7 +1515,7 @@ mod tests {
     #[test]
     fn generateblock_without_submit_includes_hex() {
         let control = FakeMiningControl::with_template(sample_template());
-        let ctx = ctx_with_control(Arc::clone(&control) as Arc<dyn MiningControl>);
+        let ctx = ctx_with_control(Arc::clone(&control));
         let result = generateblock(&ctx, &json!([MAINNET_ADDRESS, [], false]))
             .unwrap_or_else(|err| panic!("generateblock failed: {err}"));
         assert!(
@@ -1559,7 +1559,7 @@ mod tests {
     #[test]
     fn generateblock_keeps_raw_transactions() {
         let control = FakeMiningControl::with_template(sample_template());
-        let ctx = ctx_with_control(Arc::clone(&control) as Arc<dyn MiningControl>);
+        let ctx = ctx_with_control(Arc::clone(&control));
         let tx = sample_raw_tx();
         let raw_hex = to_lower_hex(&consensus_bytes(&tx));
         let txid = Txid::from(Hash256::from_le_bytes(&[0xcd; 32]));

--- a/crates/rpc/src/handlers/mining.rs
+++ b/crates/rpc/src/handlers/mining.rs
@@ -7,7 +7,10 @@ use bitcoin_rs_mining::{
     MiningCapability, MiningControlError, MiningInfo, MiningRule, TemplateMutation,
     witness_commitment_script,
 };
-use bitcoin_rs_primitives::{Block, Tx, Txid, consensus_bytes, deserialize};
+use bitcoin_rs_primitives::{
+    Amount, Block, CompactTarget, LockTime, Script, Sequence, Tx, Txid, Witness, consensus_bytes,
+    deserialize,
+};
 use compact_str::CompactString;
 use sonic_rs::{JsonContainerTrait, JsonValueTrait, Value, json};
 
@@ -729,7 +732,7 @@ mod tests {
             previous_block_hash: previous,
             height: 101,
             version: 0x2000_0000,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             min_time: 1_700_000_001,
             current_time: 1_700_000_010,
             csv_active: true,
@@ -742,7 +745,7 @@ mod tests {
                 version: 2,
                 inputs: Vec::new(),
                 outputs: Vec::new(),
-                lock_time: 0,
+                lock_time: LockTime::ZERO,
             },
             coinbase_value: 5_000_000_000,
             fees: 0,
@@ -783,12 +786,12 @@ mod tests {
                 weight: 2_500,
                 transactions: 3,
             }),
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             difficulty: 1.0,
             network_hashes_per_second: 42.5,
             pooled_transactions: 4,
             network: Network::Regtest,
-            next_bits: 0x207f_ffff,
+            next_bits: CompactTarget::from_consensus(0x207f_ffff),
             next_difficulty: 1.0,
             minimum_fee_rate: 1_000,
             signet: None,
@@ -805,15 +808,15 @@ mod tests {
             version: 1,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0xffff_ffff),
-                script_sig: vec![0x51],
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: vec![0x51].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50 * 100_000_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50 * 100_000_000),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let merkle_root = coinbase.txid().0;
         Block {
@@ -822,7 +825,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root,
                 time: 1_296_688_602,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 2,
             },
             txs: vec![coinbase],
@@ -1048,9 +1051,9 @@ mod tests {
         let control = FakeMiningControl::with_template(sample_template());
         {
             let mut info = control.info.lock();
-            info.bits = 0x1d00_ffff;
+            info.bits = CompactTarget::from_consensus(0x1d00_ffff);
             info.difficulty = 1.0;
-            info.next_bits = 0x1c00_ffff;
+            info.next_bits = CompactTarget::from_consensus(0x1c00_ffff);
         }
         let ctx = ctx_with_control(control);
         let result = getmininginfo(&ctx, &json!([]))
@@ -1068,12 +1071,18 @@ mod tests {
             result.get("bits").and_then(JsonValueTrait::as_str),
             Some("1d00ffff")
         );
-        assert_eq!(target, compact_target_hex(0x1d00_ffff));
+        assert_eq!(
+            target,
+            compact_target_hex(CompactTarget::from_consensus(0x1d00_ffff))
+        );
         assert_eq!(
             next.get("bits").and_then(JsonValueTrait::as_str),
             Some("1c00ffff")
         );
-        assert_eq!(next_target, compact_target_hex(0x1c00_ffff));
+        assert_eq!(
+            next_target,
+            compact_target_hex(CompactTarget::from_consensus(0x1c00_ffff))
+        );
         assert_ne!(target, next_target);
     }
 
@@ -1096,7 +1105,7 @@ mod tests {
             version: 2,
             inputs: Vec::new(),
             outputs: Vec::new(),
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let txid = tx.txid();
         {
@@ -1123,10 +1132,10 @@ mod tests {
             version: 2,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 1_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1_000),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let txid = tx.txid();
         let wtxid = tx.wtxid();
@@ -1344,7 +1353,7 @@ mod tests {
             version: 2,
             inputs: Vec::new(),
             outputs: Vec::new(),
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let pooled = pooled_tx.txid();
         {
@@ -1411,15 +1420,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0),
-                script_sig: vec![],
-                sequence: u32::MAX,
-                witness: vec![],
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(50_000),
+                script_pubkey: vec![0x51].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 

--- a/crates/rpc/src/handlers/tx.rs
+++ b/crates/rpc/src/handlers/tx.rs
@@ -18,9 +18,10 @@ use bitcoin_rs_mempool::{
     AdmissionOrigin, AdmissionRequest, AdmitError, AdmitOutcome, MutationResult,
 };
 use bitcoin_rs_primitives::{
-    Amount, Block as NativeBlock, CompactTarget, Hash256, LockTime, OutPoint, Script, Sequence, Tx,
-    TxIn, TxOut, Txid, Witness, consensus_bytes, deserialize as native_deserialize,
+    Amount, Block as NativeBlock, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+    Txid, Witness, consensus_bytes, deserialize as native_deserialize,
 };
+
 use miniscript::psbt::PsbtExt as _;
 use sonic_rs::{JsonContainerTrait as _, JsonValueTrait, Value, json};
 

--- a/crates/rpc/src/handlers/tx.rs
+++ b/crates/rpc/src/handlers/tx.rs
@@ -18,8 +18,8 @@ use bitcoin_rs_mempool::{
     AdmissionOrigin, AdmissionRequest, AdmitError, AdmitOutcome, MutationResult,
 };
 use bitcoin_rs_primitives::{
-    Block as NativeBlock, Hash256, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-    deserialize as native_deserialize,
+    Amount, Block as NativeBlock, CompactTarget, Hash256, LockTime, OutPoint, Script, Sequence, Tx,
+    TxIn, TxOut, Txid, Witness, consensus_bytes, deserialize as native_deserialize,
 };
 use miniscript::psbt::PsbtExt as _;
 use sonic_rs::{JsonContainerTrait as _, JsonValueTrait, Value, json};
@@ -217,7 +217,7 @@ fn txout_typed(
     typed_to_sonic(&v31::GetTxOut {
         best_block: ctx.best_hash().to_string(),
         confirmations,
-        value: sat_to_btc(output.value),
+        value: sat_to_btc(output.value.to_sat()),
         script_pubkey: convert::script_pub_key_typed(&output.script_pubkey, ctx.chain_network)?,
         coinbase,
     })
@@ -693,9 +693,9 @@ pub(crate) fn createrawtransaction(ctx: &Arc<Context>, params: &Value) -> Result
         };
         tx_inputs.push(TxIn {
             previous_output: OutPoint::new(txid, vout),
-            script_sig: Vec::new(),
-            sequence,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::from_consensus(sequence),
+            witness: Witness::new(),
         });
     }
 
@@ -711,8 +711,8 @@ pub(crate) fn createrawtransaction(ctx: &Arc<Context>, params: &Value) -> Result
             let mut script = vec![opcode::OP_RETURN];
             script.extend_from_slice(&push_data(&data));
             tx_outputs.push(TxOut {
-                value: 0,
-                script_pubkey: script,
+                value: Amount::from_sat(0),
+                script_pubkey: script.into(),
             });
             continue;
         }
@@ -722,14 +722,14 @@ pub(crate) fn createrawtransaction(ctx: &Arc<Context>, params: &Value) -> Result
             .require_network(network)
             .map_err(|_| RpcError::InvalidParams("invalid Bitcoin address"))?;
         tx_outputs.push(TxOut {
-            value: parse_btc_amount(value)?,
-            script_pubkey: address.script_pubkey().as_bytes().to_vec(),
+            value: Amount::from_sat(parse_btc_amount(value)?),
+            script_pubkey: address.script_pubkey().as_bytes().to_vec().into(),
         });
     }
 
     let tx = Tx {
         version: 2,
-        lock_time: locktime,
+        lock_time: LockTime::from_consensus(locktime),
         inputs: tx_inputs,
         outputs: tx_outputs,
     };
@@ -886,22 +886,21 @@ fn resolve_full_context(
             continue;
         }
         if let Some(output) = mempool_prevouts.get(&input.previous_output) {
-            input_value = input_value.saturating_add(output.value);
+            input_value = input_value.saturating_add(output.value.to_sat());
             prevouts.push((input.previous_output, output.clone()));
             continue;
         }
         if let Some(live) = ctx.utxo.get_entry(&input.previous_output) {
-            input_value = input_value.saturating_add(live.txout.value);
+            input_value = input_value.saturating_add(live.txout.value.to_sat());
             prevouts.push((input.previous_output, live.txout.clone()));
             continue;
         }
         missing_inputs = true;
     }
 
-    let output_value = tx
-        .outputs
-        .iter()
-        .fold(0_u64, |sum, output| sum.saturating_add(output.value));
+    let output_value = tx.outputs.iter().fold(0_u64, |sum, output| {
+        sum.saturating_add(output.value.to_sat())
+    });
     let fee = input_value.saturating_sub(output_value);
     let vsize = u32::try_from(tx.vsize()).unwrap_or(u32::MAX);
     let sigop_cost = u32::try_from(total_sigop_cost(tx, &prevouts)).unwrap_or(u32::MAX);
@@ -941,8 +940,8 @@ fn package_contexts(
                 prevouts.push((
                     input.previous_output,
                     TxOut {
-                        value: *value,
-                        script_pubkey: Vec::new(),
+                        value: Amount::from_sat(*value),
+                        script_pubkey: Script::new(),
                     },
                 ));
                 continue;
@@ -951,22 +950,21 @@ fn package_contexts(
                 && let Ok(vout) = usize::try_from(input.previous_output.vout)
                 && let Some(output) = parent.outputs.get(vout)
             {
-                input_value = input_value.saturating_add(output.value);
+                input_value = input_value.saturating_add(output.value.to_sat());
                 prevouts.push((input.previous_output, output.clone()));
                 continue;
             }
             if let Some(live) = ctx.utxo.get_entry(&input.previous_output) {
-                input_value = input_value.saturating_add(live.txout.value);
+                input_value = input_value.saturating_add(live.txout.value.to_sat());
                 prevouts.push((input.previous_output, live.txout.clone()));
                 continue;
             }
             missing_inputs = true;
         }
 
-        let output_value = tx
-            .outputs
-            .iter()
-            .fold(0_u64, |sum, output| sum.saturating_add(output.value));
+        let output_value = tx.outputs.iter().fold(0_u64, |sum, output| {
+            sum.saturating_add(output.value.to_sat())
+        });
         let fee = input_value.saturating_sub(output_value);
         let vsize = u32::try_from(tx.vsize()).unwrap_or(u32::MAX);
         let sigop_cost = u32::try_from(total_sigop_cost(tx, &prevouts)).unwrap_or(u32::MAX);
@@ -981,7 +979,7 @@ fn package_contexts(
         let txid = tx.txid();
         for (vout, output) in tx.outputs.iter().enumerate() {
             let vout = u32::try_from(vout).unwrap_or(u32::MAX);
-            package_outputs.insert((txid, vout), output.value);
+            package_outputs.insert((txid, vout), output.value.to_sat());
         }
     }
 
@@ -1225,8 +1223,8 @@ mod tests {
         AdmissionOrigin, MempoolEntry, arm_admission_park, reset_admission_park,
     };
     use bitcoin_rs_primitives::{
-        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-        encode::double_sha256,
+        Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script,
+        Sequence, Tx, TxIn, TxOut, Txid, Witness, consensus_bytes, encode::double_sha256,
     };
     use bitcoin_rs_utxo::{BlockChanges, UtxoAdd};
     use sonic_rs::{JsonContainerTrait as _, JsonValueTrait as _, json};
@@ -1246,16 +1244,16 @@ mod tests {
     fn fixture_genesis() -> Block {
         let coinbase = Tx {
             version: 1,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                script_sig: vec![0x51; 4],
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: vec![0x51; 4].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(50),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let mut block = Block {
@@ -1264,7 +1262,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0,
+                bits: CompactTarget::from_consensus(0),
                 nonce: 0,
             },
             txs: vec![coinbase],
@@ -1661,7 +1659,7 @@ mod tests {
     fn distinct_block(marker: u8) -> Block {
         let mut block = fixture_genesis();
         if let Some(input) = block.txs.first_mut().and_then(|tx| tx.inputs.first_mut()) {
-            input.script_sig = vec![marker; 4];
+            input.script_sig = vec![marker; 4].into();
         }
         block.header.merkle_root = merkle_root_for(&block.txs);
         block
@@ -1675,16 +1673,16 @@ mod tests {
         // MerkleBlock seam, whose decoder rejects input-less transactions.
         let extra = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[marker; 32])), 0),
-                script_sig: Vec::new(),
-                sequence: u32::MAX,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1_000 + u64::from(marker),
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(1_000 + u64::from(marker)),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         block.txs.push(extra);
@@ -2214,8 +2212,8 @@ mod tests {
         changes.add(UtxoAdd::new(
             OutPoint::new(Txid(Hash256::from_le_bytes(&[label; 32])), 0),
             TxOut {
-                value,
-                script_pubkey: retry_spendable_script(),
+                value: Amount::from_sat(value),
+                script_pubkey: retry_spendable_script().into(),
             },
             false,
             1,
@@ -2230,16 +2228,16 @@ mod tests {
     fn retry_tx(prevout: OutPoint, output_value: u64) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: prevout,
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: vec![vec![0x51]],
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: vec![vec![0x51]].into(),
             }],
             outputs: vec![TxOut {
-                value: output_value,
-                script_pubkey: retry_spendable_script(),
+                value: Amount::from_sat(output_value),
+                script_pubkey: retry_spendable_script().into(),
             }],
         }
     }
@@ -2373,11 +2371,11 @@ mod gettxout_via_utxo_tests {
         let ctx = Arc::new(Context::new());
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 50_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(50_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
         let txid = ctx.add_transaction(tx);
@@ -2398,7 +2396,8 @@ mod acceptance_tests {
     use bitcoin::hex::DisplayHex as _;
     use bitcoin_rs_chain::{BlockHeader, NodeId, NodeStatus, TipSnapshot};
     use bitcoin_rs_primitives::{
-        BlockHash, Hash256, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
+        Amount, BlockHash, CompactTarget, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn,
+        TxOut, Txid, Witness, consensus_bytes,
     };
     use bitcoin_rs_utxo::{BlockChanges, UtxoAdd};
     use sonic_rs::{JsonContainerTrait as _, JsonValueTrait as _, json};
@@ -2421,8 +2420,8 @@ mod acceptance_tests {
         changes.add(UtxoAdd::new(
             internal_outpoint(tag),
             TxOut {
-                value,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(value),
+                script_pubkey: vec![0x51].into(),
             },
             false,
             7,
@@ -2435,15 +2434,15 @@ mod acceptance_tests {
     fn spending_tx(tag: u8, output_value: u64) -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![TxIn {
                 previous_output: spent_outpoint(tag),
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: output_value,
+                value: Amount::from_sat(output_value),
                 script_pubkey: {
                     let mut out = Vec::with_capacity(25);
                     out.push(0x76); // OP_DUP
@@ -2453,7 +2452,8 @@ mod acceptance_tests {
                     out.push(0x88); // OP_EQUALVERIFY
                     out.push(0xac); // OP_CHECKSIG
                     out
-                },
+                }
+                .into(),
             }],
         }
     }
@@ -2595,24 +2595,24 @@ mod acceptance_tests {
         let prev = spent_outpoint(1);
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: vec![
                 TxIn {
                     previous_output: prev,
-                    script_sig: Vec::new(),
-                    sequence: 0xffff_ffff,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 },
                 TxIn {
                     previous_output: prev,
-                    script_sig: Vec::new(),
-                    sequence: 0xffff_ffff,
-                    witness: Vec::new(),
+                    script_sig: Script::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
                 },
             ],
             outputs: vec![TxOut {
-                value: 90_000,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(90_000),
+                script_pubkey: vec![0x51].into(),
             }],
         };
 
@@ -2660,7 +2660,7 @@ mod acceptance_tests {
         seed_utxo(&ctx, 1, 100_000);
 
         let mut original = spending_tx(1, 90_000);
-        original.inputs[0].sequence = 0xFFFF_FFFD;
+        original.inputs[0].sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
         let original_hex = hex_of(&original);
         let original_txid = original.txid();
         let params = json!([original_hex]);
@@ -2833,7 +2833,7 @@ mod acceptance_tests {
                     prev_blockhash: BlockHash::from(prev_hash),
                     merkle_root: Hash256::default(),
                     time: BASE + STEP * height,
-                    bits: 0x207f_ffff,
+                    bits: CompactTarget::from_consensus(0x207f_ffff),
                     nonce: 0,
                 };
                 let id = tree
@@ -2896,8 +2896,8 @@ mod acceptance_tests {
 
         seed_utxo(&ctx, 1, 100_000);
         let mut tx = spending_tx(1, 90_000);
-        tx.lock_time = lock_time;
-        tx.inputs[0].sequence = 0xFFFF_FFFE; // non-final
+        tx.lock_time = LockTime::from_consensus(lock_time);
+        tx.inputs[0].sequence = Sequence::from_consensus(0xFFFF_FFFE); // non-final
 
         let result = sendrawtransaction(&ctx, &json!([hex_of(&tx)]));
         assert!(

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -10,7 +10,8 @@ use alloc::sync::Arc;
 use std::str::FromStr;
 
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, TxOut, Txid, consensus_bytes, deserialize,
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Script, Sequence, TxOut,
+    Txid, Witness, consensus_bytes, deserialize,
 };
 use sonic_rs::{JsonValueTrait as _, Value, json};
 
@@ -396,7 +397,7 @@ fn route_getutxos(ctx: &Arc<Context>, suffix: &str) -> Response {
                 .map(|(height, txout)| {
                     json!({
                         "height": height,
-                        "value": tx_render::btc_amount_json(txout.value),
+                        "value": tx_render::btc_amount_json(txout.value.to_sat()),
                         "scriptPubKey": tx_render::script_pub_key_json(&txout.script_pubkey, ctx.chain_network)
                     })
                 })
@@ -976,7 +977,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 1,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 0,
             },
             txs: Vec::new(),
@@ -1089,7 +1090,7 @@ mod tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 1,
         };
         let genesis = Block {
@@ -1101,7 +1102,7 @@ mod tests {
             prev_blockhash: genesis.block_hash(),
             merkle_root: Hash256::default(),
             time: 2,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 2,
         };
         let child = Block {
@@ -1113,7 +1114,7 @@ mod tests {
             prev_blockhash: child.block_hash(),
             merkle_root: Hash256::default(),
             time: 3,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 3,
         };
         let tip = Block {
@@ -1153,7 +1154,7 @@ mod tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 1,
         };
         let applied = Header {
@@ -1161,7 +1162,7 @@ mod tests {
             prev_blockhash: genesis.compute_hash(),
             merkle_root: Hash256::default(),
             time: 2,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 2,
         };
         let header_tip = Header {
@@ -1169,7 +1170,7 @@ mod tests {
             prev_blockhash: applied.compute_hash(),
             merkle_root: Hash256::default(),
             time: 3,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 3,
         };
         let applied_tip = {
@@ -1207,7 +1208,7 @@ mod tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 1,
         };
         let child = Header {
@@ -1215,7 +1216,7 @@ mod tests {
             prev_blockhash: genesis.compute_hash(),
             merkle_root: Hash256::default(),
             time: 2,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 2,
         };
         let tip = Header {
@@ -1223,7 +1224,7 @@ mod tests {
             prev_blockhash: child.compute_hash(),
             merkle_root: Hash256::default(),
             time: 3,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 3,
         };
         publish_active_chain(&ctx, &[genesis, child, tip]);
@@ -1254,7 +1255,7 @@ mod tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 1,
         };
         let active_child = Header {
@@ -1262,7 +1263,7 @@ mod tests {
             prev_blockhash: genesis.compute_hash(),
             merkle_root: Hash256::default(),
             time: 2,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 2,
         };
         let active_tip = Header {
@@ -1270,7 +1271,7 @@ mod tests {
             prev_blockhash: active_child.compute_hash(),
             merkle_root: Hash256::default(),
             time: 3,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 3,
         };
         let side_child = Header {
@@ -1278,7 +1279,7 @@ mod tests {
             prev_blockhash: genesis.compute_hash(),
             merkle_root: Hash256::default(),
             time: 4,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 4,
         };
         let ids = publish_active_chain(&ctx, &[genesis, active_child, active_tip]);
@@ -1312,7 +1313,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 1,
-                bits,
+                bits: CompactTarget::from_consensus(bits),
                 nonce: 1,
             },
             txs: Vec::new(),
@@ -1323,7 +1324,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: Hash256::default(),
                 time: 2,
-                bits,
+                bits: CompactTarget::from_consensus(bits),
                 nonce: 2,
             },
             txs: Vec::new(),
@@ -1379,7 +1380,7 @@ mod tests {
             prev_blockhash: BlockHash::default(),
             merkle_root: Hash256::default(),
             time: 1,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 1,
         };
         let first = Header {
@@ -1387,7 +1388,7 @@ mod tests {
             prev_blockhash: genesis.compute_hash(),
             merkle_root: Hash256::default(),
             time: 2,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 2,
         };
         let middle = Header {
@@ -1395,7 +1396,7 @@ mod tests {
             prev_blockhash: first.compute_hash(),
             merkle_root: Hash256::default(),
             time: 3,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 3,
         };
         let tail = Header {
@@ -1403,7 +1404,7 @@ mod tests {
             prev_blockhash: middle.compute_hash(),
             merkle_root: Hash256::default(),
             time: 4,
-            bits,
+            bits: CompactTarget::from_consensus(bits),
             nonce: 4,
         };
         let hashes = publish_active_chain(&ctx, &[genesis, first, middle, tail]);
@@ -1438,15 +1439,15 @@ mod tests {
             version: 1,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0xffff_ffff),
-                script_sig: vec![0x51],
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: vec![0x51].into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 50 * 100_000_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(50 * 100_000_000),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         Block {
             header: Header {
@@ -1454,7 +1455,7 @@ mod tests {
                 prev_blockhash: BlockHash::default(),
                 merkle_root: coinbase.txid().0,
                 time: 1_296_688_602,
-                bits: 0x207f_ffff,
+                bits: CompactTarget::from_consensus(0x207f_ffff),
                 nonce: 2,
             },
             txs: vec![coinbase],

--- a/crates/rpc/src/rest.rs
+++ b/crates/rpc/src/rest.rs
@@ -10,9 +10,11 @@ use alloc::sync::Arc;
 use std::str::FromStr;
 
 use bitcoin_rs_primitives::{
-    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Script, Sequence, TxOut,
-    Txid, Witness, consensus_bytes, deserialize,
+    Block, BlockHash, Hash256, Header, TxOut, Txid, consensus_bytes, deserialize,
 };
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, CompactTarget, LockTime, Script, Sequence, Witness};
 use sonic_rs::{JsonValueTrait as _, Value, json};
 
 use crate::context::{BlockRecord, Context};

--- a/crates/rpc/src/tx_render.rs
+++ b/crates/rpc/src/tx_render.rs
@@ -8,10 +8,10 @@
 // the sanctioned rust-bitcoin compat seam (`Address<T>`/`Script` disassembly);
 // all transaction/amount/hash plumbing here is native.
 use bitcoin::Address;
-use bitcoin_rs_primitives::{
-    Amount, BlockHash, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid,
-    Witness, consensus_bytes,
-};
+use bitcoin_rs_primitives::{BlockHash, Network, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes};
+
+#[cfg(test)]
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence, Witness};
 use sonic_rs::{Value, json};
 
 use crate::script_util::{
@@ -182,6 +182,12 @@ fn input_json(
     // (consensus wire layout), so field references would be unaligned.
     let (prev_txid, prev_vout) = (previous_output.txid, previous_output.vout);
     let mut value = json!({
+        "txid": prev_txid.to_string(),
+        "vout": prev_vout,
+        "scriptSig": {
+            "asm": script_asm(&input.script_sig),
+            "hex": hex_encode(&input.script_sig)
+        },
         "sequence": input.sequence.to_consensus()
     });
     if !input.witness.is_empty() {
@@ -387,6 +393,41 @@ mod tests {
             Some("51")
         );
         assert!(first.get("txid").is_none());
+    }
+
+    #[test]
+    fn non_coinbase_input_renders_outpoint_and_script_sig() {
+        let tx = Tx {
+            version: 2,
+            lock_time: LockTime::ZERO,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid::default(), 7),
+                script_sig: vec![0x51].into(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            outputs: vec![TxOut {
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
+            }],
+        };
+        let value = transaction_json(&tx, Network::Regtest, None);
+        let first = &value.get("vin").expect("vin present")[0];
+        assert_eq!(
+            first.get("txid").and_then(JsonValueTrait::as_str),
+            Some("0000000000000000000000000000000000000000000000000000000000000000")
+        );
+        assert_eq!(first.get("vout").and_then(JsonValueTrait::as_u64), Some(7));
+        let script_sig = first.get("scriptSig").expect("scriptSig present");
+        assert_eq!(
+            script_sig.get("hex").and_then(JsonValueTrait::as_str),
+            Some("51")
+        );
+        assert_eq!(
+            first.get("sequence").and_then(JsonValueTrait::as_u64),
+            Some(u64::from(Sequence::ENABLE_RBF_NO_LOCKTIME.to_consensus()))
+        );
+        assert!(first.get("coinbase").is_none());
     }
 
     #[test]

--- a/crates/rpc/src/tx_render.rs
+++ b/crates/rpc/src/tx_render.rs
@@ -8,7 +8,10 @@
 // the sanctioned rust-bitcoin compat seam (`Address<T>`/`Script` disassembly);
 // all transaction/amount/hash plumbing here is native.
 use bitcoin::Address;
-use bitcoin_rs_primitives::{BlockHash, Network, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes};
+use bitcoin_rs_primitives::{
+    Amount, BlockHash, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid,
+    Witness, consensus_bytes,
+};
 use sonic_rs::{Value, json};
 
 use crate::script_util::{
@@ -108,7 +111,7 @@ pub fn transaction_json_with_prevouts(
         "size": size,
         "vsize": vsize,
         "weight": weight,
-        "locktime": tx.lock_time,
+        "locktime": tx.lock_time.to_consensus(),
         "vin": vin,
         "vout": vout,
         "hex": hex_encode(&consensus_bytes(tx))
@@ -130,10 +133,9 @@ pub fn transaction_json_with_prevouts(
         let input_value = prevouts.iter().fold(0_u64, |sum, prevout| {
             sum.saturating_add(prevout.as_ref().map_or(0, |prevout| prevout.value))
         });
-        let output_value = tx
-            .outputs
-            .iter()
-            .fold(0_u64, |sum, output| sum.saturating_add(output.value));
+        let output_value = tx.outputs.iter().fold(0_u64, |sum, output| {
+            sum.saturating_add(output.value.to_sat())
+        });
         let _ = value.insert(
             "fee",
             btc_amount_json(input_value.saturating_sub(output_value)),
@@ -167,7 +169,7 @@ fn input_json(
     if coinbase {
         let mut value = json!({
             "coinbase": hex_encode(&input.script_sig),
-            "sequence": input.sequence
+            "sequence": input.sequence.to_consensus()
         });
         if !input.witness.is_empty() {
             let witness: Vec<String> = input.witness.iter().map(|item| hex_encode(item)).collect();
@@ -180,13 +182,7 @@ fn input_json(
     // (consensus wire layout), so field references would be unaligned.
     let (prev_txid, prev_vout) = (previous_output.txid, previous_output.vout);
     let mut value = json!({
-        "txid": prev_txid.to_string(),
-        "vout": prev_vout,
-        "scriptSig": {
-            "asm": script_asm(&input.script_sig),
-            "hex": hex_encode(&input.script_sig)
-        },
-        "sequence": input.sequence
+        "sequence": input.sequence.to_consensus()
     });
     if !input.witness.is_empty() {
         let witness: Vec<String> = input.witness.iter().map(|item| hex_encode(item)).collect();
@@ -208,7 +204,7 @@ fn input_json(
 
 fn output_json(output: &TxOut, n: usize, network: Network) -> Value {
     json!({
-        "value": btc_amount_json(output.value),
+        "value": btc_amount_json(output.value.to_sat()),
         "n": n,
         "scriptPubKey": script_pub_key_json(&output.script_pubkey, network)
     })
@@ -308,11 +304,11 @@ mod tests {
     fn sample_tx() -> Tx {
         Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(1),
+                script_pubkey: Script::new(),
             }],
         }
     }
@@ -360,16 +356,16 @@ mod tests {
         let mut tx = sample_tx();
         tx.inputs.push(TxIn {
             previous_output: null_outpoint(),
-            script_sig: vec![1, 2, 3],
-            sequence: 0xFFFF_FFFF,
-            witness: Vec::new(),
+            script_sig: vec![1, 2, 3].into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         });
         assert!(is_coinbase(&tx));
         tx.inputs.push(TxIn {
             previous_output: null_outpoint(),
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFF,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         });
         assert!(!is_coinbase(&tx));
     }
@@ -379,9 +375,9 @@ mod tests {
         let mut tx = sample_tx();
         tx.inputs.push(TxIn {
             previous_output: null_outpoint(),
-            script_sig: vec![0x51],
-            sequence: 0xFFFF_FFFF,
-            witness: Vec::new(),
+            script_sig: vec![0x51].into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         });
         let value = transaction_json(&tx, Network::Regtest, None);
         let vin = value.get("vin").expect("vin present");
@@ -397,14 +393,15 @@ mod tests {
     fn p2wpkh_output_classifies_and_addresses_on_regtest() {
         let tx = Tx {
             version: 2,
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             inputs: Vec::new(),
             outputs: vec![TxOut {
-                value: 5_000,
+                value: Amount::from_sat(5_000),
                 script_pubkey: vec![
                     0x00, 0x14, 0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94, 0x1c,
                     0x45, 0xd1, 0xb3, 0xa3, 0x23, 0xf1, 0x43, 0x3b, 0xd6,
-                ],
+                ]
+                .into(),
             }],
         };
         let value = transaction_json(&tx, Network::Regtest, None);

--- a/crates/rpc/tests/core_compat.rs
+++ b/crates/rpc/tests/core_compat.rs
@@ -18,7 +18,10 @@ use bitcoin_rs_mining::{
     BlockTemplate, BlockTemplateRequest, BlockTemplateResult, BlockValidationResult, Candidate,
     MiningCapability, MiningControl, MiningControlError, MiningInfo, TemplateId, TemplateMutation,
 };
-use bitcoin_rs_primitives::{Block, Hash256, Network, OutPoint, Tx, TxIn, Txid, client_version};
+use bitcoin_rs_primitives::{
+    Block, CompactTarget, Hash256, LockTime, Network, OutPoint, Script, Sequence, Tx, TxIn, Txid,
+    Witness, client_version,
+};
 use bitcoin_rs_rpc::Handler;
 use bitcoin_rs_rpc::context::Context;
 use sonic_rs::{JsonContainerTrait as _, JsonValueTrait as _, json};
@@ -278,7 +281,7 @@ impl MiningControl for CompatMiningControl {
                 previous_block_hash,
                 height: 0,
                 version: 0x2000_0000,
-                bits: 0x1d00_ffff,
+                bits: CompactTarget::from_consensus(0x1d00_ffff),
                 min_time: 0,
                 current_time: 0,
                 csv_active: false,
@@ -289,12 +292,12 @@ impl MiningControl for CompatMiningControl {
                 mempool_sequence: 0,
                 coinbase: Tx {
                     version: 1,
-                    lock_time: 0,
+                    lock_time: LockTime::ZERO,
                     inputs: vec![TxIn {
                         previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                        script_sig: Vec::new(),
-                        sequence: u32::MAX,
-                        witness: Vec::new(),
+                        script_sig: Script::new(),
+                        sequence: Sequence::MAX,
+                        witness: Witness::new(),
                     }],
                     outputs: Vec::new(),
                 },
@@ -326,12 +329,12 @@ impl MiningControl for CompatMiningControl {
         Ok(MiningInfo {
             blocks: 0,
             last_candidate: None,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             difficulty: 1.0,
             network_hashes_per_second: 0.0,
             pooled_transactions: 0,
             network: Network::Regtest,
-            next_bits: 0x207f_ffff,
+            next_bits: CompactTarget::from_consensus(0x207f_ffff),
             next_difficulty: 1.0,
             minimum_fee_rate: 1_000,
             signet: None,

--- a/crates/rpc/tests/handler_smoke.rs
+++ b/crates/rpc/tests/handler_smoke.rs
@@ -17,8 +17,8 @@ use bitcoin_rs_mining::{
 };
 use bitcoin_rs_p2p::{PeerInfo, PeerLease, PeerTable};
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, Network, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
-    encode::double_sha256,
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Network, OutPoint, Script,
+    Sequence, Tx, TxIn, TxOut, Txid, Witness, consensus_bytes, encode::double_sha256,
 };
 use bitcoin_rs_rpc::context::{BlockRecord, ChainControl, ChainControlError, Context};
 use bitcoin_rs_rpc::{Handler, RpcError};
@@ -45,7 +45,7 @@ impl MiningControl for SmokeMiningControl {
                 previous_block_hash,
                 height: 0,
                 version: 0x2000_0000,
-                bits: 0x1d00_ffff,
+                bits: CompactTarget::from_consensus(0x1d00_ffff),
                 min_time: 0,
                 current_time: 0,
                 csv_active: false,
@@ -56,12 +56,12 @@ impl MiningControl for SmokeMiningControl {
                 mempool_sequence: 0,
                 coinbase: Tx {
                     version: 1,
-                    lock_time: 0,
+                    lock_time: LockTime::ZERO,
                     inputs: vec![TxIn {
                         previous_output: OutPoint::new(Txid::default(), u32::MAX),
-                        script_sig: Vec::new(),
-                        sequence: u32::MAX,
-                        witness: Vec::new(),
+                        script_sig: Script::new(),
+                        sequence: Sequence::MAX,
+                        witness: Witness::new(),
                     }],
                     outputs: Vec::new(),
                 },
@@ -89,12 +89,12 @@ impl MiningControl for SmokeMiningControl {
         Ok(MiningInfo {
             blocks: 0,
             last_candidate: None,
-            bits: 0x207f_ffff,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
             difficulty: 1.0,
             network_hashes_per_second: 0.0,
             pooled_transactions: 0,
             network: Network::Regtest,
-            next_bits: 0x207f_ffff,
+            next_bits: CompactTarget::from_consensus(0x207f_ffff),
             next_difficulty: 1.0,
             minimum_fee_rate: 1_000,
             signet: None,
@@ -305,8 +305,8 @@ fn gettxoutsetinfo_returns_real_utxo_counts() -> Result<(), Box<dyn std::error::
     changes.add(UtxoAdd::new(
         OutPoint::new(Txid(Hash256::from_le_bytes(&[1; 32])), 0),
         TxOut {
-            value: 50_000,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(50_000),
+            script_pubkey: vec![0x51].into(),
         },
         false,
         1,
@@ -655,11 +655,11 @@ fn fee_stats_context(values: Option<HashMap<OutPoint, u64>>) -> (Arc<Context>, T
                 Txid(Hash256::from_le_bytes(&[label; 32])),
                 Tx {
                     version: 2,
-                    lock_time: 0,
+                    lock_time: LockTime::ZERO,
                     inputs: Vec::new(),
                     outputs: vec![TxOut {
-                        value: 10_000,
-                        script_pubkey: Vec::new(),
+                        value: Amount::from_sat(10_000),
+                        script_pubkey: Script::new(),
                     }],
                 },
             );
@@ -744,16 +744,16 @@ fn fixture_merkle_root(txs: &[Tx]) -> Hash256 {
 fn fee_block(low_tx: Tx, high_tx: Tx) -> Block {
     let coinbase = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0_u8; 32])), u32::MAX),
-            script_sig: vec![0x51],
-            sequence: 0xFFFF_FFFE,
-            witness: Vec::new(),
+            script_sig: vec![0x51].into(),
+            sequence: Sequence::from_consensus(0xFFFF_FFFE),
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 50_000,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(50_000),
+            script_pubkey: vec![0x51].into(),
         }],
     };
     let txs = vec![coinbase, low_tx, high_tx];
@@ -764,7 +764,7 @@ fn fee_block(low_tx: Tx, high_tx: Tx) -> Block {
             prev_blockhash: BlockHash::default(),
             merkle_root,
             time: 1_231_006_505,
-            bits: 0x1d00_ffff,
+            bits: CompactTarget::from_consensus(0x1d00_ffff),
             nonce: 0,
         },
         txs,
@@ -774,16 +774,16 @@ fn fee_block(low_tx: Tx, high_tx: Tx) -> Block {
 fn fee_tx(label: u8, output_sat: u64) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: outpoint(label),
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFE,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::from_consensus(0xFFFF_FFFE),
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: output_sat,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(output_sat),
+            script_pubkey: vec![0x51].into(),
         }],
     }
 }
@@ -818,7 +818,7 @@ impl Fixture {
                 prev_blockhash: BlockHash::default(),
                 merkle_root,
                 time: 1_231_006_505,
-                bits: 0x1d00_ffff,
+                bits: CompactTarget::from_consensus(0x1d00_ffff),
                 nonce: 0,
             },
             txs: vec![tx.clone()],
@@ -871,16 +871,16 @@ fn context_with_peers(peer_table: Arc<PeerTable>) -> Arc<Context> {
 fn tx(label: u8, script_pubkey: Vec<u8>) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: outpoint(label),
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFE,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::from_consensus(0xFFFF_FFFE),
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 5_000,
-            script_pubkey,
+            value: Amount::from_sat(5_000),
+            script_pubkey: script_pubkey.into(),
         }],
     }
 }

--- a/crates/rpc/tests/policy_contract.rs
+++ b/crates/rpc/tests/policy_contract.rs
@@ -21,7 +21,10 @@ use bitcoin_rs_mempool::{
 use bitcoin_rs_node::reorg::{ReorgError, invalidate_block};
 use bitcoin_rs_node::{Network, NodeConfig, state::NodeState};
 use bitcoin_rs_primitives::encode::double_sha256;
-use bitcoin_rs_primitives::{Block, Hash256, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes};
+use bitcoin_rs_primitives::{
+    Amount, Block, CompactTarget, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut,
+    Txid, Witness, consensus_bytes,
+};
 use bitcoin_rs_rpc::context::{
     ChainControl, ChainControlError, ChainHandles, Context, ContextHandles, IndexHandles,
     MempoolHandles, MiningHandles, NetworkHandles,
@@ -42,16 +45,16 @@ fn op_true_script() -> Vec<u8> {
 fn tx(prevout: OutPoint, output_value: u64, sequence: u32) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: prevout,
-            script_sig: Vec::new(),
-            sequence,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::from_consensus(sequence),
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: output_value,
-            script_pubkey: p2wpkh_script(),
+            value: Amount::from_sat(output_value),
+            script_pubkey: p2wpkh_script().into(),
         }],
     }
 }
@@ -84,8 +87,8 @@ fn fund_utxo(ctx: &Context, label: u8, value: u64) -> OutPoint {
     changes.add(UtxoAdd::new(
         OutPoint::new(Txid(Hash256::from_le_bytes(&[label; 32])), 0),
         TxOut {
-            value,
-            script_pubkey: op_true_script(),
+            value: Amount::from_sat(value),
+            script_pubkey: op_true_script().into(),
         },
         false,
         1,
@@ -436,15 +439,15 @@ fn testmempoolaccept_reports_a_policy_verdict_per_row() -> Result<(), Box<dyn Er
     let below_min = tx(fund_utxo(&ctx, 0x52, 10_000), 9_999, 0xffff_ffff);
     let nonstandard = Tx {
         outputs: vec![TxOut {
-            value: 9_000,
-            script_pubkey: op_true_script(),
+            value: Amount::from_sat(9_000),
+            script_pubkey: op_true_script().into(),
         }],
         ..tx(fund_utxo(&ctx, 0x53, 10_000), 9_000, 0xffff_ffff)
     };
     let dust = Tx {
         outputs: vec![TxOut {
-            value: 100,
-            script_pubkey: p2wpkh_script(),
+            value: Amount::from_sat(100),
+            script_pubkey: p2wpkh_script().into(),
         }],
         ..tx(fund_utxo(&ctx, 0x54, 10_000), 100, 0xffff_ffff)
     };
@@ -525,8 +528,8 @@ fn sendrawtransaction_rejects_oversized_and_nonstandard_txs() -> Result<(), Box<
     let mut oversized = tx(fund_utxo(&ctx, 0x55, 10_000), 1_000, 0xffff_ffff);
     oversized.outputs = (0..3_400)
         .map(|_| TxOut {
-            value: 1_000,
-            script_pubkey: p2wpkh_script(),
+            value: Amount::from_sat(1_000),
+            script_pubkey: p2wpkh_script().into(),
         })
         .collect();
     let message = reject_message(
@@ -542,8 +545,8 @@ fn sendrawtransaction_rejects_oversized_and_nonstandard_txs() -> Result<(), Box<
 
     let weird = Tx {
         outputs: vec![TxOut {
-            value: 9_000,
-            script_pubkey: op_true_script(),
+            value: Amount::from_sat(9_000),
+            script_pubkey: op_true_script().into(),
         }],
         ..tx(fund_utxo(&ctx, 0x56, 10_000), 9_000, 0xffff_ffff)
     };
@@ -966,7 +969,7 @@ fn assert_both_rpcs_agree_on_replacement_rejection(
         let output_value = tx
             .outputs
             .iter()
-            .fold(0_u64, |sum, o| sum.saturating_add(o.value));
+            .fold(0_u64, |sum, o| sum.saturating_add(o.value.to_sat()));
         input_value.saturating_sub(output_value)
     };
     let candidate = ReplacementCandidate::new(Arc::new(tx.clone()), vsize, fee, 1_000);
@@ -1154,24 +1157,24 @@ fn sendrawtransaction_enforces_ancestor_count_limits_at_admission() -> Result<()
 fn tx_multi_child(funded: &OutPoint, tip: &Tx) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![
             TxIn {
                 previous_output: *funded,
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             },
             TxIn {
                 previous_output: OutPoint::new(tip.txid(), 0),
-                script_sig: Vec::new(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             },
         ],
         outputs: vec![TxOut {
-            value: 90_000,
-            script_pubkey: p2wpkh_script(),
+            value: Amount::from_sat(90_000),
+            script_pubkey: p2wpkh_script().into(),
         }],
     }
 }
@@ -1392,8 +1395,8 @@ fn testmempoolaccept_and_sendrawtransaction_agree_on_replacement_into_a_full_clu
         // P2WPKH here is what produced consensus-verification-failed.
         let root = Tx {
             outputs: vec![TxOut {
-                value: 50_000,
-                script_pubkey: op_true_script(),
+                value: Amount::from_sat(50_000),
+                script_pubkey: op_true_script().into(),
             }],
             ..tx(
                 OutPoint {
@@ -1457,19 +1460,19 @@ fn testmempoolaccept_and_sendrawtransaction_agree_on_replacement_into_a_full_clu
 fn tx_spending(inputs: &[(OutPoint, u32)], output_value: u64) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: inputs
             .iter()
             .map(|(prevout, sequence)| TxIn {
                 previous_output: *prevout,
-                script_sig: Vec::new(),
-                sequence: *sequence,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(*sequence),
+                witness: Witness::new(),
             })
             .collect(),
         outputs: vec![TxOut {
-            value: output_value,
-            script_pubkey: p2wpkh_script(),
+            value: Amount::from_sat(output_value),
+            script_pubkey: p2wpkh_script().into(),
         }],
     }
 }
@@ -1478,18 +1481,18 @@ fn tx_spending(inputs: &[(OutPoint, u32)], output_value: u64) -> Tx {
 fn tx_outputs(prevout: OutPoint, sequence: u32, values: &[u64]) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: prevout,
-            script_sig: Vec::new(),
-            sequence,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::from_consensus(sequence),
+            witness: Witness::new(),
         }],
         outputs: values
             .iter()
             .map(|value| TxOut {
-                value: *value,
-                script_pubkey: p2wpkh_script(),
+                value: Amount::from_sat(*value),
+                script_pubkey: p2wpkh_script().into(),
             })
             .collect(),
     }
@@ -1500,17 +1503,17 @@ fn tx_outputs(prevout: OutPoint, sequence: u32, values: &[u64]) -> Tx {
 fn many_output_tx(prevout: OutPoint, value_each: u64, count: usize) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: prevout,
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![
             TxOut {
-                value: value_each,
-                script_pubkey: p2wpkh_script(),
+                value: Amount::from_sat(value_each),
+                script_pubkey: p2wpkh_script().into(),
             };
             count
         ],
@@ -1784,15 +1787,15 @@ fn testmempoolaccept_and_sendrawtransaction_agree_on_each_class() -> Result<(), 
     let below_min = tx(fund_utxo(&ctx, 0x71, 10_000), 9_999, 0xffff_ffff);
     let nonstandard = Tx {
         outputs: vec![TxOut {
-            value: 9_000,
-            script_pubkey: op_true_script(),
+            value: Amount::from_sat(9_000),
+            script_pubkey: op_true_script().into(),
         }],
         ..tx(fund_utxo(&ctx, 0x72, 10_000), 9_000, 0xffff_ffff)
     };
     let dust = Tx {
         outputs: vec![TxOut {
-            value: 100,
-            script_pubkey: p2wpkh_script(),
+            value: Amount::from_sat(100),
+            script_pubkey: p2wpkh_script().into(),
         }],
         ..tx(fund_utxo(&ctx, 0x73, 10_000), 100, 0xffff_ffff)
     };
@@ -1916,15 +1919,17 @@ fn reorg_seed_coinbase(height: u32) -> Tx {
             previous_output: null_prevout(),
             // BIP34 height push plus one pad byte: consensus requires a
             // 2..=100 byte coinbase scriptSig (Core bad-cb-length).
-            script_sig: [script_push_int(i64::from(height)), script_push_int(0)].concat(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: [script_push_int(i64::from(height)), script_push_int(0)]
+                .concat()
+                .into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REORG_SUBSIDY_SATS,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(REORG_SUBSIDY_SATS),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 
@@ -1935,15 +1940,15 @@ fn reorg_seed_coinbase_spend_with_fee(fee_sats: u64) -> Tx {
         version: 2,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(reorg_seed_coinbase(1).txid(), 0),
-            script_sig: Vec::new(),
-            sequence: 0xffff_ffff,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: REORG_SUBSIDY_SATS - fee_sats,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(REORG_SUBSIDY_SATS - fee_sats),
+            script_pubkey: vec![0x51].into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 
@@ -1961,7 +1966,8 @@ fn reorg_grind_pow(block: &mut Block) -> Result<(), Box<dyn Error>> {
 
 /// Returns true when the header hash, read as a little-endian integer, meets
 /// the compact bits target (Core `CheckProofOfWork` shape).
-fn pow_is_met(bits: u32, hash: &Hash256) -> bool {
+fn pow_is_met(bits: CompactTarget, hash: &Hash256) -> bool {
+    let bits = bits.to_consensus();
     let exponent = usize::try_from(bits >> 24).unwrap_or(usize::MAX);
     let mantissa = bits & 0x00ff_ffff;
     if mantissa == 0 || mantissa & 0x0080_0000 != 0 || exponent > 32 {
@@ -2027,7 +2033,7 @@ fn reorg_mine_and_apply(
             merkle_root: Hash256::from_le_bytes(&[0_u8; 32]),
             time: REORG_SEED_BASE_TIME
                 .saturating_add(REORG_SEED_BLOCK_INTERVAL.saturating_mul(height)),
-            bits: REORG_REGTEST_BITS,
+            bits: CompactTarget::from_consensus(REORG_REGTEST_BITS),
             nonce: 0,
         },
         txs: std::iter::once(reorg_seed_coinbase(height))

--- a/crates/rpc/tests/support/chain.rs
+++ b/crates/rpc/tests/support/chain.rs
@@ -10,7 +10,10 @@
 use super::{GateResult, fail};
 use bitcoin_rs_node::{Network, NodeConfig, state::NodeState};
 use bitcoin_rs_primitives::encode::double_sha256;
-use bitcoin_rs_primitives::{Block, Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{
+    Amount, Block, CompactTarget, Hash256, LockTime, OutPoint, Sequence, Tx, TxIn, TxOut, Txid,
+    Witness,
+};
 
 /// Block the seed chain starts from; one minute after the genesis stamp, so
 /// mediantime arithmetic matches Core's regtest spacing.
@@ -55,15 +58,17 @@ pub(crate) fn seed_chain(state: &NodeState, count: u32) -> GateResult<SeedChain>
                 previous_output: null_prevout(),
                 // BIP34 height push plus one pad byte: consensus requires a
                 // 2..=100 byte coinbase scriptSig (Core bad-cb-length).
-                script_sig: [script_push_int(i64::from(height)), script_push_int(0)].concat(),
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: [script_push_int(i64::from(height)), script_push_int(0)]
+                    .concat()
+                    .into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: REGTEST_SUBSIDY_SATS,
-                script_pubkey: vec![0x51],
+                value: Amount::from_sat(REGTEST_SUBSIDY_SATS),
+                script_pubkey: vec![0x51].into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         let mut block = Block {
             header: bitcoin_rs_primitives::Header {
@@ -71,7 +76,7 @@ pub(crate) fn seed_chain(state: &NodeState, count: u32) -> GateResult<SeedChain>
                 prev_blockhash: bitcoin_rs_primitives::BlockHash::from(tip.hash),
                 merkle_root: Hash256::from_le_bytes(&[0_u8; 32]),
                 time: SEED_BASE_TIME.saturating_add(SEED_BLOCK_INTERVAL.saturating_mul(height)),
-                bits: REGTEST_BITS,
+                bits: CompactTarget::from_consensus(REGTEST_BITS),
                 nonce: 0,
             },
             txs: vec![coinbase],
@@ -128,7 +133,8 @@ fn grind_pow(block: &mut Block) -> GateResult<()> {
 
 /// Returns true when the header hash, read as a little-endian integer, meets
 /// the compact bits target (Core `CheckProofOfWork` shape).
-fn pow_is_met(bits: u32, hash: &Hash256) -> bool {
+fn pow_is_met(bits: CompactTarget, hash: &Hash256) -> bool {
+    let bits = bits.to_consensus();
     let exponent = usize::try_from(bits >> 24).unwrap_or(usize::MAX);
     let mantissa = bits & 0x00ff_ffff;
     if mantissa == 0 || mantissa & 0x0080_0000 != 0 || exponent > 32 {

--- a/crates/rpc/tests/transaction_methods.rs
+++ b/crates/rpc/tests/transaction_methods.rs
@@ -12,7 +12,8 @@ use alloc::sync::Arc;
 
 use bitcoin_rs_mempool::{AdmissionOrigin, MempoolEntry};
 use bitcoin_rs_primitives::{
-    Hash256, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes, deserialize,
+    Amount, Hash256, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    consensus_bytes, deserialize,
 };
 use bitcoin_rs_rpc::context::Context;
 use bitcoin_rs_rpc::{Handler, RpcError};
@@ -64,16 +65,16 @@ fn is_op_return(script: &[u8]) -> bool {
 fn make_tx(prevout: OutPoint, output_value: u64, script: Vec<u8>) -> Tx {
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: prevout,
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFE,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::from_consensus(0xFFFF_FFFE),
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: output_value,
-            script_pubkey: script,
+            value: Amount::from_sat(output_value),
+            script_pubkey: script.into(),
         }],
     }
 }
@@ -85,10 +86,10 @@ fn fund_utxo(ctx: &Context, txid_byte: u8, value: u64) -> OutPoint {
     changes.add(UtxoAdd::new(
         outpoint,
         TxOut {
-            value,
+            value: Amount::from_sat(value),
             // OP_TRUE: an anyone-can-spend prevout, so the empty scriptSigs
             // these fixtures build satisfy script verification.
-            script_pubkey: vec![0x51],
+            script_pubkey: vec![0x51].into(),
         },
         false,
         1,
@@ -298,16 +299,16 @@ fn gettxout_returns_unconfirmed_output_from_mempool() -> Result<(), Box<dyn std:
     let script = hex_decode(P2WPKH_SCRIPT_HEX)?;
     let tx = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0xaa; 32])), 0),
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFE,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::from_consensus(0xFFFF_FFFE),
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 7_500,
-            script_pubkey: script,
+            value: Amount::from_sat(7_500),
+            script_pubkey: script.into(),
         }],
     };
     let txid = tx.txid();
@@ -330,16 +331,16 @@ fn gettxout_include_mempool_false_skips_mempool() -> Result<(), Box<dyn std::err
     let script = hex_decode(P2WPKH_SCRIPT_HEX)?;
     let tx = Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0xbb; 32])), 0),
-            script_sig: Vec::new(),
-            sequence: 0xFFFF_FFFE,
-            witness: Vec::new(),
+            script_sig: Script::new(),
+            sequence: Sequence::from_consensus(0xFFFF_FFFE),
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: 7_500,
-            script_pubkey: script,
+            value: Amount::from_sat(7_500),
+            script_pubkey: script.into(),
         }],
     };
     let txid = tx.txid();

--- a/crates/script/src/checker.rs
+++ b/crates/script/src/checker.rs
@@ -9,7 +9,10 @@
 //! (`CheckSignatureEncoding`, `CheckPubKeyEncoding`, `IsLowDERSignature`,
 //! `CheckLockTime`, `CheckSequence`).
 
-use bitcoin_rs_primitives::{Hash256, Sighash, SighashCache, SighashError, Tx, TxOut};
+use bitcoin_rs_primitives::{
+    Amount, Hash256, LockTime, Script, Sequence, Sighash, SighashCache, SighashError, Tx, TxOut,
+    Witness,
+};
 use secp256k1::{Message, PublicKey, XOnlyPublicKey, ecdsa::Signature as EcdsaSig};
 
 use crate::interpreter::{ScriptErrCode, ScriptError, VerifyFlags};
@@ -51,7 +54,7 @@ const SIGHASH_ANYONECANPAY: u8 = 0x80;
 pub struct TxSignatureChecker<'a> {
     tx: &'a Tx,
     input_index: usize,
-    amount: u64,
+    amount: Amount,
     prevouts: &'a [TxOut],
     cache: SighashCache<'a>,
     /// Raw taproot annex bytes, when present (BIP341). Used by
@@ -117,7 +120,7 @@ impl<'a> TxSignatureChecker<'a> {
     /// Builds a checker for one input of `tx`, with `prevouts` covering every
     /// input so taproot sighashes can commit to all spent outputs.
     #[must_use]
-    pub fn new(tx: &'a Tx, input_index: usize, amount: u64, prevouts: &'a [TxOut]) -> Self {
+    pub fn new(tx: &'a Tx, input_index: usize, amount: Amount, prevouts: &'a [TxOut]) -> Self {
         Self {
             tx,
             input_index,
@@ -341,7 +344,7 @@ impl<'a> TxSignatureChecker<'a> {
     /// and the input's sequence is not `SEQUENCE_FINAL`.
     #[must_use]
     pub fn check_locktime(&self, locktime: i64) -> bool {
-        let tx_locktime = i64::from(self.tx.lock_time);
+        let tx_locktime = i64::from(self.tx.lock_time.to_consensus());
 
         // Both must be the same type: below threshold = block height,
         // at or above = timestamp.
@@ -362,7 +365,7 @@ impl<'a> TxSignatureChecker<'a> {
             Some(inp) => inp,
             None => return false,
         };
-        if input.sequence == SEQUENCE_FINAL {
+        if input.sequence == bitcoin_rs_primitives::Sequence::MAX {
             return false;
         }
 
@@ -382,7 +385,7 @@ impl<'a> TxSignatureChecker<'a> {
             Some(inp) => inp,
             None => return false,
         };
-        let tx_sequence = i64::from(input.sequence);
+        let tx_sequence = i64::from(input.sequence.to_consensus());
 
         // Transaction version must be >= 2 for BIP68 rules. Core stores
         // version as uint32_t, so 0xffffffff is a large positive number, not
@@ -399,7 +402,7 @@ impl<'a> TxSignatureChecker<'a> {
 
         // If the input's own sequence has the disable bit set, CSV cannot
         // be used to get around it.
-        if (input.sequence & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
+        if (input.sequence.to_consensus() & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
             return false;
         }
 
@@ -678,7 +681,10 @@ fn sighash_to_script_error(error: &SighashError) -> ScriptError {
 #[cfg(test)]
 mod tests {
     #![expect(clippy::expect_used, reason = "test assertions")]
-    use bitcoin_rs_primitives::{Hash256, OutPoint, SighashCache, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, Hash256, LockTime, OutPoint, Script, Sequence, SighashCache, Tx, TxIn, TxOut, Txid,
+        Witness,
+    };
 
     use super::{
         LOCKTIME_THRESHOLD, SEQUENCE_FINAL, SEQUENCE_LOCKTIME_DISABLE_FLAG,
@@ -693,22 +699,22 @@ mod tests {
             version,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0),
-                script_sig: Vec::new(),
-                sequence,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(sequence),
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 49_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(49_000),
+                script_pubkey: Script::new(),
             }],
-            lock_time,
+            lock_time: LockTime::from_consensus(lock_time),
         }
     }
 
     fn make_prevouts() -> Vec<TxOut> {
         vec![TxOut {
-            value: 50_000,
-            script_pubkey: Vec::new(),
+            value: Amount::from_sat(50_000),
+            script_pubkey: Script::new(),
         }]
     }
 
@@ -720,7 +726,7 @@ mod tests {
     fn der_flag_rejects_non_der_signature() {
         let tx = make_tx(2, 0, SEQUENCE_FINAL);
         let prevouts = make_prevouts();
-        let mut checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let mut checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // A non-DER signature: just random bytes with a hashtype appended.
         let bad_sig = [0x00, 0x01, 0x02, 0x03, 0x01_u8];
@@ -755,7 +761,7 @@ mod tests {
     fn der_flag_accepts_empty_signature() {
         let tx = make_tx(2, 0, SEQUENCE_FINAL);
         let prevouts = make_prevouts();
-        let mut checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let mut checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         let result = checker.check_ecdsa_signature(
             &[],
@@ -776,7 +782,7 @@ mod tests {
     fn low_s_flag_rejects_high_s_signature() {
         let tx = make_tx(2, 0, SEQUENCE_FINAL);
         let prevouts = make_prevouts();
-        let mut checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let mut checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // Construct a DER-encoded signature with a high S value that is
         // still valid DER (positive integer). S = 0x80...00 (32 bytes) is
@@ -826,7 +832,7 @@ mod tests {
     fn strictenc_rejects_undefined_hashtype() {
         let tx = make_tx(2, 0, SEQUENCE_FINAL);
         let prevouts = make_prevouts();
-        let mut checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let mut checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // Build a valid DER signature with an undefined hashtype (0x05).
         let sig: Vec<u8> = [0x30, 0x44, 0x02, 0x20]
@@ -864,7 +870,7 @@ mod tests {
     fn strictenc_rejects_invalid_pubkey() {
         let tx = make_tx(2, 0, SEQUENCE_FINAL);
         let prevouts = make_prevouts();
-        let mut checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let mut checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // A valid DER sig with low S.
         let sig: Vec<u8> = [0x30, 0x44, 0x02, 0x20]
@@ -905,7 +911,7 @@ mod tests {
     fn witness_pubkeytype_rejects_uncompressed_in_segwit() {
         let tx = make_tx(2, 0, SEQUENCE_FINAL);
         let prevouts = make_prevouts();
-        let mut checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let mut checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // Uncompressed pubkey (0x04 prefix, 65 bytes).
         let uncompressed = [0x04_u8; 65];
@@ -945,7 +951,7 @@ mod tests {
     fn nullfail_rejects_nonempty_failing_signature() {
         let tx = make_tx(2, 0, SEQUENCE_FINAL);
         let prevouts = make_prevouts();
-        let mut checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let mut checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // Valid DER, low S, valid hashtype — but the signature won't verify
         // against this random pubkey, so without NULLFAIL it would be Ok(false).
@@ -974,7 +980,7 @@ mod tests {
         // With NULLFAIL: check_ecdsa_signature returns Ok(false) — NULLFAIL
         // enforcement is the caller's job (eval_checksig / check_multisig
         // cleanup), not the checker's.
-        let mut checker2 = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let mut checker2 = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
         let result_nullfail = checker2.check_ecdsa_signature(
             &sig,
             &pubkey,
@@ -995,7 +1001,7 @@ mod tests {
     fn nullfail_allows_empty_signature() {
         let tx = make_tx(2, 0, SEQUENCE_FINAL);
         let prevouts = make_prevouts();
-        let mut checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let mut checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         let result = checker.check_ecdsa_signature(
             &[],
@@ -1016,7 +1022,7 @@ mod tests {
     fn check_locktime_satisfied_when_types_match_and_locktime_le_tx() {
         let tx = make_tx(2, 100, 0);
         let prevouts = make_prevouts();
-        let checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // locktime 50 <= tx locktime 100, both block height, input not finalized.
         assert!(checker.check_locktime(50));
@@ -1027,7 +1033,7 @@ mod tests {
     fn check_locktime_fails_when_locktime_exceeds_tx() {
         let tx = make_tx(2, 100, 0);
         let prevouts = make_prevouts();
-        let checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         assert!(!checker.check_locktime(101));
     }
@@ -1036,7 +1042,7 @@ mod tests {
     fn check_locktime_fails_on_type_mismatch() {
         let tx = make_tx(2, 100, 0); // tx locktime = block height
         let prevouts = make_prevouts();
-        let checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // Timestamp locktime vs block-height tx locktime.
         let timestamp = i64::from(LOCKTIME_THRESHOLD) + 100;
@@ -1047,7 +1053,7 @@ mod tests {
     fn check_locktime_fails_when_input_finalized() {
         let tx = make_tx(2, 100, SEQUENCE_FINAL);
         let prevouts = make_prevouts();
-        let checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // Even though locktime 50 <= 100 and types match, the input is finalized.
         assert!(!checker.check_locktime(50));
@@ -1063,7 +1069,7 @@ mod tests {
         let sequence = 100_u32; // block-height type, value 100
         let tx = make_tx(2, 0, sequence);
         let prevouts = make_prevouts();
-        let checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // Required sequence 50 <= input sequence 100, same type.
         assert!(checker.check_sequence(50));
@@ -1075,7 +1081,7 @@ mod tests {
         let sequence = 100_u32;
         let tx = make_tx(2, 0, sequence);
         let prevouts = make_prevouts();
-        let checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         assert!(!checker.check_sequence(101));
     }
@@ -1084,7 +1090,7 @@ mod tests {
     fn check_sequence_fails_when_tx_version_too_low() {
         let tx = make_tx(1, 0, 100);
         let prevouts = make_prevouts();
-        let checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         assert!(!checker.check_sequence(50));
     }
@@ -1094,7 +1100,7 @@ mod tests {
         let sequence = 0x64_u32 | SEQUENCE_LOCKTIME_DISABLE_FLAG;
         let tx = make_tx(2, 0, sequence);
         let prevouts = make_prevouts();
-        let checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         assert!(!checker.check_sequence(50));
     }
@@ -1104,7 +1110,7 @@ mod tests {
         // Input sequence: block-height type (value < TYPE_FLAG).
         let tx = make_tx(2, 0, 100);
         let prevouts = make_prevouts();
-        let checker = TxSignatureChecker::new(&tx, 0, 50_000, &prevouts);
+        let checker = TxSignatureChecker::new(&tx, 0, Amount::from_sat(50_000), &prevouts);
 
         // Required: time-based type (value >= TYPE_FLAG).
         let time_based = i64::from(SEQUENCE_LOCKTIME_TYPE_FLAG) + 50;

--- a/crates/script/src/checker.rs
+++ b/crates/script/src/checker.rs
@@ -9,10 +9,7 @@
 //! (`CheckSignatureEncoding`, `CheckPubKeyEncoding`, `IsLowDERSignature`,
 //! `CheckLockTime`, `CheckSequence`).
 
-use bitcoin_rs_primitives::{
-    Amount, Hash256, LockTime, Script, Sequence, Sighash, SighashCache, SighashError, Tx, TxOut,
-    Witness,
-};
+use bitcoin_rs_primitives::{Amount, Hash256, Sighash, SighashCache, SighashError, Tx, TxOut};
 use secp256k1::{Message, PublicKey, XOnlyPublicKey, ecdsa::Signature as EcdsaSig};
 
 use crate::interpreter::{ScriptErrCode, ScriptError, VerifyFlags};
@@ -365,7 +362,7 @@ impl<'a> TxSignatureChecker<'a> {
             Some(inp) => inp,
             None => return false,
         };
-        if input.sequence == bitcoin_rs_primitives::Sequence::MAX {
+        if input.sequence.to_consensus() == SEQUENCE_FINAL {
             return false;
         }
 

--- a/crates/script/src/interpreter.rs
+++ b/crates/script/src/interpreter.rs
@@ -9,7 +9,9 @@
 use std::borrow::Cow;
 use std::fmt;
 
-use bitcoin_rs_primitives::{Sighash, SighashCache, Tx, TxOut};
+use bitcoin_rs_primitives::{
+    Amount, LockTime, Script, Sequence, Sighash, SighashCache, Tx, TxOut, Witness,
+};
 use secp256k1::{Message, XOnlyPublicKey, schnorr::Signature};
 use thiserror::Error;
 
@@ -522,8 +524,8 @@ impl Interpreter {
                         index: input_idx,
                         inputs,
                     })?;
-            grafted_input.script_sig = script_sig.to_vec();
-            grafted_input.witness = witness.to_vec();
+            grafted_input.script_sig = Script::from_bytes(script_sig.to_vec());
+            grafted_input.witness = Witness::from_stack(witness.to_vec());
             Cow::Owned(grafted)
         };
 
@@ -955,7 +957,7 @@ fn verify_taproot_scriptpath(
         i64::try_from(witness_serialized_size).unwrap_or(i64::MAX) + eval::VALIDATION_WEIGHT_OFFSET,
     );
 
-    let mut checker = TxSignatureChecker::new(spending, input_idx, 0, prevouts);
+    let mut checker = TxSignatureChecker::new(spending, input_idx, Amount::ZERO, prevouts);
     checker.set_annex(annex_bytes);
 
     eval::eval_script(
@@ -990,7 +992,9 @@ fn varint_len(data_len: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin_rs_primitives::{OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    };
 
     use super::{Interpreter, ScriptErrCode, ScriptError, VerifyFlags};
 
@@ -999,8 +1003,8 @@ mod tests {
         let interpreter = Interpreter;
         let tx = unsigned_spend();
         let prevout = TxOut {
-            value: 50_000,
-            script_pubkey: vec![0x51],
+            value: Amount::from_sat(50_000),
+            script_pubkey: vec![0x51].into(),
         };
 
         assert_eq!(
@@ -1030,15 +1034,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0),
-                script_sig: Vec::new(),
-                sequence: 0xffff_fffe,
-                witness: Vec::new(),
+                script_sig: Script::new(),
+                sequence: Sequence::from_consensus(0xffff_fffe),
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 49_000,
-                script_pubkey: Vec::new(),
+                value: Amount::from_sat(49_000),
+                script_pubkey: Script::new(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         }
     }
 }

--- a/crates/script/src/interpreter.rs
+++ b/crates/script/src/interpreter.rs
@@ -9,9 +9,7 @@
 use std::borrow::Cow;
 use std::fmt;
 
-use bitcoin_rs_primitives::{
-    Amount, LockTime, Script, Sequence, Sighash, SighashCache, Tx, TxOut, Witness,
-};
+use bitcoin_rs_primitives::{Amount, Script, Sighash, SighashCache, Tx, TxOut, Witness};
 use secp256k1::{Message, XOnlyPublicKey, schnorr::Signature};
 use thiserror::Error;
 

--- a/crates/script/src/sigops.rs
+++ b/crates/script/src/sigops.rs
@@ -8,7 +8,7 @@
 //! data pushes are skipped, and a malformed push ends the count (Core's
 //! `if (!GetOp(pc, opcode)) break;`).
 
-use bitcoin_rs_primitives::{Block, Tx};
+use bitcoin_rs_primitives::{Amount, Block, LockTime, Script, Sequence, Tx, Witness};
 
 use crate::script::{EarlyEndOfScript, Instruction, instructions, is_p2wpkh, is_p2wsh, opcode};
 
@@ -93,7 +93,9 @@ fn count_script(script: &[u8], accurate: bool) -> u32 {
 mod tests {
     use bitcoin::ScriptBuf as OracleScriptBuf;
 
-    use bitcoin_rs_primitives::{Block, OutPoint, Tx, TxIn, TxOut, Txid};
+    use bitcoin_rs_primitives::{
+        Amount, Block, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+    };
 
     const fn pushnum(n: u8) -> u8 {
         opcode::OP_PUSHNUM_1 + (n - 1)
@@ -149,15 +151,15 @@ mod tests {
             version: 2,
             inputs: vec![TxIn {
                 previous_output: OutPoint::new(Txid::default(), 0),
-                script_sig,
-                sequence: 0xffff_ffff,
-                witness: Vec::new(),
+                script_sig: script_sig.into(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
             }],
             outputs: vec![TxOut {
-                value: 1,
-                script_pubkey,
+                value: Amount::SAT,
+                script_pubkey: script_pubkey.into(),
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
         };
         assert_eq!(count_tx_legacy(&tx), 1 + 20);
 

--- a/crates/script/src/sigops.rs
+++ b/crates/script/src/sigops.rs
@@ -8,7 +8,7 @@
 //! data pushes are skipped, and a malformed push ends the count (Core's
 //! `if (!GetOp(pc, opcode)) break;`).
 
-use bitcoin_rs_primitives::{Amount, Block, LockTime, Script, Sequence, Tx, Witness};
+use bitcoin_rs_primitives::{Block, Tx};
 
 use crate::script::{EarlyEndOfScript, Instruction, instructions, is_p2wpkh, is_p2wsh, opcode};
 
@@ -94,7 +94,7 @@ mod tests {
     use bitcoin::ScriptBuf as OracleScriptBuf;
 
     use bitcoin_rs_primitives::{
-        Amount, Block, LockTime, OutPoint, Script, Sequence, Tx, TxIn, TxOut, Txid, Witness,
+        Amount, Block, LockTime, OutPoint, Sequence, Tx, TxIn, TxOut, Txid, Witness,
     };
 
     const fn pushnum(n: u8) -> u8 {

--- a/crates/script/tests/core_vectors.rs
+++ b/crates/script/tests/core_vectors.rs
@@ -33,7 +33,10 @@ use bitcoin::ScriptBuf;
 use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey, XOnlyPublicKey};
 use bitcoin::taproot::{LeafVersion, TaprootBuilder};
 use bitcoin_rs_primitives::tapleaf_hash;
-use bitcoin_rs_primitives::{Hash256, OutPoint, SighashCache, Tx, TxIn, TxOut, Txid, deserialize};
+use bitcoin_rs_primitives::{
+    Amount, Hash256, LockTime, OutPoint, Script, Sequence, SighashCache, Tx, TxIn, TxOut, Txid,
+    Witness, deserialize,
+};
 use bitcoin_rs_script::{
     Interpreter, ScriptError, VerifyFlags, opcode, push_data, push_int, taproot,
 };
@@ -551,22 +554,20 @@ fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, String> {
 // Transaction construction — Core's BuildCrediting/BuildSpending
 // ===========================================================================
 
-const SEQUENCE_FINAL: u32 = 0xffff_ffff;
-
 fn build_crediting_tx(script_pubkey: &[u8], amount: u64) -> Tx {
     Tx {
         version: 1,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(Txid::default(), u32::MAX),
-            script_sig: vec![opcode::OP_0, opcode::OP_0],
-            sequence: SEQUENCE_FINAL,
-            witness: Vec::new(),
+            script_sig: vec![opcode::OP_0, opcode::OP_0].into(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
         }],
         outputs: vec![TxOut {
-            value: amount,
-            script_pubkey: script_pubkey.to_vec(),
+            value: Amount::from_sat(amount),
+            script_pubkey: script_pubkey.to_vec().into(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 
@@ -576,15 +577,15 @@ fn build_spending_tx(script_sig: &[u8], witness: &[Vec<u8>], credit_tx: &Tx) -> 
         version: 1,
         inputs: vec![TxIn {
             previous_output: OutPoint::new(credit_txid, 0),
-            script_sig: script_sig.to_vec(),
-            sequence: SEQUENCE_FINAL,
-            witness: witness.to_vec(),
+            script_sig: script_sig.to_vec().into(),
+            sequence: Sequence::MAX,
+            witness: witness.to_vec().into(),
         }],
         outputs: vec![TxOut {
             value: credit_tx.outputs[0].value,
-            script_pubkey: Vec::new(),
+            script_pubkey: Script::new(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     }
 }
 
@@ -1217,8 +1218,8 @@ fn load_tx_vectors(
             prevouts.push((
                 OutPoint::new(txid, vout),
                 TxOut {
-                    value: amount,
-                    script_pubkey,
+                    value: Amount::from_sat(amount),
+                    script_pubkey: script_pubkey.into(),
                 },
             ));
         }
@@ -1292,7 +1293,10 @@ fn run_tx_vectors_native(rows: &[TxVectorRow], counts: &mut Counts) -> Vec<Strin
                 verdict,
                 row.flags.bits(),
                 row.tx.lock_time,
-                row.tx.inputs.first().map_or(0, |input| input.sequence)
+                row.tx
+                    .inputs
+                    .first()
+                    .map_or(0, |input| input.sequence.to_consensus())
             ));
         }
     }
@@ -1319,7 +1323,10 @@ fn run_tx_vectors_kernel(rows: &[TxVectorRow], counts: &mut Counts) -> Vec<Strin
                 verdict,
                 row.flags.bits(),
                 row.tx.lock_time,
-                row.tx.inputs.first().map_or(0, |input| input.sequence)
+                row.tx
+                    .inputs
+                    .first()
+                    .map_or(0, |input| input.sequence.to_consensus())
             ));
         }
     }

--- a/crates/script/tests/proptest.rs
+++ b/crates/script/tests/proptest.rs
@@ -9,10 +9,10 @@ use bitcoin::script::Builder;
 use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey};
 use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
 use bitcoin::{
-    Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut as OracleTxOut, Txid, Witness,
-    absolute, transaction,
+    Amount as OracleAmount, OutPoint, ScriptBuf, Sequence as OracleSequence, Transaction, TxIn,
+    TxOut as OracleTxOut, Txid, Witness as OracleWitness, absolute, transaction,
 };
-use bitcoin_rs_primitives::{Tx, TxOut};
+use bitcoin_rs_primitives::{Amount, LockTime, Sequence, Tx, TxOut, Witness};
 use bitcoin_rs_script::{Interpreter, ScriptErrCode, ScriptError, VerifyFlags};
 use proptest::prelude::*;
 
@@ -25,8 +25,8 @@ fn to_native(tx: &Transaction) -> Tx {
 
 fn to_native_prevout(prevout: &OracleTxOut) -> TxOut {
     TxOut {
-        value: prevout.value.to_sat(),
-        script_pubkey: prevout.script_pubkey.as_bytes().to_vec(),
+        value: bitcoin_rs_primitives::Amount::from_sat(prevout.value.to_sat()),
+        script_pubkey: prevout.script_pubkey.as_bytes().to_vec().into(),
     }
 }
 
@@ -132,7 +132,7 @@ fn signed_p2tr(byte: u8) -> Option<SpendFixture> {
     let tweaked = bitcoin::key::TapTweak::tap_tweak(keypair, &secp, None);
     let (output_key, _) = tweaked.public_parts();
     let prevout = OracleTxOut {
-        value: Amount::from_sat(50_000),
+        value: OracleAmount::from_sat(50_000),
         script_pubkey: ScriptBuf::new_p2tr_tweaked(output_key),
     };
     let mut tx = unsigned_spend(byte);
@@ -147,7 +147,7 @@ fn signed_p2tr(byte: u8) -> Option<SpendFixture> {
     };
     let message = Message::from_digest(*sighash.as_byte_array());
     let signature = secp.sign_schnorr(&message, tweaked.as_keypair());
-    tx.input[0].witness = Witness::from_slice(&[signature.serialize().to_vec()]);
+    tx.input[0].witness = OracleWitness::from_slice(&[signature.serialize().to_vec()]);
     Some(SpendFixture {
         prevout: to_native_prevout(&prevout),
         tx: to_native(&tx),
@@ -168,7 +168,7 @@ fn signed_multi_input_p2tr(seeds: [u8; 2]) -> Option<(Transaction, Vec<OracleTxO
         let tweaked = bitcoin::key::TapTweak::tap_tweak(keypair, &secp, None);
         let (output_key, _) = tweaked.public_parts();
         prevouts.push(OracleTxOut {
-            value: Amount::from_sat(50_000),
+            value: OracleAmount::from_sat(50_000),
             script_pubkey: ScriptBuf::new_p2tr_tweaked(output_key),
         });
         keypairs.push(tweaked);
@@ -186,12 +186,12 @@ fn signed_multi_input_p2tr(seeds: [u8; 2]) -> Option<(Transaction, Vec<OracleTxO
                     vout: u32::try_from(index).unwrap_or_else(|_| panic!("input index fits u32")),
                 },
                 script_sig: ScriptBuf::new(),
-                sequence: Sequence::MAX,
-                witness: Witness::new(),
+                sequence: OracleSequence::MAX,
+                witness: OracleWitness::new(),
             })
             .collect(),
         output: vec![OracleTxOut {
-            value: Amount::from_sat(99_000),
+            value: OracleAmount::from_sat(99_000),
             script_pubkey: Builder::new().push_int(1).into_script(),
         }],
     };
@@ -207,7 +207,7 @@ fn signed_multi_input_p2tr(seeds: [u8; 2]) -> Option<(Transaction, Vec<OracleTxO
         };
         let message = Message::from_digest(*sighash.as_byte_array());
         let signature = secp.sign_schnorr(&message, keypair.as_keypair());
-        tx.input[input_idx].witness = Witness::from_slice(&[signature.serialize().to_vec()]);
+        tx.input[input_idx].witness = OracleWitness::from_slice(&[signature.serialize().to_vec()]);
     }
 
     Some((tx, prevouts))
@@ -223,11 +223,11 @@ fn unsigned_spend(byte: u8) -> Transaction {
                 vout: 0,
             },
             script_sig: ScriptBuf::new(),
-            sequence: Sequence::MAX,
-            witness: Witness::new(),
+            sequence: OracleSequence::MAX,
+            witness: OracleWitness::new(),
         }],
         output: vec![OracleTxOut {
-            value: Amount::from_sat(49_000),
+            value: OracleAmount::from_sat(49_000),
             script_pubkey: Builder::new().push_int(1).into_script(),
         }],
     }

--- a/crates/script/tests/proptest.rs
+++ b/crates/script/tests/proptest.rs
@@ -12,7 +12,7 @@ use bitcoin::{
     Amount as OracleAmount, OutPoint, ScriptBuf, Sequence as OracleSequence, Transaction, TxIn,
     TxOut as OracleTxOut, Txid, Witness as OracleWitness, absolute, transaction,
 };
-use bitcoin_rs_primitives::{Amount, LockTime, Sequence, Tx, TxOut, Witness};
+use bitcoin_rs_primitives::{Tx, TxOut};
 use bitcoin_rs_script::{Interpreter, ScriptErrCode, ScriptError, VerifyFlags};
 use proptest::prelude::*;
 

--- a/crates/utxo/benches/utxo_commit.rs
+++ b/crates/utxo/benches/utxo_commit.rs
@@ -12,7 +12,7 @@ static GLOBAL_MIMALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::hint::black_box;
 
-use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, TxOut};
 use bitcoin_rs_utxo::{BlockChanges, UtxoAdd, UtxoSet};
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 
@@ -73,8 +73,8 @@ fn txout(seed: u64) -> TxOut {
     script.extend_from_slice(&[0x00, 0x20]);
     script.extend_from_slice(&txid(seed).to_le_bytes());
     TxOut {
-        value: 5_000 + seed,
-        script_pubkey: script,
+        value: Amount::from_sat(5_000 + seed),
+        script_pubkey: script.into(),
     }
 }
 
@@ -140,15 +140,15 @@ fn synthetic_case(seed: u64, shape: ShardShape) -> (UtxoSet, BlockChanges) {
 
 fn spend_proxy_coinbase_txout() -> TxOut {
     TxOut {
-        value: SPEND_PROXY_COINBASE_OUTPUT_VALUE,
-        script_pubkey: vec![0x51],
+        value: Amount::from_sat(SPEND_PROXY_COINBASE_OUTPUT_VALUE),
+        script_pubkey: vec![0x51].into(),
     }
 }
 
 fn spend_proxy_spend_txout() -> TxOut {
     TxOut {
-        value: SPEND_PROXY_SPEND_OUTPUT_VALUE,
-        script_pubkey: vec![0x51],
+        value: Amount::from_sat(SPEND_PROXY_SPEND_OUTPUT_VALUE),
+        script_pubkey: vec![0x51].into(),
     }
 }
 

--- a/crates/utxo/src/connect.rs
+++ b/crates/utxo/src/connect.rs
@@ -128,7 +128,7 @@ pub fn build_block_changes<'a>(
             // Before the unspendable-output skip below: an OP_RETURN output
             // never enters the UTXO set, but the transaction that created it
             // still paid for it, so it counts against the fee.
-            let value = txout.value;
+            let value = txout.value.to_sat();
             let vout =
                 u32::try_from(vout_idx).map_err(|_| BlockChangeError::HeightOverflow(height))?;
             let outpoint = OutPoint::new(txid, vout);
@@ -194,7 +194,7 @@ pub fn build_block_changes<'a>(
                 )?;
                 totals.spent_in = totals
                     .spent_in
-                    .checked_add(spent.txout.value)
+                    .checked_add(spent.txout.value.to_sat())
                     .ok_or(BlockChangeError::BlockValueOverflow)?;
                 undo.restore(UtxoAdd::new(
                     previous_output,

--- a/crates/utxo/src/shard.rs
+++ b/crates/utxo/src/shard.rs
@@ -1,4 +1,4 @@
-use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, Script, TxOut};
 use crossbeam_utils::CachePadded;
 use hashbrown::HashTable;
 use parking_lot::RwLock;
@@ -809,7 +809,7 @@ fn find_record(table: &ShardTable, key: UtxoKey, txid: Hash256) -> Option<&UtxoR
 fn payload_parts<'a>(payload: &BuildPayload<'a>) -> OutputParts<'a> {
     OutputParts::new(
         payload.vout,
-        payload.txout.value,
+        payload.txout.value.to_sat(),
         payload.txout.script_pubkey.as_slice(),
         payload.coinbase,
         payload.height,
@@ -969,8 +969,8 @@ fn flush_inserted_coins(
 
 fn txout_from_parts(value: u64, script: &[u8]) -> TxOut {
     TxOut {
-        value,
-        script_pubkey: script.to_vec(),
+        value: Amount::from_sat(value),
+        script_pubkey: Script::from_bytes(script.to_vec()),
     }
 }
 

--- a/crates/utxo/src/stats/coin_stats.rs
+++ b/crates/utxo/src/stats/coin_stats.rs
@@ -5,7 +5,7 @@ use crate::{
     SnapshotCoin, SnapshotCoinObserver, UtxoChangeEvents, UtxoChangeListener, UtxoCommittedEvent,
     UtxoInserted, UtxoRemoved,
 };
-use bitcoin_rs_primitives::{Amount, OutPoint, TxOut};
+use bitcoin_rs_primitives::{OutPoint, TxOut};
 use parking_lot::Mutex;
 use rayon::prelude::*;
 use smallvec::SmallVec;

--- a/crates/utxo/src/stats/coin_stats.rs
+++ b/crates/utxo/src/stats/coin_stats.rs
@@ -5,7 +5,7 @@ use crate::{
     SnapshotCoin, SnapshotCoinObserver, UtxoChangeEvents, UtxoChangeListener, UtxoCommittedEvent,
     UtxoInserted, UtxoRemoved,
 };
-use bitcoin_rs_primitives::{OutPoint, TxOut};
+use bitcoin_rs_primitives::{Amount, OutPoint, TxOut};
 use parking_lot::Mutex;
 use rayon::prelude::*;
 use smallvec::SmallVec;
@@ -95,7 +95,7 @@ impl CoinStats {
     }
 
     fn account_insert(&mut self, txout: &TxOut) {
-        self.total_amount = self.total_amount.saturating_add(txout.value);
+        self.total_amount = self.total_amount.saturating_add(txout.value.to_sat());
         self.bogo_size = self.bogo_size.saturating_add(bogo_size(txout));
         self.utxo_count = self.utxo_count.saturating_add(1);
     }
@@ -108,7 +108,7 @@ impl CoinStats {
     }
 
     fn account_remove(&mut self, txout: &TxOut) {
-        self.total_amount = self.total_amount.saturating_sub(txout.value);
+        self.total_amount = self.total_amount.saturating_sub(txout.value.to_sat());
         self.bogo_size = self.bogo_size.saturating_sub(bogo_size(txout));
         self.utxo_count = self.utxo_count.saturating_sub(1);
     }
@@ -564,7 +564,7 @@ impl CoinStatsDelta {
     ) {
         coin_hash_bytes_into(scratch, op, txout, height, coinbase);
         self.muhash.insert(scratch.as_slice());
-        self.added_amount = self.added_amount.saturating_add(txout.value);
+        self.added_amount = self.added_amount.saturating_add(txout.value.to_sat());
         self.added_bogo_size = self.added_bogo_size.saturating_add(bogo_size(txout));
         self.added_utxos = self.added_utxos.saturating_add(1);
     }
@@ -592,7 +592,7 @@ impl CoinStatsDelta {
     ) {
         coin_hash_bytes_into(scratch, op, txout, height, coinbase);
         self.muhash.remove(scratch.as_slice());
-        self.removed_amount = self.removed_amount.saturating_add(txout.value);
+        self.removed_amount = self.removed_amount.saturating_add(txout.value.to_sat());
         self.removed_bogo_size = self.removed_bogo_size.saturating_add(bogo_size(txout));
         self.removed_utxos = self.removed_utxos.saturating_add(1);
     }
@@ -812,7 +812,7 @@ fn coin_hash_bytes_into(
     coin_hash_bytes_raw_into(
         out,
         op,
-        txout.value,
+        txout.value.to_sat(),
         txout.script_pubkey.as_slice(),
         height,
         coinbase,
@@ -848,7 +848,7 @@ fn coin_hash_bytes_raw_append(
 #[cfg(test)]
 #[inline]
 fn encode_txout_into(out: &mut Vec<u8>, txout: &TxOut) {
-    encode_value_and_script_into(out, txout.value, txout.script_pubkey.as_slice());
+    encode_value_and_script_into(out, txout.value.to_sat(), txout.script_pubkey.as_slice());
 }
 
 #[inline]
@@ -1020,8 +1020,8 @@ mod tests {
             let value = 50_000 + u64::try_from(len).unwrap_or(u64::MAX);
             let script = vec![0x51; len];
             let txout = TxOut {
-                value,
-                script_pubkey: script.clone(),
+                value: bitcoin_rs_primitives::Amount::from_sat(value),
+                script_pubkey: script.clone().into(),
             };
             let mut manual = Vec::new();
             encode_txout_into(&mut manual, &txout);
@@ -1048,12 +1048,12 @@ mod tests {
             txid_bytes[0] = u8::try_from(i + 1).unwrap_or(u8::MAX);
             let output = OutPoint::new(Hash256::from_le_bytes(&txid_bytes).into(), u32::MAX);
             let txout = TxOut {
-                value: if i == 4 {
+                value: bitcoin_rs_primitives::Amount::from_sat(if i == 4 {
                     u64::MAX
                 } else {
                     u64::try_from(i).unwrap_or(u64::MAX).saturating_mul(100_000)
-                },
-                script_pubkey: vec![0x51; script_len],
+                }),
+                script_pubkey: vec![0x51; script_len].into(),
             };
             changes.add(UtxoAdd::new(
                 output,

--- a/crates/utxo/src/undo_codec.rs
+++ b/crates/utxo/src/undo_codec.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashSet;
 
-use bitcoin_rs_primitives::{Amount, ConsensusDecode, ConsensusEncode, Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{ConsensusDecode, ConsensusEncode, Hash256, OutPoint, TxOut};
 use thiserror::Error;
 
 use crate::set::{UndoBatch, UtxoAdd};

--- a/crates/utxo/src/undo_codec.rs
+++ b/crates/utxo/src/undo_codec.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashSet;
 
-use bitcoin_rs_primitives::{ConsensusDecode, ConsensusEncode, Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{Amount, ConsensusDecode, ConsensusEncode, Hash256, OutPoint, TxOut};
 use thiserror::Error;
 
 use crate::set::{UndoBatch, UtxoAdd};
@@ -306,8 +306,8 @@ mod tests {
 
     pub(super) fn txout(sats: u64) -> TxOut {
         TxOut {
-            value: sats,
-            script_pubkey: vec![0x51, byte_of(sats)],
+            value: bitcoin_rs_primitives::Amount::from_sat(sats),
+            script_pubkey: vec![0x51, byte_of(sats)].into(),
         }
     }
 

--- a/crates/utxo/tests/coin_stats_roundtrip.rs
+++ b/crates/utxo/tests/coin_stats_roundtrip.rs
@@ -1,6 +1,6 @@
 //! Coinstats persistence round-trip tests.
 
-use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, TxOut};
 use bitcoin_rs_storage::{
     ColumnFamily, KvIter, KvSnapshot, KvStore, StorageError, WriteBatch, WriteCondition,
 };
@@ -19,8 +19,8 @@ fn coin_stats_persist_load_roundtrips_byte_equal() -> Result<(), Box<dyn std::er
     for index in 0_u32..100 {
         let outpoint = OutPoint::new(txid(index).into(), index % 64);
         let txout = TxOut {
-            value: 1_000 + u64::from(index),
-            script_pubkey: vec![0x51, index.to_le_bytes()[0]],
+            value: Amount::from_sat(1_000 + u64::from(index)),
+            script_pubkey: vec![0x51, index.to_le_bytes()[0]].into(),
         };
         stats.insert_utxo(&outpoint, &txout, 42, index == 0);
     }
@@ -57,8 +57,8 @@ fn coin_stats_codec_is_exact_and_preserves_muhash_continuation()
 -> Result<(), Box<dyn std::error::Error>> {
     let old_op = OutPoint::new(txid(1_000).into(), 3);
     let old_txout = TxOut {
-        value: 12_345,
-        script_pubkey: vec![0x51, 0x21],
+        value: Amount::from_sat(12_345),
+        script_pubkey: vec![0x51, 0x21].into(),
     };
     let mut original = CoinStats::new();
     original.insert_utxo(&old_op, &old_txout, 100, true);
@@ -82,8 +82,8 @@ fn coin_stats_codec_is_exact_and_preserves_muhash_continuation()
 
     let new_op = OutPoint::new(txid(1_001).into(), 4);
     let new_txout = TxOut {
-        value: 54_321,
-        script_pubkey: vec![0x51, 0x22],
+        value: Amount::from_sat(54_321),
+        script_pubkey: vec![0x51, 0x22].into(),
     };
     original.remove_utxo(&old_op, &old_txout, 100, true);
     restored.remove_utxo(&old_op, &old_txout, 100, true);

--- a/crates/utxo/tests/commit_roundtrip.rs
+++ b/crates/utxo/tests/commit_roundtrip.rs
@@ -1,6 +1,6 @@
 //! Public commit/get coverage for the UTXO set.
 
-use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut, varint};
+use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, Script, TxOut, varint};
 use bitcoin_rs_utxo::{
     BlockChanges, UtxoAdd, UtxoError, UtxoSet, hash_serialized_3,
     set::{BorrowedBlockChanges, BorrowedUtxoAdd},
@@ -21,8 +21,8 @@ fn txout(seed: u64) -> TxOut {
     script.extend_from_slice(&[0x51, 0x20]);
     script.extend_from_slice(&seed.to_le_bytes());
     TxOut {
-        value: 1_000 + seed,
-        script_pubkey: script,
+        value: Amount::from_sat(1_000 + seed),
+        script_pubkey: script.into(),
     }
 }
 
@@ -109,8 +109,8 @@ fn invalid_add_does_not_apply_removes_in_same_commit() -> Result<(), Box<dyn std
     invalid.add(UtxoAdd::new(
         OutPoint::new(txid(12).into(), 0),
         TxOut {
-            value: 12,
-            script_pubkey: vec![0; usize::from(u16::MAX) + 1],
+            value: Amount::from_sat(12),
+            script_pubkey: vec![0; usize::from(u16::MAX) + 1].into(),
         },
         false,
         2,
@@ -225,8 +225,8 @@ fn borrowed_commit_preserves_invalid_add_atomicity() -> Result<(), Box<dyn std::
     let invalid_adds = vec![(
         invalid_outpoint,
         TxOut {
-            value: 8_012,
-            script_pubkey: vec![0; usize::from(u16::MAX) + 1],
+            value: Amount::from_sat(8_012),
+            script_pubkey: vec![0; usize::from(u16::MAX) + 1].into(),
         },
         false,
         2,
@@ -501,24 +501,24 @@ fn zero_and_unequal_script_lengths_roundtrip_and_scan() -> Result<(), Box<dyn st
     let script_10kb = vec![0x52; 10_000];
 
     let txout_empty = TxOut {
-        value: 100,
-        script_pubkey: script_empty.clone(),
+        value: Amount::from_sat(100),
+        script_pubkey: script_empty.clone().into(),
     };
     let txout_1b = TxOut {
-        value: 200,
-        script_pubkey: script_1b,
+        value: Amount::from_sat(200),
+        script_pubkey: script_1b.into(),
     };
     let txout_34b = TxOut {
-        value: 300,
-        script_pubkey: script_34b,
+        value: Amount::from_sat(300),
+        script_pubkey: script_34b.into(),
     };
     let txout_520b = TxOut {
-        value: 400,
-        script_pubkey: script_520b,
+        value: Amount::from_sat(400),
+        script_pubkey: script_520b.into(),
     };
     let txout_10kb = TxOut {
-        value: 500,
-        script_pubkey: script_10kb.clone(),
+        value: Amount::from_sat(500),
+        script_pubkey: script_10kb.clone().into(),
     };
 
     let op0 = OutPoint::new(live_txid.into(), 0);
@@ -586,8 +586,8 @@ fn multi_shard_invalid_add_preserves_commit_rejection_atomicity()
     invalid_changes.add(UtxoAdd::new(
         OutPoint::new(txid_in_shard(1, 101).into(), 0),
         TxOut {
-            value: 103,
-            script_pubkey: vec![0; usize::from(u16::MAX) + 1],
+            value: Amount::from_sat(103),
+            script_pubkey: vec![0; usize::from(u16::MAX) + 1].into(),
         },
         false,
         11,
@@ -623,16 +623,16 @@ fn hash_serialized_3_matches_independent_core_serialization_for_edge_cases()
     let op3 = OutPoint::new(txid(842).into(), 64);
 
     let txout1 = TxOut {
-        value: 0,
-        script_pubkey: Vec::new(),
+        value: Amount::from_sat(0),
+        script_pubkey: Script::new(),
     };
     let txout2 = TxOut {
-        value: u64::MAX,
-        script_pubkey: vec![0x51; 520],
+        value: Amount::from_sat(u64::MAX),
+        script_pubkey: vec![0x51; 520].into(),
     };
     let txout3 = TxOut {
-        value: 12_345,
-        script_pubkey: vec![0x6a],
+        value: Amount::from_sat(12_345),
+        script_pubkey: vec![0x6a].into(),
     };
 
     let mut changes = BlockChanges::default();

--- a/crates/utxo/tests/reorg.rs
+++ b/crates/utxo/tests/reorg.rs
@@ -1,5 +1,5 @@
 //! Undo coverage for deterministic block disconnects.
-use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, TxOut};
 use bitcoin_rs_utxo::{BlockChanges, UndoBatch, UtxoAdd, UtxoSet, aggregate_hash};
 
 fn txid(seed: u64) -> Hash256 {
@@ -16,8 +16,8 @@ fn txout(seed: u64) -> TxOut {
     script.extend_from_slice(&[0x00, 0x08]);
     script.extend_from_slice(&seed.to_le_bytes());
     TxOut {
-        value: 50_000 + seed,
-        script_pubkey: script,
+        value: Amount::from_sat(50_000 + seed),
+        script_pubkey: script.into(),
     }
 }
 

--- a/crates/utxo/tests/snapshot_roundtrip.rs
+++ b/crates/utxo/tests/snapshot_roundtrip.rs
@@ -2,7 +2,7 @@
 
 use std::io::{Cursor, Seek};
 
-use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, Script, TxOut};
 use bitcoin_rs_utxo::{
     BlockChanges, SnapshotCoin, SnapshotCoinObserver, UtxoAdd, UtxoChangeEvents,
     UtxoChangeListener, UtxoError, UtxoInserted, UtxoKey, UtxoRemoved, UtxoSet, hash_serialized_3,
@@ -22,8 +22,8 @@ fn txid(seed: u64) -> Hash256 {
 
 fn txout(seed: u64) -> TxOut {
     TxOut {
-        value: 2_000 + seed,
-        script_pubkey: vec![0x51, u8::try_from(seed % 256).unwrap_or(0)],
+        value: Amount::from_sat(2_000 + seed),
+        script_pubkey: vec![0x51, u8::try_from(seed % 256).unwrap_or(0)].into(),
     }
 }
 
@@ -38,8 +38,8 @@ fn snapshot_roundtrip_preserves_vout_and_metadata_boundaries()
     let low_txout = txout(42_001);
     let high_txout = txout(42_002);
     let max_txout = TxOut {
-        value: 42_003,
-        script_pubkey: Vec::new(),
+        value: Amount::from_sat(42_003),
+        script_pubkey: Script::new(),
     };
     let mut changes = BlockChanges::default();
     changes.add(UtxoAdd::new(low, low_txout.clone(), false, 400));
@@ -146,8 +146,8 @@ fn observed_snapshot_traversal_matches_the_current_reader() -> Result<(), Box<dy
     let second_txid = txid(200_001);
     let first = txout(200_010);
     let second = TxOut {
-        value: 200_011,
-        script_pubkey: Vec::new(),
+        value: Amount::from_sat(200_011),
+        script_pubkey: Script::new(),
     };
     let mut changes = BlockChanges::default();
     changes.add(UtxoAdd::new(

--- a/crates/utxo/tests/snapshot_with_muhash.rs
+++ b/crates/utxo/tests/snapshot_with_muhash.rs
@@ -1,5 +1,5 @@
 //! Snapshot trailer integration tests for coinstats.
-use bitcoin_rs_primitives::{Hash256, OutPoint, TxOut};
+use bitcoin_rs_primitives::{Amount, Hash256, OutPoint, TxOut};
 use bitcoin_rs_utxo::stats::{CoinStats, CoinStatsListener};
 use bitcoin_rs_utxo::{
     BlockChanges, UndoBatch, UtxoAdd, UtxoChangeListener, UtxoInserted, UtxoKey, UtxoRemoved,
@@ -68,7 +68,7 @@ fn snapshot_trailer_tracks_listener_after_removal() -> Result<(), Box<dyn std::e
         before_removal.muhash.finalize()
     );
     assert_eq!(after_removal.utxo_count, 1);
-    assert_eq!(after_removal.total_amount, kept_txout.value);
+    assert_eq!(after_removal.total_amount, kept_txout.value.to_sat());
 
     let mut snapshot = Vec::new();
     let trailer = write_snapshot(&set, &txid(101), 8, &mut snapshot)?;
@@ -106,7 +106,7 @@ fn listener_tracks_duplicate_txid_overwrite() -> Result<(), Box<dyn std::error::
     assert_eq!(set.get(&outpoint), Some(replacement.clone()));
     assert_eq!(after_overwrite, expected);
     assert_eq!(after_overwrite.utxo_count, 1);
-    assert_eq!(after_overwrite.total_amount, replacement.value);
+    assert_eq!(after_overwrite.total_amount, replacement.value.to_sat());
     Ok(())
 }
 
@@ -398,8 +398,8 @@ fn first_undo_test_block(
 
 fn txout(index: u32) -> TxOut {
     TxOut {
-        value: 50_000 + u64::from(index),
-        script_pubkey: vec![0x51, index.to_le_bytes()[0]],
+        value: Amount::from_sat(50_000 + u64::from(index)),
+        script_pubkey: vec![0x51, index.to_le_bytes()[0]].into(),
     }
 }
 

--- a/fuzz/fuzz_targets/script_eval.rs
+++ b/fuzz/fuzz_targets/script_eval.rs
@@ -3,6 +3,7 @@
 use libfuzzer_sys::fuzz_target;
 
 use bitcoin_rs_script::{Interpreter, VerifyFlags};
+use bitcoin_rs_primitives::{Amount, LockTime, Script, Sequence};
 
 /// Fuzz the production default script interpreter.
 ///
@@ -101,22 +102,22 @@ fuzz_target!(|data: &[u8]| {
     let script_sig = script_sig.to_vec();
     let script_pubkey = script_pubkey.to_vec();
     let prevout = bitcoin_rs_primitives::TxOut {
-        value: 10_000,
-        script_pubkey: script_pubkey.clone(),
+        value: Amount::from_sat(10_000),
+        script_pubkey: script_pubkey.clone().into(),
     };
     let tx = bitcoin_rs_primitives::Tx {
         version: 2,
         inputs: vec![bitcoin_rs_primitives::TxIn {
             previous_output: bitcoin_rs_primitives::OutPoint::default(),
-            script_sig: script_sig.clone(),
-            sequence: u32::MAX,
-            witness: witness.clone(),
+            script_sig: script_sig.clone().into(),
+            sequence: Sequence::MAX,
+            witness: witness.clone().into(),
         }],
         outputs: vec![bitcoin_rs_primitives::TxOut {
-            value: 9_000,
-            script_pubkey: Vec::new(),
+            value: Amount::from_sat(9_000),
+            script_pubkey: Script::new(),
         }],
-        lock_time: 0,
+        lock_time: LockTime::ZERO,
     };
 
     let interpreter = Interpreter::default();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #522 (and #483). Breaking field types for native primitives.

`Tx`, `TxIn`, `TxOut`, and `Header` now use bitcoin-rs newtypes instead of raw integers and byte vectors:

- `TxOut.value`: `Amount`
- `TxIn.sequence` / `Tx.lock_time`: `Sequence` / `LockTime`
- `TxIn.script_sig` / `TxOut.script_pubkey`: `Script`
- `TxIn.witness`: `Witness`
- `Header.bits`: `CompactTarget`

These types live in `crates/primitives` (`units.rs`, `script.rs`). They are not `rust-bitcoin` aliases or conversion shims. Wire conversion is `from_sat` / `to_sat` and `from_consensus` / `to_consensus`. JSON, RPC, and packed UTXO layouts still speak satoshis and consensus `u32` at those boundaries.

Integer comparisons (`Amount == 50_000`, `Sequence < 0xfffffffe`, `CompactTarget == 0x1d00ffff`) and `From<u32>`/`From<u64>` keep call sites tight without Deref to the inner integer.

Workspace consumers (chain, consensus, script, mempool, mining, utxo, node, rpc, p2p, index) are updated. rust-bitcoin remains only at RPC/wallet-facing and differential-oracle seams.

Toward #172: `crates/primitives` owns the protocol vocabulary end to end.

Review follow-up (`fda86b80`):

- `Amount::MAX_MONEY` is the sole 21-million-BTC owner; consensus `MAX_MONEY` is `Amount::MAX_MONEY.to_sat()`, and output-value checks compare against the typed limit.
- Verbose RPC vin again emits `txid`, `vout`, and `scriptSig` for non-coinbase inputs.
- Production primitive imports stay limited to types named on the production path; tests import the rest under `cfg(test)`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4df26bd0-14e0-4eff-b8d3-2604a54ab001?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4df26bd0-14e0-4eff-b8d3-2604a54ab001&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

