### PR TITLE
ci: compile native profiles on the declared Rust 1.95 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,34 @@ jobs:
           cargo clippy --locked -p bitcoin-rs-node \
             --no-default-features --features fjall,zmq --all-targets -- -D warnings
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        id: toolchain
+        with:
+          toolchain: "1.95.0"
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      # Compile only: the policy promise is that workspace crates build on the
+      # declared MSRV. Tests, benches, kernel/C++ features, and deep feature
+      # combinations remain owned by their existing stable/nightly lanes.
+      - name: Workspace default targets on Rust 1.95
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' }}
+        run: |
+          cargo check --locked --workspace \
+            --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node
+      - name: Native consensus on Rust 1.95
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' }}
+        run: |
+          cargo check --locked -p bitcoin-rs-consensus \
+            --no-default-features
+      - name: Native node on Rust 1.95
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' }}
+        run: |
+          cargo check --locked -p bitcoin-rs-node \
+            --no-default-features --features fjall,zmq
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem

The workspace declares `rust-version = "1.95.0"`, `clippy.toml` mirrors that MSRV, and `docs/policies/source-compatibility.md` says every workspace crate must compile on Rust 1.95. Current CI only installs `stable`, so the compatibility promise can regress without a pull-request failure.

## Fix

Add one compile-only `msrv` job to the fast PR workflow:

- install Rust `1.95.0` explicitly;
- `cargo check --locked --workspace --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node`;
- check native consensus with `--no-default-features`;
- check native node with `--no-default-features --features fjall,zmq`.

These are the same native ownership boundaries used by the fast Clippy/test jobs. The gate does not run tests or benches and does not enable `kernel`, RocksDB, MDBX, or other deep feature combinations; those remain owned by existing stable/nightly/main-only lanes. The purpose here is only to make the declared language/compiler floor executable.

## Scope

One workflow file, +28 lines. No source, dependency, lockfile, lint policy, feature default, MSRV value, or test semantics change.

## Acceptance

All three compile profiles must pass with Rust 1.95.0 and the committed lockfile. A future dependency or language change that requires a newer compiler must fail this job until the MSRV declaration and policy are deliberately updated together.

The ordinary stable formatting, Clippy, test, benchmark, and deep-main jobs remain required independently; this job is not a substitute for them.

## Validation status

Source diff was checked against main `d493b5dc24a1d3d10a9158caec2739e9f2741996`, and GitHub reports the branch as one commit ahead with only `.github/workflows/ci.yml` changed. No executed Rust 1.95 CI result is claimed yet, so this PR remains draft pending its own workflow result and review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compile-only MSRV gate to CI so the declared Rust 1.95.0 compatibility floor is enforced on every PR. Previously CI only compiled with stable, so a dependency or code change requiring a newer compiler could pass without breaking the MSRV promise.

- Installs Rust 1.95.0 explicitly and runs `cargo check --locked` on three native profiles: the workspace default targets, consensus with `--no-default-features`, and node with `--no-default-features --features fjall,zmq`.
- Does not run tests, benches, or deep feature combinations like `kernel`, RocksDB, or MDBX; those remain covered by existing stable/nightly lanes.

<sup>Written for commit 2f06836b3e32f83f6c8bc0c4ff9e43ae7832420c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

