### PR TITLE
Work/ci repair staging 20260910

### DIFF
--- a/.ci-repair-prepare.py
+++ b/.ci-repair-prepare.py
@@ -1,0 +1,244 @@
+"""Temporary, identity-checked candidate construction. Not part of the candidate tree."""
+from pathlib import Path
+import hashlib
+import re
+
+root = Path.cwd()
+p = root / 'crates/consensus/src/verify_block.rs'
+legacy_path = p.with_name('verify_block_impl.rs')
+wrapper = p.read_text()
+legacy = legacy_path.read_text()
+assert hashlib.sha256(wrapper.encode()).hexdigest() == 'ec8c8a3f3957930c38344031dc61365cd2152ec960e135b475f85781c0029700', 'verifier changed; rebase'
+assert hashlib.sha256(legacy.encode()).hexdigest() == 'd129117a582d307161d37918b29c5aa9fbeab2905f376d36d79c0d029d2c2c9b', 'legacy verifier changed; rebase'
+start = '/// Verifies non-contextual block rules that do not require a UTXO set.\n'
+end = '/// Verifies the header Merkle root and rejects mutated Merkle trees.\n'
+body = wrapper[wrapper.index(start):wrapper.index('/// Returns `true` for the one-input, null-prevout coinbase shape.')]
+new = legacy[:legacy.index(start)] + body + legacy[legacy.index(end):]
+new = '//! Block rule checks over shared parse-once facts.\n\n' + new
+new = new.replace('use crate::ConsensusError;\n', 'use crate::ConsensusError;\nuse crate::block_view::BlockFacts;\n', 1)
+old = '''        let wtxids: Vec<Wtxid> = block.txs.iter().map(Tx::wtxid).collect();
+        let has_witness = block_has_witness(block);
+        verify_block_rules_precomputed(block, context, &txids, &wtxids, has_witness)'''
+replacement = '''        let mut facts = BlockFacts::from_txids(&block.txs, txids);
+        if context.segwit_active && facts.has_witness() {
+            facts.or_insert_wtxids_from(&block.txs);
+        }
+        verify_block_rules_precomputed(block, context, &facts)'''
+assert new.count(old) == 1
+new = new.replace(old, replacement, 1)
+new = new.replace('        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid, Wtxid,', '        Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid,', 1)
+new = new.replace('        BlockRuleContext, WITNESS_COMMITMENT_PREFIX, block_has_witness,', '        BlockRuleContext, WITNESS_COMMITMENT_PREFIX,', 1)
+new = new.replace('    use crate::ConsensusError;\n', '    use crate::ConsensusError;\n    use crate::block_view::BlockFacts;\n', 1)
+assert new.count('#[test]') == legacy.count('#[test]') == 24
+assert set(re.findall(r'fn (\w+)\(', new)) == set(re.findall(r'fn (\w+)\(', legacy))
+extra = '''    #[test]
+    fn precomputed_rules_reject_a_different_transaction_count() {
+        let block = block_with_transactions(vec![coinbase_tx()]);
+        let facts = BlockFacts::from_txids(&[], Vec::new());
+        assert_eq!(
+            verify_block_rules_precomputed(&block, BlockRuleContext::non_contextual(), &facts),
+            Err(ConsensusError::MerkleRoot)
+        );
+    }
+
+    #[test]
+    fn precomputed_rules_require_cached_witness_ids() {
+        let reserved = vec![0_u8; 32];
+        let spend = witness_spend_tx();
+        let commitment = compute_witness_commitment(&[coinbase_tx(), spend.clone()], &reserved);
+        let mut coinbase = coinbase_tx();
+        coinbase.inputs[0].witness = vec![reserved];
+        coinbase.outputs.push(TxOut {
+            value: 0,
+            script_pubkey: commitment_script(&commitment),
+        });
+        let block = block_with_transactions(vec![coinbase, spend]);
+        let txids = block.txs.iter().map(Tx::txid).collect();
+        let mut facts = BlockFacts::from_txids(&block.txs, txids);
+        let context = BlockRuleContext::non_contextual();
+
+        assert!(facts.has_witness());
+        assert!(facts.wtxids().is_none());
+        assert_eq!(
+            verify_block_rules_precomputed(&block, context, &facts),
+            Err(ConsensusError::WitnessCommitment)
+        );
+        facts.or_insert_wtxids_from(&block.txs);
+        assert_eq!(verify_block_rules_precomputed(&block, context, &facts), Ok(()));
+    }
+
+'''
+anchor = '    // --- BIP141 witness commitment tests ---\n'
+assert new.count(anchor) == 1
+new = new.replace(anchor, extra + anchor, 1)
+assert new.count('#[test]') == 26
+p.write_text(new)
+legacy_path.unlink()
+
+p = root / 'docs/models/ChainAdmission.tla'
+original = p.read_bytes()
+old_hash = 'e82138365787f075f1ebe232e4c609cec47b515d29cd11d29fe7d35c6f522d83'
+assert hashlib.sha256(original).hexdigest() == old_hash, 'ChainAdmission changed; rebase'
+text = original.decode()
+old = '''(*************************************************************************)
+(* Next: one hoisted edge-observer conjunct over the whole union,       *)
+(* equivalent to the former per-action form by distribution and         *)
+(* identical on every [][Next]_vars behavior for each <<A>>_vars        *)
+(* fairness occurrence.                                                 *)
+(*************************************************************************)
+Next == NextCore /\\ stepOK' = StepSafe
+
+'''
+assert text.count(old) == 1
+text = text.replace(old, '', 1)
+anchor = '          deadlineExp, compCredits, stepOK>>\n'
+assert text.count(anchor) == 1
+replacement = '''
+(*************************************************************************)
+(* Apalache consumes INIT/NEXT directly, not a SPECIFICATION containing *)
+(* [][Next]_vars. Include that closure explicitly: every original action *)
+(* still records StepSafe, while stutter preserves every variable,       *)
+(* including the last edge verdict. A completed shutdown can therefore  *)
+(* remain in Done instead of being reported as a deadlock.               *)
+(* This adds no fairness assumption and removes no original transition. *)
+(*************************************************************************)
+Next ==
+  \\/ (NextCore /\\ stepOK' = StepSafe)
+  \\/ UNCHANGED vars
+'''
+text = text.replace(anchor, anchor + replacement, 1)
+text = text.replace('(* Stutter is supplied by [][Next]_vars at the use sites; no fairness or   *)', '(* Next explicitly includes UNCHANGED vars for INIT/NEXT checking; no     *)', 1)
+text = text.replace('(* priority occurs inside Next.  Weak fairness appears only inside the     *)', '(* fairness or priority occurs inside Next. Weak fairness is only in the   *)', 1)
+text = text.replace('(* Stutter arises from [][Next]_vars at the use sites; no fairness or   *)', '(* Next adds the stutter closure explicitly; no fairness or             *)', 1)
+text = text.replace('(* [][Next]_vars.                                                        *)', '(* the explicit UNCHANGED vars branch in Next.                           *)', 1)
+p.write_text(text)
+new_hash = hashlib.sha256(p.read_bytes()).hexdigest()
+assert new_hash == '7d43768179d15e35ab548604082a614d775221644a05f295ea3b28cf55e83c92'
+register = root / 'CONSTRAINTS.md'
+old_register = register.read_text()
+old_row = f'| ChainAdmission | {old_hash} |'
+assert old_register.count(old_row) == 1
+register_text = old_register.replace(old_row, f'| ChainAdmission | {new_hash} |', 1)
+anchor = 'Model to implementer gates: ChainAdmission gates T08, T11, T18; PeerLeases\n'
+assert register_text.count(anchor) == 1
+register_text = register_text.replace(anchor, '''Before the six canonical invocations, G20 also checks the focused
+`regressions/ChainAdmissionShutdown.tla` fixture: the four real shutdown
+actions followed by the canonical `Next`, with the original constants and
+`TypeOK,Safety,TransitionSafety,ReachedDone`. Its additional five-step
+regression catches a missing terminal stutter. It neither replaces any
+canonical invocation nor changes their K = 128 bound or proof denominator.
+The fixture, imported canonical source, config, and checker output are
+retained under `target/apalache/shutdown-regression/`.
+
+''' + anchor, 1)
+register.write_text(register_text)
+
+fixture = root / 'docs/models/regressions/ChainAdmissionShutdown.tla'
+assert not fixture.exists()
+fixture.parent.mkdir(parents=True, exist_ok=True)
+fixture.write_text(r'''---- MODULE ChainAdmissionShutdown ----
+(* Additional regression, not a replacement for the full model check. *)
+(* Follow four real shutdown actions, then require canonical Next to    *)
+(* allow the terminal state to persist. Removing its stutter branch     *)
+(* makes this check deadlock at step five. Constants remain unchanged.  *)
+EXTENDS ChainAdmission
+
+VARIABLE
+  \* @type: Int;
+  pc
+
+ProbeInit == Init /\ pc' = 0
+
+Prefix ==
+  \/ /\ pc = 0 /\ CloseInput /\ pc' = 1
+  \/ /\ pc = 1 /\ ChainFinish /\ pc' = 2
+  \/ /\ pc = 2 /\ Settle /\ pc' = 3
+  \/ /\ pc = 3 /\ EnterDone /\ pc' = 4
+
+ProbeNext ==
+  \/ /\ Prefix /\ stepOK' = StepSafe
+  \/ /\ pc = 4 /\ Next /\ UNCHANGED pc
+
+ReachedDone == pc = 4 => lifePhase = 3 /\ chainPhase = 11 /\ inputClosed
+====
+''')
+
+p = root / 'bin/bitcoin-rs/tests/gates/g20_formal_models.rs'
+s = p.read_text()
+anchor = 'const LENGTH: &str = "--length=128";\n'
+assert s.count(anchor) == 1
+s = s.replace(anchor, anchor + '''// Additional deterministic shutdown regression; canonical proofs stay at 128.
+const SHUTDOWN_MODEL: &str = "ChainAdmissionShutdown";
+const SHUTDOWN_INV: &str = "--inv=TypeOK,Safety,TransitionSafety,ReachedDone";
+const SHUTDOWN_LENGTH: &str = "--length=5";
+''', 1)
+old = '''    match kind {
+        CheckKind::Safety => args.push(SAFETY_INV.to_string()),
+        CheckKind::Temporal => args.push(TEMPORAL.to_string()),
+    }
+    args.push(LENGTH.to_string());'''
+new = '''    let length = if model == SHUTDOWN_MODEL {
+        assert_eq!(kind, CheckKind::Safety);
+        args.extend([
+            "--init=ProbeInit".to_string(),
+            "--next=ProbeNext".to_string(),
+            SHUTDOWN_INV.to_string(),
+        ]);
+        SHUTDOWN_LENGTH
+    } else {
+        match kind {
+            CheckKind::Safety => args.push(SAFETY_INV.to_string()),
+            CheckKind::Temporal => args.push(TEMPORAL.to_string()),
+        }
+        LENGTH
+    };
+    args.push(length.to_string());'''
+assert s.count(old) == 1
+s = s.replace(old, new, 1)
+s = s.replace('args.iter().any(|a| a == SAFETY_INV || a == TEMPORAL)', 'args.iter().any(|a| a == SAFETY_INV || a == TEMPORAL || a == SHUTDOWN_INV)', 1)
+s = s.replace('args.iter().any(|a| a == LENGTH),\n        "g20: argv missing --length=128"', 'args.iter().any(|a| a == length),\n        "g20: argv missing expected bound {length}"', 1)
+anchor = '#[test]\nfn all_model_specs_check_with_apalache() {\n'
+assert s.count(anchor) == 1
+helper = '''/// Run serially with the canonical checks: a second concurrent 4 GiB JVM
+/// would consume the test runner's memory budget. The copied inputs remain
+/// in the existing formal-diagnostics artifact even when a later check fails.
+fn check_shutdown_stutter(root: &Path, exe: &Path) {
+    let regression = root.join("target/apalache/shutdown-regression");
+    let models = regression.join("docs/models");
+    fs::create_dir_all(&models).expect("create shutdown regression directory");
+    fs::copy(root.join(CONSTRAINTS), regression.join(CONSTRAINTS))
+        .expect("copy canonical checker configuration");
+    fs::copy(
+        root.join("docs/models/ChainAdmission.tla"),
+        models.join("ChainAdmission.tla"),
+    )
+    .expect("copy pinned canonical model for regression");
+    fs::copy(
+        root.join("docs/models/ChainAdmission.cfg"),
+        models.join(format!("{SHUTDOWN_MODEL}.cfg")),
+    )
+    .expect("copy unchanged canonical constants for regression");
+    fs::copy(
+        root.join(format!("docs/models/regressions/{SHUTDOWN_MODEL}.tla")),
+        models.join(format!("{SHUTDOWN_MODEL}.tla")),
+    )
+    .expect("copy shutdown regression fixture");
+    run_one(&regression, exe, SHUTDOWN_MODEL, CheckKind::Safety, 0);
+}
+
+'''
+s = s.replace(anchor, helper + anchor, 1)
+old = '''    let exe = apalache_executable(&home);
+
+    for model in MODELS {'''
+new = '''    let exe = apalache_executable(&home);
+
+    check_shutdown_stutter(&root, &exe);
+    for model in MODELS {'''
+assert s.count(old) == 1
+s = s.replace(old, new, 1)
+assert 'const LENGTH: &str = "--length=128";' in s
+assert 'run_one(&root, &exe, model, CheckKind::Safety, 1);' in s
+assert 'run_one(&root, &exe, model, CheckKind::Temporal, 2);' in s
+p.write_text(s)
+print('Prepared: production verifier tests, terminal stutter, and additional shutdown regression')

--- a/.github/workflows/ci-repair-candidate.yml
+++ b/.github/workflows/ci-repair-candidate.yml
@@ -1,0 +1,217 @@
+name: ci-repair-candidate
+
+on:
+  push:
+    branches: [work/ci-repair-staging-20260910]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-repair-candidate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: never
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    outputs:
+      candidate_sha: ${{ steps.publish.outputs.candidate_sha }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
+        with:
+          components: rustfmt
+      - name: Construct the identity-checked candidate
+        run: |
+          python3 .ci-repair-prepare.py
+          rustfmt --edition 2024 crates/consensus/src/verify_block.rs bin/bitcoin-rs/tests/gates/g20_formal_models.rs
+          git diff --check
+          mkdir -p "$RUNNER_TEMP/repair-evidence"
+          git diff > "$RUNNER_TEMP/repair-evidence/candidate.patch"
+          rustc --version > "$RUNNER_TEMP/repair-evidence/toolchain.txt"
+      # No repository tests/build scripts execute in this write-capable job.
+      # This token is exposed only to the fixed API publisher below. The
+      # candidate tree starts at BASE_SHA and cannot include staging files.
+      - name: Publish only reviewed source paths to a new candidate branch
+        id: publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: 3363cff27664d9f9e7bac91f69bc900f70bbf3ea
+          CANDIDATE_BRANCH: ci/repair-stutter-verifier-20260910
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import hashlib
+          import json
+          import os
+          import urllib.request
+
+          repository = os.environ['GITHUB_REPOSITORY']
+          assert repository == 'gosuda/bitcoin-rs'
+          api = f'https://api.github.com/repos/{repository}'
+          headers = {
+              'Authorization': 'Bearer ' + os.environ['GH_TOKEN'],
+              'Accept': 'application/vnd.github+json',
+              'X-GitHub-Api-Version': '2022-11-28',
+              'Content-Type': 'application/json',
+          }
+          def call(path, data=None):
+              req = urllib.request.Request(api + path,
+                  data=None if data is None else json.dumps(data).encode(),
+                  headers=headers, method='GET' if data is None else 'POST')
+              with urllib.request.urlopen(req, timeout=60) as response:
+                  return json.load(response)
+
+          paths = [
+              'crates/consensus/src/verify_block.rs',
+              'docs/models/ChainAdmission.tla',
+              'docs/models/regressions/ChainAdmissionShutdown.tla',
+              'bin/bitcoin-rs/tests/gates/g20_formal_models.rs',
+              'CONSTRAINTS.md',
+          ]
+          base = call('/git/commits/' + os.environ['BASE_SHA'])
+          tree = []
+          identities = {}
+          for name in paths:
+              content = Path(name).read_bytes()
+              identities[name] = hashlib.sha256(content).hexdigest()
+              blob = call('/git/blobs', {'content': content.decode(), 'encoding': 'utf-8'})
+              tree.append({'path': name, 'mode': '100644', 'type': 'blob', 'sha': blob['sha']})
+          tree.append({'path': 'crates/consensus/src/verify_block_impl.rs',
+                       'mode': '100644', 'type': 'blob', 'sha': None})
+          proposed = call('/git/trees', {'base_tree': base['tree']['sha'], 'tree': tree})
+          commit = call('/git/commits', {
+              'message': 'fix: exercise production block rules and restore terminal model stutter\n\nRetain all 24 original verifier tests on the production BlockFacts entry,\nadd missing-facts regressions, and remove the obsolete verifier copy.\nRestore ChainAdmission stuttering for direct INIT/NEXT checking and add\nan independent shutdown regression before the unchanged K=128 proof suite.\n',
+              'tree': proposed['sha'], 'parents': [os.environ['BASE_SHA']],
+          })
+          # Create-only: never rewrite main or overwrite an existing branch.
+          call('/git/refs', {'ref': 'refs/heads/' + os.environ['CANDIDATE_BRANCH'],
+                            'sha': commit['sha']})
+          identities['candidate_sha'] = commit['sha']
+          Path(os.environ['RUNNER_TEMP'], 'repair-evidence', 'identities.json').write_text(
+              json.dumps(identities, indent=2) + '\n')
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+              output.write('candidate_sha=' + commit['sha'] + '\n')
+          print('Candidate commit:', commit['sha'])
+          PY
+      - name: Preserve candidate construction evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ci-repair-construction-${{ github.run_id }}
+          path: ${{ runner.temp }}/repair-evidence/
+          retention-days: 3
+
+  consensus:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ needs.prepare.outputs.candidate_sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
+        with:
+          components: clippy,rustfmt
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
+      - name: Test and lint the actual production verifier
+        run: |
+          mkdir -p target/repair-evidence
+          git rev-parse HEAD > target/repair-evidence/source-sha.txt
+          set -o pipefail
+          cargo test --locked -p bitcoin-rs-consensus --no-default-features --no-fail-fast 2>&1 | tee target/repair-evidence/consensus-tests.txt
+          cargo clippy --locked -p bitcoin-rs-consensus --no-default-features --all-targets -- -D warnings 2>&1 | tee target/repair-evidence/consensus-clippy.txt
+          cargo clippy --locked -p bitcoin-rs --test g20_formal_models --no-default-features --features fjall -- -D warnings 2>&1 | tee target/repair-evidence/g20-clippy.txt
+          cargo fmt --all -- --check 2>&1 | tee target/repair-evidence/fmt.txt
+      - name: Prove the retained weight test reaches production code
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          p = Path('crates/consensus/src/verify_block.rs')
+          text = p.read_text()
+          old = '    let weight = facts.weight();'
+          assert text.count(old) == 1
+          p.write_text(text.replace(old, '    let weight = 0_u64;', 1))
+          PY
+          set +e
+          cargo test --locked -p bitcoin-rs-consensus --no-default-features --lib verify_block::tests::contextual_rules_always_enforce_block_weight_limit -- --exact > target/repair-evidence/weight-mutant.txt 2>&1
+          status=$?
+          set -e
+          git restore crates/consensus/src/verify_block.rs
+          tail -40 target/repair-evidence/weight-mutant.txt
+          test "$status" -ne 0
+          grep -q 'test result: FAILED' target/repair-evidence/weight-mutant.txt
+          grep -q 'contextual_rules_always_enforce_block_weight_limit.*FAILED' target/repair-evidence/weight-mutant.txt
+          git diff --exit-code
+      - name: Preserve exact-source native validation evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ci-repair-consensus-${{ github.run_id }}
+          path: target/repair-evidence/
+          retention-days: 3
+
+  shutdown-model:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ needs.prepare.outputs.candidate_sha }}
+          persist-credentials: false
+      - name: Provision and verify the exact pinned checker
+        run: bash scripts/provision-ci-reference-fixtures.sh
+      - name: Validate shutdown and detect the missing-stutter mutant
+        env:
+          JVM_ARGS: -Xmx4096m
+          SMT_SOLVER: z3
+        run: |
+          mkdir -p target/repair-evidence/shutdown
+          cp docs/models/ChainAdmission.{tla,cfg} target/repair-evidence/shutdown/
+          cp docs/models/regressions/ChainAdmissionShutdown.tla target/repair-evidence/shutdown/
+          checker="$PWD/target/tools/apalache-0.62.2/bin/apalache-mc"
+          cd target/repair-evidence/shutdown
+          sha256sum *.tla *.cfg > SHA256SUMS
+          args=(check --config=ChainAdmission.cfg --init=ProbeInit --next=ProbeNext --inv=TypeOK,Safety,TransitionSafety,ReachedDone --length=5 --smt-encoding=funArrays)
+          printf '%q ' "$checker" "${args[@]}" > argv.txt
+          printf '\n' >> argv.txt
+          set -o pipefail
+          timeout --kill-after=10s 300s "$checker" "${args[@]}" --out-dir=positive ChainAdmissionShutdown.tla 2>&1 | tee positive.txt
+          grep -q 'The outcome is: NoError' positive.txt
+          grep -q 'EXITCODE: OK' positive.txt
+          # Mutation is only in the isolated copy, never in the commit.
+          python3 - <<'PY'
+          from pathlib import Path
+          p = Path('ChainAdmission.tla')
+          s = p.read_text()
+          old = '  \\/ UNCHANGED vars\n'
+          assert s.count(old) == 1
+          p.write_text(s.replace(old, '', 1))
+          PY
+          set +e
+          timeout --kill-after=10s 300s "$checker" "${args[@]}" --out-dir=negative ChainAdmissionShutdown.tla > negative.txt 2>&1
+          status=$?
+          set -e
+          tail -40 negative.txt
+          echo "$status" > negative-exit-code.txt
+          test "$status" -eq 12
+          grep -q 'The outcome is: Deadlock' negative.txt
+      - name: Preserve pinned model regression evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ci-repair-shutdown-${{ github.run_id }}
+          path: target/repair-evidence/
+          retention-days: 3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stages a deterministic CI repair that rebuilds the consensus verifier tests on the production block-rule pathway and restores the terminal stutter in the `ChainAdmission` model, without merging staging files into main.

**Candidate construction**
- `.ci-repair-prepare.py` builds and publishes a candidate commit to `ci/repair-stutter-verifier-20260910`, only on push to this staging branch.
- The script pins SHA-256 hashes of the edited files, so any upstream drift aborts with a rebase request.
- Deletes `verify_block_impl.rs`; the 24 original verifier tests now run against `verify_block_rules_precomputed` via `BlockFacts`, with two new regressions for mismatched transaction counts and missing cached witness IDs.
- `ChainAdmission.tla` gains an explicit `UNCHANGED vars` branch in `Next` because Apalache consumes INIT/NEXT directly, and a new `ChainAdmissionShutdown` fixture covers the completed-shutdown state.
- `CONSTRAINTS.md` is updated with the new model hash, and `g20_formal_models.rs` runs the fixture serially with the unchanged K=128 proofs.

**Validation**
- The new workflow builds the candidate, then runs consensus tests, clippy, and fmt, and mutates the production weight call to confirm the retained weight test fails when production code diverges.
- The shutdown job runs Apalache on the fixture with `NoError`, then removes the stutter branch and expects a `Deadlock` result; all evidence is uploaded as artifacts.
- No repository builds or tests run in the write-capable prepare job, and the candidate tree starts from pinned base `3363cff` so staging files can never leak in.

<sup>Written for commit 2965143143d4d93b9c1dd836c0e047ec471b167b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

