### PR TITLE
test: finish G18 Rustdoc and verifier clone lint cleanup

### DIFF
--- a/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
+++ b/bin/bitcoin-rs/tests/gates/g18_hot_path_ledger.rs
@@ -335,7 +335,7 @@ fn declared_sample_paths_preserve_repetitions_and_empty_cells() {
     }
 }
 
-/// HPA-05: the declared inventory may extend REQUIRED_PATHS.
+/// HPA-05: the declared inventory may extend `REQUIRED_PATHS`.
 #[test]
 fn additional_declared_sample_paths_are_allowed() {
     let ledger = ledger_with_sample_paths("p2p.cmodern.arm64.redb", &["p2p.apply_idle"]);

--- a/crates/script/tests/verifier_boundaries.rs
+++ b/crates/script/tests/verifier_boundaries.rs
@@ -122,7 +122,7 @@ fn bip341_binds_all_prevouts_and_the_transaction() {
             .is_err()
     );
 
-    let mut altered_tx = tx.clone();
+    let mut altered_tx = tx;
     altered_tx.outputs[0].value -= 1;
     assert!(verify(&altered_tx, &prevouts, 0).is_err());
 }
@@ -135,7 +135,7 @@ fn supplied_witness_is_verified_without_mutating_the_transaction() {
     let (tx, prevouts) = signed_spend();
     assert_eq!(verify(&tx, &prevouts, 0), Ok(true));
     let witness = tx.inputs[0].witness.clone();
-    let mut corrupted_tx = tx.clone();
+    let mut corrupted_tx = tx;
     corrupted_tx.inputs[0].witness[0][0] ^= 1;
     assert!(verify(&corrupted_tx, &prevouts, 0).is_err());
     let unchanged_tx = corrupted_tx.clone();


### PR DESCRIPTION
## Scope

Three-line, two-file follow-up to merged #712 and #696, based on main `51ed6b123bda3b775aabc008ad581c338b96da79`.

- Mark `REQUIRED_PATHS` as code in the G18 regression's Rustdoc comment, satisfying the documentation-format requirement without suppressing a lint.
- Move the finished transaction fixture into `altered_tx` and `corrupted_tx` instead of cloning it after its last use. Keep the separate `unchanged_tx` snapshot and whole-transaction equality assertion: the public verifier's nonmutation check is not weakened.

The final diff is **+3/-3 across two test files**. No production behavior, dependency, schema, assertion, recorded evidence, or lint allowance changes.

## Observed validation before this correction

The [completed verifier job](https://github.com/gosuda/bitcoin-rs/actions/runs/34409034018/job/102658857046) ran on `e8dc3ae452625616b8544bb4985e88667fb48d5c` with Rust 1.98.1:

- 37 script unit tests, 6 Core-vector test functions, and 3 verifier-boundary tests passed.
- Formatting, native consensus Clippy, and native node Clippy passed.
- Workspace Clippy failed on `clippy::redundant_clone` at `verifier_boundaries.rs:138`. That diagnostic is addressed here; the equivalent final-use clone in the neighboring test is simplified too.

These are executed results for the earlier tree, not a final-head success claim. The separate #705 validation job completed successfully, including all three strict Clippy profiles and its parsing/reference/metrics checks.

## Integrity checks performed

The G18 source was verified against original blob `dd20968ca4ee96e465471d20f74af1f1dcf4f978` before applying the exact backtick replacement. The corrected local blob hash `70ab2f9ffcefdc161d61eaa5397ca350bb4c9fe2` matches GitHub's published blob. The complete PR diff was then read back and verified to contain only that comment edit and the two final-use clone removals.

## Final-head validation still required

The isolated read-only validation is pinned to `6417d90e1f595ced7ddc3b7bea7ad115fffde56e`. It must run formatting, G18/evidence tests, script unit/boundary/Core-vector tests, and all three locked strict Clippy profiles. The G18 negative control must demonstrate acceptance of the same undeclared sample by the original gate and rejection specifically by the corrected membership check, restoring all fixture bytes afterward.

No local Rust execution is claimed: the environment has no Rust toolchain and cannot resolve the clone host. Final-head execution remains pending until inspected. CodeRabbit's rate-limit notice is not an approval. Keep this PR unmerged pending final validation; no merge or auto-merge was performed by this publication pass.