### PR TITLE
fix(rpc): omit content length from no-content responses

### DIFF
--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -687,11 +687,10 @@ fn write_headers(stream: &mut TcpStream, head: &ResponseHead<'_>) -> io::Result<
         write_header_list(stream, "Access-Control-Allow-Headers", headers)?;
         write_header_list(stream, "Access-Control-Expose-Headers", expose)?;
     }
-    write!(
-        stream,
-        "Content-Length: {}\r\nConnection: {connection}\r\n\r\n",
-        head.content_length
-    )
+    if head.status != 204 {
+        write!(stream, "Content-Length: {}\r\n", head.content_length)?;
+    }
+    write!(stream, "Connection: {connection}\r\n\r\n")
 }
 
 fn write_header_list(stream: &mut TcpStream, name: &str, values: &[&str]) -> io::Result<()> {

--- a/crates/rpc/tests/auth.rs
+++ b/crates/rpc/tests/auth.rs
@@ -217,6 +217,7 @@ fn public_esplora_options_returns_cors_preflight_response() -> Result<(), Box<dy
     assert!(response.contains("Access-Control-Expose-Headers: X-Total-Results\r\n"));
     assert!(response.contains("Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"));
     assert!(response.contains("Access-Control-Allow-Headers: Content-Type\r\n"));
+    assert!(!response.contains("Content-Length:"));
     assert!(response.ends_with("\r\n\r\n"));
     Ok(())
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes 204 No Content responses incorrectly including a `Content-Length` header, which violates RFC 9110. The header is now omitted for 204 responses, and the test suite verifies it is not present.

<sup>Written for commit fa9df9068068464745f534540cae2afae2694a86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

