### PR TITLE
fix(node): restore admission after coherent reorg failures

### DIFF
--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -9375,7 +9375,7 @@ mod consensus_rule_tests {
             vec![coinbase_transaction(1)],
         )?;
         let raw = bytes::Bytes::from(consensus_bytes(&block));
-        let applied = apply_block_with_serialized(&handles, &block, raw)?;
+        let applied = apply_block_with_serialized(&handles, &block, raw.clone())?;
         bodies
             .bodies
             .write()
@@ -9402,6 +9402,31 @@ mod consensus_rule_tests {
         assert_eq!(handles.chain_tip.load_full(), header_tip_before);
         assert_eq!(handles.applied_tip.load_full(), applied_tip_before);
         assert_eq!(utxo.len(), utxo_len_before);
+        // MPL-04: a read-only preflight refusal must release its generation.
+        assert!(
+            handles.mempool_gateway.stable_generation().is_some(),
+            "missing disconnect data must not leave admission closed"
+        );
+
+        bodies
+            .bodies
+            .write()
+            .insert((applied.height, applied.hash), raw.to_vec());
+        crate::reorg::invalidate_block(
+            &handles,
+            &crate::chain_effects::ChainFollowers::noop(),
+            applied.hash,
+        )?;
+        assert_eq!(
+            handles.applied_tip.load_full().map(|tip| tip.hash),
+            Some(genesis_hash),
+            "restoring the body must allow invalidation without restarting"
+        );
+        assert_eq!(
+            handles.block_tree.read().node(applied.tip_id)?.status,
+            NodeStatus::Invalid
+        );
+        assert!(handles.mempool_gateway.stable_generation().is_some());
         Ok(())
     }
 
@@ -9891,11 +9916,7 @@ mod consensus_rule_tests {
                 vec![coinbase_transaction(seed)],
             )?;
             let raw = bytes::Bytes::from(consensus_bytes(&block));
-            let tip = apply_block_with_serialized(&handles, &block, raw.clone())?;
-            bodies
-                .bodies
-                .write()
-                .insert((tip.height, tip.hash), raw.to_vec());
+            let tip = apply_block_with_serialized(&handles, &block, raw)?;
             old_tips.push(tip);
             prev = block.block_hash();
         }
@@ -9961,6 +9982,31 @@ mod consensus_rule_tests {
             Some(12),
             "applied tip must be at the height reached by the completed window"
         );
+        // MPL-04: the completed disconnect prefix is a stable chain, even
+        // when the next window cannot load its bodies.
+        assert_eq!(utxo.len(), 12);
+        assert!(
+            handles.mempool_gateway.stable_generation().is_some(),
+            "mid-rollback body loss must reopen admission at the committed prefix"
+        );
+        bodies
+            .fail_on_second_read
+            .write()
+            .remove(&(target_tip.height, target_tip.hash));
+        crate::reorg::switch_to_branch(
+            &handles,
+            &crate::chain_effects::ChainFollowers::noop(),
+            fork_target,
+            |_| None,
+            |_| {},
+        )?;
+        assert_eq!(
+            handles.applied_tip.load_full().map(|tip| tip.hash),
+            Some(Hash256::from(fork_prev)),
+            "retry must resume from the committed prefix and reach the fork tip"
+        );
+        assert_eq!(utxo.len(), 21);
+        assert!(handles.mempool_gateway.stable_generation().is_some());
         Ok(())
     }
 
@@ -10129,57 +10175,17 @@ mod consensus_rule_tests {
     #[test]
     fn a_coinstats_desync_refuses_before_it_can_tear_anything()
     -> Result<(), Box<dyn std::error::Error>> {
-        let utxo = Arc::new(UtxoSet::new());
-        let mut handles = apply_handles_without_tx_index(Network::Regtest, Arc::clone(&utxo));
-        let bodies = Arc::new(MapBodyStore::default());
-        let body_arc = Arc::clone(&bodies);
-        let body_handle: Arc<dyn crate::apply::PruneBodyStore> = body_arc;
-        handles.block_body_store = Some(body_handle);
+        let ReorgBodyLoadingFixture {
+            handles,
+            utxo,
+            target,
+            losing,
+            applied,
+            ..
+        } = reorg_body_loading_fixture()?;
 
-        let genesis = Network::Regtest.genesis_block();
-        let genesis_hash = Hash256::from(genesis.block_hash());
-        let genesis_tip = applied_header_tip(&handles, genesis_hash, &genesis, 0)?;
-        handles.applied_tip.store(Some(Arc::new(genesis_tip)));
-
-        let losing = mined_block_with_prev_hash_and_transactions(
-            genesis.block_hash(),
-            vec![coinbase_transaction(1)],
-        )?;
-        let raw = bytes::Bytes::from(consensus_bytes(&losing));
-        let applied = apply_block_with_serialized(&handles, &losing, raw.clone())?;
-        bodies
-            .bodies
-            .write()
-            .insert((applied.height, applied.hash), raw.to_vec());
-
-        let win_one = mined_block_with_prev_hash_and_transactions(
-            genesis.block_hash(),
-            vec![coinbase_transaction(2)],
-        )?;
-        let win_two = mined_block_with_prev_hash_and_transactions(
-            win_one.block_hash(),
-            vec![coinbase_transaction(3)],
-        )?;
-        let target = {
-            let mut tree = handles.block_tree.write();
-            let mut last = None;
-            for (height, block) in [(1_u32, &win_one), (2_u32, &win_two)] {
-                let hash = Hash256::from(block.block_hash());
-                last = Some(tree.insert_header(
-                    block.header,
-                    bitcoin_rs_chain::node::NodeStatus::HeaderValid,
-                )?);
-                bodies
-                    .bodies
-                    .write()
-                    .insert((height, hash), consensus_bytes(block));
-            }
-            last.ok_or_else(|| anyhow::anyhow!("no winning branch built"))?
-        };
-
-        // Desynchronise the coinstats height. The disconnect's UTXO undo lands
-        // first and the coinstats rewind then rejects the height, which is a
-        // real tear: some state reverted, some did not.
+        // Inject only the stats height mismatch. The disconnect precheck must
+        // catch it before committing any UTXO undo.
         handles.coin_stats.finish_block(999, 0);
 
         let outcome = crate::reorg::switch_to_branch(
@@ -10202,6 +10208,27 @@ mod consensus_rule_tests {
             utxo.has_live_outputs_for_txid(&Hash256::from(losing.txs[0].txid())),
             "a refused disconnect must not have undone any coins"
         );
+        // MPL-04: a refused disconnect leaves the original committed tip
+        // coherent and must release the generation before another attempt.
+        assert!(
+            handles.mempool_gateway.stable_generation().is_some(),
+            "a clean disconnect refusal must reopen admission"
+        );
+        handles.coin_stats.finish_block(applied.height, 0);
+        crate::reorg::switch_to_branch(
+            &handles,
+            &crate::chain_effects::ChainFollowers::noop(),
+            target,
+            |_| None,
+            |_| {},
+        )?;
+        assert_eq!(
+            handles.applied_tip.load_full().map(|tip| tip.tip_id),
+            Some(target),
+            "repairing the injected stats mismatch must permit the same reorg"
+        );
+        assert!(!utxo.has_live_outputs_for_txid(&Hash256::from(losing.txs[0].txid())));
+        assert!(handles.mempool_gateway.stable_generation().is_some());
         Ok(())
     }
 

--- a/crates/node/src/reorg.rs
+++ b/crates/node/src/reorg.rs
@@ -18,6 +18,9 @@ use crate::apply::{ChainTransition, Chainstate};
 use crate::chain_effects::ChainFollowers;
 use crate::{ApplyError, DisconnectError};
 
+#[cfg(test)]
+mod tests;
+
 /// Settles a rolled-back disconnect marker once the reorg owner has released
 /// its chain-transition proof.
 ///
@@ -32,6 +35,39 @@ fn settle_disconnect_debt(handles: &Chainstate) -> core::result::Result<(), Reor
         Ok(false) => Ok(()),
         Err(error) => Err(ReorgError::CheckpointSettlement(anyhow::Error::new(error))),
     }
+}
+
+/// Completes a coherent reorg attempt before publishing its disconnect debt.
+/// Potentially torn state retains the odd generation and never checkpoints.
+fn settle_reorg_transition(
+    transition: ChainTransition<'_>,
+    outcome: core::result::Result<(), ReorgError>,
+) -> core::result::Result<(), ReorgError> {
+    if outcome.as_ref().is_err_and(ReorgError::requires_recovery) {
+        return outcome;
+    }
+    let handles = transition.chainstate();
+    if let Err(source) = transition.finish() {
+        handles.admission.close_permanently();
+        handles
+            .shutdown
+            .store(true, std::sync::atomic::Ordering::Release);
+        tracing::error!(
+            original = ?outcome,
+            finish = %source,
+            "reorg generation could not be settled; admission remains closed"
+        );
+        return Err(ReorgError::TransitionSettlement {
+            source: Box::new(source),
+            original: outcome.err().map(Box::new),
+        });
+    }
+    if let Err(settlement) = settle_disconnect_debt(handles) {
+        tracing::error!(%settlement, "reorg checkpoint debt remains unsettled");
+        outcome?;
+        return Err(settlement);
+    }
+    outcome
 }
 
 /// Maximum number of disconnect-side block bodies held in memory at once
@@ -65,67 +101,63 @@ pub fn invalidate_block(
     let transition = handles
         .begin_transition()
         .map_err(|source| ReorgError::Unavailable(Box::new(source)))?;
-    loop {
-        let (root, target) = {
-            let tree = handles.block_tree.read();
-            let root = tree.lookup(hash).ok_or(ReorgError::UnknownBlock(hash))?;
-            if tree.node(root).map_err(ReorgError::Plan)?.height == 0 {
-                return Err(ReorgError::CannotInvalidateGenesis);
-            }
-            let target = tree
-                .tip_after_invalidation(root)
-                .map_err(ReorgError::Plan)?
-                .ok_or(ReorgError::NoValidTip)?;
-            (root, target)
-        };
+    // Keep read-only planning refusals in the same settlement path as the
+    // execution outcome; an early `?` must not strand a coherent generation.
+    let outcome = (|| {
+        loop {
+            let (root, target) = {
+                let tree = handles.block_tree.read();
+                let root = tree.lookup(hash).ok_or(ReorgError::UnknownBlock(hash))?;
+                if tree.node(root).map_err(ReorgError::Plan)?.height == 0 {
+                    return Err(ReorgError::CannotInvalidateGenesis);
+                }
+                let target = tree
+                    .tip_after_invalidation(root)
+                    .map_err(ReorgError::Plan)?
+                    .ok_or(ReorgError::NoValidTip)?;
+                (root, target)
+            };
 
-        let plan = current_reorg_plan(handles, target)?;
-        let mut no_staged_body = |_| None;
-        let (disconnect_nodes, connect) = match plan.as_ref() {
-            Some(plan) => {
-                let disconnect_nodes = branch_nodes(handles, &plan.disconnect)?;
-                let connect = load_branch_bodies(handles, &plan.connect, &mut no_staged_body)?;
-                (disconnect_nodes, connect)
+            let plan = current_reorg_plan(handles, target)?;
+            let mut no_staged_body = |_| None;
+            let (disconnect_nodes, connect) = match plan.as_ref() {
+                Some(plan) => {
+                    let disconnect_nodes = branch_nodes(handles, &plan.disconnect)?;
+                    let connect = load_branch_bodies(handles, &plan.connect, &mut no_staged_body)?;
+                    (disconnect_nodes, connect)
+                }
+                None => (Vec::new(), Vec::new()),
+            };
+            if !disconnect_nodes.is_empty() {
+                preflight_disconnect_bodies(handles, &disconnect_nodes, &mut no_staged_body)?;
             }
-            None => (Vec::new(), Vec::new()),
-        };
-        if !disconnect_nodes.is_empty() {
-            preflight_disconnect_bodies(handles, &disconnect_nodes, &mut no_staged_body)?;
-        }
 
-        let published_target = {
-            let mut tree = handles.block_tree.write();
-            let current_root = tree.lookup(hash).ok_or(ReorgError::UnknownBlock(hash))?;
-            let current_target = tree
-                .tip_after_invalidation(current_root)
-                .map_err(ReorgError::Plan)?
-                .ok_or(ReorgError::NoValidTip)?;
-            if current_root != root || current_target != target {
-                continue;
-            }
-            tree.invalidate_subtree(root).map_err(ReorgError::Plan)?;
-            let tip = tree.tip().ok_or(ReorgError::NoValidTip)?;
-            handles.chain_tip.store(Some(tip.clone()));
-            handles.assume_valid_gate.evaluate(&tree);
-            tip.tip_id
-        };
-        debug_assert_eq!(published_target, target);
+            let published_target = {
+                let mut tree = handles.block_tree.write();
+                let current_root = tree.lookup(hash).ok_or(ReorgError::UnknownBlock(hash))?;
+                let current_target = tree
+                    .tip_after_invalidation(current_root)
+                    .map_err(ReorgError::Plan)?
+                    .ok_or(ReorgError::NoValidTip)?;
+                if current_root != root || current_target != target {
+                    continue;
+                }
+                tree.invalidate_subtree(root).map_err(ReorgError::Plan)?;
+                let tip = tree.tip().ok_or(ReorgError::NoValidTip)?;
+                handles.chain_tip.store(Some(tip.clone()));
+                handles.assume_valid_gate.evaluate(&tree);
+                tip.tip_id
+            };
+            debug_assert_eq!(published_target, target);
 
-        let (progress, outcome) = execute_streamed_plan(
-            &transition,
-            followers,
-            &disconnect_nodes,
-            &connect,
-            &mut no_staged_body,
-        );
-        match &outcome {
-            // A fatal disconnect marker left the chainstate torn: abort
-            // without reconsidering anything.
-            Err(ReorgError::Fatal(_)) => {}
-            // Nonfatal: the final active chain is the successful connected
-            // prefix. Reconsider exactly the disconnected transactions that
-            // remain off-chain, once, while the transition is still held.
-            Ok(()) => {
+            let (progress, outcome) = execute_streamed_plan(
+                &transition,
+                followers,
+                &disconnect_nodes,
+                &connect,
+                &mut no_staged_body,
+            );
+            if !outcome.as_ref().is_err_and(ReorgError::requires_recovery) {
                 reconsider_disconnected_transactions(
                     handles,
                     &disconnect_nodes,
@@ -134,34 +166,16 @@ pub fn invalidate_block(
                     &mut no_staged_body,
                 );
             }
-            Err(_) => reconsider_disconnected_transactions(
-                handles,
-                &disconnect_nodes,
-                progress.disconnected,
-                &connect[..progress.connected],
-                &mut no_staged_body,
-            ),
+            return outcome;
         }
-        if matches!(&outcome, Ok(())) {
-            let _ = transition.finish();
-        } else {
-            drop(transition);
-        }
-        let settle_debt = !matches!(&outcome, Err(ReorgError::Fatal(_)));
-        if settle_debt {
-            if let Err(settlement) = settle_disconnect_debt(handles) {
-                outcome?;
-                return Err(settlement);
-            }
-        }
-        return outcome;
-    }
+    })();
+    settle_reorg_transition(transition, outcome)
 }
 
 /// Why a branch switch stopped, and what the chain looks like now.
 ///
-/// Four outcomes rather than one error type, because the caller must act
-/// differently for each and the difference is exactly how much damage there is.
+/// Typed outcomes preserve whether the reached state is coherent or requires
+/// recovery, along with the committed prefix and original failure.
 #[derive(Debug, thiserror::Error)]
 pub enum ReorgError {
     /// The requested block hash is unknown.
@@ -284,11 +298,14 @@ pub enum ReorgError {
     },
     /// A connect failed after some of the new branch was applied.
     ///
-    /// The chain is consistent at a prefix of the target branch: every block
-    /// before this one committed fully. The switch is abandoned rather than
-    /// rolled back — undoing the prefix means disconnecting blocks that just
+    /// Every block before this one committed fully. A refusal before the UTXO
+    /// commit leaves a consistent prefix of the target branch; a
+    /// [`ApplyError::UtxoCommit`] failure may leave partial coin changes and
+    /// requires recovery with admission closed. The switch is abandoned
+    /// rather than rolled back — undoing the prefix means disconnecting blocks that just
     /// applied, which can fail Fatal and turn a recoverable stop into an
-    /// unrecoverable one. A later switch can move the chain from here.
+    /// unrecoverable one. A later switch can continue from a coherent prefix;
+    /// a failed UTXO commit must first recover its authoritative state.
     ///
     /// When `source` is permanently invalid (`PoW`, `nBits`, or consensus),
     /// the failed block's subtree is invalidated while the chain transition is
@@ -321,6 +338,16 @@ pub enum ReorgError {
     /// refuses rather than serving it.
     #[error("reorg left the chainstate inconsistent: {0}")]
     Fatal(#[source] Box<DisconnectError>),
+    /// The chain walk concluded, but its stable generation could not be
+    /// published. Admission is permanently closed and shutdown is requested.
+    #[error("reorg generation could not be settled: {source}")]
+    TransitionSettlement {
+        /// Why the reserved even generation could not be published.
+        #[source]
+        source: Box<ApplyError>,
+        /// Execution failure retained when settlement followed a refusal.
+        original: Option<Box<Self>>,
+    },
     /// A nonfatal reorg completed, but the rolled-back state could not be
     /// checkpointed. The chain is coherent at the reached tip and the
     /// disconnect marker remains `RolledBack`; a restart will refuse the data
@@ -329,12 +356,39 @@ pub enum ReorgError {
     CheckpointSettlement(#[source] anyhow::Error),
 }
 
+impl ReorgError {
+    /// Whether the execution outcome forbids stable publication and derived
+    /// work. Keep this decision with the original typed cause, not a second
+    /// disposition that can drift from it.
+    fn requires_recovery(&self) -> bool {
+        match self {
+            Self::Fatal(_) | Self::TransitionSettlement { .. } => true,
+            Self::ConnectFailed { source, .. } => {
+                matches!(source.as_ref(), ApplyError::UtxoCommit(_))
+            }
+            Self::UnknownBlock(_)
+            | Self::CannotInvalidateGenesis
+            | Self::NoValidTip
+            | Self::Plan(_)
+            | Self::MissingBody { .. }
+            | Self::BodyStore { .. }
+            | Self::BodyDecode { .. }
+            | Self::BodyHashMismatch { .. }
+            | Self::BodyBytesMismatch { .. }
+            | Self::Unavailable(_)
+            | Self::Refused { .. }
+            | Self::DisconnectBodyLost { .. }
+            | Self::CheckpointSettlement(_) => false,
+        }
+    }
+}
+
 /// Switches the applied chain to `target`.
 ///
 /// Disconnects back to the common ancestor, then applies the target branch
 /// forward. Both walks take the plan's order: `disconnect` runs from the old
 /// tip downward, `connect` from the ancestor's child upward. `connected_body`
-/// runs once per committed new-branch block after the transition guard releases.
+/// runs once per committed new-branch block while the transition is still held.
 ///
 /// # Errors
 ///
@@ -386,8 +440,8 @@ where
         // G5: start the guard after fallible read-only planning and before the
         // first chain mutation. A replan above drops the lock without
         // beginning a generation, so the gateway stays even and the loop
-        // retries. An error during execution leaves the generation odd by
-        // design — admission stays closed.
+        // retries. Execution settles coherent prefixes explicitly; possibly
+        // torn state retains the odd generation until recovery.
         let transition = handles
             .begin_transition_locked(lock)
             .map_err(|_| ReorgError::Unavailable(Box::new(ApplyError::Shutdown)))?;
@@ -398,37 +452,21 @@ where
             &connect,
             &mut staged_body,
         );
-        match &outcome {
-            // A fatal disconnect marker left the chainstate torn: abort
-            // without reconsidering anything.
-            Err(ReorgError::Fatal(_)) => {}
-            // Every other outcome leaves the final active chain known: the
-            // successful connected prefix. Reconsider exactly the
-            // disconnected transactions that remain off-chain, exactly once,
-            // while the chain transition is still held.
-            _ => reconsider_disconnected_transactions(
+        if !outcome.as_ref().is_err_and(ReorgError::requires_recovery) {
+            // Reconsider only against a coherent committed prefix, before
+            // reopening admission at the reserved even generation.
+            reconsider_disconnected_transactions(
                 handles,
                 &disconnect_nodes,
                 progress.disconnected,
                 &connect[..progress.connected],
                 &mut staged_body,
-            ),
+            );
         }
         for body in &connect[..progress.connected] {
             connected_body(body.hash);
         }
-        if matches!(&outcome, Ok(())) {
-            let _ = transition.finish();
-        } else {
-            drop(transition);
-        }
-        if !matches!(&outcome, Err(ReorgError::Fatal(_))) {
-            if let Err(settlement) = settle_disconnect_debt(handles) {
-                outcome?;
-                return Err(settlement);
-            }
-        }
-        outcome?;
+        settle_reorg_transition(transition, outcome)?;
         if let Some((hash, height)) = missing_connect {
             return Err(ReorgError::MissingBody { hash, height });
         }

--- a/crates/node/src/reorg.rs
+++ b/crates/node/src/reorg.rs
@@ -132,24 +132,6 @@ pub fn invalidate_block(
                 preflight_disconnect_bodies(handles, &disconnect_nodes, &mut no_staged_body)?;
             }
 
-            let published_target = {
-                let mut tree = handles.block_tree.write();
-                let current_root = tree.lookup(hash).ok_or(ReorgError::UnknownBlock(hash))?;
-                let current_target = tree
-                    .tip_after_invalidation(current_root)
-                    .map_err(ReorgError::Plan)?
-                    .ok_or(ReorgError::NoValidTip)?;
-                if current_root != root || current_target != target {
-                    continue;
-                }
-                tree.invalidate_subtree(root).map_err(ReorgError::Plan)?;
-                let tip = tree.tip().ok_or(ReorgError::NoValidTip)?;
-                handles.chain_tip.store(Some(tip.clone()));
-                handles.assume_valid_gate.evaluate(&tree);
-                tip.tip_id
-            };
-            debug_assert_eq!(published_target, target);
-
             let (progress, outcome) = execute_streamed_plan(
                 &transition,
                 followers,
@@ -157,6 +139,14 @@ pub fn invalidate_block(
                 &connect,
                 &mut no_staged_body,
             );
+            if progress.disconnected == disconnect_nodes.len() {
+                let mut tree = handles.block_tree.write();
+                let root = tree.lookup(hash).ok_or(ReorgError::UnknownBlock(hash))?;
+                tree.invalidate_subtree(root).map_err(ReorgError::Plan)?;
+                let tip = tree.tip().ok_or(ReorgError::NoValidTip)?;
+                handles.chain_tip.store(Some(tip));
+                handles.assume_valid_gate.evaluate(&tree);
+            }
             if !outcome.as_ref().is_err_and(ReorgError::requires_recovery) {
                 reconsider_disconnected_transactions(
                     handles,

--- a/crates/node/src/reorg/tests.rs
+++ b/crates/node/src/reorg/tests.rs
@@ -1,0 +1,173 @@
+use std::sync::atomic::Ordering;
+
+use bitcoin_rs_primitives::{Hash256, Network};
+use bitcoin_rs_storage::{DisconnectMarker, DisconnectPhase};
+
+use super::{ReorgError, settle_reorg_transition};
+use crate::state::NodeState;
+use crate::{ApplyError, NodeConfig};
+
+fn regtest_state() -> anyhow::Result<(tempfile::TempDir, NodeState)> {
+    let dir = tempfile::tempdir()?;
+    let mut config = NodeConfig::default_for_network(Network::Regtest);
+    config.data_dir = dir.path().join("node");
+    config.p2p.listen.clear();
+    let state = NodeState::open(config, None)?;
+    state.apply_block(&Network::Regtest.genesis_block())?;
+    Ok((dir, state))
+}
+
+fn connect_failure(source: ApplyError) -> ReorgError {
+    ReorgError::ConnectFailed {
+        disconnected: 3,
+        connected: 2,
+        hash: Hash256::from_le_bytes(&[0x67; 32]),
+        stopped_at: 42,
+        source: Box::new(source),
+        invalidated: Vec::new(),
+    }
+}
+
+/// MPL-04: a possibly torn commit must neither finish generation nor publish
+/// the rolled-back disconnect debt, even if its generation moved meanwhile.
+#[test]
+fn utxo_commit_failure_preserves_odd_generation_and_disconnect_debt() -> anyhow::Result<()> {
+    for move_generation in [false, true] {
+        let (_dir, state) = regtest_state()?;
+        let handles = state.apply_handles();
+        assert!(handles.checkpoint_publisher.is_some());
+        let marker = DisconnectMarker {
+            hash: Hash256::from_le_bytes(&[0x68; 32]),
+            height: 1,
+            phase: DisconnectPhase::RolledBack,
+        };
+        handles
+            .undo_store
+            .arm_disconnect(marker.height, marker.hash)?;
+        handles
+            .undo_store
+            .complete_disconnect(marker.height, marker.hash)?;
+        assert_eq!(
+            handles.undo_store.load_disconnect_marker()?,
+            Some(marker.clone())
+        );
+        let transition = handles.begin_transition()?;
+        if move_generation {
+            handles
+                .mempool_gateway
+                .force_chain_generation(transition.proof().odd_generation() + 2);
+        }
+
+        let outcome = settle_reorg_transition(
+            transition,
+            Err(connect_failure(ApplyError::UtxoCommit(
+                bitcoin_rs_utxo::UtxoError::CorruptRecord,
+            ))),
+        );
+
+        let Err(ReorgError::ConnectFailed {
+            disconnected: 3,
+            connected: 2,
+            stopped_at: 42,
+            source,
+            ..
+        }) = outcome
+        else {
+            anyhow::bail!("UTXO failure must bypass finish and retain its source: {outcome:?}");
+        };
+        assert!(matches!(
+            source.as_ref(),
+            ApplyError::UtxoCommit(bitcoin_rs_utxo::UtxoError::CorruptRecord)
+        ));
+        assert_eq!(handles.mempool_gateway.stable_generation(), None);
+        assert_eq!(
+            handles.undo_store.load_disconnect_marker()?,
+            Some(marker),
+            "possibly torn state must never publish or clear disconnect debt"
+        );
+        // Positive control: the fixture injected only an error outcome, not
+        // torn coins. Its real publisher can settle this synthetic debt, so
+        // reaching checkpoint publication above would have cleared the marker.
+        assert!(handles.checkpoint()?);
+        assert_eq!(handles.undo_store.load_disconnect_marker()?, None);
+    }
+    Ok(())
+}
+
+/// MPL-04: success is not reportable unless the reserved even generation was
+/// published; a failed CAS closes the owner and requests shutdown.
+#[test]
+fn successful_reorg_with_failed_finish_closes_admission() -> anyhow::Result<()> {
+    let (_dir, state) = regtest_state()?;
+    let handles = state.apply_handles();
+    let transition = handles.begin_transition()?;
+    handles
+        .mempool_gateway
+        .force_chain_generation(transition.proof().odd_generation() + 2);
+
+    let outcome = settle_reorg_transition(transition, Ok(()));
+
+    let Err(ReorgError::TransitionSettlement {
+        source,
+        original: None,
+    }) = outcome
+    else {
+        anyhow::bail!("failed finish must replace apparent success: {outcome:?}");
+    };
+    assert!(matches!(source.as_ref(), ApplyError::Shutdown));
+    assert_eq!(handles.mempool_gateway.stable_generation(), None);
+    assert!(matches!(
+        handles.lock_transition(),
+        Err(ApplyError::Shutdown)
+    ));
+    assert!(handles.shutdown.load(Ordering::Acquire));
+    Ok(())
+}
+
+/// MPL-04: a failed finish after a clean refusal must retain both the refusal
+/// and its committed progress while closing admission.
+#[test]
+fn refused_reorg_with_failed_finish_preserves_original_progress() -> anyhow::Result<()> {
+    let (_dir, state) = regtest_state()?;
+    let handles = state.apply_handles();
+    let transition = handles.begin_transition()?;
+    handles
+        .mempool_gateway
+        .force_chain_generation(transition.proof().odd_generation() + 2);
+
+    let outcome = settle_reorg_transition(
+        transition,
+        Err(connect_failure(ApplyError::BlockValueOverflow)),
+    );
+
+    let Err(ReorgError::TransitionSettlement {
+        source,
+        original: Some(original),
+    }) = outcome
+    else {
+        anyhow::bail!("failed finish must retain the clean refusal: {outcome:?}");
+    };
+    assert!(matches!(source.as_ref(), ApplyError::Shutdown));
+    let ReorgError::ConnectFailed {
+        disconnected,
+        connected,
+        hash,
+        stopped_at,
+        source,
+        invalidated,
+    } = *original
+    else {
+        anyhow::bail!("settlement lost its original ConnectFailed outcome");
+    };
+    assert_eq!((disconnected, connected, stopped_at), (3, 2, 42));
+    assert_eq!(hash, Hash256::from_le_bytes(&[0x67; 32]));
+    assert!(matches!(source.as_ref(), ApplyError::BlockValueOverflow));
+    assert!(invalidated.is_empty());
+    assert_eq!(handles.mempool_gateway.stable_generation(), None);
+    assert!(matches!(
+        handles.lock_transition(),
+        Err(ApplyError::Shutdown)
+    ));
+    assert!(handles.shutdown.load(Ordering::Acquire));
+    Ok(())
+}

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -2792,9 +2792,9 @@ mod tests {
     }
 
     #[test]
-    fn operational_reorg_failure_preserves_branch_and_ownership()
+    fn operational_reorg_failure_preserves_branch_and_retries_without_restart()
     -> Result<(), Box<dyn std::error::Error>> {
-        let (mut sync, _peers, _applied_tip, main, _blocks_tx) = sync_with_mined_chain(1)?;
+        let (mut sync, _peers, applied_tip, main, _blocks_tx) = sync_with_mined_chain(1)?;
         sync.ensure_genesis_tip();
         stage_body(&sync, &main[0]);
         assert_eq!(sync.apply_buffered_blocks(None), (1, 0));
@@ -2835,7 +2835,29 @@ mod tests {
                 .mark_received(hash, bytes, Instant::now());
         }
 
-        sync.switch_branch_if_outweighed();
+        let outcome = crate::reorg::switch_to_branch(
+            &sync.handles,
+            &sync.followers,
+            descendant_id,
+            |hash| sync.block_stager.lock().staged_body(hash),
+            |hash| sync.retire_applied_reorg_body(hash),
+        );
+        assert!(
+            matches!(
+                outcome,
+                Err(crate::reorg::ReorgError::ConnectFailed {
+                    disconnected: 1,
+                    connected: 0,
+                    ..
+                })
+            ),
+            "the body-store refusal must follow a committed disconnect, got {outcome:?}"
+        );
+        assert_eq!(
+            applied_tip.load_full().map(|tip| tip.hash),
+            Some(Hash256::from_le_bytes(genesis.block_hash().as_bytes())),
+            "a refused pre-UTXO connect leaves the fork point as the committed tip"
+        );
 
         {
             let tree = sync.handles.block_tree.read();
@@ -2848,6 +2870,29 @@ mod tests {
         assert!(stager.contains(&descendant_hash));
         drop(stager);
         assert_eq!(sync.download_window.lock().received_len(), 2);
+        // MPL-04: a known committed prefix must finish its generation, so a
+        // transient pre-UTXO refusal cannot wedge admission and later applies.
+        assert!(
+            sync.handles.mempool_gateway.stable_generation().is_some(),
+            "admission must reopen after the clean connect refusal"
+        );
+
+        crate::reorg::switch_to_branch(
+            &sync.handles,
+            &sync.followers,
+            descendant_id,
+            |hash| sync.block_stager.lock().staged_body(hash),
+            |hash| sync.retire_applied_reorg_body(hash),
+        )?;
+        assert_eq!(
+            applied_tip.load_full().map(|tip| tip.hash),
+            Some(descendant_hash),
+            "retrying the same reorg must reach the target without restarting"
+        );
+        assert!(sync.handles.mempool_gateway.stable_generation().is_some());
+        assert!(!sync.block_stager.lock().contains(&fork_hash));
+        assert!(!sync.block_stager.lock().contains(&descendant_hash));
+        assert_eq!(sync.download_window.lock().received_len(), 0);
         Ok(())
     }
 

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -821,6 +821,10 @@ impl BlockSync {
                     "block sync: chainstate torn by a failed disconnect, shutting down"
                 );
             }
+            Err(error @ crate::reorg::ReorgError::TransitionSettlement { .. }) => {
+                // The reorg owner has closed admission and requested shutdown.
+                tracing::error!(%error, "block sync: reorg generation settlement failed");
+            }
             Err(error @ crate::reorg::ReorgError::CheckpointSettlement(_)) => {
                 tracing::error!(
                     %error,
@@ -2788,9 +2792,20 @@ mod tests {
         assert!(!stager.contains(&descendant_hash));
         drop(stager);
         assert_eq!(sync.download_window.lock().received_len(), 0);
+        // MPL-04: rejecting the invalid branch must still allow the selected
+        // valid main branch to reconnect through ordinary forward apply.
+        assert!(sync.handles.mempool_gateway.stable_generation().is_some());
+        assert_eq!(sync.apply_buffered_blocks(None), (1, 0));
+        assert_eq!(
+            sync.handles.applied_tip.load_full().map(|tip| tip.hash),
+            Some(main_hash)
+        );
+        assert!(sync.handles.mempool_gateway.stable_generation().is_some());
         Ok(())
     }
 
+    /// Generation settlement: MPL-04 in docs/contracts/mempool-mutations.md.
+    /// Prefix and body ownership: docs/solutions/architecture-patterns/node-reorg-execution-design.md.
     #[test]
     fn operational_reorg_failure_preserves_branch_and_retries_without_restart()
     -> Result<(), Box<dyn std::error::Error>> {
@@ -2844,12 +2859,13 @@ mod tests {
         );
         assert!(
             matches!(
-                outcome,
+                &outcome,
                 Err(crate::reorg::ReorgError::ConnectFailed {
                     disconnected: 1,
                     connected: 0,
+                    source,
                     ..
-                })
+                }) if matches!(source.as_ref(), crate::ApplyError::BlockBodyPersistence(_))
             ),
             "the body-store refusal must follow a committed disconnect, got {outcome:?}"
         );
@@ -8206,6 +8222,8 @@ mod tests {
             Some(connected_tip),
             "the successful connected prefix is the final active chain"
         );
+        // MPL-04: the valid connected prefix reopens only after re-admission.
+        assert!(handles.mempool_gateway.stable_generation().is_some());
         let mempool = handles.mempool.read();
         assert_eq!(
             mempool.len(),
@@ -8284,6 +8302,9 @@ mod tests {
             "a fatal disconnect must never reconsider disconnected transactions"
         );
         assert_eq!(handles.mempool.read().sequence_number(), 0);
+        // MPL-04: a stuck marker must keep all later chain changes fenced.
+        assert!(handles.mempool_gateway.stable_generation().is_none());
+        assert!(handles.begin_transition().is_err());
         let spend_in_pool = handles.mempool.read().contains_txid(&spend_txid);
         assert!(
             !spend_in_pool,

--- a/docs/contracts/mempool-mutations.md
+++ b/docs/contracts/mempool-mutations.md
@@ -96,6 +96,15 @@ state (`crates/mempool/src/orphan.rs`).
   explicit `finish` leaves the generation odd — admission stays closed.
   Only `finish` may compare-exchange the odd value to the reserved even value,
   reopening admission. One guard covers one externally coherent chain operation.
+- The reorg owner settles both sync branch switches and RPC invalidation.
+  A clean refusal finishes at the fully committed disconnect/connect prefix,
+  after reconsidering its disconnected transactions under the odd generation.
+  Read-only planning or body-loading refusals also leave admission usable.
+  `ConnectFailed` caused by `ApplyError::UtxoCommit`, fatal disconnects and
+  stuck markers retain the odd generation; reorg must not reconsider
+  transactions or checkpoint possibly torn state. A failed `finish` is a
+  fatal invariant failure: retain the execution cause, close apply admission
+  and request shutdown rather than report success or retry the chain walk.
 - `submit_transaction` owns common preparation and bounded retry for RPC
   and peer submissions in mempool. `admit_transaction` remains their
   atomic admission operation:
@@ -208,6 +217,13 @@ state (`crates/mempool/src/orphan.rs`).
 - `crates/node/src/apply.rs` (inline tests, `chain_generation_tests` module):
   `stable_generation_is_even_before_and_after_connect`,
   `stable_generation_is_even_after_disconnect`.
+- `crates/node/src/sync.rs`: clean reorg retry preserves branch and download
+  ownership; partial and fatal reorgs preserve generation fencing.
+- `crates/node/src/apply.rs`: RPC body preflight, mid-rollback body loss and
+  clean disconnect refusal permit retry from their coherent committed state.
+- `crates/node/src/reorg/tests.rs`: possibly torn UTXO commits retain the
+  fence and checkpoint debt; failed generation settlement preserves its
+  original cause and requests shutdown.
 - `crates/rpc/src/handlers/tx.rs` (inline tests):
   admission retry rebuilds context after a transient rejection.
 - `crates/mempool/src/admission.rs` (inline tests):


### PR DESCRIPTION
A transient connect refusal during a reorg could leave the mempool generation odd after already disconnecting blocks. Every subsequent transition was then refused until restart. Reorg now explicitly finishes a coherent committed prefix so the same branch can be retried, while possibly torn UTXO or disconnect state remains fenced.

One reorg settlement path serves sync branch switching and RPC invalidation. It uses the existing typed `ConnectFailed.source`, keeps transaction reconsideration under the active odd generation, and skips reconsideration and reorg checkpoint publication for unsafe outcomes. RPC planning/preflight errors also reach settlement. A failed generation finish preserves the original error/progress, closes apply admission, and requests shutdown instead of returning success or retrying.

## Acceptance criteria

- [x] A fail-once block-body persistence refusal after a committed disconnect reopens admission; retry reaches the same target without restart.
- [x] Permanent rejection, partial connect progress, streamed disconnect body loss, and clean disconnect refusal preserve their committed prefix and permit appropriate later progress.
- [x] UTXO commit and fatal/stuck-marker outcomes remain fenced. The UTXO boundary test preserves real checkpoint debt and includes a positive publication control.
- [x] Finish failures after success and after a clean refusal are reported as fatal settlement failures; the original cause and progress survive.
- [x] RPC invalidation can recover from a missing-body preflight refusal without stranding generation.
- [x] Existing contracts and fault seams supply the regression coverage; no storage format, validation default, mempool policy, or direct Chainstate convenience-entry-point behavior changes.

## Validation

- Native node library: **550 passed**; kernel node library: **553 passed**.
- Journal: **6 passed in each profile**. Crash recovery: **2 passed in each profile**; one helper remains intentionally ignored and is launched by the SIGKILL parent test.
- Strict Clippy for all node targets passes with both `fjall` and `fjall,kernel`.
- Ownership, reference-set and evidence checks: **17 passed**.
- Rust 1.95.0 MSRV compilation, changed-file formatting and `git diff --check` pass.

The repository-wide formatter reports existing differences in three untouched files. `CONSTRAINTS.md` CL-18 names `overhaul_streaming_reorg`, which does not exist on the base commit; its prescribed invocation is unavailable, not a passing gate. Existing streaming reorg unit tests and both recovery suites above passed. This PR makes no full-release or power-loss durability claim.

Closes #678.
