### PR TITLE
Fix stable Clippy digest iteration and synchronize the workspace lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "anyhow",
  "bitcoin",
  "bitcoin-rs-node",
+ "bitcoin-rs-rpc",
  "bitcoin-rs-storage",
  "clap",
  "mimalloc",

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -360,7 +360,7 @@ impl core::str::FromStr for Sha256Hex {
             return Err(malformed());
         }
         let mut bytes = [0_u8; 32];
-        for (byte, pair) in bytes.iter_mut().zip(text.as_bytes().chunks_exact(2)) {
+        for (byte, pair) in bytes.iter_mut().zip(text.as_bytes().as_chunks::<2>().0) {
             let text = core::str::from_utf8(pair).map_err(|_| malformed())?;
             if text.bytes().any(|c| c.is_ascii_uppercase()) {
                 return Err(malformed());


### PR DESCRIPTION
## Scope

Follow-up to #680/#693 and the independent Clippy reporting landed in #695. Two small build/lint corrections, based on main `7d384289f6d47a6c44705ad05b7aa14926624e4b`:

- Replace the fixed-size `chunks_exact(2)` digest iteration with `as_chunks::<2>().0`, addressing `clippy::chunks_exact_to_as_chunks` on Rust stable 1.98.1. The existing 64-byte length check makes the remainder empty. Parsing, error behavior, and accepted input grammar are unchanged.
- Synchronize `Cargo.lock` with the binary's already-declared `bitcoin-rs-rpc` workspace dependency. Without that edge, `cargo test --locked` and `cargo clippy --locked` stop before compilation. The correction adds one dependency entry, not a new manifest dependency.

The entire comparison is two additions and one deletion across `metrics.rs` and `Cargo.lock`. No lint allowance, dependency upgrade, public API change, workflow change, or helper script is included. This does not replace #692's separate digest-validation or storage changes.

## Review and validation

- Re-read the parser and its existing length/error checks; reviewed the exact candidate comparison and dependency graph repair.
- The validation runner required every external lockfile package record, package identity/version, and lockfile format version to remain unchanged. That check passed before publishing the candidate.
- Candidate head: `fd0d37ae7b2dc0b80b741f3d481c2e8caa88be2c`. The generated candidate is source-only; runner files are isolated on a separate validation branch.
- Actual GitHub Actions execution, including all three locked strict Clippy profiles, metrics unit tests, and workspace formatting: https://github.com/gosuda/bitcoin-rs/actions/runs/34406157791 . It is still in progress at PR creation; passing results are not claimed in advance.
- The first isolated attempt exposed the stale lockfile; that failure was not treated as a successful lint or test run.

Keep this PR draft until its final tree passes the required checks. The normal PR workflow must also run; targeted metrics tests alone do not establish workspace test success.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stable Clippy digest iteration and syncs `Cargo.lock` so `cargo test --locked` and `cargo clippy --locked` no longer stop before compilation.

- Replaces `chunks_exact(2)` with `as_chunks::<2>().0` in `metrics.rs`; the existing 64-byte length check keeps the remainder empty, so parsing and error behavior are unchanged.
- Adds the missing `bitcoin-rs-rpc` entry to the lockfile; this is not a new manifest dependency.
- No lint allowance, dependency upgrade, public API change, or workflow change is included.

<sup>Written for commit c473c4265242d6432620567331eb0a71c9d0cfa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

