### PR TITLE
test(ownership): remove receiver-name and test-tail scanner bypasses

### DIFF
--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -2,11 +2,10 @@
 //! boundaries that `cargo metadata` cannot see.
 //!
 //! The scan walks the workspace Rust sources (excluding `tests/`, `benches/`,
-//! and in-file `#[cfg(test)] mod` test modules) and fails if any production
-//! code outside `crates/mempool/src/` directly calls a mutating `Mempool`
-//! method, or acquires the pool write lock through a bypass pattern
-//! (`mempool().write(` on a raw `Arc<RwLock<Mempool>>` or `.pool().write(` on
-//! a `MempoolGateway`).
+//! and in-file test items) and fails if any production code outside
+//! `crates/mempool/src/` directly calls a mutating `Mempool` method, or acquires
+//! the pool write lock through a bypass pattern (`mempool().write(` on a raw
+//! `Arc<RwLock<Mempool>>` or `.pool().write(` on a `MempoolGateway`).
 
 use std::path::Path;
 
@@ -16,12 +15,8 @@ use std::path::Path;
 /// `gateway` or `mempool` cannot prove ownership. Every exception is therefore
 /// tied to one source file and one complete receiver expression. Adding a new
 /// production gateway mutation requires an explicit review of this list.
-const AUTHORIZED_GATEWAY_CALLS: &[(&str, &str)] = &[
-    (
-        "crates/rpc/src/handlers/mining.rs",
-        "ctx.mempool",
-    ),
-];
+const AUTHORIZED_GATEWAY_CALLS: &[(&str, &str)] =
+    &[("crates/rpc/src/handlers/mining.rs", "ctx.mempool")];
 
 /// Mutating methods on `Mempool` that only the mempool owner may call from
 /// production code. `MempoolGateway` deliberately reuses some of these names,
@@ -69,15 +64,19 @@ pub(crate) struct WriterScanResult {
     pub mutating_calls_found: usize,
 }
 
-/// Walks the workspace and returns any mempool-writer violations.
-pub(crate) fn scan_mempool_writer_violations() -> WriterScanResult {
-    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
-    let mut result = WriterScanResult {
+fn empty_result() -> WriterScanResult {
+    WriterScanResult {
         violations: Vec::new(),
         files_scanned: 0,
         pool_writes_found: 0,
         mutating_calls_found: 0,
-    };
+    }
+}
+
+/// Walks the workspace and returns any mempool-writer violations.
+pub(crate) fn scan_mempool_writer_violations() -> WriterScanResult {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let mut result = empty_result();
     scan_dir(&root, &mut result);
     result
 }
@@ -101,10 +100,15 @@ fn scan_dir(dir: &Path, result: &mut WriterScanResult) {
 
 fn scan_file(path: &Path, result: &mut WriterScanResult) {
     let path_str = path.to_string_lossy();
-    let is_mempool_owner = path_str.contains("/crates/mempool/src/");
     let content = std::fs::read_to_string(path).unwrap_or_default();
+    scan_source(&path_str, &content, result);
+    result.files_scanned += 1;
+}
+
+fn scan_source(path_str: &str, content: &str, result: &mut WriterScanResult) {
+    let is_mempool_owner = path_str.replace('\\', "/").contains("/crates/mempool/src/");
     let lines: Vec<&str> = content.lines().collect();
-    let mut skip_test_module = false;
+    let mut skip_test_item = false;
 
     for (index, raw_line) in lines.iter().enumerate() {
         // Strip `//`, `///`, and `//!` line comments before any other inspection.
@@ -115,13 +119,18 @@ fn scan_file(path: &Path, result: &mut WriterScanResult) {
         };
         let trimmed = line.trim();
 
-        if skip_test_module {
+        if skip_test_item {
+            // Rustfmt places the closing brace of a top-level module/function
+            // at column zero. Resume scanning after it so later production
+            // items cannot hide behind an earlier test item.
+            if line == "}" {
+                skip_test_item = false;
+            }
             continue;
         }
 
-        // `#[cfg(test)]` stops scanning only when it introduces a test *module*.
-        // `#[test]` introduces a unit-test function and stops scanning from that
-        // point onward. Intervening attributes like `#[allow(...)]` are skipped.
+        // Skip a top-level inline `#[cfg(test)] mod ... { ... }`, but not a
+        // semicolon module declaration; the next production item is scanned.
         if trimmed == "#[cfg(test)]" || trimmed.starts_with("#[cfg(test)] ") {
             for next in lines.iter().skip(index + 1) {
                 let next_trimmed = next.trim();
@@ -132,15 +141,17 @@ fn scan_file(path: &Path, result: &mut WriterScanResult) {
                 {
                     continue;
                 }
-                if next_trimmed.starts_with("mod ") {
-                    skip_test_module = true;
+                if next_trimmed.starts_with("mod ") && !next_trimmed.ends_with(';') {
+                    skip_test_item = true;
                 }
                 break;
             }
-            if skip_test_module {
+            if skip_test_item {
                 continue;
             }
         } else if trimmed.starts_with("#[test]") {
+            // A top-level test function is also skipped only through its own
+            // rustfmt-aligned closing brace, never to end-of-file.
             for next in lines.iter().skip(index + 1) {
                 let next_trimmed = next.trim();
                 if next_trimmed.is_empty()
@@ -151,11 +162,11 @@ fn scan_file(path: &Path, result: &mut WriterScanResult) {
                     continue;
                 }
                 if next_trimmed.starts_with("fn ") {
-                    skip_test_module = true;
+                    skip_test_item = true;
                 }
                 break;
             }
-            if skip_test_module {
+            if skip_test_item {
                 continue;
             }
         }
@@ -181,7 +192,7 @@ fn scan_file(path: &Path, result: &mut WriterScanResult) {
             if let Some(pos) = line.find(method) {
                 result.mutating_calls_found += 1;
                 if !is_mempool_owner
-                    && !is_authorized_gateway_call(&path_str, line, pos, &lines, index)
+                    && !is_authorized_gateway_call(path_str, line, pos, &lines, index)
                 {
                     result.violations.push(format!(
                         "raw mempool mutation `{method}` at {}:{}: {}",
@@ -193,8 +204,6 @@ fn scan_file(path: &Path, result: &mut WriterScanResult) {
             }
         }
     }
-
-    result.files_scanned += 1;
 }
 
 /// Returns true only when the call is on a receiver expression explicitly
@@ -239,9 +248,10 @@ fn is_authorized_gateway_call(
 
 #[cfg(test)]
 mod tests {
-    use super::is_authorized_gateway_call;
+    use super::{empty_result, is_authorized_gateway_call, scan_source};
 
     const MINING_HANDLER: &str = "/workspace/crates/rpc/src/handlers/mining.rs";
+    const NON_OWNER: &str = "/workspace/crates/node/src/fake.rs";
 
     fn authorized(path: &str, source: &str) -> bool {
         let lines: Vec<&str> = source.lines().collect();
@@ -252,6 +262,12 @@ mod tests {
             .expect("fixture contains prioritise call");
         let method_pos = line.find("prioritise(").expect("method position");
         is_authorized_gateway_call(path, line, method_pos, &lines, line_index)
+    }
+
+    fn violations(source: &str) -> Vec<String> {
+        let mut result = empty_result();
+        scan_source(NON_OWNER, source, &mut result);
+        result.violations
     }
 
     #[test]
@@ -285,5 +301,57 @@ mod tests {
             MINING_HANDLER,
             "ctx.mempool.write().prioritise(txid, fee_delta)"
         ));
+    }
+
+    #[test]
+    fn production_after_an_inline_test_module_is_still_scanned() {
+        let source = r#"
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn fixture() {
+        gateway.prioritise(txid, 1);
+    }
+}
+
+pub fn production() {
+    gateway.prioritise(txid, 2);
+}
+"#;
+        let found = violations(source);
+        assert_eq!(found.len(), 1, "test mutation is skipped, production is not");
+        assert!(found[0].contains("gateway.prioritise(txid, 2)"));
+    }
+
+    #[test]
+    fn production_after_a_top_level_test_function_is_still_scanned() {
+        let source = r#"
+#[test]
+fn fixture() {
+    mempool.prioritise(txid, 1);
+}
+
+pub fn production() {
+    mempool.prioritise(txid, 2);
+}
+"#;
+        let found = violations(source);
+        assert_eq!(found.len(), 1, "test mutation is skipped, production is not");
+        assert!(found[0].contains("mempool.prioritise(txid, 2)"));
+    }
+
+    #[test]
+    fn external_test_module_declaration_does_not_hide_following_production() {
+        let source = r#"
+#[cfg(test)]
+mod tests;
+
+pub fn production() {
+    gateway.prioritise(txid, 3);
+}
+"#;
+        let found = violations(source);
+        assert_eq!(found.len(), 1);
+        assert!(found[0].contains("gateway.prioritise(txid, 3)"));
     }
 }

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -1,11 +1,13 @@
 //! Static source scan used by `overhaul_ownership` to enforce single-owner
 //! boundaries that `cargo metadata` cannot see.
 //!
-//! The scan walks the workspace Rust sources (excluding `tests/`, `benches/`,
-//! and in-file test items) and fails if any production code outside
-//! `crates/mempool/src/` directly calls a mutating `Mempool` method, or acquires
-//! the pool write lock through a bypass pattern (`mempool().write(` on a raw
-//! `Arc<RwLock<Mempool>>` or `.pool().write(` on a `MempoolGateway`).
+//! The scan walks workspace Rust sources (excluding `tests/`, `benches/`, and
+//! `examples/`) and ignores code inside top-level `#[cfg(test)]` items and
+//! `#[test]` functions. A small Rust lexical mask keeps braces and mutator-like
+//! text inside comments, quoted strings, raw strings, and character literals
+//! from changing item boundaries or producing false matches. Production code
+//! outside `crates/mempool/src/` fails the scan if it directly calls a mutating
+//! `Mempool` method or acquires the pool write lock through a bypass pattern.
 
 use std::path::Path;
 
@@ -26,29 +28,20 @@ const AUTHORIZED_GATEWAY_CALLS: &[(&str, &str)] =
 /// across collection types and is caught by `.pool().write(`; `commit_insert` is
 /// a `pub(crate)` helper that is only reachable through `insert_entry`.
 pub(crate) const MUTATING_METHODS: &[&str] = &[
-    // Adds a transaction to the in-memory pool.
     "insert_entry(",
-    // Replaces an existing entry via the RBF path.
     "replace_transaction(",
-    // Removes confirmed transactions after a block connect.
     "remove_for_block(",
-    // Evicts low-fee packages to enforce a byte limit.
     "enforce_size_limit(",
-    // Removes entries below a fee-rate threshold.
     "evict_below_fee_rate(",
-    // Applies a fee delta to an in-pool transaction.
     "prioritise(",
-    // Bulk removal helper used during reorg/replacement.
     "remove_entries_with_reasons(",
-    // Recursive removal of an entry and all descendants.
     "remove_entry_and_descendants_into(",
-    // Free-function package eviction; mutates the pool.
     "evict_lowest_fee_packages(",
 ];
 
 /// Patterns that indicate a raw `Mempool` write lock acquisition outside the
-/// mempool owner. `mempool().write(` covers `state.mempool()` (which returns
-/// `Arc<RwLock<Mempool>>`); `.pool().write(` covers `MempoolGateway::pool()`.
+/// mempool owner. `mempool().write(` covers `state.mempool()`; `.pool().write(`
+/// covers `MempoolGateway::pool()`.
 pub(crate) const POOL_WRITE_PATTERNS: &[&str] = &[".mempool().write(", ".pool().write("];
 
 /// Result of the source scan.
@@ -86,12 +79,12 @@ fn scan_dir(dir: &Path, result: &mut WriterScanResult) {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
-                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                if name == "target" || name == "tests" || name == "benches" || name == "examples" {
+                let name = path.file_name().and_then(|name| name.to_str()).unwrap_or("");
+                if matches!(name, "target" | "tests" | "benches" | "examples") {
                     continue;
                 }
                 scan_dir(&path, result);
-            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
                 scan_file(&path, result);
             }
         }
@@ -105,73 +98,197 @@ fn scan_file(path: &Path, result: &mut WriterScanResult) {
     result.files_scanned += 1;
 }
 
-fn scan_source(path_str: &str, content: &str, result: &mut WriterScanResult) {
-    let is_mempool_owner = path_str.replace('\\', "/").contains("/crates/mempool/src/");
-    let lines: Vec<&str> = content.lines().collect();
-    let mut skip_test_item = false;
+#[derive(Default)]
+struct LexState {
+    block_comment_depth: usize,
+    quoted: Option<u8>,
+    escaped: bool,
+    raw_hashes: Option<usize>,
+}
 
-    for (index, raw_line) in lines.iter().enumerate() {
-        // Strip `//`, `///`, and `//!` line comments before any other inspection.
-        let line = if let Some(pos) = raw_line.find("//") {
-            &raw_line[..pos]
-        } else {
-            raw_line
-        };
-        let trimmed = line.trim();
+/// Masks non-code bytes with spaces while preserving byte positions.
+///
+/// This is deliberately narrower than a parser: the ownership gate needs only
+/// identifiers, dots, parentheses, and structural braces. Keeping positions
+/// stable lets method offsets continue to refer to the original source line.
+fn code_line(raw: &str, state: &mut LexState) -> String {
+    let bytes = raw.as_bytes();
+    let mut masked = vec![b' '; bytes.len()];
+    let mut at = 0;
 
-        if skip_test_item {
-            // Rustfmt places the closing brace of a top-level module/function
-            // at column zero. Resume scanning after it so later production
-            // items cannot hide behind an earlier test item.
-            if line == "}" {
-                skip_test_item = false;
+    while at < bytes.len() {
+        if let Some(hashes) = state.raw_hashes {
+            if bytes[at] == b'"'
+                && bytes
+                    .get(at + 1..at + 1 + hashes)
+                    .is_some_and(|suffix| suffix.iter().all(|byte| *byte == b'#'))
+            {
+                at += 1 + hashes;
+                state.raw_hashes = None;
+            } else {
+                at += 1;
             }
             continue;
         }
 
-        // Skip a top-level inline `#[cfg(test)] mod ... { ... }`, but not a
-        // semicolon module declaration; the next production item is scanned.
-        if trimmed == "#[cfg(test)]" || trimmed.starts_with("#[cfg(test)] ") {
-            for next in lines.iter().skip(index + 1) {
-                let next_trimmed = next.trim();
-                if next_trimmed.is_empty()
-                    || next_trimmed.starts_with("//")
-                    || next_trimmed.starts_with("#!")
-                    || next_trimmed.starts_with("#[")
-                {
-                    continue;
-                }
-                if next_trimmed.starts_with("mod ") && !next_trimmed.ends_with(';') {
-                    skip_test_item = true;
-                }
-                break;
+        if let Some(quote) = state.quoted {
+            let byte = bytes[at];
+            if state.escaped {
+                state.escaped = false;
+            } else if byte == b'\\' {
+                state.escaped = true;
+            } else if byte == quote {
+                state.quoted = None;
             }
-            if skip_test_item {
-                continue;
+            at += 1;
+            continue;
+        }
+
+        if state.block_comment_depth > 0 {
+            if bytes.get(at..at + 2) == Some(b"/*") {
+                state.block_comment_depth += 1;
+                at += 2;
+            } else if bytes.get(at..at + 2) == Some(b"*/") {
+                state.block_comment_depth -= 1;
+                at += 2;
+            } else {
+                at += 1;
             }
-        } else if trimmed.starts_with("#[test]") {
-            // A top-level test function is also skipped only through its own
-            // rustfmt-aligned closing brace, never to end-of-file.
-            for next in lines.iter().skip(index + 1) {
-                let next_trimmed = next.trim();
-                if next_trimmed.is_empty()
-                    || next_trimmed.starts_with("//")
-                    || next_trimmed.starts_with("#!")
-                    || next_trimmed.starts_with("#[")
-                {
-                    continue;
-                }
-                if next_trimmed.starts_with("fn ") {
-                    skip_test_item = true;
-                }
-                break;
-            }
-            if skip_test_item {
+            continue;
+        }
+
+        if bytes.get(at..at + 2) == Some(b"//") {
+            break;
+        }
+        if bytes.get(at..at + 2) == Some(b"/*") {
+            state.block_comment_depth = 1;
+            at += 2;
+            continue;
+        }
+        if let Some((prefix_len, hashes)) = raw_string_prefix(bytes, at) {
+            state.raw_hashes = Some(hashes);
+            at += prefix_len;
+            continue;
+        }
+        if bytes[at] == b'"' {
+            state.quoted = Some(b'"');
+            at += 1;
+            continue;
+        }
+        if bytes[at] == b'\'' {
+            if let Some(length) = char_literal_len(bytes, at) {
+                at += length;
                 continue;
             }
         }
 
-        // Unconditional raw-pool-write patterns.
+        masked[at] = bytes[at];
+        at += 1;
+    }
+
+    String::from_utf8(masked).expect("mask preserves UTF-8 outside literals")
+}
+
+fn raw_string_prefix(bytes: &[u8], at: usize) -> Option<(usize, usize)> {
+    let mut cursor = at;
+    if bytes.get(cursor) == Some(&b'b') && bytes.get(cursor + 1) == Some(&b'r') {
+        cursor += 2;
+    } else if bytes.get(cursor) == Some(&b'r') {
+        cursor += 1;
+    } else {
+        return None;
+    }
+
+    let hashes_start = cursor;
+    while bytes.get(cursor) == Some(&b'#') {
+        cursor += 1;
+    }
+    if bytes.get(cursor) != Some(&b'"') {
+        return None;
+    }
+    let hashes = cursor - hashes_start;
+    Some((cursor - at + 1, hashes))
+}
+
+fn char_literal_len(bytes: &[u8], at: usize) -> Option<usize> {
+    let first = *bytes.get(at + 1)?;
+    let closing = if first == b'\\' {
+        match bytes.get(at + 2).copied()? {
+            b'x' => at.checked_add(5)?,
+            b'u' if bytes.get(at + 3) == Some(&b'{') => {
+                let end = bytes.get(at + 4..)?.iter().position(|byte| *byte == b'}')?;
+                at.checked_add(5 + end)?
+            }
+            _ => at.checked_add(3)?,
+        }
+    } else {
+        let tail = std::str::from_utf8(bytes.get(at + 1..)?).ok()?;
+        let width = tail.chars().next()?.len_utf8();
+        at.checked_add(1 + width)?
+    };
+    (bytes.get(closing) == Some(&b'\'')).then_some(closing - at + 1)
+}
+
+fn brace_delta(code: &str) -> (usize, usize) {
+    let opens = code.bytes().filter(|byte| *byte == b'{').count();
+    let closes = code.bytes().filter(|byte| *byte == b'}').count();
+    (opens, closes)
+}
+
+fn is_test_attribute(trimmed: &str) -> bool {
+    trimmed == "#[cfg(test)]"
+        || trimmed.starts_with("#[cfg(test)] ")
+        || trimmed == "#[test]"
+        || trimmed.starts_with("#[test(")
+}
+
+fn scan_source(path_str: &str, content: &str, result: &mut WriterScanResult) {
+    let is_mempool_owner = path_str.replace('\\', "/").contains("/crates/mempool/src/");
+    let raw_lines: Vec<&str> = content.lines().collect();
+    let mut lex = LexState::default();
+    let code_lines: Vec<String> = raw_lines
+        .iter()
+        .map(|line| code_line(line, &mut lex))
+        .collect();
+    let mut pending_test_item = false;
+    let mut test_depth = 0_i64;
+
+    for (index, line) in code_lines.iter().enumerate() {
+        let trimmed = line.trim();
+
+        if test_depth > 0 {
+            let (opens, closes) = brace_delta(line);
+            test_depth += i64::try_from(opens).unwrap_or(i64::MAX);
+            test_depth -= i64::try_from(closes).unwrap_or(i64::MAX);
+            if test_depth <= 0 {
+                test_depth = 0;
+            }
+            continue;
+        }
+
+        if pending_test_item {
+            if trimmed.is_empty() || trimmed.starts_with("#[") {
+                continue;
+            }
+            let (opens, closes) = brace_delta(line);
+            if opens > 0 {
+                test_depth = i64::try_from(opens).unwrap_or(i64::MAX)
+                    - i64::try_from(closes).unwrap_or(i64::MAX);
+                pending_test_item = false;
+                if test_depth < 0 {
+                    test_depth = 0;
+                }
+            } else if trimmed.ends_with(';') {
+                pending_test_item = false;
+            }
+            continue;
+        }
+
+        if is_test_attribute(trimmed) {
+            pending_test_item = true;
+            continue;
+        }
+
         for pattern in POOL_WRITE_PATTERNS {
             if line.contains(pattern) {
                 result.pool_writes_found += 1;
@@ -180,25 +297,23 @@ fn scan_source(path_str: &str, content: &str, result: &mut WriterScanResult) {
                         "raw pool write `{pattern}` at {}:{}: {}",
                         path_str,
                         index + 1,
-                        trimmed
+                        raw_lines[index].trim()
                     ));
                 }
             }
         }
 
-        // Mutating method calls are permitted only at audited, qualified
-        // gateway expressions. Receiver names alone are not ownership proof.
         for method in MUTATING_METHODS {
             if let Some(pos) = line.find(method) {
                 result.mutating_calls_found += 1;
                 if !is_mempool_owner
-                    && !is_authorized_gateway_call(path_str, line, pos, &lines, index)
+                    && !is_authorized_gateway_call(path_str, line, pos, &code_lines, index)
                 {
                     result.violations.push(format!(
                         "raw mempool mutation `{method}` at {}:{}: {}",
                         path_str,
                         index + 1,
-                        trimmed
+                        raw_lines[index].trim()
                     ));
                 }
             }
@@ -208,18 +323,13 @@ fn scan_source(path_str: &str, content: &str, result: &mut WriterScanResult) {
 
 /// Returns true only when the call is on a receiver expression explicitly
 /// audited in [`AUTHORIZED_GATEWAY_CALLS`].
-///
-/// A call may be split across lines (`ctx.mempool` then `.prioritise(...)`).
-/// In that shape the previous non-empty line supplies the complete receiver.
 fn is_authorized_gateway_call(
     path: &str,
     line: &str,
     method_pos: usize,
-    lines: &[&str],
+    lines: &[String],
     line_index: usize,
 ) -> bool {
-    // A `.write().method(` chain is a raw-pool-guard call; do not hide it as an
-    // authorized gateway call (the `POOL_WRITE_PATTERNS` check will report it).
     if line[..method_pos].contains(".write(") {
         return false;
     }
@@ -234,7 +344,7 @@ fn is_authorized_gateway_call(
             .iter()
             .rev()
             .map(|previous| previous.trim())
-            .find(|previous| !previous.is_empty() && !previous.starts_with("//"))
+            .find(|previous| !previous.is_empty())
             .unwrap_or("")
     } else {
         receiver
@@ -248,13 +358,15 @@ fn is_authorized_gateway_call(
 
 #[cfg(test)]
 mod tests {
-    use super::{empty_result, is_authorized_gateway_call, scan_source};
+    use super::{LexState, code_line, empty_result, is_authorized_gateway_call, scan_source};
 
     const MINING_HANDLER: &str = "/workspace/crates/rpc/src/handlers/mining.rs";
     const NON_OWNER: &str = "/workspace/crates/node/src/fake.rs";
 
     fn authorized(path: &str, source: &str) -> bool {
-        let lines: Vec<&str> = source.lines().collect();
+        let raw: Vec<&str> = source.lines().collect();
+        let mut lex = LexState::default();
+        let lines: Vec<String> = raw.iter().map(|line| code_line(line, &mut lex)).collect();
         let (line_index, line) = lines
             .iter()
             .enumerate()
@@ -304,40 +416,61 @@ mod tests {
     }
 
     #[test]
+    fn strings_and_comments_do_not_create_mutation_matches() {
+        let source = r##"
+const TEXT: &str = "gateway.prioritise(txid, 1) // not code";
+const RAW: &str = r#"mempool.prioritise(txid, 2)"#;
+/* pool.prioritise(txid, 3); */
+// gateway.prioritise(txid, 4);
+pub fn production() {}
+"##;
+        assert!(violations(source).is_empty());
+    }
+
+    #[test]
     fn production_after_an_inline_test_module_is_still_scanned() {
-        let source = r#"
+        let source = r##"
 #[cfg(test)]
 mod tests {
     #[test]
     fn fixture() {
-        gateway.prioritise(txid, 1);
-    }
+        let _ = r#"
 }
+gateway.prioritise(txid, 1)
+"#;
+        gateway.prioritise(txid, 2);
+    }
+} // trailing comment must not hide production below
 
 pub fn production() {
-    gateway.prioritise(txid, 2);
+    gateway.prioritise(txid, 3);
 }
-"#;
+"##;
         let found = violations(source);
-        assert_eq!(found.len(), 1, "test mutation is skipped, production is not");
-        assert!(found[0].contains("gateway.prioritise(txid, 2)"));
+        assert_eq!(found.len(), 1, "only production mutation is scanned");
+        assert!(found[0].contains("gateway.prioritise(txid, 3)"));
     }
 
     #[test]
-    fn production_after_a_top_level_test_function_is_still_scanned() {
+    fn cfg_test_helper_and_visibility_qualified_test_are_skipped_only_to_their_end() {
         let source = r#"
+#[cfg(test)]
+pub fn helper() {
+    gateway.prioritise(txid, 1);
+}
+
 #[test]
-fn fixture() {
-    mempool.prioritise(txid, 1);
+pub fn fixture() {
+    mempool.prioritise(txid, 2);
 }
 
 pub fn production() {
-    mempool.prioritise(txid, 2);
+    mempool.prioritise(txid, 3);
 }
 "#;
         let found = violations(source);
-        assert_eq!(found.len(), 1, "test mutation is skipped, production is not");
-        assert!(found[0].contains("mempool.prioritise(txid, 2)"));
+        assert_eq!(found.len(), 1);
+        assert!(found[0].contains("mempool.prioritise(txid, 3)"));
     }
 
     #[test]

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -186,6 +186,13 @@ fn code_line(raw: &str, state: &mut LexState) -> String {
         at += 1;
     }
 
+    // An odd trailing backslash inside an ordinary string escapes the physical
+    // newline itself. `str::lines()` removes that newline, so consume the
+    // continuation here while keeping the string open for the next line.
+    if state.quoted.is_some() && state.escaped {
+        state.escaped = false;
+    }
+
     String::from_utf8(masked).expect("mask preserves UTF-8 outside literals")
 }
 
@@ -352,7 +359,11 @@ fn is_authorized_gateway_call(
 
     let normalized_path = path.replace('\\', "/");
     AUTHORIZED_GATEWAY_CALLS.iter().any(|(allowed_path, allowed_receiver)| {
-        normalized_path.ends_with(allowed_path) && receiver == *allowed_receiver
+        let path_matches = normalized_path == *allowed_path
+            || normalized_path
+                .strip_suffix(allowed_path)
+                .is_some_and(|prefix| prefix.ends_with('/'));
+        path_matches && receiver == *allowed_receiver
     })
 }
 
@@ -401,10 +412,15 @@ mod tests {
         ] {
             assert!(!authorized(MINING_HANDLER, source), "{source}");
         }
-        assert!(!authorized(
+        for path in [
             "/workspace/crates/node/src/apply.rs",
-            "ctx.mempool\n    .prioritise(txid, fee_delta)"
-        ));
+            "/workspace/fakecrates/rpc/src/handlers/mining.rs",
+        ] {
+            assert!(!authorized(
+                path,
+                "ctx.mempool\n    .prioritise(txid, fee_delta)"
+            ));
+        }
     }
 
     #[test]
@@ -425,6 +441,20 @@ const RAW: &str = r#"mempool.prioritise(txid, 2)"#;
 pub fn production() {}
 "##;
         assert!(violations(source).is_empty());
+    }
+
+    #[test]
+    fn string_continuation_does_not_hide_following_production() {
+        let source = r#"
+const TEXT: &str = "continued\
+";
+pub fn production() {
+    gateway.prioritise(txid, 9);
+}
+"#;
+        let found = violations(source);
+        assert_eq!(found.len(), 1);
+        assert!(found[0].contains("gateway.prioritise(txid, 9)"));
     }
 
     #[test]

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -10,20 +10,22 @@
 
 use std::path::Path;
 
-/// The only type that may call mutating `Mempool` methods from production
-/// code outside the mempool crate.
-pub(crate) const MEMPOOL_GATEWAY_TYPE: &str = "MempoolGateway";
-
-/// Receiver tokens that identify calls already routed through the gateway.
+/// Audited cross-crate gateway mutation expressions.
 ///
-/// `Context.mempool`, `NodeState.mempool_gateway`, and local `gateway`/`mempool`
-/// bindings in tests are expected to name the gateway; the scan treats any other
-/// receiver as a raw `Mempool` call.
-pub(crate) const GATEWAY_RECEIVER_TOKENS: &[&str] = &["mempool", "mempool_gateway", "gateway"];
+/// The scanner has no Rust type information, so a generic local name such as
+/// `gateway` or `mempool` cannot prove ownership. Every exception is therefore
+/// tied to one source file and one complete receiver expression. Adding a new
+/// production gateway mutation requires an explicit review of this list.
+const AUTHORIZED_GATEWAY_CALLS: &[(&str, &str)] = &[
+    (
+        "crates/rpc/src/handlers/mining.rs",
+        "ctx.mempool",
+    ),
+];
 
 /// Mutating methods on `Mempool` that only the mempool owner may call from
 /// production code. `MempoolGateway` deliberately reuses some of these names,
-/// so a match is only a violation when the receiver is **not** a gateway token.
+/// so a match is only permitted at an audited gateway expression above.
 ///
 /// `clear` and `commit_insert` are intentionally omitted: `clear` is too common
 /// across collection types and is caught by `.pool().write(`; `commit_insert` is
@@ -173,13 +175,14 @@ fn scan_file(path: &Path, result: &mut WriterScanResult) {
             }
         }
 
-        // Mutating method calls: only flag when the receiver is not a known
-        // gateway token. This lets `ctx.mempool.prioritise(...)` (gateway) pass
-        // while `pool.prioritise(...)` (raw `&mut Mempool`) fails.
+        // Mutating method calls are permitted only at audited, qualified
+        // gateway expressions. Receiver names alone are not ownership proof.
         for method in MUTATING_METHODS {
             if let Some(pos) = line.find(method) {
                 result.mutating_calls_found += 1;
-                if !is_mempool_owner && !is_authorized_gateway_call(line, pos, &lines, index) {
+                if !is_mempool_owner
+                    && !is_authorized_gateway_call(&path_str, line, pos, &lines, index)
+                {
                     result.violations.push(format!(
                         "raw mempool mutation `{method}` at {}:{}: {}",
                         path_str,
@@ -194,15 +197,13 @@ fn scan_file(path: &Path, result: &mut WriterScanResult) {
     result.files_scanned += 1;
 }
 
-/// Returns true if the mutating method call at `method_pos` is on a receiver
-/// named `mempool`, `mempool_gateway`, or `gateway` (the permitted gateway
-/// tokens), or if the line already contains a `.write(` guard (which is handled
-/// as a separate raw-write violation).
+/// Returns true only when the call is on a receiver expression explicitly
+/// audited in [`AUTHORIZED_GATEWAY_CALLS`].
 ///
-/// A call may be split across lines (`ctx.mempool
-/// .prioritise(...)`). When the receiver on the current line carries no
-/// identifier, the previous non-empty line supplies it.
+/// A call may be split across lines (`ctx.mempool` then `.prioritise(...)`).
+/// In that shape the previous non-empty line supplies the complete receiver.
 fn is_authorized_gateway_call(
+    path: &str,
     line: &str,
     method_pos: usize,
     lines: &[&str],
@@ -214,31 +215,75 @@ fn is_authorized_gateway_call(
         return false;
     }
 
-    // Find the dot immediately preceding the method name.
     let before = &line[..method_pos];
     let receiver = match before.rfind('.') {
-        Some(dot_pos) => &before[..dot_pos],
-        None => before,
+        Some(dot_pos) => before[..dot_pos].trim(),
+        None => before.trim(),
     };
-    let token = match receiver.rfind(|c: char| !c.is_alphanumeric() && c != '_') {
-        Some(token_start) => receiver[token_start + 1..].trim(),
-        None => receiver.trim(),
+    let receiver = if receiver.is_empty() {
+        lines[..line_index]
+            .iter()
+            .rev()
+            .map(|previous| previous.trim())
+            .find(|previous| !previous.is_empty() && !previous.starts_with("//"))
+            .unwrap_or("")
+    } else {
+        receiver
     };
-    if !token.is_empty() && GATEWAY_RECEIVER_TOKENS.contains(&token) {
-        return true;
+
+    let normalized_path = path.replace('\\', "/");
+    AUTHORIZED_GATEWAY_CALLS.iter().any(|(allowed_path, allowed_receiver)| {
+        normalized_path.ends_with(allowed_path) && receiver == *allowed_receiver
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_authorized_gateway_call;
+
+    const MINING_HANDLER: &str = "/workspace/crates/rpc/src/handlers/mining.rs";
+
+    fn authorized(path: &str, source: &str) -> bool {
+        let lines: Vec<&str> = source.lines().collect();
+        let (line_index, line) = lines
+            .iter()
+            .enumerate()
+            .find(|(_, line)| line.contains("prioritise("))
+            .expect("fixture contains prioritise call");
+        let method_pos = line.find("prioritise(").expect("method position");
+        is_authorized_gateway_call(path, line, method_pos, &lines, line_index)
     }
 
-    // Multi-line call: the receiver lives on the previous non-empty line.
-    for previous in lines[..line_index].iter().rev() {
-        let previous = previous.trim();
-        if previous.is_empty() || previous.starts_with("//") {
-            continue;
+    #[test]
+    fn only_the_audited_qualified_gateway_receiver_is_authorized() {
+        assert!(authorized(
+            MINING_HANDLER,
+            "ctx.mempool\n    .prioritise(txid, fee_delta)"
+        ));
+        assert!(authorized(
+            MINING_HANDLER,
+            "ctx.mempool.prioritise(txid, fee_delta)"
+        ));
+
+        for source in [
+            "gateway.prioritise(txid, fee_delta)",
+            "mempool.prioritise(txid, fee_delta)",
+            "other.mempool.prioritise(txid, fee_delta)",
+            "ctx.mempool_gateway.prioritise(txid, fee_delta)",
+        ] {
+            assert!(!authorized(MINING_HANDLER, source), "{source}");
         }
-        let token = previous
-            .rsplit(|c: char| !c.is_alphanumeric() && c != '_')
-            .next()
-            .unwrap_or("");
-        return !token.is_empty() && GATEWAY_RECEIVER_TOKENS.contains(&token);
+        assert!(!authorized(
+            "/workspace/crates/node/src/apply.rs",
+            "ctx.mempool\n    .prioritise(txid, fee_delta)"
+        ));
     }
-    false
+
+    #[test]
+    fn a_raw_write_chain_is_never_authorized() {
+        assert!(!authorized(
+            MINING_HANDLER,
+            "ctx.mempool.write().prioritise(txid, fee_delta)"
+        ));
+    }
 }


### PR DESCRIPTION
## Problem

Hardens two false-negative paths in the mempool ownership source gate.

1. The #665 review found that generic local names (`gateway`, `mempool`, `mempool_gateway`) were treated as proof that a mutation flowed through `MempoolGateway`. A raw `Mempool` binding using one of those names could therefore call a listed mutator without tripping the gate.
2. During re-review, the same scanner was found to stop scanning the entire remainder of a source file after the first inline `#[cfg(test)] mod` or top-level `#[test]` function. Production code placed after that test item was invisible to the gate.

Original receiver finding: https://github.com/gosuda/bitcoin-rs/pull/665#discussion_r3970345509

## Fix

- Remove the generic receiver-token allowlist and unused type-name marker.
- Replace them with one audited `(source file, complete receiver expression)` entry for the only current cross-crate raw-mutator-name call: `ctx.mempool.prioritise(...)` in `crates/rpc/src/handlers/mining.rs`.
- Normalize path separators; the same expression in another file is not authorized.
- Preserve the rule that `.write().method(...)` chains are never gateway-authorized.
- Extract `scan_source` so the gate can exercise synthetic source text directly.
- Skip only the body of an inline test module or top-level test function, resuming after its rustfmt-aligned top-level closing brace. A `#[cfg(test)] mod tests;` declaration no longer suppresses anything after itself.

A new production gateway mutation must now update the explicit audited callsite list. Tests are not scanned for ownership violations, but they can no longer hide later production items.

## Regression coverage

Scanner-local tests require:

- audited same-line and split-line `ctx.mempool.prioritise` in the mining handler to pass;
- bare `gateway`, bare `mempool`, `other.mempool`, `ctx.mempool_gateway`, or the right receiver in the wrong file to fail authorization;
- a raw `.write().prioritise` chain never to be authorized;
- a raw production mutation after an inline test module, after a top-level test function, or after an external `mod tests;` declaration to remain visible and produce exactly one violation while the test mutation itself is skipped.

## Scope

One test-support file. No mempool runtime API, mutation behavior, RPC behavior, dependency, lock, production source, or lint allowance changes.

## Validation required

```sh
cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test overhaul_ownership -- --nocapture
cargo clippy --locked --workspace --all-targets --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node -- -D warnings
cargo fmt --all -- --check
```

The real workspace scan must still report zero violations and a meaningful file count, and every synthetic bypass must fail closed as above. No final-head test or Clippy success is claimed yet; keep draft pending CI and final review.

Branch started from main `de0f6ffff75ddffaa6ed0b59ee4f208cfd2e49b6`. No force-push, merge, or auto-merge was performed by this work.