### PR TITLE
ci: test function-array encoding for G20 formal gate

### DIFF
--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -24,6 +24,7 @@ results. Unknown is not false; a missing measurement blocks the owning task.
 | Install root | `${APALACHE_HOME}`, default `target/tools/apalache-0.62.2` (untracked) |
 | Version check | `apalache-mc version` must print `0.62.2`; mismatch is skill rc 11 |
 | Solver | `SMT_SOLVER=z3`; `JVM_ARGS` default `-Xmx4096m` (complete JVM option) |
+| SMT encoding | `funArrays` (`--smt-encoding=funArrays`) |
 | Step bound | K = 128 (`--length=128`); a verification bound, not a production limit |
 
 The docker tag `ghcr.io/apalache-mc/apalache:main` is a moving branch tag and

--- a/bin/bitcoin-rs/tests/gates/g20_formal_models.rs
+++ b/bin/bitcoin-rs/tests/gates/g20_formal_models.rs
@@ -40,6 +40,7 @@ const CONSTRAINTS: &str = "CONSTRAINTS.md";
 const JAR: &str = "lib/apalache.jar";
 const JVM_ARGS_DEFAULT: &str = "-Xmx4096m";
 const SMT_SOLVER_DEFAULT: &str = "z3";
+const SMT_ENCODING_DEFAULT: &str = "funArrays";
 const TIMEOUT_SECS: u64 = 3600;
 const OUTPUT_TAIL_BYTES: usize = 1024 * 1024;
 const OUTCOME_NO_ERROR: &str = "The outcome is: NoError";
@@ -456,8 +457,22 @@ fn execute_and_capture(
     (native_rc, stdout, stderr)
 }
 
+fn configured_smt_encoding(root: &Path) -> String {
+    let constraints = fs::read_to_string(root.join(CONSTRAINTS))
+        .expect("read canonical formal-tool configuration");
+    let prefix = "| SMT encoding | `";
+    let suffix = "` (";
+    constraints
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix)?.split_once(suffix).map(|(value, _)| value))
+        .filter(|value| !value.is_empty())
+        .unwrap_or(SMT_ENCODING_DEFAULT)
+        .to_string()
+}
+
 fn run_one(root: &Path, exe: &Path, model: &str, kind: CheckKind, n: u8) {
     let mut args = vec![
+
         "check".to_string(),
         format!("--config=docs/models/{model}.cfg"),
     ];
@@ -466,6 +481,8 @@ fn run_one(root: &Path, exe: &Path, model: &str, kind: CheckKind, n: u8) {
         CheckKind::Temporal => args.push(TEMPORAL.to_string()),
     }
     args.push(LENGTH.to_string());
+    let smt_encoding = configured_smt_encoding(root);
+    args.push(format!("--smt-encoding={smt_encoding}"));
     args.push(format!("--out-dir=target/apalache/{model}"));
     args.push(format!("docs/models/{model}.tla"));
 
@@ -501,7 +518,7 @@ fn run_one(root: &Path, exe: &Path, model: &str, kind: CheckKind, n: u8) {
     let mut run_text = String::new();
     run_text.push_str(&format!("# argv: {} {}\n", exe.display(), args.join(" ")));
     run_text.push_str(&format!(
-        "# env: JVM_ARGS={jvm_args} SMT_SOLVER={smt_solver}\n"
+        "# env: JVM_ARGS={jvm_args} SMT_SOLVER={smt_solver} SMT_ENCODING={smt_encoding}\n"
     ));
     run_text.push_str(&format!("# native rc: {native_rc:?}, skill rc: {skill}\n"));
     run_text.push_str(&format!(

--- a/scripts/provision-ci-reference-fixtures.sh
+++ b/scripts/provision-ci-reference-fixtures.sh
@@ -65,6 +65,10 @@ export PATH="$JAVA_HOME/bin:$PATH"
 
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   printf 'JAVA_HOME=%s\n' "$JAVA_HOME" >> "$GITHUB_ENV"
+  # `funArrays` preserves the TLA+ model while encoding its function-heavy
+  # state with SMT arrays; this branch tests whether that avoids g20's
+  # ChainAdmission temporal translation/solver timeout.
+  printf 'SMT_ENCODING=funArrays\n' >> "$GITHUB_ENV"
 fi
 if [[ -n "${GITHUB_PATH:-}" ]]; then
   printf '%s\n' "$JAVA_HOME/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Scope

Test Apalache's `funArrays` SMT encoding for the pinned G20 formal checks. The current `ChainAdmission` K=128 check has an observed one-hour timeout; the model is dominated by bounded function-valued state over the 12 job/request slots.

This candidate changes only the CI environment after fixture provisioning:

- keep Apalache 0.62.2 pinned
- keep Z3 (`SMT_SOLVER=z3`)
- keep every model, invariant, temporal property, constant, and `--length=128` unchanged
- set `SMT_ENCODING=funArrays`, which encodes TLA+ functions as SMT arrays

No pass is claimed in advance. This PR exists to obtain a syntax/type/solver run on the exact candidate. If the encoding does not materially improve G20, it should not merge. If it does, the final change should also make the encoding part of the recorded proof configuration rather than leaving it as implicit CI state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the G20 formal gate to use Apalache's `funArrays` SMT encoding and records it as part of the proof configuration, testing whether it avoids the one-hour timeout on the `ChainAdmission` K=128 check.

- Reads the encoding from `CONSTRAINTS.md` and passes it as `--smt-encoding` to Apalache.
- Records the encoding in the run environment output and documents it in `CONSTRAINTS.md`.
- Keeps Apalache 0.62.2, Z3, and all model parameters unchanged.

<sup>Written for commit 941c349193934fab9603a85febe6fdeed70c7ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

