### PR TITLE
ci: report every strict Clippy profile without masking failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,29 +52,28 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        id: toolchain
         with:
           components: clippy
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
-      # Pure-Rust clippy gate with -D warnings. consensus and node have
-      # `kernel` in their per-crate defaults, which would pull in the C++
-      # libbitcoinkernel build (cmake + libboost-dev); exclude them from the
-      # workspace-wide pass and lint them separately with --no-default-features
-      # so the PR gate needs no C++ toolchain install.
-      - run: |
+      # Keep the three native all-target profiles independent. A lint failure
+      # must not hide later diagnostics, but still fails this job. Do not run
+      # after cancellation or a failed toolchain installation. Kernel and
+      # backend-specific profiles remain in main.yml.
+      - name: Workspace Clippy
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' }}
+        run: |
           cargo clippy --workspace --all-targets \
             --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node \
             -- -D warnings
-          # consensus without kernel: --all-targets compiles its unit tests
-          # (bip30/bip34/bip112/bip113/bip141/bip143 modules in src/),
-          # integration tests (vectors, coinbase_amount), and benches.
-          # Previously invisible to the hook lanes: the workspace-wide pass
-          # would either fail (no cmake for kernel) or the crate was excluded
-          # entirely, leaving its test-target lints unchecked.
+      - name: Native consensus Clippy
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' }}
+        run: |
           cargo clippy -p bitcoin-rs-consensus \
             --no-default-features --all-targets -- -D warnings
-          # node without kernel: add back fjall and zmq (the pure-Rust
-          # defaults from bin/bitcoin-rs) so the crate and its test/bench
-          # targets compile and are linted.
+      - name: Native node Clippy
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' }}
+        run: |
           cargo clippy -p bitcoin-rs-node \
             --no-default-features --features fjall,zmq --all-targets -- -D warnings
 


### PR DESCRIPTION
## Scope

Implements the CI isolation part of proposal C from the review of #686. Based on main `de81e329c783247e1e57bf0402fdf5adf294001e`; this is a new branch, not an update to #686.

The three existing all-target Clippy commands ran in one fail-fast shell step. A workspace failure hid the consensus and node results. Give each command a named step that runs after a preceding lint failure, provided the job was not cancelled and Rust installation succeeded. No `continue-on-error` is used: any failed profile still fails the existing `clippy` job.

## Preserved behavior

- Same package exclusions, feature selections, all-target coverage, and `-D warnings`.
- Same job name, required-check identity, concurrency/cancellation policy, and pinned action revisions.
- Tests, benchmarks, dependency audit, formal fixtures, and main-only feature profiles are unchanged.
- No lint allowances, dependency upgrades, or lockfile changes.

## Acceptance and remaining work

- All three lint profiles must produce independent results on this PR's final head.
- A deliberately failing earlier profile must not suppress later profiles or turn the aggregate job green.
- Cancellation or failed toolchain installation must prevent further lint work.
- Fix remaining source diagnostics in focused follow-up commits after inspecting these results. This PR does **not** claim that every lint is already fixed.

## Validation

Source-level review of the workflow and its prior failed Clippy run completed. Rust and GitHub Actions execution have not been validated locally: this environment has no Rust toolchain and cannot resolve github.com for a clone. Kept draft pending CI and review.

Related work: #685 owns witness-activation accounting; #689 and #692 already cover storage/persistent-coin corrections. This PR does not duplicate those implementations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs each strict Clippy profile as its own CI step so a workspace lint failure no longer hides `bitcoin-rs-consensus` and `bitcoin-rs-node` diagnostics.

**Behavior**
- Each profile step runs only when the job was not cancelled and the toolchain installation succeeded.
- Any failed profile still fails the existing `clippy` job, and later profiles are not suppressed.
- Package exclusions, feature selections, all-target coverage, and `-D warnings` stay the same.

**Scope**
- No lint allowances, dependency upgrades, or lockfile changes.
- Kernel and backend-specific profiles remain in `main.yml`.

<sup>Written for commit 6b9eceacf64d1fbb46e9778fdeedad00160ea625. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

