### PR TITLE
Prepare local-relay admission identity regression tests

### DIFF
--- a/.github/review/relay_admission_patch.py
+++ b/.github/review/relay_admission_patch.py
@@ -1,0 +1,268 @@
+"""Apply the local-relay admission-identity candidate to a verified source tree."""
+from pathlib import Path
+import subprocess
+import sys
+
+BASE = "6838258a3dbca18e78e1995cd5c274d52460167b"
+EXPECTED = {
+    "crates/mempool/src/pool.rs": "f45739921f96aa2e392f056ec08cf3012e401da8",
+    "crates/p2p/src/tx_relay.rs": "cf4de6cec7fbca404460d55fae5410e498456a75",
+    "docs/policies/p2p-compatibility.md": "bdf95fd02b249748434ac49a2911cb50d59f3ac3",
+}
+
+
+def replace(path, old, new, count=1):
+    p = Path(path)
+    text = p.read_text()
+    if text.count(old) != count:
+        raise RuntimeError(f"unexpected preimage count in {path}: {old!r}: {text.count(old)}")
+    p.write_text(text.replace(old, new))
+
+
+TESTS = r'''
+    fn relay_identity_tx() -> Arc<bitcoin_rs_primitives::Tx> {
+        use bitcoin_rs_primitives::{OutPoint, Tx, TxIn, TxOut};
+        Arc::new(Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(dummy_txid(90), 0),
+                script_sig: Vec::new(),
+                sequence: 0xffff_fffd,
+                witness: vec![vec![1]],
+            }],
+            outputs: vec![TxOut {
+                value: 1_000,
+                script_pubkey: vec![0x6a, 4, 1, 2, 3, 4],
+            }],
+            lock_time: 0,
+        })
+    }
+
+    fn relay_identity_peer() -> AdmissionOrigin {
+        AdmissionOrigin::Peer(bitcoin_rs_mempool::PeerToken {
+            addr: SocketAddr::from(([127, 0, 0, 1], 8333)),
+            connection_id: 7,
+        })
+    }
+
+    fn relay_identity_gateway() -> Arc<MempoolGateway> {
+        use bitcoin_rs_mempool::{CompositeObserver, Mempool, MempoolLimits};
+        Arc::new(MempoolGateway::new(
+            Arc::new(parking_lot::RwLock::new(Mempool::new(MempoolLimits::default()))),
+            Some(Arc::new(CompositeObserver::new())),
+        ))
+    }
+
+    struct MutateBeforeLocalRelay {
+        gateway: Weak<MempoolGateway>,
+        next: Mutex<Option<bitcoin_rs_mempool::MempoolEntry>>,
+        clear_first: bool,
+    }
+
+    impl MempoolObserver for MutateBeforeLocalRelay {
+        fn on_mutation(&self, envelope: &MutationEnvelope) {
+            let Some(entry) = self.next.lock().take() else {
+                return;
+            };
+            let gateway = self.gateway.upgrade().expect("fixture gateway lives");
+            if self.clear_first {
+                gateway.clear(AdmissionOrigin::Block);
+            }
+            gateway.insert_entry(relay_identity_peer(), entry).expect("nested admission");
+            let original = Txid(envelope.result.changes[0].txid);
+            gateway.prioritise(original, 1).expect("fee overlay does not change admission identity");
+        }
+    }
+
+    fn delayed_relay_fixture(
+        origin: AdmissionOrigin,
+        original: Arc<bitcoin_rs_primitives::Tx>,
+        next: Arc<bitcoin_rs_primitives::Tx>,
+        clear_first: bool,
+    ) -> (Arc<MempoolGateway>, Receiver<RelayRequest>) {
+        use bitcoin_rs_mempool::MempoolEntry;
+        let gateway = relay_identity_gateway();
+        let (relay, rx) = TxRelayQueue::new(8);
+        gateway.attach_observer_leg("mutate-first", Arc::new(MutateBeforeLocalRelay {
+            gateway: Arc::downgrade(&gateway),
+            next: Mutex::new(Some(MempoolEntry::new(next, 100, 10_000, 2, 0))),
+            clear_first,
+        })).expect("fixture observer slot");
+        gateway.attach_observer_leg("relay", Arc::new(LocalTxRelayObserver::new(
+            relay, Arc::downgrade(&gateway),
+        ))).expect("relay observer slot");
+        gateway.insert_entry(origin, MempoolEntry::new(original, 100, 10_000, 1, 0))
+            .expect("local admission");
+        (gateway, rx)
+    }
+
+    // P2P-01 / MPL-01: callbacks may re-enter the gateway before a later leg.
+    // An old local event must not borrow a new peer admission's identity.
+    #[test]
+    fn delayed_local_relay_does_not_adopt_a_reinserted_body() {
+        for origin in [AdmissionOrigin::Rpc, AdmissionOrigin::Reorg] {
+            for alternate_witness in [false, true] {
+                let original = relay_identity_tx();
+                let next = if alternate_witness {
+                    let mut variant = (*original).clone();
+                    variant.inputs[0].witness = vec![vec![2]];
+                    Arc::new(variant)
+                } else {
+                    // Same allocation, not merely equal bytes: Arc identity is
+                    // not an admission identity either.
+                    Arc::clone(&original)
+                };
+                assert_eq!(original.txid(), next.txid());
+                assert_eq!(original.wtxid() != next.wtxid(), alternate_witness);
+                let txid = original.txid();
+                let (gateway, rx) = delayed_relay_fixture(origin, original, Arc::clone(&next), true);
+                assert_eq!(gateway.read().entry_by_txid(&txid).map(|entry| entry.wtxid), Some(next.wtxid()));
+                assert!(rx.try_recv().is_err(), "old local event cannot advertise the peer re-admission");
+            }
+        }
+    }
+
+    #[test]
+    fn delayed_local_relay_survives_unrelated_mutations() {
+        let original = relay_identity_tx();
+        let mut unrelated = (*original).clone();
+        unrelated.inputs[0].previous_output = bitcoin_rs_primitives::OutPoint::new(dummy_txid(91), 0);
+        let (gateway, rx) = delayed_relay_fixture(AdmissionOrigin::Rpc, Arc::clone(&original), Arc::new(unrelated), false);
+        assert_eq!(gateway.read().sequence_number(), 2);
+        let request = rx.try_recv().expect("unrelated mutation does not invalidate the local admission");
+        assert_eq!((request.txid, request.wtxid, request.source), (original.txid(), original.wtxid(), None));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn local_replacement_relay_uses_the_accepted_change_sequence() {
+        use bitcoin_rs_mempool::{MempoolEntry, ReplacementCandidate};
+        let gateway = relay_identity_gateway();
+        let (relay, rx) = TxRelayQueue::new(8);
+        gateway.attach_observer_leg("relay", Arc::new(LocalTxRelayObserver::new(relay, Arc::downgrade(&gateway))))
+            .expect("observer slot");
+        let original = relay_identity_tx();
+        gateway.insert_entry(relay_identity_peer(), MempoolEntry::new(Arc::clone(&original), 100, 10_000, 1, 0))
+            .expect("original peer admission");
+        assert!(rx.try_recv().is_err());
+        let mut replacement = (*original).clone();
+        replacement.outputs[0].value = 900;
+        let replacement = Arc::new(replacement);
+        let outcome = gateway.replace_transaction(
+            AdmissionOrigin::Rpc,
+            ReplacementCandidate::new(Arc::clone(&replacement), 100, 11_000, 1_000),
+            2, 0, 4,
+        ).expect("local replacement");
+        assert_eq!(outcome.mutation().len(), 2);
+        assert!(matches!(outcome.mutation().changes[0].outcome, MutationOutcome::Removed(_)));
+        assert_eq!(outcome.mutation().changes[1].outcome, MutationOutcome::Accepted);
+        let request = rx.try_recv().expect("accepted change after removal is announced");
+        assert_eq!((request.txid, request.wtxid, request.source), (replacement.txid(), replacement.wtxid(), None));
+        assert!(rx.try_recv().is_err());
+    }
+'''
+
+
+def tests():
+    for path, expected in EXPECTED.items():
+        actual = subprocess.check_output(["git", "hash-object", path], text=True).strip()
+        if actual != expected:
+            raise RuntimeError(f"changed base file {path}: {actual}")
+    p = Path("crates/p2p/src/tx_relay.rs")
+    text = p.read_text()
+    if not text.endswith("}\n"):
+        raise RuntimeError("unexpected test module end")
+    p.write_text(text[:-2] + TESTS + "}\n")
+
+
+def fix():
+    pool = "crates/mempool/src/pool.rs"
+    replace(pool, "by_txid: HashMap<Txid, EntryId>,", "by_txid: HashMap<Txid, IndexedEntry>,")
+    replace(pool, "pub(crate) struct PreparedInsert {", '''/// Current pool membership, retired together with the existing txid index row.
+#[derive(Clone, Copy, Debug)]
+struct IndexedEntry {
+    id: EntryId,
+    admitted_sequence: u64,
+}
+
+pub(crate) struct PreparedInsert {''')
+    replace(pool, "    /// Tx id to entry id lookup. Owned by this module; reach it\n", "    /// Tx id to entry id and acceptance sequence. Owned by this module; reach it\n")
+    replace(pool, "        let mut changes = Vec::new();\n        self.push_change(&mut changes, txid, MutationOutcome::Accepted);\n", "")
+    replace(pool, "        self.by_txid.insert(txid, id);", '''        let mut changes = Vec::new();
+        self.push_change(&mut changes, txid, MutationOutcome::Accepted);
+        self.by_txid.insert(txid, IndexedEntry {
+            id,
+            admitted_sequence: self.mempool_sequence,
+        });''')
+    replace(pool, ".is_some_and(|id| excluded.contains(id))", ".is_some_and(|indexed| excluded.contains(&indexed.id))")
+    replace(pool, "        let id = *self.by_txid.get(txid)?;\n        self.entry(id)", "        self.entry(self.entry_id_by_txid(txid)?)")
+    replace(pool, "    /// Composite of `self.by_txid.get(txid)` and `self.entry(*id)`. Saves the\n", "    /// Composite of `self.entry_id_by_txid(txid)` and `self.entry(id)`. Saves the\n")
+    replace(pool, '''    pub fn entry_id_by_txid(&self, txid: &Txid) -> Option<EntryId> {
+        self.by_txid.get(txid).copied()
+    }''', '''    pub fn entry_id_by_txid(&self, txid: &Txid) -> Option<EntryId> {
+        self.by_txid.get(txid).map(|indexed| indexed.id)
+    }
+
+    /// Returns the resident entry only when its acceptance has `sequence`.
+    ///
+    /// Compare with the sequence of an `Accepted` mutation change from this
+    /// pool. Removal and re-admission invalidate the old receipt, even when
+    /// the same transaction allocation is reused. Unrelated mutations and fee
+    /// prioritisation do not invalidate it. The returned reference shares the
+    /// pool borrow, so identity and body are observed together.
+    #[must_use]
+    pub fn entry_by_txid_at_sequence(&self, txid: &Txid, sequence: u64) -> Option<&MempoolEntry> {
+        let indexed = self.by_txid.get(txid)?;
+        if indexed.admitted_sequence != sequence {
+            return None;
+        }
+        self.entry(indexed.id)
+    }''')
+    replace(pool, "self.by_txid.get(txid).copied()", "self.entry_id_by_txid(txid)", count=2)
+    replace(pool, "let Some(&id) = self.by_txid.get(&txid) else", "let Some(id) = self.entry_id_by_txid(&txid) else")
+    replace(pool, '''                modified_fee: self
+                    .by_txid
+                    .get(&txid)
+                    .and_then(|&id| self.entry(id).map(MempoolEntry::modified_fee)),''', '''                modified_fee: self.entry_by_txid(&txid).map(MempoolEntry::modified_fee),''')
+    replace(pool, "self.by_txid.get(&input.previous_output.txid).copied()", "self.entry_id_by_txid(&input.previous_output.txid)", count=3)
+    replace(pool, '''                    if let Some(parent) = self.by_txid.get(&input.previous_output.txid) {
+                        stack.push(*parent);''', '''                    if let Some(parent) = self.entry_id_by_txid(&input.previous_output.txid) {
+                        stack.push(parent);''')
+    replace(pool, "size_of::<(Txid, EntryId)>()", "size_of::<(Txid, IndexedEntry)>()")
+
+    relay = "crates/p2p/src/tx_relay.rs"
+    replace(relay, "        for change in &envelope.result.changes {", "        for (index, change) in envelope.result.changes.iter().enumerate() {")
+    replace(relay, '''            let wtxid = gateway.read().entry_by_txid(&txid).map(|entry| entry.wtxid);''', '''            let Some(sequence) = envelope.result.sequence_of(index) else {
+                continue;
+            };
+            let wtxid = gateway
+                .read()
+                .entry_by_txid_at_sequence(&txid, sequence)
+                .map(|entry| entry.wtxid);''')
+    replace(relay, "//! entry's real wtxid and skip entries removed before observer delivery. The\n", "//! entry's real wtxid only while that acceptance remains resident. The\n")
+
+    policy = "docs/policies/p2p-compatibility.md"
+    replace(policy, '''RPC/reorg mutation observers resolve the retained entry's wtxid and skip
+entries removed before observer delivery. Missing-parent requests use txids,''', '''RPC/reorg mutation observers resolve the retained entry's wtxid only when
+its acceptance sequence matches the committed event. Removal and re-admission
+invalidate older callbacks, including reinsertion of an identical body;
+unrelated mutations and fee prioritisation do not. Identity and body are read
+under one pool guard, released before relay enqueue. A later removal can still
+overtake an already queued best-effort announcement. Missing-parent requests use txids,''')
+    replace(policy, "  cover negotiated announcements and actual retained witness identity.\n", '''  cover negotiated announcements and actual retained witness identity.
+  `delayed_local_relay_does_not_adopt_a_reinserted_body`,
+  `delayed_local_relay_survives_unrelated_mutations`, and
+  `local_replacement_relay_uses_the_accepted_change_sequence` cover delayed
+  callback identity and per-change sequence selection.
+''')
+
+
+if __name__ == "__main__":
+    if subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip() != BASE:
+        raise SystemExit("expected the pinned source checkout")
+    if sys.argv[1:] == ["tests"]:
+        tests()
+    elif sys.argv[1:] == ["fix"]:
+        fix()
+    else:
+        raise SystemExit("usage: relay_admission_patch.py tests|fix")

--- a/.github/workflows/local-relay-admission-validation.yml
+++ b/.github/workflows/local-relay-admission-validation.yml
@@ -1,0 +1,145 @@
+name: local-relay-admission-validation
+
+on:
+  push:
+    branches: [validation/local-relay-admission-20260910]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: local-relay-admission-validation
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: never
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+
+jobs:
+  relay-admission:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          path: runner
+          persist-credentials: false
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: 6838258a3dbca18e78e1995cd5c274d52460167b
+          path: candidate
+          fetch-depth: 1
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
+        with:
+          components: rustfmt,clippy
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
+        with:
+          workspaces: candidate -> target
+          shared-key: tx-followups
+      - name: Require assertion failure on the original relay implementation
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/relay-evidence"
+          rustc --version | tee "$RUNNER_TEMP/relay-evidence/toolchain.txt"
+          python3 -m py_compile ../runner/.github/review/relay_admission_patch.py
+          python3 ../runner/.github/review/relay_admission_patch.py tests
+          set +e
+          cargo test --locked -p bitcoin-rs-p2p --lib tx_relay::tests::delayed_local_relay_ -- --nocapture > "$RUNNER_TEMP/relay-evidence/red.log" 2>&1
+          status=$?
+          set -e
+          tail -n 120 "$RUNNER_TEMP/relay-evidence/red.log"
+          test "$status" -ne 0
+          grep -q 'test result: FAILED' "$RUNNER_TEMP/relay-evidence/red.log"
+          grep -q 'delayed_local_relay_does_not_adopt_a_reinserted_body' "$RUNNER_TEMP/relay-evidence/red.log"
+      - name: Apply the fix and require the relay regressions to pass
+        id: fixed
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 ../runner/.github/review/relay_admission_patch.py fix
+          rustfmt --edition 2024 crates/mempool/src/pool.rs crates/p2p/src/tx_relay.rs
+          git diff --check
+          python3 - <<'PY'
+          import subprocess
+          expected = {'crates/mempool/src/pool.rs', 'crates/p2p/src/tx_relay.rs', 'docs/policies/p2p-compatibility.md'}
+          actual = set(subprocess.check_output(['git', 'diff', '--name-only'], text=True).splitlines())
+          if actual != expected:
+              raise SystemExit(f'unexpected change scope: {actual ^ expected}')
+          PY
+          git diff > "$RUNNER_TEMP/relay-evidence/candidate.patch"
+          cargo test --locked -p bitcoin-rs-p2p --lib tx_relay::tests -- --nocapture > "$RUNNER_TEMP/relay-evidence/relay-green.log" 2>&1
+          tail -n 100 "$RUNNER_TEMP/relay-evidence/relay-green.log"
+      - name: Publish only the source candidate on a new branch
+        id: published
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add crates/mempool/src/pool.rs crates/p2p/src/tx_relay.rs docs/policies/p2p-compatibility.md
+          git commit -m 'fix(p2p): bind delayed local relay to the committed admission'
+          git rev-parse HEAD | tee "$RUNNER_TEMP/relay-evidence/candidate-sha.txt"
+          git ls-tree HEAD crates/mempool/src/pool.rs crates/p2p/src/tx_relay.rs docs/policies/p2p-compatibility.md | tee "$RUNNER_TEMP/relay-evidence/blobs.txt"
+          git archive HEAD | gzip > "$RUNNER_TEMP/relay-evidence/source.tar.gz"
+          git push origin HEAD:refs/heads/followup/local-relay-admission-identity
+      - name: Mempool and P2P library and protocol tests
+        if: ${{ !cancelled() && steps.fixed.outcome == 'success' }}
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -uo pipefail
+          status=0
+          cargo test --locked -p bitcoin-rs-mempool --lib > "$RUNNER_TEMP/relay-evidence/mempool.log" 2>&1 || status=1
+          tail -n 35 "$RUNNER_TEMP/relay-evidence/mempool.log"
+          cargo test --locked -p bitcoin-rs-p2p --lib --test core_compat > "$RUNNER_TEMP/relay-evidence/p2p.log" 2>&1 || status=1
+          tail -n 45 "$RUNNER_TEMP/relay-evidence/p2p.log"
+          exit "$status"
+      - name: Workspace strict Clippy
+        if: ${{ !cancelled() && steps.fixed.outcome == 'success' }}
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo clippy --locked --workspace --all-targets --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node -- -D warnings 2>&1 | tee "$RUNNER_TEMP/relay-evidence/clippy-workspace.log"
+      - name: Native consensus strict Clippy
+        if: ${{ !cancelled() && steps.fixed.outcome == 'success' }}
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo clippy --locked -p bitcoin-rs-consensus --no-default-features --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/relay-evidence/clippy-consensus.log"
+      - name: Native node strict Clippy
+        if: ${{ !cancelled() && steps.fixed.outcome == 'success' }}
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/relay-evidence/clippy-node.log"
+      - name: Real-socket ingress and owner regression gates
+        if: ${{ !cancelled() && steps.fixed.outcome == 'success' }}
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -uo pipefail
+          status=0
+          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --test tx_ingress_e2e > "$RUNNER_TEMP/relay-evidence/ingress.log" 2>&1 || status=1
+          tail -n 45 "$RUNNER_TEMP/relay-evidence/ingress.log"
+          cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test overhaul_ownership > "$RUNNER_TEMP/relay-evidence/ownership.log" 2>&1 || status=1
+          tail -n 45 "$RUNNER_TEMP/relay-evidence/ownership.log"
+          cargo fmt --all -- --check > "$RUNNER_TEMP/relay-evidence/fmt.log" 2>&1 || status=1
+          tail -n 50 "$RUNNER_TEMP/relay-evidence/fmt.log"
+          git diff --exit-code || status=1
+          exit "$status"
+      - name: Preserve exact source and all execution evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: local-relay-admission-evidence
+          path: ${{ runner.temp }}/relay-evidence
+          retention-days: 3
+          if-no-files-found: error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a validation workflow and Python patch script that reproduce a local-relay admission identity bug and verify a fix against a pinned source checkout.

- The workflow runs the new regression tests on the original code (expecting failure), applies the fix, and requires them to pass.
- The fixed source is published to a followup branch and checked with strict clippy, formatting, and mempool/P2P/node test gates.

<sup>Written for commit bdac264f7fd532be2b47f2b10fb23b324b0274d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

