### PR TITLE
docs(p2p): fix witness capability markup for strict Clippy

### DIFF
--- a/crates/node/tests/tx_ingress_e2e.rs
+++ b/crates/node/tests/tx_ingress_e2e.rs
@@ -449,7 +449,7 @@ fn announces_tx(frames: &[Message], txid: &Txid) -> bool {
     })
 }
 
-/// P2P-01 / BIP144: these dialers advertise NODE_WITNESS, so require
+/// P2P-01 / BIP144: these dialers advertise `NODE_WITNESS`, so require
 /// witness-serialized getdata rather than accepting the legacy request.
 fn requests_tx(frames: &[Message], txid: &Txid) -> bool {
     frames.iter().any(|message| match message {

--- a/crates/p2p/src/dispatch.rs
+++ b/crates/p2p/src/dispatch.rs
@@ -964,7 +964,7 @@ mod tests {
         }
     }
 
-    /// P2P-01 / BIP144: NODE_WITNESS controls getdata serialization, not hashes.
+    /// P2P-01 / BIP144: `NODE_WITNESS` controls getdata serialization, not hashes.
     /// <https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki#relay>
     #[test]
     fn announced_transactions_request_witness_without_changing_hashes() {


### PR DESCRIPTION
## Scope

Two-line follow-up to merged #708: wrap `NODE_WITNESS` in code backticks in the dispatch regression and node loopback request helper documentation. This fixes strict Clippy's documentation-markdown finding without changing runtime code, assertions, dependencies, protocol behavior, or lint settings.

Correction commit: `190805f01acd9d65092a9c9d485f53a5a67ba979`. Tested main-integrated commit: `2edf1d885e504b31d0560ebc22fd0a9e345771e3`, which incorporates main `5936baddf37442521c142ae2f3be17af4df75f6c`. The diff against that main is exactly two comment lines. P2P-01/BIP144 contract references and existing regression coverage are unchanged.

## Executed validation — exact commit 2edf1d8

[Run 34413809725, attempt 1, P2P job log](https://github.com/gosuda/bitcoin-rs/actions/runs/34413809725/job/102674026954), Rust/Cargo 1.98.1, locked dependencies:

| Check | Observed result |
| --- | --- |
| P2P all-target strict Clippy | Passed with `-D warnings` |
| Native node `tx_ingress_e2e` strict Clippy, Fjall | Passed with `-D warnings` |
| P2P unit tests | 188 passed; 0 failed; 0 ignored |
| `core_compat` | 23 passed; 0 failed; 0 ignored |
| Node `tx_ingress_e2e` | Compiled; run cancelled immediately after its four tests started. No passing result claimed. |
| Workspace formatting / final clean-tree check | Skipped after cancellation. No passing result claimed. |

The run was superseded by a concurrent update to the execution branch. Replacement run 34414240912 was also cancelled. The execution branch was subsequently merged separately in #721 and deleted; that merge is not additional validation of this PR.

The recorded successful commands were:

```sh
cargo +stable clippy --locked -p bitcoin-rs-p2p --no-default-features --all-targets -- -D warnings
cargo +stable clippy --locked -p bitcoin-rs-node --no-default-features --features fjall --test tx_ingress_e2e -- -D warnings
cargo +stable test --locked -p bitcoin-rs-p2p --lib --test core_compat --no-fail-fast
```

No source or lockfile workaround was used for these results. Earlier #708 candidate results are not substituted for this commit's execution evidence.

## Review

The complete source diff was read back and both corrected blobs checked against main. No additional behavioral correction was identified in the scoped transfer changes. Usage-limit notices from review bots are not counted as completed reviews. An uncancelled node-loopback/formatting run and normal repository-wide CI remain outstanding; no complete green or zero-findings sign-off is claimed.