### PR TITLE
Fix main full-node CI fixture provisioning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - name: Provision pinned Core and Apalache fixtures
+        run: bash scripts/provision-ci-reference-fixtures.sh
       # Node / binary tests run with the full-node feature set. -p is
       # required because `--workspace --features` silently ignores --features
       # in a virtual workspace (no root [package] section in the top-level


### PR DESCRIPTION
## Summary

The main-only `full-node` lane runs the full `bitcoin-rs` integration-test surface, including tests that require the repository's pinned Bitcoin Core and Apalache fixtures. Unlike the PR `test` job, it did not provision those fixtures first.

Reuse the existing `scripts/provision-ci-reference-fixtures.sh` step in `ci-main` before the broad full-node test command.

## Failure evidence

`ci-main` run 34405214460 failed in `full-node` because:

- `g20_formal_models` could not find `target/tools/apalache-0.62.2/bin/apalache-mc`.
- `overhaul_process_harness` could not find the pinned `target/reference-core-31.1/.../bitcoind` binary.

Both paths are created and identity-verified by the existing provisioning script already used by `.github/workflows/ci.yml`.

## Validation

- Branch is based on current `main` (`8e1bc07a9648293768ca1109118ba89e87f7b6de`).
- Diff is limited to two added workflow lines; no test behavior, fixture identity, or runtime code changes.
- Confirmed the PR test workflow already uses the same provisioner before exercising the affected integration-test surface.
- Local execution is unavailable because this sandbox cannot resolve `github.com`; GitHub Actions is the runtime verification path.

## Risk

Low. The change adds network/download work to `ci-main`'s `full-node` job, but the script validates archive and binary/JAR digests and is already part of the PR CI path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the main `full-node` CI lane so it provisions the pinned Bitcoin Core and Apalache fixtures before running integration tests, just like the PR `test` job does. Previously the main-only lane skipped this step and tests failed because `apalache-mc` and `bitcoind` binaries were missing. The added step downloads and verifies the fixtures, adding some network time to `ci-main` but no change to test behavior.

<sup>Written for commit 5c3cc0829d4ca492f3eaabc8ffe43a90e157fac6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

