### PR TITLE
Fix stable Clippy chunk iteration

### DIFF
--- a/crates/primitives/src/network.rs
+++ b/crates/primitives/src/network.rs
@@ -545,7 +545,9 @@ fn decode_compiled_hex(hex: &str) -> Vec<u8> {
         "compiled-in hex constant has even length"
     );
     bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| (nibble(pair[0]) << 4) | nibble(pair[1]))
         .collect()
 }


### PR DESCRIPTION
Follow-up to #675.

Rust stable is now 1.98.1 in CI. Its Clippy adds `chunks_exact_to_as_chunks`, and the PR-gate clippy job fails in `crates/primitives/src/network.rs` with `-D warnings`.

Replace the fixed-size `chunks_exact(2)` iterator with `as_chunks::<2>().0.iter()`. The preceding even-length assertion preserves the existing invariant, so behavior is unchanged while satisfying current stable Clippy.

## Validation

- Reproduced from the post-#675 GitHub Actions clippy failure on Rust 1.98.1.
- Diff is limited to the reported iterator construction in `decode_compiled_hex`.
- Full PR CI should confirm whether any additional Rust 1.98 Clippy findings remain.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stable Clippy failure on Rust 1.98.1 in `crates/primitives/src/network.rs` by replacing `chunks_exact(2)` with `as_chunks::<2>().0.iter()`. The preceding even-length assertion preserves the existing invariant, so behavior is unchanged.

<sup>Written for commit 3efe5f6a7b2f4887cd294f1af3f89d16b7080746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

