### PR TITLE
Validate Clippy corrections and improve test linting processes

### DIFF
--- a/.github/workflows/clippy-followup-validation.yml
+++ b/.github/workflows/clippy-followup-validation.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: fd0d37ae7b2dc0b80b741f3d481c2e8caa88be2c
+          ref: f211c2f99174cdc41ffac0a6cc5d15013a1eb961
           fetch-depth: 1
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
         with:
@@ -31,7 +31,7 @@ jobs:
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
         with:
           cache-on-failure: true
-      - name: Apply the two diagnostics without changing test semantics
+      - name: Prepare test-only corrections on the merged baseline
         id: candidate
         shell: bash
         run: |
@@ -52,30 +52,90 @@ jobs:
                'assert_eq!(parsed.facts().transaction_spans().len(), parsed.transaction_count());'),
           ]
           for path, sha, old, new in edits:
-              actual = subprocess.check_output(['git','hash-object',path],text=True).strip()
-              if actual != sha:
-                  raise SystemExit(f'preimage changed: {path}: {actual}')
+              if subprocess.check_output(['git','hash-object',path],text=True).strip() != sha:
+                  raise SystemExit(f'preimage changed: {path}')
               p = Path(path)
               text = p.read_text()
               if text.count(old) != 1:
                   raise SystemExit(f'expected one edit target: {path}')
               p.write_text(text.replace(old,new,1))
+          p = Path('crates/node/src/metrics.rs')
+          if subprocess.check_output(['git','hash-object',str(p)],text=True).strip() != 'ab998373fbd7e7fbf385ad2673214e1306f77bd8':
+              raise SystemExit('metrics preimage changed')
+          text = p.read_text()
+          anchor = '    fn occupied_address_bind_errors_and_in_process_retry_succeeds() {\n'
+          prefix = '''        const CHILD: &str = "BITCOIN_RS_METRICS_BIND_CHILD";
+                  const FINISHED: &str = "fresh-recorder-bind-probe-finished";
+                  // Recorder installation is process-global and cannot be reset.
+                  // A fresh process makes this probe independent of test order and
+                  // keeps the empty-slot assertion meaningful, not merely race-free.
+                  if std::env::var_os(CHILD).is_none() {
+                      let executable = std::env::current_exe()
+                          .unwrap_or_else(|error| panic!("locate metrics test executable: {error}"));
+                      let output = std::process::Command::new(executable)
+                          .args([
+                              "--exact",
+                              "metrics::tests::occupied_address_bind_errors_and_in_process_retry_succeeds",
+                              "--nocapture",
+                          ])
+                          .env(CHILD, "1")
+                          .output()
+                          .unwrap_or_else(|error| panic!("run isolated metrics probe: {error}"));
+                      let stdout = String::from_utf8_lossy(&output.stdout);
+                      assert!(
+                          output.status.success(),
+                          "isolated metrics probe failed: {stdout}\\n{}",
+                          String::from_utf8_lossy(&output.stderr)
+                      );
+                      assert!(stdout.contains(FINISHED), "isolated probe did not execute: {stdout}");
+                      return;
+                  }
+          '''
+          if text.count(anchor) != 1:
+              raise SystemExit('metrics probe anchor changed')
+          text = text.replace(anchor,anchor+prefix,1)
+          old = '        let installed_before = PROMETHEUS_HANDLE.lock().is_some();'
+          new = '        assert!(PROMETHEUS_HANDLE.lock().is_none(), "probe requires a fresh recorder slot");'
+          if text.count(old) != 1:
+              raise SystemExit('metrics precondition changed')
+          text = text.replace(old,new,1)
+          old = '''        assert_eq!(
+                      PROMETHEUS_HANDLE.lock().is_some(),
+                      installed_before,
+                      "failed bind must not install the process recorder"
+                  );'''
+          old = '\n'.join(line[10:] if line.startswith('          ') else line for line in old.splitlines())
+          # Use the exact original formatting rather than indentation of this runner.
+          old = '        assert_eq!(\n            PROMETHEUS_HANDLE.lock().is_some(),\n            installed_before,\n            "failed bind must not install the process recorder"\n        );'
+          new = '        assert!(\n            PROMETHEUS_HANDLE.lock().is_none(),\n            "failed bind must not install the process recorder"\n        );'
+          if text.count(old) != 1:
+              raise SystemExit('metrics assertion changed')
+          text = text.replace(old,new,1)
+          end = '        server.join();\n    }\n\n    #[test]\n    fn scrape_returns_prometheus_text_with_recorded_metrics()'
+          if text.count(end) != 1:
+              raise SystemExit('metrics probe end changed')
+          text = text.replace(end, '        server.join();\n        println!("{FINISHED}");\n    }\n\n    #[test]\n    fn scrape_returns_prometheus_text_with_recorded_metrics()',1)
+          p.write_text(text)
           PY
-          rustfmt --edition 2024 bin/bitcoin-rs/tests/overhaul_reference_set.rs crates/consensus/tests/overhaul_parse_parity.rs
+          rustfmt --edition 2024 bin/bitcoin-rs/tests/overhaul_reference_set.rs crates/consensus/tests/overhaul_parse_parity.rs crates/node/src/metrics.rs
           git diff --check
           python3 - <<'PY'
           import subprocess
           paths = set(subprocess.check_output(['git','diff','--name-only'],text=True).splitlines())
-          if paths != {'bin/bitcoin-rs/tests/overhaul_reference_set.rs','crates/consensus/tests/overhaul_parse_parity.rs'}:
+          if paths != {'bin/bitcoin-rs/tests/overhaul_reference_set.rs','crates/consensus/tests/overhaul_parse_parity.rs','crates/node/src/metrics.rs'}:
               raise SystemExit(f'unexpected scope: {paths}')
+          before = subprocess.check_output(['git','show','HEAD:crates/node/src/metrics.rs'],text=True).split('#[cfg(test)]')[0]
+          after = open('crates/node/src/metrics.rs').read().split('#[cfg(test)]')[0]
+          if before != after:
+              raise SystemExit('production metrics code changed')
           PY
-          git diff | tee "$RUNNER_TEMP/clippy-evidence/correction.patch"
+          git diff | tee "$RUNNER_TEMP/clippy-evidence/candidate.patch"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add bin/bitcoin-rs/tests/overhaul_reference_set.rs crates/consensus/tests/overhaul_parse_parity.rs
-          git commit -m 'fix(tests): satisfy newly exposed strict Clippy diagnostics'
+          git add bin/bitcoin-rs/tests/overhaul_reference_set.rs crates/consensus/tests/overhaul_parse_parity.rs crates/node/src/metrics.rs
+          git commit -m 'test: fix strict Clippy diagnostics and isolate first-recorder initialization'
           git rev-parse HEAD | tee "$RUNNER_TEMP/clippy-evidence/candidate-sha.txt"
-          git push origin HEAD:refs/heads/followup/stable-clippy-cleanup
+          git push origin HEAD:refs/heads/followup/test-lints-recorder-isolation
           git archive --format=tar.gz HEAD > "$RUNNER_TEMP/clippy-evidence/source.tar.gz"
       - name: Workspace Clippy
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
@@ -102,19 +162,49 @@ jobs:
           set -uo pipefail
           status=0
           cargo test --locked -p bitcoin-rs-consensus --no-default-features --test overhaul_parse_parity > "$RUNNER_TEMP/clippy-evidence/parity-tests.log" 2>&1 || status=1
-          tail -n 60 "$RUNNER_TEMP/clippy-evidence/parity-tests.log"
+          tail -n 50 "$RUNNER_TEMP/clippy-evidence/parity-tests.log"
           cargo test --locked -p bitcoin-rs --test overhaul_reference_set > "$RUNNER_TEMP/clippy-evidence/reference-tests.log" 2>&1 || status=1
-          tail -n 60 "$RUNNER_TEMP/clippy-evidence/reference-tests.log"
+          tail -n 50 "$RUNNER_TEMP/clippy-evidence/reference-tests.log"
           cargo fmt --all -- --check > "$RUNNER_TEMP/clippy-evidence/fmt.log" 2>&1 || status=1
-          tail -n 60 "$RUNNER_TEMP/clippy-evidence/fmt.log"
+          tail -n 50 "$RUNNER_TEMP/clippy-evidence/fmt.log"
           exit "$status"
-      - name: Preserve the unresolved metrics test result
+      - name: Repeated parallel metrics tests and complete native node library
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
         shell: bash
         run: |
-          set -o pipefail
-          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics:: 2>&1 | tee "$RUNNER_TEMP/clippy-evidence/metrics-tests.log"
-      - name: Preserve candidate and all profile results
+          set -euo pipefail
+          for attempt in $(seq 1 20); do
+            cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics:: -- --test-threads=8 > "$RUNNER_TEMP/clippy-evidence/metrics-$attempt.log" 2>&1
+          done
+          tail -n 25 "$RUNNER_TEMP/clippy-evidence/metrics-20.log"
+          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib > "$RUNNER_TEMP/clippy-evidence/node-tests.log" 2>&1
+          tail -n 40 "$RUNNER_TEMP/clippy-evidence/node-tests.log"
+      - name: Mutation-test listener-before-recorder ordering
+        if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          p = Path('crates/node/src/metrics.rs')
+          text = p.read_text()
+          old = '        let listener = TcpListener::bind(addr)?;\n        let local_addr = listener.local_addr()?;\n        let handle = prometheus_handle(identity)?;'
+          new = '        let handle = prometheus_handle(identity)?;\n        let listener = TcpListener::bind(addr)?;\n        let local_addr = listener.local_addr()?;'
+          if text.count(old) != 1:
+              raise SystemExit('ordering mutation preimage changed')
+          p.write_text(text.replace(old,new,1))
+          PY
+          set +e
+          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics::tests::occupied_address_bind_errors_and_in_process_retry_succeeds -- --exact --nocapture > "$RUNNER_TEMP/clippy-evidence/ordering-mutant.log" 2>&1
+          status=$?
+          set -e
+          git restore crates/node/src/metrics.rs
+          tail -n 70 "$RUNNER_TEMP/clippy-evidence/ordering-mutant.log"
+          test "$status" -ne 0
+          grep -q 'failed bind must not install the process recorder' "$RUNNER_TEMP/clippy-evidence/ordering-mutant.log"
+          grep -q 'test result: FAILED' "$RUNNER_TEMP/clippy-evidence/ordering-mutant.log"
+          git diff --exit-code
+      - name: Preserve exact source and all validation results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/clippy-followup-validation.yml
+++ b/.github/workflows/clippy-followup-validation.yml
@@ -29,39 +29,66 @@ jobs:
         with:
           components: rustfmt,clippy
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
-      - name: Prepare the source-only candidate
+      - name: Prepare the source-only candidate and reconcile workspace lock entries
         id: candidate
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/clippy-evidence"
           rustc --version | tee "$RUNNER_TEMP/clippy-evidence/toolchain.txt"
+          if git ls-remote --exit-code --heads origin refs/heads/followup/stable-clippy-cleanup; then
+            git fetch origin refs/heads/followup/stable-clippy-cleanup
+            git diff --quiet 7d384289f6d47a6c44705ad05b7aa14926624e4b FETCH_HEAD -- . ':!crates/node/src/metrics.rs' ':!Cargo.lock'
+            git checkout --detach FETCH_HEAD
+          fi
           python3 - <<'PY'
           from pathlib import Path
           import subprocess
           path = 'crates/node/src/metrics.rs'
-          expected = '801775b321dd24bd4e29c35daf91460dffa309e5'
-          actual = subprocess.check_output(['git', 'hash-object', path], text=True).strip()
-          if actual != expected:
-              raise SystemExit(f'metrics preimage changed: {actual}')
-          p = Path(path)
-          text = p.read_text()
+          base = '7d384289f6d47a6c44705ad05b7aa14926624e4b'
+          original = subprocess.check_output(['git', 'show', f'{base}:{path}'], text=True)
           old = 'bytes.iter_mut().zip(text.as_bytes().chunks_exact(2))'
           new = 'bytes.iter_mut().zip(text.as_bytes().as_chunks::<2>().0)'
-          if text.count(old) != 1:
+          if original.count(old) != 1:
               raise SystemExit('expected exactly one chunk iteration preimage')
-          p.write_text(text.replace(old, new, 1))
+          replacement = original.replace(old, new, 1)
+          p = Path(path)
+          if p.read_text() not in (original, replacement):
+              raise SystemExit('candidate contains unrelated metrics changes')
+          p.write_text(replacement)
+          PY
+          cp Cargo.lock "$RUNNER_TEMP/clippy-evidence/Cargo.lock.before"
+          cargo metadata --format-version=1 > "$RUNNER_TEMP/clippy-metadata.json"
+          python3 - <<'PY'
+          from pathlib import Path
+          import subprocess, tomllib
+          base = '7d384289f6d47a6c44705ad05b7aa14926624e4b'
+          before = tomllib.loads(subprocess.check_output(['git','show',f'{base}:Cargo.lock'],text=True))
+          after = tomllib.loads(Path('Cargo.lock').read_text())
+          def external(lock):
+              return {(p['name'],p['version'],p['source']):p for p in lock['package'] if 'source' in p}
+          def identities(lock):
+              return {(p['name'],p['version'],p.get('source')) for p in lock['package']}
+          if external(before) != external(after) or identities(before) != identities(after) or before['version'] != after['version']:
+              raise SystemExit('lock reconciliation changed an external dependency or package identity')
           PY
           rustfmt --edition 2024 crates/node/src/metrics.rs
           git diff --check
-          test "$(git diff --name-only)" = crates/node/src/metrics.rs
-          git diff | tee "$RUNNER_TEMP/clippy-evidence/candidate.patch"
+          python3 - <<'PY'
+          import subprocess
+          paths = set(subprocess.check_output(['git','diff','--name-only','7d384289f6d47a6c44705ad05b7aa14926624e4b'],text=True).splitlines())
+          if paths != {'Cargo.lock','crates/node/src/metrics.rs'}:
+              raise SystemExit(f'unexpected candidate scope: {paths}')
+          PY
+          git diff 7d384289f6d47a6c44705ad05b7aa14926624e4b | tee "$RUNNER_TEMP/clippy-evidence/candidate.patch"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add crates/node/src/metrics.rs
-          git commit -m 'fix(node): use fixed-size digest chunks for current-stable Clippy'
+          git add Cargo.lock crates/node/src/metrics.rs
+          if ! git diff --cached --quiet; then
+            git commit -m 'fix(node): satisfy stable Clippy with a consistent workspace lock'
+          fi
           git rev-parse HEAD | tee "$RUNNER_TEMP/clippy-evidence/candidate-sha.txt"
-          git ls-tree HEAD crates/node/src/metrics.rs | tee "$RUNNER_TEMP/clippy-evidence/blobs.txt"
+          git ls-tree HEAD Cargo.lock crates/node/src/metrics.rs | tee "$RUNNER_TEMP/clippy-evidence/blobs.txt"
           git push origin HEAD:refs/heads/followup/stable-clippy-cleanup
       - name: Workspace Clippy
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}

--- a/.github/workflows/clippy-followup-validation.yml
+++ b/.github/workflows/clippy-followup-validation.yml
@@ -17,169 +17,99 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  clippy-followup:
+  metrics-bind-proof:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: f211c2f99174cdc41ffac0a6cc5d15013a1eb961
-          fetch-depth: 1
+          ref: 39582762a94f0573ff12bd2ae643ee933b8bec15
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
         with:
           components: rustfmt,clippy
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
         with:
           cache-on-failure: true
-      - name: Prepare test-only corrections on the merged baseline
+      - name: Extract only the tested fresh-process probe onto current main
         id: candidate
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/clippy-evidence"
-          rustc --version | tee "$RUNNER_TEMP/clippy-evidence/toolchain.txt"
+          mkdir -p "$RUNNER_TEMP/metrics-evidence"
+          rustc --version | tee "$RUNNER_TEMP/metrics-evidence/toolchain.txt"
+          git fetch origin 5efe8c3281465bb8999b3d305119c9c519bd6833
           python3 - <<'PY'
           from pathlib import Path
           import subprocess
-          edits = [
-              ('bin/bitcoin-rs/tests/overhaul_reference_set.rs',
-               'a92d9a6f21835b3ae8a08fe8da566e8c20a141e0',
-               'for (at, pair) in bytes.chunks_exact(2).enumerate() {',
-               'for (at, pair) in bytes.as_chunks::<2>().0.iter().enumerate() {'),
-              ('crates/consensus/tests/overhaul_parse_parity.rs',
-               'f6f5918c68e8be999f4d4af1def197c941f921e5',
-               'assert!(parsed.facts().transaction_spans().len() == parsed.transaction_count());',
-               'assert_eq!(parsed.facts().transaction_spans().len(), parsed.transaction_count());'),
-          ]
-          for path, sha, old, new in edits:
-              if subprocess.check_output(['git','hash-object',path],text=True).strip() != sha:
-                  raise SystemExit(f'preimage changed: {path}')
-              p = Path(path)
-              text = p.read_text()
-              if text.count(old) != 1:
-                  raise SystemExit(f'expected one edit target: {path}')
-              p.write_text(text.replace(old,new,1))
-          p = Path('crates/node/src/metrics.rs')
-          if subprocess.check_output(['git','hash-object',str(p)],text=True).strip() != 'ab998373fbd7e7fbf385ad2673214e1306f77bd8':
-              raise SystemExit('metrics preimage changed')
-          text = p.read_text()
-          anchor = '    fn occupied_address_bind_errors_and_in_process_retry_succeeds() {\n'
-          prefix = '''        const CHILD: &str = "BITCOIN_RS_METRICS_BIND_CHILD";
-                  const FINISHED: &str = "fresh-recorder-bind-probe-finished";
-                  // Recorder installation is process-global and cannot be reset.
-                  // A fresh process makes this probe independent of test order and
-                  // keeps the empty-slot assertion meaningful, not merely race-free.
-                  if std::env::var_os(CHILD).is_none() {
-                      let executable = std::env::current_exe()
-                          .unwrap_or_else(|error| panic!("locate metrics test executable: {error}"));
-                      let output = std::process::Command::new(executable)
-                          .args([
-                              "--exact",
-                              "metrics::tests::occupied_address_bind_errors_and_in_process_retry_succeeds",
-                              "--nocapture",
-                          ])
-                          .env(CHILD, "1")
-                          .output()
-                          .unwrap_or_else(|error| panic!("run isolated metrics probe: {error}"));
-                      let stdout = String::from_utf8_lossy(&output.stdout);
-                      assert!(
-                          output.status.success(),
-                          "isolated metrics probe failed: {stdout}\\n{}",
-                          String::from_utf8_lossy(&output.stderr)
-                      );
-                      assert!(stdout.contains(FINISHED), "isolated probe did not execute: {stdout}");
-                      return;
-                  }
-          '''
-          if text.count(anchor) != 1:
-              raise SystemExit('metrics probe anchor changed')
-          text = text.replace(anchor,anchor+prefix,1)
-          old = '        let installed_before = PROMETHEUS_HANDLE.lock().is_some();'
-          new = '        assert!(PROMETHEUS_HANDLE.lock().is_none(), "probe requires a fresh recorder slot");'
-          if text.count(old) != 1:
-              raise SystemExit('metrics precondition changed')
-          text = text.replace(old,new,1)
-          old = '''        assert_eq!(
-                      PROMETHEUS_HANDLE.lock().is_some(),
-                      installed_before,
-                      "failed bind must not install the process recorder"
-                  );'''
-          old = '\n'.join(line[10:] if line.startswith('          ') else line for line in old.splitlines())
-          # Use the exact original formatting rather than indentation of this runner.
-          old = '        assert_eq!(\n            PROMETHEUS_HANDLE.lock().is_some(),\n            installed_before,\n            "failed bind must not install the process recorder"\n        );'
-          new = '        assert!(\n            PROMETHEUS_HANDLE.lock().is_none(),\n            "failed bind must not install the process recorder"\n        );'
-          if text.count(old) != 1:
-              raise SystemExit('metrics assertion changed')
-          text = text.replace(old,new,1)
-          end = '        server.join();\n    }\n\n    #[test]\n    fn scrape_returns_prometheus_text_with_recorded_metrics()'
-          if text.count(end) != 1:
-              raise SystemExit('metrics probe end changed')
-          text = text.replace(end, '        server.join();\n        println!("{FINISHED}");\n    }\n\n    #[test]\n    fn scrape_returns_prometheus_text_with_recorded_metrics()',1)
-          p.write_text(text)
+          path = 'crates/node/src/metrics.rs'
+          tested = subprocess.check_output(['git','show',f'5efe8c3281465bb8999b3d305119c9c519bd6833:{path}'],text=True)
+          current = Path(path).read_text()
+          start = '    fn occupied_address_bind_errors_and_in_process_retry_succeeds() {\n'
+          end = '\n    #[test]\n    fn scrape_returns_prometheus_text_with_recorded_metrics()'
+          def span(text):
+              if text.count(start) != 1 or text.count(end) != 1:
+                  raise SystemExit('metrics function boundaries changed')
+              a = text.index(start)
+              b = text.index(end,a)
+              return a,b
+          a,b = span(tested)
+          replacement = tested[a:b]
+          # Preserve the newly merged test mutex and all other server guards.
+          needle = '        const FINISHED: &str = "fresh-recorder-bind-probe-finished";\n'
+          if replacement.count(needle) != 1:
+              raise SystemExit('tested probe changed')
+          replacement = replacement.replace(needle,needle+'        let _guard = SERVER_TEST_LOCK.lock();\n',1)
+          a,b = span(current)
+          if current[a:b].count('let _guard = SERVER_TEST_LOCK.lock();') != 1:
+              raise SystemExit('expected the merged fixture guard')
+          updated = current[:a]+replacement+current[b:]
+          if updated.split('#[cfg(test)]')[0] != current.split('#[cfg(test)]')[0]:
+              raise SystemExit('production metrics changed')
+          Path(path).write_text(updated)
           PY
-          rustfmt --edition 2024 bin/bitcoin-rs/tests/overhaul_reference_set.rs crates/consensus/tests/overhaul_parse_parity.rs crates/node/src/metrics.rs
+          rustfmt --edition 2024 crates/node/src/metrics.rs
           git diff --check
-          python3 - <<'PY'
-          import subprocess
-          paths = set(subprocess.check_output(['git','diff','--name-only'],text=True).splitlines())
-          if paths != {'bin/bitcoin-rs/tests/overhaul_reference_set.rs','crates/consensus/tests/overhaul_parse_parity.rs','crates/node/src/metrics.rs'}:
-              raise SystemExit(f'unexpected scope: {paths}')
-          before = subprocess.check_output(['git','show','HEAD:crates/node/src/metrics.rs'],text=True).split('#[cfg(test)]')[0]
-          after = open('crates/node/src/metrics.rs').read().split('#[cfg(test)]')[0]
-          if before != after:
-              raise SystemExit('production metrics code changed')
-          PY
-          git diff | tee "$RUNNER_TEMP/clippy-evidence/candidate.patch"
+          test "$(git diff --name-only)" = crates/node/src/metrics.rs
+          git diff | tee "$RUNNER_TEMP/metrics-evidence/candidate.patch"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add bin/bitcoin-rs/tests/overhaul_reference_set.rs crates/consensus/tests/overhaul_parse_parity.rs crates/node/src/metrics.rs
-          git commit -m 'test: fix strict Clippy diagnostics and isolate first-recorder initialization'
-          git rev-parse HEAD | tee "$RUNNER_TEMP/clippy-evidence/candidate-sha.txt"
-          git push origin HEAD:refs/heads/followup/test-lints-recorder-isolation
-          git archive --format=tar.gz HEAD > "$RUNNER_TEMP/clippy-evidence/source.tar.gz"
+          git add crates/node/src/metrics.rs
+          git commit -m 'test(node): prove failed metrics bind leaves a fresh recorder uninstalled'
+          git rev-parse HEAD | tee "$RUNNER_TEMP/metrics-evidence/candidate-sha.txt"
+          git push origin HEAD:refs/heads/followup/metrics-bind-proof
+          git archive --format=tar.gz HEAD > "$RUNNER_TEMP/metrics-evidence/source.tar.gz"
       - name: Workspace Clippy
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
         shell: bash
         run: |
           set -o pipefail
-          cargo clippy --locked --workspace --all-targets --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy-evidence/workspace.log"
+          cargo clippy --locked --workspace --all-targets --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node -- -D warnings 2>&1 | tee "$RUNNER_TEMP/metrics-evidence/workspace.log"
       - name: Native consensus Clippy
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
         shell: bash
         run: |
           set -o pipefail
-          cargo clippy --locked -p bitcoin-rs-consensus --no-default-features --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy-evidence/consensus.log"
+          cargo clippy --locked -p bitcoin-rs-consensus --no-default-features --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/metrics-evidence/consensus.log"
       - name: Native node Clippy
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
         shell: bash
         run: |
           set -o pipefail
-          cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy-evidence/node.log"
-      - name: Changed test targets and formatting
-        if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
-        shell: bash
-        run: |
-          set -uo pipefail
-          status=0
-          cargo test --locked -p bitcoin-rs-consensus --no-default-features --test overhaul_parse_parity > "$RUNNER_TEMP/clippy-evidence/parity-tests.log" 2>&1 || status=1
-          tail -n 50 "$RUNNER_TEMP/clippy-evidence/parity-tests.log"
-          cargo test --locked -p bitcoin-rs --test overhaul_reference_set > "$RUNNER_TEMP/clippy-evidence/reference-tests.log" 2>&1 || status=1
-          tail -n 50 "$RUNNER_TEMP/clippy-evidence/reference-tests.log"
-          cargo fmt --all -- --check > "$RUNNER_TEMP/clippy-evidence/fmt.log" 2>&1 || status=1
-          tail -n 50 "$RUNNER_TEMP/clippy-evidence/fmt.log"
-          exit "$status"
-      - name: Repeated parallel metrics tests and complete native node library
+          cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/metrics-evidence/node.log"
+      - name: Parallel metrics stress, complete native node library, and formatting
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
         shell: bash
         run: |
           set -euo pipefail
           for attempt in $(seq 1 20); do
-            cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics:: -- --test-threads=8 > "$RUNNER_TEMP/clippy-evidence/metrics-$attempt.log" 2>&1
+            cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics:: -- --test-threads=8 > "$RUNNER_TEMP/metrics-evidence/metrics-$attempt.log" 2>&1
           done
-          tail -n 25 "$RUNNER_TEMP/clippy-evidence/metrics-20.log"
-          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib > "$RUNNER_TEMP/clippy-evidence/node-tests.log" 2>&1
-          tail -n 40 "$RUNNER_TEMP/clippy-evidence/node-tests.log"
-      - name: Mutation-test listener-before-recorder ordering
+          tail -n 20 "$RUNNER_TEMP/metrics-evidence/metrics-20.log"
+          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib > "$RUNNER_TEMP/metrics-evidence/node-tests.log" 2>&1
+          tail -n 30 "$RUNNER_TEMP/metrics-evidence/node-tests.log"
+          cargo fmt --all -- --check > "$RUNNER_TEMP/metrics-evidence/fmt.log" 2>&1
+      - name: Verify the regression rejects recorder-before-listener initialization
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
         shell: bash
         run: |
@@ -195,20 +125,20 @@ jobs:
           p.write_text(text.replace(old,new,1))
           PY
           set +e
-          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics::tests::occupied_address_bind_errors_and_in_process_retry_succeeds -- --exact --nocapture > "$RUNNER_TEMP/clippy-evidence/ordering-mutant.log" 2>&1
+          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics::tests::occupied_address_bind_errors_and_in_process_retry_succeeds -- --exact --nocapture > "$RUNNER_TEMP/metrics-evidence/ordering-mutant.log" 2>&1
           status=$?
           set -e
           git restore crates/node/src/metrics.rs
-          tail -n 70 "$RUNNER_TEMP/clippy-evidence/ordering-mutant.log"
+          tail -n 50 "$RUNNER_TEMP/metrics-evidence/ordering-mutant.log"
           test "$status" -ne 0
-          grep -q 'failed bind must not install the process recorder' "$RUNNER_TEMP/clippy-evidence/ordering-mutant.log"
-          grep -q 'test result: FAILED' "$RUNNER_TEMP/clippy-evidence/ordering-mutant.log"
+          grep -q 'failed bind must not install the process recorder' "$RUNNER_TEMP/metrics-evidence/ordering-mutant.log"
+          grep -q 'test result: FAILED' "$RUNNER_TEMP/metrics-evidence/ordering-mutant.log"
           git diff --exit-code
-      - name: Preserve exact source and all validation results
+      - name: Preserve exact-source validation evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: stable-clippy-followup-evidence
-          path: ${{ runner.temp }}/clippy-evidence
+          name: metrics-bind-proof-evidence
+          path: ${{ runner.temp }}/metrics-evidence
           retention-days: 3
           if-no-files-found: error

--- a/.github/workflows/clippy-followup-validation.yml
+++ b/.github/workflows/clippy-followup-validation.yml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: clippy-followup-validation
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: never
@@ -23,73 +23,60 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: 7d384289f6d47a6c44705ad05b7aa14926624e4b
+          ref: fd0d37ae7b2dc0b80b741f3d481c2e8caa88be2c
           fetch-depth: 1
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
         with:
           components: rustfmt,clippy
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
-      - name: Prepare the source-only candidate and reconcile workspace lock entries
+        with:
+          cache-on-failure: true
+      - name: Apply the two diagnostics without changing test semantics
         id: candidate
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/clippy-evidence"
           rustc --version | tee "$RUNNER_TEMP/clippy-evidence/toolchain.txt"
-          if git ls-remote --exit-code --heads origin refs/heads/followup/stable-clippy-cleanup; then
-            git fetch origin refs/heads/followup/stable-clippy-cleanup
-            git diff --quiet 7d384289f6d47a6c44705ad05b7aa14926624e4b FETCH_HEAD -- . ':!crates/node/src/metrics.rs' ':!Cargo.lock'
-            git checkout --detach FETCH_HEAD
-          fi
           python3 - <<'PY'
           from pathlib import Path
           import subprocess
-          path = 'crates/node/src/metrics.rs'
-          base = '7d384289f6d47a6c44705ad05b7aa14926624e4b'
-          original = subprocess.check_output(['git', 'show', f'{base}:{path}'], text=True)
-          old = 'bytes.iter_mut().zip(text.as_bytes().chunks_exact(2))'
-          new = 'bytes.iter_mut().zip(text.as_bytes().as_chunks::<2>().0)'
-          if original.count(old) != 1:
-              raise SystemExit('expected exactly one chunk iteration preimage')
-          replacement = original.replace(old, new, 1)
-          p = Path(path)
-          if p.read_text() not in (original, replacement):
-              raise SystemExit('candidate contains unrelated metrics changes')
-          p.write_text(replacement)
+          edits = [
+              ('bin/bitcoin-rs/tests/overhaul_reference_set.rs',
+               'a92d9a6f21835b3ae8a08fe8da566e8c20a141e0',
+               'for (at, pair) in bytes.chunks_exact(2).enumerate() {',
+               'for (at, pair) in bytes.as_chunks::<2>().0.iter().enumerate() {'),
+              ('crates/consensus/tests/overhaul_parse_parity.rs',
+               'f6f5918c68e8be999f4d4af1def197c941f921e5',
+               'assert!(parsed.facts().transaction_spans().len() == parsed.transaction_count());',
+               'assert_eq!(parsed.facts().transaction_spans().len(), parsed.transaction_count());'),
+          ]
+          for path, sha, old, new in edits:
+              actual = subprocess.check_output(['git','hash-object',path],text=True).strip()
+              if actual != sha:
+                  raise SystemExit(f'preimage changed: {path}: {actual}')
+              p = Path(path)
+              text = p.read_text()
+              if text.count(old) != 1:
+                  raise SystemExit(f'expected one edit target: {path}')
+              p.write_text(text.replace(old,new,1))
           PY
-          cp Cargo.lock "$RUNNER_TEMP/clippy-evidence/Cargo.lock.before"
-          cargo metadata --format-version=1 > "$RUNNER_TEMP/clippy-metadata.json"
-          python3 - <<'PY'
-          from pathlib import Path
-          import subprocess, tomllib
-          base = '7d384289f6d47a6c44705ad05b7aa14926624e4b'
-          before = tomllib.loads(subprocess.check_output(['git','show',f'{base}:Cargo.lock'],text=True))
-          after = tomllib.loads(Path('Cargo.lock').read_text())
-          def external(lock):
-              return {(p['name'],p['version'],p['source']):p for p in lock['package'] if 'source' in p}
-          def identities(lock):
-              return {(p['name'],p['version'],p.get('source')) for p in lock['package']}
-          if external(before) != external(after) or identities(before) != identities(after) or before['version'] != after['version']:
-              raise SystemExit('lock reconciliation changed an external dependency or package identity')
-          PY
-          rustfmt --edition 2024 crates/node/src/metrics.rs
+          rustfmt --edition 2024 bin/bitcoin-rs/tests/overhaul_reference_set.rs crates/consensus/tests/overhaul_parse_parity.rs
           git diff --check
           python3 - <<'PY'
           import subprocess
-          paths = set(subprocess.check_output(['git','diff','--name-only','7d384289f6d47a6c44705ad05b7aa14926624e4b'],text=True).splitlines())
-          if paths != {'Cargo.lock','crates/node/src/metrics.rs'}:
-              raise SystemExit(f'unexpected candidate scope: {paths}')
+          paths = set(subprocess.check_output(['git','diff','--name-only'],text=True).splitlines())
+          if paths != {'bin/bitcoin-rs/tests/overhaul_reference_set.rs','crates/consensus/tests/overhaul_parse_parity.rs'}:
+              raise SystemExit(f'unexpected scope: {paths}')
           PY
-          git diff 7d384289f6d47a6c44705ad05b7aa14926624e4b | tee "$RUNNER_TEMP/clippy-evidence/candidate.patch"
+          git diff | tee "$RUNNER_TEMP/clippy-evidence/correction.patch"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add Cargo.lock crates/node/src/metrics.rs
-          if ! git diff --cached --quiet; then
-            git commit -m 'fix(node): satisfy stable Clippy with a consistent workspace lock'
-          fi
+          git add bin/bitcoin-rs/tests/overhaul_reference_set.rs crates/consensus/tests/overhaul_parse_parity.rs
+          git commit -m 'fix(tests): satisfy newly exposed strict Clippy diagnostics'
           git rev-parse HEAD | tee "$RUNNER_TEMP/clippy-evidence/candidate-sha.txt"
-          git ls-tree HEAD Cargo.lock crates/node/src/metrics.rs | tee "$RUNNER_TEMP/clippy-evidence/blobs.txt"
           git push origin HEAD:refs/heads/followup/stable-clippy-cleanup
+          git archive --format=tar.gz HEAD > "$RUNNER_TEMP/clippy-evidence/source.tar.gz"
       - name: Workspace Clippy
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
         shell: bash
@@ -108,17 +95,25 @@ jobs:
         run: |
           set -o pipefail
           cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy-evidence/node.log"
-      - name: Metrics tests and workspace formatting
+      - name: Changed test targets and formatting
         if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
         shell: bash
         run: |
           set -uo pipefail
           status=0
-          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics:: > "$RUNNER_TEMP/clippy-evidence/metrics-tests.log" 2>&1 || status=1
-          tail -n 70 "$RUNNER_TEMP/clippy-evidence/metrics-tests.log"
+          cargo test --locked -p bitcoin-rs-consensus --no-default-features --test overhaul_parse_parity > "$RUNNER_TEMP/clippy-evidence/parity-tests.log" 2>&1 || status=1
+          tail -n 60 "$RUNNER_TEMP/clippy-evidence/parity-tests.log"
+          cargo test --locked -p bitcoin-rs --test overhaul_reference_set > "$RUNNER_TEMP/clippy-evidence/reference-tests.log" 2>&1 || status=1
+          tail -n 60 "$RUNNER_TEMP/clippy-evidence/reference-tests.log"
           cargo fmt --all -- --check > "$RUNNER_TEMP/clippy-evidence/fmt.log" 2>&1 || status=1
-          tail -n 70 "$RUNNER_TEMP/clippy-evidence/fmt.log"
+          tail -n 60 "$RUNNER_TEMP/clippy-evidence/fmt.log"
           exit "$status"
+      - name: Preserve the unresolved metrics test result
+        if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics:: 2>&1 | tee "$RUNNER_TEMP/clippy-evidence/metrics-tests.log"
       - name: Preserve candidate and all profile results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/clippy-followup-validation.yml
+++ b/.github/workflows/clippy-followup-validation.yml
@@ -1,0 +1,102 @@
+name: clippy-followup-validation
+
+on:
+  push:
+    branches: [validation/clippy-followup-20260910]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: clippy-followup-validation
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: never
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+
+jobs:
+  clippy-followup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: 7d384289f6d47a6c44705ad05b7aa14926624e4b
+          fetch-depth: 1
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
+        with:
+          components: rustfmt,clippy
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
+      - name: Prepare the source-only candidate
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/clippy-evidence"
+          rustc --version | tee "$RUNNER_TEMP/clippy-evidence/toolchain.txt"
+          python3 - <<'PY'
+          from pathlib import Path
+          import subprocess
+          path = 'crates/node/src/metrics.rs'
+          expected = '801775b321dd24bd4e29c35daf91460dffa309e5'
+          actual = subprocess.check_output(['git', 'hash-object', path], text=True).strip()
+          if actual != expected:
+              raise SystemExit(f'metrics preimage changed: {actual}')
+          p = Path(path)
+          text = p.read_text()
+          old = 'bytes.iter_mut().zip(text.as_bytes().chunks_exact(2))'
+          new = 'bytes.iter_mut().zip(text.as_bytes().as_chunks::<2>().0)'
+          if text.count(old) != 1:
+              raise SystemExit('expected exactly one chunk iteration preimage')
+          p.write_text(text.replace(old, new, 1))
+          PY
+          rustfmt --edition 2024 crates/node/src/metrics.rs
+          git diff --check
+          test "$(git diff --name-only)" = crates/node/src/metrics.rs
+          git diff | tee "$RUNNER_TEMP/clippy-evidence/candidate.patch"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add crates/node/src/metrics.rs
+          git commit -m 'fix(node): use fixed-size digest chunks for current-stable Clippy'
+          git rev-parse HEAD | tee "$RUNNER_TEMP/clippy-evidence/candidate-sha.txt"
+          git ls-tree HEAD crates/node/src/metrics.rs | tee "$RUNNER_TEMP/clippy-evidence/blobs.txt"
+          git push origin HEAD:refs/heads/followup/stable-clippy-cleanup
+      - name: Workspace Clippy
+        if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo clippy --locked --workspace --all-targets --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy-evidence/workspace.log"
+      - name: Native consensus Clippy
+        if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo clippy --locked -p bitcoin-rs-consensus --no-default-features --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy-evidence/consensus.log"
+      - name: Native node Clippy
+        if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy-evidence/node.log"
+      - name: Metrics tests and workspace formatting
+        if: ${{ !cancelled() && steps.candidate.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          status=0
+          cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib metrics:: > "$RUNNER_TEMP/clippy-evidence/metrics-tests.log" 2>&1 || status=1
+          tail -n 70 "$RUNNER_TEMP/clippy-evidence/metrics-tests.log"
+          cargo fmt --all -- --check > "$RUNNER_TEMP/clippy-evidence/fmt.log" 2>&1 || status=1
+          tail -n 70 "$RUNNER_TEMP/clippy-evidence/fmt.log"
+          exit "$status"
+      - name: Preserve candidate and all profile results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: stable-clippy-followup-evidence
+          path: ${{ runner.temp }}/clippy-evidence
+          retention-days: 3
+          if-no-files-found: error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a CI workflow that validates the focused Clippy corrections for test targets and proves the metrics bind fix prevents the process recorder from being installed after a failed bind. It runs strict Clippy on workspace and native profiles, stress-tests the metrics tests, and confirms a regression test rejects recorder-before-listener initialization.

<sup>Written for commit f54a3a9c2490da2bfeb386485644b40879bec3cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

