### PR TITLE
docs(storage): define retry semantics after ambiguous durable errors

### DIFF
--- a/crates/storage/src/trait_.rs
+++ b/crates/storage/src/trait_.rs
@@ -150,8 +150,11 @@ impl PersistFaultSlot {
 ///
 /// Every batch is atomic across all column families it touches. `write` and
 /// `write_deferred` need not survive a crash; `write_durable`,
-/// `write_durable_if`, and successful `flush` complete durability. Snapshots
-/// are coherent across families.
+/// `write_durable_if`, and successful `flush` complete durability. Atomicity
+/// prevents partial batches, but an error from a durability API is not a
+/// rollback receipt: application may already have completed before the
+/// durability completion failed or was lost. Snapshots are coherent across
+/// families.
 pub trait KvStore: Send + Sync + 'static {
     /// Backend-specific atomic write-batch type.
     type WriteBatch: WriteBatch;
@@ -202,6 +205,19 @@ pub trait KvStore: Send + Sync + 'static {
     }
 
     /// Atomically applies a batch and completes its durability before success.
+    ///
+    /// `Ok(())` is the durability receipt. `Err` is not a rollback receipt:
+    /// the failure may occur before application, or after the whole atomic
+    /// batch became visible while durability completion failed or was lost.
+    /// [`StorageError`] does not classify that phase. A caller must therefore
+    /// not blindly retry a non-idempotent batch after `Err`; it must reconcile
+    /// through the state owner's recovery protocol, or independently prove
+    /// that the batch did not apply before retrying.
+    ///
+    /// The default implementation makes the ambiguous post-application case
+    /// explicit: it applies through [`Self::write_deferred`] and then calls
+    /// [`Self::flush`]. Backend overrides must preserve the same receipt and
+    /// error semantics even when they use one synchronous commit.
     fn write_durable(&self, batch: Self::WriteBatch) -> Result<(), StorageError> {
         self.write_deferred(batch)?;
         self.flush()
@@ -210,9 +226,13 @@ pub trait KvStore: Send + Sync + 'static {
     /// Durably commits `batch` iff every condition matches the pre-batch state.
     ///
     /// Conditions and commit form one write boundary. `Ok(true)` means the
-    /// whole batch is durable; `Ok(false)` means no operation applied. Lookup,
-    /// backend, or persistence failures return `Err` rather than a mismatch or
-    /// false durability confirmation.
+    /// whole batch is durable; `Ok(false)` is the only result that proves the
+    /// conditions did not match and no operation applied. Lookup, backend, or
+    /// persistence failures return `Err` rather than a mismatch or false
+    /// durability confirmation. After conditions matched, an `Err` may occur
+    /// after the atomic batch applied but before durability was confirmed, so
+    /// it must not be treated as `Ok(false)` or as permission to blindly retry
+    /// a non-idempotent batch. The state owner must reconcile the outcome.
     fn write_durable_if(
         &self,
         conditions: &[WriteCondition<'_>],
@@ -220,6 +240,13 @@ pub trait KvStore: Send + Sync + 'static {
     ) -> Result<bool, StorageError>;
 
     /// Makes every earlier completed write durable before success.
+    ///
+    /// `Ok(())` is the receipt covering those writes. `Err` provides no such
+    /// receipt, but also does not prove that earlier writes were unapplied or
+    /// non-durable: synchronization can fail or its completion can be lost
+    /// after writes became visible. Callers that track pending durability must
+    /// retain that bookkeeping until a successful receipt or owner-specific
+    /// recovery establishes the durable state.
     fn flush(&self) -> Result<(), StorageError>;
 
     /// Captures a coherent point-in-time view across column families.


### PR DESCRIPTION
## Problem

Closes the still-live review finding from #665 that `KvStore::write_durable` did not tell callers what an error means after the batch may already have applied. #689/#692 corrected the backend behavior—lost sync/flush completions no longer report success—but the public trait still returned the same `StorageError` shape for pre-apply and post-apply failures.

The original finding: https://github.com/gosuda/bitcoin-rs/pull/665#discussion_r3970119722

## Contract clarification

- Atomicity prevents a partial batch; it does **not** make `Err` a rollback receipt.
- `write_durable` `Ok(())` is the durability receipt. On `Err`, the batch may have failed before application or may already be atomically visible with durability completion failed/lost. Since `StorageError` does not encode that phase, callers must not blindly retry a non-idempotent batch; they must reconcile via the state owner's recovery protocol or independently prove non-application first.
- `write_durable_if`: `Ok(false)` is the only result proving conditions did not match and no operation applied. `Err` is not equivalent to a mismatch and may follow application after conditions matched.
- `flush`: `Err` gives no durability receipt but also does not prove earlier deferred writes were unapplied or non-durable. Pending durability bookkeeping must remain until a successful receipt or owner-specific recovery establishes state.
- Backend overrides must preserve the same receipt/failure semantics as the default `write_deferred` + `flush` implementation.

## Scope

Rustdoc only in `crates/storage/src/trait_.rs`. No error variants, backend behavior, persistence fault injection, lock ordering, storage format, test assertion, dependency, or recovery authority changes. This deliberately avoids inventing a phase-classified error API solely to document semantics that the existing backends already expose.

## Integration

Based on current main `2aab3aefa78016d30dd26ddbb9c10314ce4c8e41`; no overlap with the separate CI/TLS reproducibility PR #730.

## Validation required

```sh
cargo fmt --all -- --check
cargo clippy --locked -p bitcoin-rs-storage --all-targets --all-features -- -D warnings
cargo test --locked -p bitcoin-rs-storage --all-features --no-fail-fast
```

The existing four-backend durability/reopen fault matrix remains the behavioral proof; this change aligns the public caller contract with it. No final-head CI pass or fresh CodeRabbit approval is claimed yet, so the PR remains draft.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the retry and recovery contract for durable storage APIs when errors are ambiguous. Previously, `KvStore::write_durable` returned the same error for failures before and after batch application, leaving callers unsure whether a non-idempotent batch might already be applied. The docs now state that `Err` is not a rollback receipt and callers must reconcile or prove non-application before retrying.

- Updates rustdoc for `write_durable`, `write_durable_if`, and `flush` to define receipt semantics.
- Clarifies that `Ok(false)` from `write_durable_if` is the only proof conditions did not match.
- Notes that backend overrides must preserve the same receipt and error semantics.
- Documentation-only change; no behavior, error variants, or storage format changes.

<sup>Written for commit 97a1827fd9e931696e6b7222be7131ccf2baddcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

