### PR TITLE
Pin formal-checker inputs for isolated CI reproduction

### DIFF
--- a/.github/workflows/g20-repro-bundle.yml
+++ b/.github/workflows/g20-repro-bundle.yml
@@ -1,0 +1,43 @@
+name: g20-repro-bundle
+
+on:
+  push:
+    branches: [ci/g20-repro-bundle-20260910]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: g20-repro-bundle-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Provision and verify the exact pinned checker
+        run: bash scripts/provision-ci-reference-fixtures.sh
+      - name: Record reproduction identity
+        run: |
+          mkdir -p target/g20-repro
+          printf 'commit=%s\nrun_id=%s\nattempt=%s\n' \
+            "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" \
+            > target/g20-repro/context.txt
+          sha256sum docs/models/*.tla docs/models/*.cfg \
+            target/tools/apalache-0.62.2/lib/apalache.jar \
+            > target/g20-repro/SHA256SUMS
+          # Only tracked public source and the verified public checker are
+          # bundled. No credentials, live state, or Git metadata is included.
+          git archive --format=tar HEAD > target/g20-repro/source.tar
+      - name: Upload isolated reproduction bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: g20-repro-${{ github.sha }}
+          path: |
+            target/g20-repro/
+            target/tools/apalache-0.62.2/
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a CI workflow that packages the pinned formal-checker inputs (Apalache 0.62.2) and model sources into an isolated reproduction bundle for the g20 issue.

- Runs on pushes to the `ci/g20-repro-bundle-20260910` branch.
- Verifies the pinned checker before bundling and records commit, run ID, and SHA256 checksums of source and model files.
- Uploads the bundle as a 1-day artifact, excluding credentials, live state, and Git metadata.

<sup>Written for commit db29faa88e9d0586ea50ba081ceb46feb46006e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

