### PR TITLE
test(g18): reject undeclared sample paths without discarding evidence

### DIFF
--- a/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
+++ b/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
@@ -335,7 +335,7 @@ fn declared_sample_paths_preserve_repetitions_and_empty_cells() {
     }
 }
 
-/// HPA-05: the declared inventory may extend `REQUIRED_PATHS`.
+/// HPA-05: the declared inventory may extend REQUIRED_PATHS.
 #[test]
 fn additional_declared_sample_paths_are_allowed() {
     let ledger = ledger_with_sample_paths("p2p.cmodern.arm64.redb", &["p2p.apply_idle"]);
@@ -509,7 +509,7 @@ fn candidate_list_is_ordered_and_points_at_paths() {
 #[test]
 fn levers_and_forbidden_probes_are_complete() {
     let ledger = load_ledger();
-    let ids: BTreeSet<&str> = ledger.paths.iter().map(|row| row.id.clone()).collect();
+    let ids: BTreeSet<&str> = ledger.paths.iter().map(|row| row.id.as_str()).collect();
     let mut lever_ids = BTreeSet::new();
     for lever in &ledger.levers {
         assert!(lever_ids.insert(lever.id.as_str()), "duplicate lever id");

--- a/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
+++ b/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
@@ -323,7 +323,11 @@ fn declared_sample_paths_preserve_repetitions_and_empty_cells() {
     assert_eq!(ledger.cells.len(), CELL_COUNT);
     for cell in &ledger.cells {
         if cell.id == cell_id {
-            let recorded: Vec<&str> = cell.samples.iter().map(|sample| sample.path.as_str()).collect();
+            let recorded: Vec<&str> = cell
+                .samples
+                .iter()
+                .map(|sample| sample.path.as_str())
+                .collect();
             assert_eq!(recorded, paths);
         } else {
             assert!(cell.samples.is_empty());
@@ -342,7 +346,14 @@ fn additional_declared_sample_paths_are_allowed() {
 #[test]
 fn undeclared_sample_paths_are_rejected_in_later_histories() {
     let cell_id = "muhash.cmodern.arm64.redb";
-    for path in ["not.declared", "", " ", "CELL.WALL", "cell.wall.extra", "probe.assume_valid"] {
+    for path in [
+        "not.declared",
+        "",
+        " ",
+        "CELL.WALL",
+        "cell.wall.extra",
+        "probe.assume_valid",
+    ] {
         let ledger = ledger_with_sample_paths(cell_id, &["cell.wall", path]);
         assert_eq!(check_sample_paths(&ledger), Err((cell_id, path)));
     }
@@ -505,7 +516,8 @@ fn levers_and_forbidden_probes_are_complete() {
         assert!(
             ids.contains(lever.path.as_str()),
             "lever `{}` path `{}` is missing",
-            lever.id
+            lever.id,
+            lever.path
         );
         assert!(
             known(&lever.disposition, &DISPOSITIONS),

--- a/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
+++ b/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
@@ -8,7 +8,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use bitcoin_rs_node::metrics::{Ledger as RuntimeLedger, Sample};
+use bitcoin_rs_node::metrics::{
+    CorpusIdentity, EvidenceIdentity, Interval, IntervalKind, Ledger as RuntimeLedger, Sample,
+    Sha256Hex,
+};
 use serde::Deserialize;
 
 const SCHEMA: &str = "bitcoin-rs-hot-path-ledger-v2";
@@ -229,9 +232,26 @@ fn matrix_is_the_frozen_36_cell_denominator() {
     assert_eq!(ledger.matrix.backends, ["fjall", "rocksdb", "redb"]);
 }
 
+/// HPA-05: use the actual inventory, not just its required minimum.
+/// Returns the offending cell and path without changing sample histories.
+fn check_sample_paths(ledger: &Ledger) -> Result<(), (&str, &str)> {
+    let ids: BTreeSet<&str> = ledger.paths.iter().map(|row| row.id.as_str()).collect();
+    for cell in &ledger.cells {
+        for sample in &cell.samples {
+            if sample.path.is_empty() || !ids.contains(sample.path.as_str()) {
+                return Err((cell.id.as_str(), sample.path.as_str()));
+            }
+        }
+    }
+    Ok(())
+}
+
 #[test]
 fn cell_histories_match_the_matrix_and_runtime_schema() {
     let ledger = load_ledger();
+    check_sample_paths(&ledger).unwrap_or_else(|(cell, path)| {
+        panic!("cell `{cell}` contains undeclared sample path `{path}`");
+    });
     let mut actual = BTreeSet::new();
     for cell in &ledger.cells {
         assert!(!cell.id.is_empty(), "empty cell id");
@@ -240,13 +260,6 @@ fn cell_histories_match_the_matrix_and_runtime_schema() {
             "duplicate cell id `{}`",
             cell.id
         );
-        for sample in &cell.samples {
-            assert!(
-                !sample.path.is_empty(),
-                "cell `{}` contains an empty sample path",
-                cell.id
-            );
-        }
     }
     assert_eq!(
         ledger.cells.len(),
@@ -258,6 +271,81 @@ fn cell_histories_match_the_matrix_and_runtime_schema() {
         ledger.matrix.cell_ids(),
         "cell histories must equal the matrix cross-product"
     );
+}
+
+/// Synthetic HPA-05/HPA-12 schema fixtures, never recorded as measurements.
+/// Both fixture cells use Cmodern, redb, and arm64; only the path varies.
+fn ledger_with_sample_paths(cell_id: &str, paths: &[&str]) -> Ledger {
+    let mut ledger = load_ledger();
+    let cell = ledger
+        .cells
+        .iter_mut()
+        .find(|cell| cell.id == cell_id)
+        .expect("fixture cell is declared");
+    for path in paths {
+        cell.samples.push(Sample {
+            path: (*path).to_owned(),
+            owner: "node".into(),
+            identity: EvidenceIdentity {
+                binary_sha256: Sha256Hex([1; 32]),
+                version: "test".into(),
+                config_sha256: Sha256Hex([2; 32]),
+                corpus: Some(CorpusIdentity {
+                    id: "Cmodern".into(),
+                    manifest_sha256: Sha256Hex([3; 32]),
+                }),
+                backend: "redb".into(),
+                durability: "test-only".into(),
+                hardware: "test arm64".into(),
+            },
+            interval: Interval {
+                kind: IntervalKind::Inside,
+                start_ns: 0,
+                end_ns: 1,
+            },
+            cpu_ns: None,
+            elapsed_ns: 1,
+            rss_peak_bytes: None,
+            io_bytes: None,
+            storage_bytes: None,
+        });
+    }
+    ledger
+}
+
+/// HPA-05/HPA-12: declared paths, repeated samples, and empty cells survive.
+#[test]
+fn declared_sample_paths_preserve_repetitions_and_empty_cells() {
+    let cell_id = "muhash.cmodern.arm64.redb";
+    let paths = ["cell.wall", "muhash.response", "cell.wall"];
+    let ledger = ledger_with_sample_paths(cell_id, &paths);
+    assert_eq!(check_sample_paths(&ledger), Ok(()));
+    assert_eq!(ledger.cells.len(), CELL_COUNT);
+    for cell in &ledger.cells {
+        if cell.id == cell_id {
+            let recorded: Vec<&str> = cell.samples.iter().map(|sample| sample.path.as_str()).collect();
+            assert_eq!(recorded, paths);
+        } else {
+            assert!(cell.samples.is_empty());
+        }
+    }
+}
+
+/// HPA-05: the declared inventory may extend REQUIRED_PATHS.
+#[test]
+fn additional_declared_sample_paths_are_allowed() {
+    let ledger = ledger_with_sample_paths("p2p.cmodern.arm64.redb", &["p2p.apply_idle"]);
+    assert_eq!(check_sample_paths(&ledger), Ok(()));
+}
+
+/// HPA-05: a valid earlier sample must not hide a bad later sample or cell.
+#[test]
+fn undeclared_sample_paths_are_rejected_in_later_histories() {
+    let cell_id = "muhash.cmodern.arm64.redb";
+    for path in ["not.declared", "", " ", "CELL.WALL", "cell.wall.extra", "probe.assume_valid"] {
+        let ledger = ledger_with_sample_paths(cell_id, &["cell.wall", path]);
+        assert_eq!(check_sample_paths(&ledger), Err((cell_id, path)));
+    }
 }
 
 #[test]
@@ -417,8 +505,7 @@ fn levers_and_forbidden_probes_are_complete() {
         assert!(
             ids.contains(lever.path.as_str()),
             "lever `{}` path `{}` is missing",
-            lever.id,
-            lever.path
+            lever.id
         );
         assert!(
             known(&lever.disposition, &DISPOSITIONS),

--- a/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
+++ b/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
@@ -335,7 +335,7 @@ fn declared_sample_paths_preserve_repetitions_and_empty_cells() {
     }
 }
 
-/// HPA-05: the declared inventory may extend REQUIRED_PATHS.
+/// HPA-05: the declared inventory may extend `REQUIRED_PATHS`.
 #[test]
 fn additional_declared_sample_paths_are_allowed() {
     let ledger = ledger_with_sample_paths("p2p.cmodern.arm64.redb", &["p2p.apply_idle"]);
@@ -509,7 +509,7 @@ fn candidate_list_is_ordered_and_points_at_paths() {
 #[test]
 fn levers_and_forbidden_probes_are_complete() {
     let ledger = load_ledger();
-    let ids: BTreeSet<&str> = ledger.paths.iter().map(|row| row.id.as_str()).collect();
+    let ids: BTreeSet<&str> = ledger.paths.iter().map(|row| row.id.clone()).collect();
     let mut lever_ids = BTreeSet::new();
     for lever in &ledger.levers {
         assert!(lever_ids.insert(lever.id.as_str()), "duplicate lever id");

--- a/docs/contracts/hot-path-attribution.md
+++ b/docs/contracts/hot-path-attribution.md
@@ -76,6 +76,10 @@ The 2.0x speed gate and the 36-cell denominator live in issues #33 and
 - `docs/benchmarks/hot-path-ledger.toml` is the only inventory of
   measured product hot paths, cost classes, known levers, and forbidden
   probes.
+- Every recorded `Sample.path` must exactly match a declared `paths.id`.
+  G18 rejects empty or undeclared paths in every cell history. The
+  declared inventory may extend the gate's required minimum; validating
+  membership never deduplicates samples or removes empty cells.
 - A row records applicability, custody, wall contribution,
   disable/neutralize delta, overlap, affected cells, and disposition.
 - Shared versus backend-, corpus-, domain-, or architecture-specific
@@ -180,7 +184,10 @@ posture.
 ## Proven by
 
 - `bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs`
-  (`cargo test -p bitcoin-rs --test g18_hot_path_ledger`)
+  (`cargo test -p bitcoin-rs --test g18_hot_path_ledger`), including
+  `declared_sample_paths_preserve_repetitions_and_empty_cells`,
+  `additional_declared_sample_paths_are_allowed`, and
+  `undeclared_sample_paths_are_rejected_in_later_histories` for HPA-05.
 - `bin/bitcoin-rs/tests/overhaul_evidence.rs` (planned): rejects evidence
   missing binary, corpus, configuration, or durability identity; rejects
   summing nested or concurrent intervals; retains repeated samples and


### PR DESCRIPTION
## Problem

Closes the implementation gap identified in the [G18 review on #665](https://github.com/gosuda/bitcoin-rs/pull/665#discussion_r3970119729). The product ledger gate only checked that `Sample.path` was nonempty, so a sample naming an invented nonempty path could pass without belonging to the declared attribution inventory.

## Fix and simplification

- Derive one borrowed set of path identifiers from the existing `ledger.paths` inventory and validate every sample in every cell against it.
- Replace the weaker nonempty-only loop with the shared check. Keep empty-path rejection and report the offending cell and path.
- Use the actual declared inventory, not a second hard-coded path table or the gate's minimum required-path list.
- Keep the schema, 36-cell matrix, sample histories, empty cells, and every existing gate assertion unchanged.
- State exact path membership in the existing HPA-05 contract and link its regression tests.

The validator is a private G18 helper. Runtime metrics, benchmark APIs, reference loading, formal checks, storage, mempool, and generated/recorded ledger data are untouched. This does not duplicate the active storage/evidence work in #689 or #692.

## Regression coverage

Three test groups exercise the same helper invoked by the real gate:

- Declared sample paths and repeated samples are retained, with other cells remaining empty.
- An additional declared path beyond the required minimum (`p2p.apply_idle`) is accepted.
- An invalid later sample in a later cell is rejected: undeclared, empty, whitespace-only, case-mismatched, prefixed lookalike, or a forbidden probe identifier absent from the inventory.

Fixtures are synthetic, in-memory schema checks, not measured product evidence. These checks establish identifier membership only; they do not certify timing, provenance, performance, or complete axis applicability.

## Validation

Source changes are based on main `6838258a3dbca18e78e1995cd5c274d52460167b`. No local Rust execution is claimed: this environment has no Rust toolchain and GitHub cloning fails on DNS resolution.

An isolated workflow outside the PR prepares formatting and runs a before/after negative control: it inserts the same syntactically valid, undeclared sample into the last cell, demonstrates acceptance with the base gate, then requires rejection specifically by the new membership check. It restores all modified fixture bytes afterward. The workflow also runs the full G18/evidence tests, workspace formatting, and all three locked strict Clippy profiles. Results are pending until inspected, not assumed passing.

Required final-head commands:

```sh
cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test g18_hot_path_ledger --test overhaul_evidence
cargo clippy --locked --workspace --all-targets --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node -- -D warnings
cargo clippy --locked -p bitcoin-rs-consensus --no-default-features --all-targets -- -D warnings
cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings
cargo fmt --all -- --check
```

No lint allowance, relaxed check, discarded history, dependency upgrade, public API, or validation-default change is introduced. Keep draft until final-head execution and review complete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the G18 hot-path ledger gate so every sample path must exactly match a declared `ledger.paths` id instead of merely being nonempty. The gate now rejects empty or undeclared paths in any cell and reports the offending cell and path.

**Regression Coverage**
- Adds synthetic in-memory fixtures covering declared paths, repeated samples, extra declared paths, and rejection of undeclared, empty, whitespace-only, case-mismatched, prefixed, and forbidden probe paths.
- Documents the exact path membership requirement in the HPA-05 contract, without discarding evidence or changing sample histories.

<sup>Written for commit 59e149b5eea2e802fc050eef822904d0897a825d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

