### PR TITLE
docs: consolidate contract entry points and correct REST enablement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,62 +1,49 @@
 # Documentation
 
-## Start here
+## Entry points
 
-- [getting-started.md](getting-started.md): build, configuration, startup, RPC, indexes, and consumers
-- [contracts/README.md](contracts/README.md): normative contract index and precedence
-- [../CONCEPTS.md](../CONCEPTS.md): project vocabulary
-- [../CONSTRAINTS.md](../CONSTRAINTS.md): gate and evidence register
-- [../AGENTS.md](../AGENTS.md): repository-change rules
+| Need | Owner |
+| --- | --- |
+| Build, configure, and run a node | [Getting started](getting-started.md) |
+| Find a normative clause and its tests | [Contract index](contracts/README.md) |
+| Understand project vocabulary | [Concepts](../CONCEPTS.md) |
+| Inspect gate and evidence status | [Constraint register](../CONSTRAINTS.md) |
+| Change the repository | [Agent guidelines](../AGENTS.md) and [contributing](../CONTRIBUTING.md) |
+| Operate recovery or REST | [Recovery summary](chainstate-recovery.md) and [REST guide](rest-interface.md) |
 
-[chainstate-recovery.md](chainstate-recovery.md) and [rest-interface.md](rest-interface.md) are operator summaries. Their linked contract pages remain authoritative.
+The contract index owns the clause/proof map; this page does not maintain a
+second inventory. Contracts take precedence over local source comments,
+detailed policies, and informative guides, in that order. A disagreement
+between code and contract is drift to investigate, not permission to silently
+change either side.
 
-## Authority
+## Detailed policies and generated inputs
 
-Use this order when documents disagree:
+[Source compatibility](policies/source-compatibility.md) owns toolchain,
+dependency, TLS, and versioning policy. [Database migration](policies/db-migration.md)
+owns format changes. Detailed admission and peer matrices live in
+[mempool policy](policies/mempool-policy.md) and
+[P2P compatibility](policies/p2p-compatibility.md).
 
-1. [contracts/](contracts/)
-2. source comments for local invariants
-3. [policies/](policies/) for detailed domain matrices
-4. benchmarks, solutions, concepts, and consumer guides
+Treat [core-compat.toml](api/core-compat.toml),
+[core-rpc-schema.json](api/core-rpc-schema.json), and the
+[hot-path ledger](benchmarks/hot-path-ledger.toml) as machine-consumed inputs.
+[RPC reference](rpc-reference.md) is generated from
+`crates/rpc/src/manifest.rs`; do not edit it by hand.
 
-A code/contract disagreement is drift to fix, not a reason to silently rewrite one side.
+## Evidence and implementation status
 
-## Contracts
+[Benchmarks](benchmarks/) retain methods, measurements, and decisions.
+[Solutions](solutions/) are historical context, not current implementation
+promises. The [hot-path contract](contracts/hot-path-attribution.md) owns ledger
+interpretation. `UNMEASURED`, `planned`, and `BLOCKED` are not successful results.
 
-The complete clause/proof map is in [contracts/README.md](contracts/README.md). Major owners include:
+[Formal models](models/) and their configurations remain subject to the
+[constraint register](../CONSTRAINTS.md). A compiled build is not proof of a
+target design, and this index does not duplicate gate verdicts.
 
-- [architecture.md](contracts/architecture.md): crate layering and mutation ownership
-- [validation-default.md](contracts/validation-default.md): current kernel/native default decision
-- [recovery.md](contracts/recovery.md): durable-root target, crash outcomes, reorg, schema policy
-- [mempool-policy.md](contracts/mempool-policy.md) and [mempool-mutations.md](contracts/mempool-mutations.md): admission and lifecycle
-- [indexing.md](contracts/indexing.md): capability readiness and reconciliation
-- [p2p-wire.md](contracts/p2p-wire.md): current peer-wire contract
-- [external-api.md](contracts/external-api.md), [wallet-facing.md](contracts/wallet-facing.md), [embedding.md](contracts/embedding.md): public surfaces
-- [storage-footprint.md](contracts/storage-footprint.md), [hot-path-attribution.md](contracts/hot-path-attribution.md), [campaign-corpora.md](contracts/campaign-corpora.md): measurement contracts
-- [reference-set.md](contracts/reference-set.md): pinned external identities
-
-## Policies and machine-readable inputs
-
-- [policies/source-compatibility.md](policies/source-compatibility.md): toolchain, dependencies, TLS, versioning
-- [policies/db-migration.md](policies/db-migration.md): authoritative and owner-local format changes
-- [policies/mempool-policy.md](policies/mempool-policy.md): detailed Core 31.1 admission matrix
-- [policies/p2p-compatibility.md](policies/p2p-compatibility.md): detailed peer compatibility matrix
-- [api/core-compat.toml](api/core-compat.toml) and `api/core-rpc-schema.json`: machine-consumed compatibility data; treat as code
-- [rpc-reference.md](rpc-reference.md): generated from `crates/rpc/src/manifest.rs`; do not edit by hand
-- [models/](models/): TLA+ models and Apalache configurations; `CONSTRAINTS.md` records gate status
-
-## Evidence
-
-[benchmarks/](benchmarks/) contains methods, retained measurements, and decision records. A row marked `UNMEASURED`, `planned`, or `BLOCKED` is not a result. The machine ledger is [benchmarks/hot-path-ledger.toml](benchmarks/hot-path-ledger.toml); [contracts/hot-path-attribution.md](contracts/hot-path-attribution.md) owns its interpretation.
-
-[solutions/](solutions/) is historical engineering context. It is informative and may describe code or designs that have since been replaced.
-
-## Current build status
-
-The default `bitcoin-rs` binary is kernel-free; `--features kernel` builds the optional kernel lane. Library default behavior is governed separately by [contracts/validation-default.md](contracts/validation-default.md), which currently keeps `kernel` in the consensus/node library defaults until the recorded promotion gate changes.
-
-BIP324 is target work only in this checkout. There is no `bip324` Cargo feature or dependency, so documentation must not advertise `--features bip324` as a usable lane.
-
-## Release status
-
-Do not duplicate gate tables here. [../CONSTRAINTS.md](../CONSTRAINTS.md) owns current gate state and [contracts/](contracts/) owns required behavior. A build is not evidence merely because it compiles, and a target design is not implemented merely because a contract describes it.
+The default binary is kernel-free; library defaults are governed separately by
+[validation-default.md](contracts/validation-default.md). The optional
+`kernel` lane is not a claim that native-default promotion has passed.
+BIP324 remains target work: there is no usable `bip324` Cargo feature in this
+checkout.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,7 +77,7 @@ Important defaults:
 
 Change the default RPC credentials before exposing the port.
 
-`--txindex` is the explicit Core-compatible txindex promise. `--scriptindex=utxo` enables the live script view; `--scriptindex=full` also enables confirmed script history. `--rest` enables the unauthenticated Core REST routes on the RPC listener.
+`--txindex` is the explicit Core-compatible txindex promise. `--scriptindex=utxo` enables the live script view; `--scriptindex=full` also enables confirmed script history. `--rest=true` enables the unauthenticated Core REST routes on the RPC listener.
 
 ## Check progress
 
@@ -88,31 +88,13 @@ curl -s --user bitcoin-rs:bitcoin-rs \
   http://127.0.0.1:8332/
 ```
 
-For the tip only:
-
-```sh
-curl -s --user bitcoin-rs:bitcoin-rs \
-  -H 'content-type: application/json' \
-  -d '{"jsonrpc":"1.0","id":"1","method":"getbestblockhash","params":[]}' \
-  http://127.0.0.1:8332/
-```
+For the tip hash only, use `getbestblockhash` with the same empty parameter list.
 
 [rpc-reference.md](rpc-reference.md) is generated from the live RPC manifest and records implemented, deviating, and unimplemented methods. The node has no in-tree wallet or private-key custody; key-free descriptor/PSBT helpers remain available for external signers.
 
 ## Capability state
 
-Index-backed queries expose the owner's capability state rather than treating unavailable data as empty:
-
-- `Disabled`: not configured
-- `Opening`: inspecting durable state
-- `CatchingUp`: backfilling
-- `Ready`: watermark matches the active tip
-- `RollingBack`: reconciling a reorg
-- `Rebuilding`: selective reset/rebuild
-- `Failed`: worker stopped on an error
-- `Shutdown`: node is stopping
-
-See [contracts/indexing.md](contracts/indexing.md) for exact query gating.
+Index-backed queries expose the owner's capability state rather than treating unavailable data as empty. [contracts/indexing.md](contracts/indexing.md) owns the state vocabulary, readiness conditions, and exact query gating.
 
 ## Public consumers
 
@@ -134,7 +116,7 @@ The wallet-facing contract is [contracts/wallet-facing.md](contracts/wallet-faci
 
 ### REST
 
-`--rest` (or `rest=1`) serves Core-compatible REST on the RPC port without authentication. See [rest-interface.md](rest-interface.md).
+`--rest=true` (or `rest=1` in `bitcoin.conf`) serves Core-compatible REST on the RPC port without authentication. The CLI option takes an explicit boolean; bare `--rest` is not the enablement syntax. See [rest-interface.md](rest-interface.md).
 
 ### ZMQ
 


### PR DESCRIPTION
## Scope

Publishes a focused first slice of proposal D from the #686 review on a brand-new branch, based on `7d384289f6d47a6c44705ad05b7aa14926624e4b`.

- Replace the duplicate contract inventory in `docs/README.md` with concise navigation to the owning index, policies, generated inputs, and evidence register.
- Keep the distinction between the kernel-free binary and the library-default promotion contract, and retain the warning that BIP324 is not an available Cargo feature.
- Correct both REST enablement examples to `--rest=true`, matching the CLI's explicit `Option<bool>` argument, and distinguish `bitcoin.conf`'s `rest=1` syntax.
- Link the capability-state vocabulary to the indexing contract instead of maintaining another state list; collapse a duplicated RPC command example.

## Boundaries

Only two hand-maintained Markdown guides change. No normative contract, generated reference, machine-consumed table, proof gate, benchmark history, runtime code, dependency, or migration policy is deleted or changed. This is not a claim that every Markdown file has already been simplified.

Recovery/persistent-coin work already has #689 and #692, and the existing #690 covers the P2P policy reference. Those changes are not duplicated here.

## Acceptance

- Entry-point links resolve to the current owning documents.
- The REST command matches the existing CLI parser without introducing a new bare-flag behavior.
- Generated/machine-consumed documentation and retained evidence remain byte-for-byte unchanged.
- No target design, unmeasured result, or blocked gate becomes an implementation or proof claim.

## Validation

Compared the changed guides with their current source and the CLI's `rest: Option<bool>` declaration. The existing local-link targets were retained; no new external dependency is introduced. Documentation checks and Rust/CLI execution have not been run locally because this environment lacks Rust and cannot resolve github.com for a clone. Kept draft for CI and review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the documentation entry points to remove duplicate contract inventories and corrects the REST enablement examples to match the CLI's explicit boolean option.

- Replaces the contract inventory in `docs/README.md` with a concise entry-point table linking to the owning documents.
- Corrects `--rest` to `--rest=true` in the getting-started guide and distinguishes the `bitcoin.conf` syntax `rest=1`.
- Links the capability-state vocabulary to `contracts/indexing.md` instead of duplicating the state list.

<sup>Written for commit 55da5515fb6c09b31797909949031ea5a915a2ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

