### PR TITLE
fix(p2p): honor transaction witness requests and serialization

### DIFF
--- a/crates/node/tests/tx_ingress_e2e.rs
+++ b/crates/node/tests/tx_ingress_e2e.rs
@@ -449,11 +449,15 @@ fn announces_tx(frames: &[Message], txid: &Txid) -> bool {
     })
 }
 
-/// True when one of `frames` requests `txid` with `getdata`.
+/// P2P-01 / BIP144: either txid request form names the same transaction.
+/// Witness-capable fixture peers receive `MSG_WITNESS_TX`; announcements
+/// remain governed independently by their negotiated relay preference.
 fn requests_tx(frames: &[Message], txid: &Txid) -> bool {
     frames.iter().any(|message| match message {
         Message::GetData(items) => items.iter().any(|item| match item {
-            Inventory::Transaction(hash) => hash.as_byte_array() == txid.as_bytes(),
+            Inventory::Transaction(hash) | Inventory::WitnessTransaction(hash) => {
+                hash.as_byte_array() == txid.as_bytes()
+            }
             _ => false,
         }),
         _ => false,

--- a/crates/p2p/src/dispatch.rs
+++ b/crates/p2p/src/dispatch.rs
@@ -8,6 +8,7 @@ use crate::fsm::step;
 use crate::handshake::feature_messages;
 use crate::inv::{
     inventory_tx_hash, is_within_inventory_bound, request_inventory, request_inventory_filtered,
+    request_transaction_witness,
 };
 use crate::peer::{Peer, PeerState};
 use crate::wire::{Message, PeerError};
@@ -167,7 +168,13 @@ pub fn dispatch_inbound_full<S>(
                 }),
                 None => request_inventory(items),
             };
-            if let Some(response) = response {
+            if let Some(mut response) = response {
+                if let Message::GetData(items) = &mut response {
+                    let witness = peer.remote_version.as_ref().is_some_and(|version| {
+                        version.services.to_u64() & bitcoin::p2p::ServiceFlags::WITNESS.to_u64() != 0
+                    });
+                    request_transaction_witness(items, witness);
+                }
                 send(response)?;
             }
         }
@@ -224,11 +231,12 @@ fn headers_response(chain: Option<&dyn ChainQuery>, request: &GetHeadersMessage)
 ///
 /// When `tx_inventory` is `Some`, tx-typed items are served from the
 /// transaction inventory (the node's mempool): a held tx is emitted as a
-/// `tx` message (witness serialization), and a tx the node does not have is
+/// `tx` message using the requested serialization, and an unknown tx is
 /// collected into the trailing `notfound`. Block-typed items continue to
 /// stream through the chain query behind the headroom gate. BIP339 `WTx`
 /// items are resolved by wtxid; `Transaction`/`WitnessTransaction` items by
-/// txid.
+/// txid. BIP144 plain `Transaction` requests receive stripped copies;
+/// witness-typed requests retain witnesses without mutating stored bodies.
 fn serve_getdata(
     chain: Option<&dyn ChainQuery>,
     tx_inventory: Option<&dyn TxInventory>,
@@ -255,7 +263,12 @@ fn serve_getdata(
         match item {
             Inventory::Transaction(txid) | Inventory::WitnessTransaction(txid) => {
                 let native = Txid::from(Hash256::from_le_bytes(txid.as_byte_array()));
-                if let Some(tx) = inv.get_tx(native) {
+                if let Some(mut tx) = inv.get_tx(native) {
+                    if matches!(item, Inventory::Transaction(_)) {
+                        for input in &mut tx.inputs {
+                            input.witness.clear();
+                        }
+                    }
                     send(Message::Tx(tx))?;
                 } else {
                     not_found.push(*item);
@@ -950,6 +963,71 @@ mod tests {
         }
     }
 
+    /// P2P-01 / BIP144: request witnesses by service flags, not relay preference.
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki#relay>
+    #[test]
+    fn announced_transactions_request_witness_without_changing_hashes() {
+        use bitcoin::p2p::ServiceFlags;
+
+        let held = bitcoin::Txid::from_byte_array([0x44; 32]);
+        let unknown = bitcoin::Txid::from_byte_array([0x55; 32]);
+        let wtxid = bitcoin::Wtxid::from_byte_array([0x66; 32]);
+        let block = bitcoin::BlockHash::from_byte_array([0x77; 32]);
+        let items = vec![
+            Inventory::Transaction(held),
+            Inventory::Transaction(unknown),
+            Inventory::WTx(wtxid),
+            Inventory::Block(block),
+        ];
+        for witness in [false, true] {
+            for negotiated in [false, true] {
+                for filtered in [false, true] {
+                    let mut peer = ready_peer();
+                    let mut version = crate::handshake::version_message(1, 0);
+                    version.services = if witness {
+                        ServiceFlags::NETWORK | ServiceFlags::WITNESS
+                    } else {
+                        ServiceFlags::NETWORK
+                    };
+                    peer.remote_version = Some(version);
+                    peer.received_verack = true;
+                    if negotiated {
+                        peer.wtxid_relay.mark_local_advertised();
+                        peer.wtxid_relay.mark_peer_supported();
+                    }
+                    let inventory = FakeTxInventory::empty().with_have([0x44; 32]);
+                    let view: Option<&dyn TxInventory> = filtered.then_some(&inventory);
+                    let request = |txid| {
+                        if witness {
+                            Inventory::WitnessTransaction(txid)
+                        } else {
+                            Inventory::Transaction(txid)
+                        }
+                    };
+                    let mut expected = Vec::new();
+                    if !filtered {
+                        expected.push(request(held));
+                    }
+                    expected.extend([
+                        request(unknown),
+                        Inventory::WTx(wtxid),
+                        Inventory::Block(block),
+                    ]);
+                    assert_eq!(
+                        dispatch_collect_full(
+                            &mut peer,
+                            &Message::Inv(items.clone()),
+                            None,
+                            view,
+                        ),
+                        vec![Message::GetData(expected)],
+                    );
+                }
+            }
+        }
+    }
+
+    /// P2P-01 / BIP144 / BIP339: lookup identity and requested serialization.
     #[test]
     fn gateway_inventory_filters_and_serves_txid_and_wtxid() {
         use std::sync::Arc;
@@ -989,24 +1067,34 @@ mod tests {
             );
         }
 
-        // BIP339 MSG_WTX resolves the witness hash; txid requests keep their
-        // own lookup even on a wtxid-relay connection. Unknowns remain notfound.
+        let witness_item =
+            Inventory::WitnessTransaction(bitcoin::Txid::from_byte_array(*tx.txid().as_bytes()));
+        let mut stripped = tx.clone();
+        for input in &mut stripped.inputs {
+            input.witness.clear();
+        }
+        assert_eq!(stripped.txid(), tx.txid());
+        assert_ne!(stripped.wtxid(), tx.wtxid());
+        // BIP144 chooses serialization from the request type, while BIP339
+        // chooses the lookup hash. Neither may alter the retained body.
         let missing = Inventory::WTx(bitcoin::Wtxid::from_byte_array([0xFF; 32]));
         let mut peer = ready_peer();
         peer.wtxid_relay.mark_peer_supported();
         assert_eq!(
             dispatch_collect_full(
                 &mut peer,
-                &Message::GetData(vec![txid_item, wtxid_item, missing]),
+                &Message::GetData(vec![txid_item, witness_item, wtxid_item, missing]),
                 None,
                 Some(&gateway),
             ),
             vec![
+                Message::Tx(stripped),
                 Message::Tx(tx.clone()),
-                Message::Tx(tx),
+                Message::Tx(tx.clone()),
                 Message::NotFound(vec![missing])
             ],
         );
+        assert_eq!(gateway.get_tx_by_wtxid(tx.wtxid()), Some(tx));
     }
 
     #[test]

--- a/crates/p2p/src/dispatch.rs
+++ b/crates/p2p/src/dispatch.rs
@@ -171,7 +171,8 @@ pub fn dispatch_inbound_full<S>(
             if let Some(mut response) = response {
                 if let Message::GetData(items) = &mut response {
                     let witness = peer.remote_version.as_ref().is_some_and(|version| {
-                        version.services.to_u64() & bitcoin::p2p::ServiceFlags::WITNESS.to_u64() != 0
+                        version.services.to_u64() & bitcoin::p2p::ServiceFlags::WITNESS.to_u64()
+                            != 0
                     });
                     request_transaction_witness(items, witness);
                 }
@@ -1014,12 +1015,7 @@ mod tests {
                         Inventory::Block(block),
                     ]);
                     assert_eq!(
-                        dispatch_collect_full(
-                            &mut peer,
-                            &Message::Inv(items.clone()),
-                            None,
-                            view,
-                        ),
+                        dispatch_collect_full(&mut peer, &Message::Inv(items.clone()), None, view,),
                         vec![Message::GetData(expected)],
                     );
                 }

--- a/crates/p2p/src/inv.rs
+++ b/crates/p2p/src/inv.rs
@@ -36,21 +36,15 @@ pub fn request_missing_parents(
         }
     });
     let mut seen = hashbrown::HashSet::new();
-    let items: Vec<Inventory> = parents
+    let mut items: Vec<Inventory> = parents
         .iter()
         .filter(|txid| seen.insert(**txid))
-        .map(|txid| {
-            let txid = bitcoin::Txid::from_byte_array(*txid.as_bytes());
-            if witness {
-                Inventory::WitnessTransaction(txid)
-            } else {
-                Inventory::Transaction(txid)
-            }
-        })
+        .map(|txid| Inventory::Transaction(bitcoin::Txid::from_byte_array(*txid.as_bytes())))
         .collect();
     if items.is_empty() {
         return false;
     }
+    request_transaction_witness(&mut items, witness);
     // Capability metadata belongs to the same connection as the token. The
     // table rechecks that identity and pins it through the nonblocking enqueue,
     // so a replacement cannot inherit either the request or its service choice.
@@ -60,6 +54,18 @@ pub fn request_missing_parents(
         false
     } else {
         true
+    }
+}
+
+/// Selects BIP144 witness serialization for txid-based getdata requests.
+/// This does not change identifiers or outbound inv announcement types.
+pub(crate) fn request_transaction_witness(items: &mut [Inventory], witness: bool) {
+    if witness {
+        for item in items {
+            if let Inventory::Transaction(txid) = *item {
+                *item = Inventory::WitnessTransaction(txid);
+            }
+        }
     }
 }
 

--- a/crates/p2p/tests/core_compat.rs
+++ b/crates/p2p/tests/core_compat.rs
@@ -780,11 +780,15 @@ fn inv_getdata_relay_round_trip_serves_blocks_and_notfounds_misses() -> Result<(
     bodies.insert(genesis.block_hash(), genesis.clone());
     let chain = FakeChain::new(active, bodies);
     let mut peer = ready_peer(Magic::REGTEST)?;
-    // Inbound inv announcements are answered with getdata echoing the items
-    // verbatim (a wtxid-relay peer announces MSG_WTX and is asked for MSG_WTX).
-    let tx_inv = Inventory::Transaction(Txid::from_byte_array([9u8; 32]));
+    // P2P-01 / BIP144: this handshake advertises NODE_WITNESS, so a
+    // txid announcement requests the same transaction with witness data.
+    let txid = Txid::from_byte_array([9u8; 32]);
+    let tx_inv = Inventory::Transaction(txid);
     let response = dispatch_collect(&mut peer, &Message::Inv(vec![tx_inv]), Some(&chain))?;
-    assert_eq!(response, vec![Message::GetData(vec![tx_inv])]);
+    assert_eq!(
+        response,
+        vec![Message::GetData(vec![Inventory::WitnessTransaction(txid)])]
+    );
 
     // getdata over known + missing inventory serves blocks and notfounds the rest.
     let genesis_hash = genesis.block_hash();

--- a/docs/policies/p2p-compatibility.md
+++ b/docs/policies/p2p-compatibility.md
@@ -66,8 +66,8 @@ The decoder types exactly the commands in `crates/p2p/src/compat.rs::COMMANDS` (
 | `sendheaders` | negotiated | BIP130. Sent in handshake; inbound tracked. |
 | `ping` | Answered with `pong` echoing the nonce, ready peers only; pongs feed peer RTT stats. |
 | `pong` | ignored | Completes outstanding ping RTT accounting. |
-| `inv` | Answered with `getdata` for announced vectors the node does not already hold. P2P's `TxInventory` implementation queries the shared mempool gateway (accepted transactions, orphans, recent rejects); a wtxid-relay peer announcing `MSG_WTX` is asked for `MSG_WTX`. Bound: 50 000 vectors (`MAX_INV_PER_MSG`, Core `MAX_INV_SZ`). |
-| `getdata` | Blocks stream from the active chain; transaction inventory is served from the mempool / orphan map. Misses resolve to one trailing `notfound`. Bound: 50 000 vectors. |
+| `inv` | Answered with `getdata` for announced vectors the node does not already hold. P2P's `TxInventory` implementation queries the shared mempool gateway (accepted transactions, orphans, recent rejects); `MSG_WTX` is requested unchanged, while `MSG_TX` is requested as `MSG_WITNESS_TX` from `NODE_WITNESS` peers and as `MSG_TX` otherwise (BIP144). Inventory type, not the peer's announcement preference, determines the lookup hash. Bound: 50 000 vectors (`MAX_INV_PER_MSG`, Core `MAX_INV_SZ`). |
+| `getdata` | Blocks stream from the active chain; transaction inventory is served from the mempool / orphan map. Plain `MSG_TX` receives a stripped copy; `MSG_WITNESS_TX` and `MSG_WTX` retain witnesses. Serving does not alter the stored body. Misses resolve to one trailing `notfound`. Bound: 50 000 vectors. |
 | `notfound` | ignored | Decoded with the same inventory bound. |
 | `getheaders` | Answered with `headers` from the active chain: first locator hash on the active chain anchors the walk, total miss anchors after genesis, stop hash truncates inclusively, ≤ 2 000 headers per message (Core's per-message maximum). Locator bound: 101 hashes (Core `MAX_LOCATOR_SZ`). Empty locator + zero stop answers nothing (Core clients always send a locator; unreachable in practice). |
 | `getblocks` | ignored | Legacy locator request; Core answers with an `inv`, we stay silent. Documented deviation. Locator bound identical. |
@@ -147,7 +147,11 @@ Known deltas from Core 31.1:
 - **Deterministic fixtures**: `crates/p2p/tests/core_compat.rs` pins the command inventory against this table and against rust-bitcoin's v1 envelope (`RawNetworkMessage`), the handshake fields and service bits, per-network magic/ports and framing, getheaders/headers semantics and bounds, inv/getdata relay round-trips with `notfound`, the reject-or-ignore matrix of §6, and the peer-visible behavior across a chain switch (reorg) and a restart at the `ChainQuery` seam: a rebuilt query serves byte-identical answers, a switched active branch serves the new branch from the fork point and `notfound`s stale bodies. Run with `cargo test -p bitcoin-rs-p2p --test core_compat`.
 - **Transaction consumers**: `crates/p2p/src/dispatch.rs` test
   `gateway_inventory_filters_and_serves_txid_and_wtxid` exercises the
-  `TxInventory` implementation over the shared gateway. `src/inv.rs` tests
+  `TxInventory` implementation, requested serialization, and stored-body
+  preservation over the shared gateway.
+  `announced_transactions_request_witness_without_changing_hashes` covers
+  witness-capable and legacy sources, both relay preferences, filtered and
+  unfiltered requests, and unchanged wtxid/block vectors. `src/inv.rs` tests
   `missing_parents_use_txids_and_deduplicate_repeated_inputs`,
   `missing_parents_request_witness_by_service_not_announcement_preference`,
   `stale_missing_parent_source_cannot_send_to_or_cancel_replacement`,


### PR DESCRIPTION
## Scope

Independent follow-up to merged #680, on a brand-new branch based on current main `6838258a3dbca18e78e1995cd5c274d52460167b`. Targets `main` directly; does not depend on the separate RPC package-accounting fix #707.

The merged ownership work already fixed inventory hash namespaces, outbound BIP339 announcements, and missing-parent witness requests. This PR preserves those fixes and addresses the remaining ordinary transaction-request and response-serialization paths.

## Problem and fix

Ordinary `inv(MSG_TX)` currently produces a plain `getdata(MSG_TX)` even when the source advertises `NODE_WITNESS`. A compliant peer can therefore return a stripped transaction that lacks the witness needed for admission. Convert txid-based requests to `MSG_WITNESS_TX` for witness-capable sources, preserving identifiers and the existing legacy fallback. Leave `MSG_WTX` and block inventory unchanged.

The response path also treats plain `MSG_TX` and witness-bearing requests identically. Strip witnesses only from the owned response copy for `MSG_TX`; preserve full bodies for `MSG_WITNESS_TX` and `MSG_WTX`. The retained mempool/orphan body is not modified.

These are the request/serialization distinctions required by [BIP144 Relay](https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki#relay), independent of [BIP339](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki) announcement preference.

## Simplification and ownership

One crate-private conversion helper is shared by ordinary inventory requests and the existing missing-parent request path. No second peer-capability cache, observer, admission engine, public API, or dependency is introduced. The existing identity-checked `PeerTable::send` path, source exclusion, block-serving behavior, and queue-saturation policy remain unchanged.

## Regression coverage

- `announced_transactions_request_witness_without_changing_hashes`: eight combinations of witness support, relay negotiation, and inventory-filter presence; checks held-transaction suppression, unchanged identifiers, and unaffected wtxid/block vectors.
- Expanded `gateway_inventory_filters_and_serves_txid_and_wtxid`: plain, witness-txid, and wtxid requests produce stripped/full/full responses; unknown inventory remains `notfound`; the stored witness-bearing transaction remains intact.
- The existing node loopback helper now recognizes both txid-based request forms. Its announcement checks remain separate and unchanged.

The P2P-01 policy documents the serialization contract and names the executable proofs. The existing missing-parent service/negotiation matrix remains in place.

## Acceptance

```sh
cargo test --locked -p bitcoin-rs-p2p --lib --test core_compat
cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall --test tx_ingress_e2e
cargo clippy --locked -p bitcoin-rs-p2p --all-targets -- -D warnings
cargo fmt --all -- --check
```

Full required CI and fresh review remain necessary.

## Validation status

The four complete baseline files were fetched and checked against their Git blob hashes before applying the reviewed edits. Exact replacement checks and `git diff --check` passed locally. Each uploaded replacement blob matched the locally calculated SHA. The comparison from preparation base `f211c2f` to current main `6838258` confirmed no changes to these target files; the commit preserves all other current-main content.

Rust compilation, Clippy, and rustfmt have **not** been executed locally because the environment has no Rust toolchain. An isolated preparation/validation run is queued, but that is not a passing result. This PR is draft pending executable validation and fresh review.

Only the four source/test/policy files are included. Preparation scripts and workflows are outside this PR and its ancestry. Neither `main` nor PR #680's branch was modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors BIP144 witness requests and serialization for ordinary transaction relay. Txid-based announcements now request `MSG_WITNESS_TX` from `NODE_WITNESS` peers instead of plain `MSG_TX`, and plain `getdata(MSG_TX)` is answered with a witness-stripped copy while `MSG_WITNESS_TX`/`MSG_WTX` keep full bodies; the retained mempool/orphan body is never modified.

- Shares one conversion helper between ordinary inventory requests and missing-parent requests; no new caches, public APIs, or dependencies.
- Leaves `MSG_WTX` and block inventory handling unchanged; unknown txids still return `notfound`.
- Adds regression coverage for witness and legacy sources, relay preferences, filtered and unfiltered requests, and stripped/full/unchanged-stored-body responses; the node loopback helper and Core compatibility fixture now accept witness-typed txid requests.
- Updates the P2P-01 compatibility policy to document the request and serialization contract.

<sup>Written for commit 243817665ab73c208654be50f02d307e5cb9d360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

