### PR TITLE
chore: exclude data/ and backups/ from the docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ crash-*
 perf.data*
 flamegraph.svg
 docs/benchmarks/data
+data
+backups


### PR DESCRIPTION
## Problem

The explorer deployment keeps node chainstate/txindex under the repo-root `data/` directory (bind-mounted into the container). A clean-checkout `docker compose build node` fails:

```
error from sender: open .../data/mempool-db/mempool: permission denied
```

The builder walks `data/` (files owned by the container UID) and ships a ~1.6GB context before dying. `backups/` (offline chainstate archives) has the same problem class.

## Fix

Add `data` and `backups` to `.dockerignore`. Validated on the live explorer deployment build.

Fixes the build failure observed while deploying #619/#657 to the explorer node.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `data` and `backups` to `.dockerignore` so `docker compose build node` no longer fails on permission-denied errors when the repo contains chainstate files. The build context is also ~1.6GB smaller.

<sup>Written for commit 6e9f7adea71c88e831f0d30dcbd6390798e22e5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

