### PR TITLE
fix(#618): classify kernel script verification failures as Operational

### DIFF
--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -2002,17 +2002,30 @@ fn invalidate_failed_subtree(
 /// republishes the best valid tip rather than retrying the same block.
 /// Operational failures (storage, UTXO commit, undo record, shutdown) are
 /// transient and must not permanently mark a block invalid.
+///
+/// Kernel-backed script verification failures are classified Operational
+/// because `bitcoinkernel` can reject a valid block depending on process
+/// state (issue #618): the same block applies successfully after restart.
+/// Treating these as Permanent would freeze the node at the tip and
+/// invalidate a valid header subtree with no retry path. The native
+/// interpreter path does not produce this spurious failure, so its
+/// `ConsensusError::Script` remains Permanent.
 pub(crate) fn is_permanent_apply_error(error: &ApplyError) -> bool {
     match error {
         ApplyError::ProofOfWork { .. }
         | ApplyError::TargetAboveLimit
         | ApplyError::NbitsNonRetargetMismatch { .. } => true,
-        ApplyError::Consensus(error) => !matches!(
-            error,
+        ApplyError::Consensus(error) => match error {
             bitcoin_rs_consensus::ConsensusError::PrevoutMatrixSize { .. }
-                | bitcoin_rs_consensus::ConsensusError::Kernel(_)
-                | bitcoin_rs_consensus::ConsensusError::Encoding(_)
-        ),
+            | bitcoin_rs_consensus::ConsensusError::Kernel(_)
+            | bitcoin_rs_consensus::ConsensusError::Encoding(_) => false,
+            bitcoin_rs_consensus::ConsensusError::Script { reason, .. }
+                if reason.starts_with("kernel script verification failed:") =>
+            {
+                false
+            }
+            _ => true,
+        },
         _ => false,
     }
 }
@@ -10608,6 +10621,42 @@ mod consensus_rule_tests {
             "fallible tree preparation must precede the first UTXO mutation and stay absent on failure"
         );
         Ok(())
+    }
+
+    /// #618 regression: a kernel-backed script verification failure must be
+    /// classified Operational (retryable), not Permanent, because
+    /// `bitcoinkernel` can reject a valid block depending on process state.
+    /// The same block applies successfully after restart, so permanently
+    /// invalidating its header subtree would freeze the node at the tip.
+    #[test]
+    fn kernel_script_verification_failure_is_operational() {
+        let error = ApplyError::Consensus(
+            bitcoin_rs_consensus::ConsensusError::Script {
+                input_index: 0,
+                reason: "kernel script verification failed: Script verification failed"
+                    .to_owned(),
+            },
+        );
+        assert!(
+            !is_permanent_apply_error(&error),
+            "kernel script verification failures must be Operational (retryable) per #618"
+        );
+    }
+
+    /// A native (non-kernel) script verification failure remains Permanent:
+    /// the native interpreter is deterministic and not process-state-dependent.
+    #[test]
+    fn native_script_verification_failure_is_permanent() {
+        let error = ApplyError::Consensus(
+            bitcoin_rs_consensus::ConsensusError::Script {
+                input_index: 0,
+                reason: "Script verification failed".to_owned(),
+            },
+        );
+        assert!(
+            is_permanent_apply_error(&error),
+            "native script verification failures must remain Permanent"
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

Issue #618: `bitcoinkernel` produces spurious script verification failures on valid blocks at the tip. The failure is process-state-dependent — the same block applies successfully after a restart — but `is_permanent_apply_error` classified `ConsensusError::Script` as `Permanent`, causing:

1. `invalidate_failed_subtree` to mark the block and its descendants invalid
2. `sync.rs` to purge those hashes from the stager/download window
3. The node to freeze at the current height with no retry path
4. `submitblock` to return `"duplicate-invalid"` (no re-verification)

## Root Cause

`is_permanent_apply_error` (`crates/node/src/apply.rs`) treated all `ConsensusError::Script` errors as Permanent. But kernel-backed script verification (`crates/consensus/src/kernel.rs:145-148`) wraps `bitcoinkernel::verify` failures with `reason: "kernel script verification failed: {error}"`, and these failures can be spurious — caused by stale internal state in the kernel library, not by an actually invalid block.

The native Rust interpreter path is deterministic and does not produce spurious failures, so its `ConsensusError::Script` correctly remains Permanent.

## Fix

`is_permanent_apply_error` now checks the `reason` field of `ConsensusError::Script`:
- **Kernel-backed** (`reason` starts with `"kernel script verification failed:"`) → **Operational** (retryable) — the node will retry the block instead of invalidating its subtree
- **Native interpreter** (any other `reason`) → **Permanent** — unchanged behavior

This means a kernel script failure at the tip triggers a retry on the next sync cycle rather than permanently invalidating valid headers. If the block is genuinely invalid, the native interpreter will eventually reject it permanently. If the failure was spurious (#618), the retry succeeds.

## Tests

- `kernel_script_verification_failure_is_operational` — verifies kernel script errors are Operational
- `native_script_verification_failure_is_permanent` — verifies native script errors remain Permanent
- All 591 existing node lib tests pass
- `cargo clippy -p bitcoin-rs-node -- -D warnings` clean

## Observability

The live explorer node confirmed this wedge pattern multiple times:
- Height 965,625 (Sep 5 14:46Z) — restart cured it
- Height 965,743 (Sep 6 09:20Z) — restart cured it

Each time, `sync progress` showed the same `applied_height` indefinitely, and `submitblock` returned `"duplicate-invalid"`. A fresh process applied the same block successfully.

Fixes #618

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #618 by classifying `bitcoinkernel` script verification failures as Operational so valid blocks rejected due to stale process state are retried instead of permanently invalidating their header subtree.

- `ConsensusError::Script` with a reason starting with `"kernel script verification failed:"` is now retryable; native interpreter script failures remain Permanent.
- Adds regression tests for both error classifications.

<sup>Written for commit 9af19d3f690255f63c9fadbc1c97dbb3c435a283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

