### PR TITLE
fix(qa): publish golden fixtures atomically and reuse complete caches

### DIFF
--- a/.github/workflows/fixture-tools.yml
+++ b/.github/workflows/fixture-tools.yml
@@ -1,0 +1,24 @@
+name: fixture-tools
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fixture-tools-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  golden-fixtures:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Check downloader syntax
+        run: bash -n scripts/fetch-golden.sh
+      - name: Run offline downloader regressions
+        run: python3 -m unittest discover -s scripts/tests -v

--- a/scripts/fetch-golden.sh
+++ b/scripts/fetch-golden.sh
@@ -5,20 +5,54 @@ heights=(0 1 170 91722 91812 91842 91880 173818 363731 481823 481824 624455 7096
 out_dir="crates/primitives/tests/testdata"
 mkdir -p "${out_dir}"
 
+# Stage on the destination filesystem so a failed transfer cannot become a cache hit.
+tmp_dir=""
+trap 'if [[ -n "${tmp_dir}" ]]; then rm -rf -- "${tmp_dir}"; fi' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 for height in "${heights[@]}"; do
-  hash="$(curl -fsSL "https://blockstream.info/api/block-height/${height}")"
   bin_path="${out_dir}/${height}.bin"
   txids_path="${out_dir}/${height}.txids.txt"
-
-  if [[ ! -f "${bin_path}" ]]; then
-    curl -fsSL "https://blockstream.info/api/block/${hash}/raw" > "${bin_path}"
+  if [[ -s "${bin_path}" && -s "${txids_path}" ]]; then
+    continue
   fi
 
-  if [[ ! -f "${txids_path}" ]]; then
+  hash="$(curl -fsSL "https://blockstream.info/api/block-height/${height}")"
+  if [[ ! "${hash}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    printf 'Invalid block hash for height %s\n' "${height}" >&2
+    exit 1
+  fi
+
+  if [[ -z "${tmp_dir}" ]]; then
+    tmp_dir="$(mktemp -d "${out_dir}/.fetch-golden.XXXXXX")"
+  fi
+
+  if [[ ! -s "${bin_path}" ]]; then
+    curl -fsSL "https://blockstream.info/api/block/${hash}/raw" > "${tmp_dir}/block.bin"
+    if [[ ! -s "${tmp_dir}/block.bin" ]]; then
+      printf 'Empty block response for height %s\n' "${height}" >&2
+      exit 1
+    fi
+    mv -- "${tmp_dir}/block.bin" "${bin_path}"
+  fi
+
+  if [[ ! -s "${txids_path}" ]]; then
     curl -fsSL "https://blockstream.info/api/block/${hash}/txids" \
-      | python3 -c 'import json,sys; print("\n".join(json.load(sys.stdin)))' \
-      > "${txids_path}"
-    printf '\n' >> "${txids_path}"
-  fi
+      | python3 -c '
+import json
+import re
+import sys
 
+txids = json.load(sys.stdin)
+if not isinstance(txids, list) or not txids or any(
+    not isinstance(txid, str) or re.fullmatch(r"[0-9a-fA-F]{64}", txid) is None
+    for txid in txids
+):
+    sys.exit("Expected a non-empty array of 64-character hexadecimal txids")
+print("\n".join(txids))
+' > "${tmp_dir}/txids.txt"
+    mv -- "${tmp_dir}/txids.txt" "${txids_path}"
+  fi
 done

--- a/scripts/tests/test_fetch_golden.py
+++ b/scripts/tests/test_fetch_golden.py
@@ -1,18 +1,29 @@
 """Offline, subprocess-level regression tests for fetch-golden.sh.
 
+The acquisition contract and failure cases are recorded in PR #740:
+https://github.com/gosuda/bitcoin-rs/pull/740
+The baseline script (Git blob 6073db3294ec4ce88571ca55a9dad7e18b2cd7b5)
+owns fixture paths and cache reuse; PR #740 adds failure-atomic publication
+and offline reuse. Heights come from the script, not a second inventory.
+Response bytes are synthetic transport fixtures, not Bitcoin validity vectors:
+expected file contents are the stub's input bytes, never downloader output.
+
 Run from the repository root: python3 -m unittest discover -s scripts/tests -v
 """
 
 import os
 from pathlib import Path
+import re
 import subprocess
 import tempfile
 import unittest
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "fetch-golden.sh"
-HEIGHTS = (0, 1, 170, 91722, 91812, 91842, 91880, 173818, 363731,
-           481823, 481824, 624455, 709632, 800000, 880000)
+_height_array = re.search(r"^heights=\((\d+(?:\s+\d+)*)\)$", SCRIPT.read_text(), re.M)
+if _height_array is None:
+    raise RuntimeError("Cannot read the downloader's fixture-height inventory")
+HEIGHTS = tuple(int(height) for height in _height_array.group(1).split())
 TXID = "ab" * 32
 CURL_STUB = r'''#!/usr/bin/env bash
 set -eu
@@ -55,6 +66,8 @@ class FetchGoldenTests(unittest.TestCase):
         self.root = Path(self.temp.name)
         self.output = self.root / "crates/primitives/tests/testdata"
         self.output.mkdir(parents=True)
+        self.block_path = self.output / f"{HEIGHTS[0]}.bin"
+        self.txids_path = self.output / f"{HEIGHTS[0]}.txids.txt"
         self.bin = self.root / "bin"
         self.bin.mkdir()
         stub = self.bin / "curl"
@@ -95,7 +108,7 @@ class FetchGoldenTests(unittest.TestCase):
         result = self.run_fetch("offline")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(self.requests(), [])
-        self.assertEqual((self.output / "0.bin").read_bytes(), b"existing block")
+        self.assertEqual(self.block_path.read_bytes(), b"existing block")
 
     def test_complete_cache_needs_no_staging_directory(self):
         self.seed_cache()
@@ -109,44 +122,44 @@ class FetchGoldenTests(unittest.TestCase):
     def test_failed_raw_is_not_published_and_retry_succeeds(self):
         result = self.run_fetch("partial_raw")
         self.assertNotEqual(result.returncode, 0)
-        self.assertFalse((self.output / "0.bin").exists())
-        self.assertFalse((self.output / "0.txids.txt").exists())
+        self.assertFalse(self.block_path.exists())
+        self.assertFalse(self.txids_path.exists())
         retry = self.run_fetch()
         self.assertEqual(retry.returncode, 0, retry.stderr)
-        self.assertEqual((self.output / "0.bin").read_bytes(), b"block bytes")
+        self.assertEqual(self.block_path.read_bytes(), b"block bytes")
 
     def test_invalid_raw_and_hash_are_not_published(self):
         for mode in ("empty_raw", "invalid_hash"):
             with self.subTest(mode=mode):
                 result = self.run_fetch(mode)
                 self.assertNotEqual(result.returncode, 0)
-                self.assertFalse((self.output / "0.bin").exists())
-                self.assertFalse((self.output / "0.txids.txt").exists())
+                self.assertFalse(self.block_path.exists())
+                self.assertFalse(self.txids_path.exists())
 
     def test_invalid_txids_are_not_published(self):
         for mode in ("invalid_json", "invalid_txid", "wrong_shape", "empty_txids", "failed_txids"):
             with self.subTest(mode=mode):
                 result = self.run_fetch(mode)
                 self.assertNotEqual(result.returncode, 0)
-                self.assertFalse((self.output / "0.txids.txt").exists())
-                self.assertEqual((self.output / "0.bin").read_bytes(), b"block bytes")
+                self.assertFalse(self.txids_path.exists())
+                self.assertEqual(self.block_path.read_bytes(), b"block bytes")
 
     def test_empty_cache_entries_are_replaced(self):
         self.seed_cache()
-        (self.output / "0.bin").write_bytes(b"")
-        (self.output / "0.txids.txt").write_bytes(b"")
+        self.block_path.write_bytes(b"")
+        self.txids_path.write_bytes(b"")
         result = self.run_fetch()
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual((self.output / "0.bin").read_bytes(), b"block bytes")
-        self.assertEqual((self.output / "0.txids.txt").read_text(), TXID + "\n")
+        self.assertEqual(self.block_path.read_bytes(), b"block bytes")
+        self.assertEqual(self.txids_path.read_text(), TXID + "\n")
         self.assertEqual(len(self.requests()), 3)
 
     def test_partial_cache_preserves_existing_files(self):
         self.seed_cache()
-        (self.output / "0.txids.txt").unlink()
+        self.txids_path.unlink()
         result = self.run_fetch()
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual((self.output / "0.bin").read_bytes(), b"existing block")
+        self.assertEqual(self.block_path.read_bytes(), b"existing block")
         self.assertEqual(len(self.requests()), 2)
 
 

--- a/scripts/tests/test_fetch_golden.py
+++ b/scripts/tests/test_fetch_golden.py
@@ -1,0 +1,154 @@
+"""Offline, subprocess-level regression tests for fetch-golden.sh.
+
+Run from the repository root: python3 -m unittest discover -s scripts/tests -v
+"""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "fetch-golden.sh"
+HEIGHTS = (0, 1, 170, 91722, 91812, 91842, 91880, 173818, 363731,
+           481823, 481824, 624455, 709632, 800000, 880000)
+TXID = "ab" * 32
+CURL_STUB = r'''#!/usr/bin/env bash
+set -eu
+url="${!#}"
+printf '%s\n' "$url" >> "$REQUEST_LOG"
+mode="${CURL_MODE:-ok}"
+[[ "$mode" != offline ]] || exit 7
+case "$url" in
+    */block-height/*)
+        if [[ "$mode" == invalid_hash ]]; then
+            printf 'not-a-block-hash\n'
+        else
+            printf '%064x\n' "${url##*/}"
+        fi
+        ;;
+    */raw)
+        [[ "$mode" == empty_raw ]] || printf 'block bytes'
+        [[ "$mode" != partial_raw ]] || exit 18
+        ;;
+    */txids)
+        txid="abababababababababababababababababababababababababababababababab"
+        case "$mode" in
+            invalid_json) printf '[\n' ;;
+            invalid_txid) printf '["not-a-txid"]\n' ;;
+            wrong_shape) printf '{"%s":true}\n' "$txid" ;;
+            empty_txids) printf '[]\n' ;;
+            *) printf '["%s"]\n' "$txid" ;;
+        esac
+        [[ "$mode" != failed_txids ]] || exit 18
+        ;;
+    *) exit 99 ;;
+esac
+'''
+
+
+class FetchGoldenTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.output = self.root / "crates/primitives/tests/testdata"
+        self.output.mkdir(parents=True)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        stub = self.bin / "curl"
+        stub.write_text(CURL_STUB, encoding="utf-8")
+        stub.chmod(0o755)
+        self.log = self.root / "requests.log"
+        self.env = dict(os.environ, PATH=f"{self.bin}{os.pathsep}{os.environ['PATH']}",
+                        REQUEST_LOG=str(self.log))
+
+    def run_fetch(self, mode="ok"):
+        result = subprocess.run(
+            ["bash", str(SCRIPT)], cwd=self.root,
+            env=dict(self.env, CURL_MODE=mode), capture_output=True,
+            text=True, timeout=30, check=False,
+        )
+        self.assertEqual(list(self.output.glob(".fetch-golden.*")), [],
+                         "temporary files must be cleaned on success or failure")
+        return result
+
+    def requests(self):
+        return self.log.read_text(encoding="utf-8").splitlines() if self.log.exists() else []
+
+    def seed_cache(self):
+        for height in HEIGHTS:
+            (self.output / f"{height}.bin").write_bytes(b"existing block")
+            (self.output / f"{height}.txids.txt").write_text(TXID + "\n", encoding="utf-8")
+
+    def test_success_publishes_complete_fixtures(self):
+        result = self.run_fetch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(self.requests()), 3 * len(HEIGHTS))
+        for height in HEIGHTS:
+            self.assertEqual((self.output / f"{height}.bin").read_bytes(), b"block bytes")
+            self.assertEqual((self.output / f"{height}.txids.txt").read_text(), TXID + "\n")
+
+    def test_complete_cache_needs_no_network(self):
+        self.seed_cache()
+        result = self.run_fetch("offline")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.requests(), [])
+        self.assertEqual((self.output / "0.bin").read_bytes(), b"existing block")
+
+    def test_complete_cache_needs_no_staging_directory(self):
+        self.seed_cache()
+        mktemp = self.bin / "mktemp"
+        mktemp.write_text("#!/usr/bin/env bash\nexit 97\n", encoding="utf-8")
+        mktemp.chmod(0o755)
+        result = self.run_fetch("offline")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.requests(), [])
+
+    def test_failed_raw_is_not_published_and_retry_succeeds(self):
+        result = self.run_fetch("partial_raw")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.output / "0.bin").exists())
+        self.assertFalse((self.output / "0.txids.txt").exists())
+        retry = self.run_fetch()
+        self.assertEqual(retry.returncode, 0, retry.stderr)
+        self.assertEqual((self.output / "0.bin").read_bytes(), b"block bytes")
+
+    def test_invalid_raw_and_hash_are_not_published(self):
+        for mode in ("empty_raw", "invalid_hash"):
+            with self.subTest(mode=mode):
+                result = self.run_fetch(mode)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse((self.output / "0.bin").exists())
+                self.assertFalse((self.output / "0.txids.txt").exists())
+
+    def test_invalid_txids_are_not_published(self):
+        for mode in ("invalid_json", "invalid_txid", "wrong_shape", "empty_txids", "failed_txids"):
+            with self.subTest(mode=mode):
+                result = self.run_fetch(mode)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse((self.output / "0.txids.txt").exists())
+                self.assertEqual((self.output / "0.bin").read_bytes(), b"block bytes")
+
+    def test_empty_cache_entries_are_replaced(self):
+        self.seed_cache()
+        (self.output / "0.bin").write_bytes(b"")
+        (self.output / "0.txids.txt").write_bytes(b"")
+        result = self.run_fetch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.output / "0.bin").read_bytes(), b"block bytes")
+        self.assertEqual((self.output / "0.txids.txt").read_text(), TXID + "\n")
+        self.assertEqual(len(self.requests()), 3)
+
+    def test_partial_cache_preserves_existing_files(self):
+        self.seed_cache()
+        (self.output / "0.txids.txt").unlink()
+        result = self.run_fetch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.output / "0.bin").read_bytes(), b"existing block")
+        self.assertEqual(len(self.requests()), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`scripts/fetch-golden.sh` writes directly to cache destinations. A failed raw download or txid pipeline can leave a partial/empty file which the next run treats as complete. A fully populated cache also performs 15 unnecessary block-hash lookups and cannot be reused offline.

## Changes

- Stage downloads on the destination filesystem and rename each artifact only after the command/pipeline succeeds.
- Reject malformed block-hash responses, empty raw responses, and malformed/empty/non-hex txid arrays before publication.
- Treat zero-byte cache entries as missing, preserve existing nonempty artifacts, and skip all HTTP requests for complete cache entries.
- Create staging lazily and clean it on exit/HUP/INT/TERM; complete caches need no staging write.
- Emit one terminating newline for txid files, rather than an additional blank line.
- Add eight offline subprocess-level regression tests with failure injection and a small, read-only-permissions CI workflow to run them.

Publication is atomic per artifact, not across the block/txid pair. Existing nonempty cached artifacts remain trusted; this is not a consensus validator or a retrospective integrity scan.

## Verified locally

Source copy was checked against original Git blob `6073db3294ec4ce88571ca55a9dad7e18b2cd7b5` before edits.

- Baseline: seven test methods produced 12 assertion failures, including subtests.
- A second review found an eager staging-write regression; an eighth test reproduced it, and lazy staging fixed it.
- Final: `python3 -m unittest discover -s scripts/tests -v` — **8 passed**, using system Python 3.13 and an injected offline curl stub.
- `bash -n scripts/fetch-golden.sh` — passed.
- `git diff --cached --check` — passed.
- Same seeded complete cache, successful mock transport: **15 HTTP requests before, 0 after**. This is a request-count result, not a production wall-clock benchmark.

## Scope and remaining validation

One commit, three related files, based on main `d493b5dc24a1d3d10a9158caec2739e9f2741996`. No Rust source, consensus behavior, dependency lockfile, existing workflow, or operator data is changed. Scratch work and evidence logs are outside the PR.

Draft pending final-head CI/review. This environment has no Rust toolchain and terminal DNS is unavailable, so no Cargo, live Blockstream, full-repository, formal-model, or CodeRabbit success is claimed. No force-push, direct main update, merge, or auto-merge is requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `scripts/fetch-golden.sh` publish fixture downloads atomically and reuse complete caches so a failed fetch can no longer leave a partial file that later runs treat as valid. Previously each artifact was written directly to its destination and complete caches still performed block-hash lookups for every height.

- Stages downloads in a temporary directory and renames them into place only after validation succeeds.
- Treats zero-byte cache entries as missing, preserves existing nonempty artifacts, and skips all HTTP requests for complete entries.
- Rejects malformed block-hash responses, empty raw responses, and malformed or empty txid arrays before publication.
- Adds eight offline subprocess regression tests, with fixture heights derived from the script, plus a read-only CI workflow to run them.
- Publication is atomic per artifact, not across the block/txid pair, and existing nonempty cached artifacts remain trusted.

<sup>Written for commit e78753b9eedebb6989d984334634ea0ad6a811fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

