### PR TITLE
Preserve mutation sequence lookup across rollover

### DIFF
--- a/crates/mempool/src/mutation.rs
+++ b/crates/mempool/src/mutation.rs
@@ -102,7 +102,7 @@ impl MutationResult {
             return None;
         }
         let offset = u64::try_from(index).ok()?;
-        self.sequence_base.checked_add(offset)
+        Some(self.sequence_base.wrapping_add(offset))
     }
 
     /// The txid of every change that left the pool, in commit order.
@@ -233,6 +233,17 @@ mod tests {
                 "out-of-bounds index {index}"
             );
         }
+    }
+
+    #[test]
+    fn sequence_of_wraps_for_an_in_bounds_change() {
+        let result = MutationResult {
+            changes: vec![change(&Txid::default(), MutationOutcome::Accepted); 2],
+            sequence_base: u64::MAX,
+        };
+        assert_eq!(result.sequence_of(0), Some(u64::MAX));
+        assert_eq!(result.sequence_of(1), Some(0));
+        assert_eq!(result.sequence_of(2), None);
     }
 
     // MPL-02 (docs/contracts/mempool-mutations.md): an empty mutation assigns


### PR DESCRIPTION
## Summary

`MutationResult::sequence_of` currently uses `checked_add`, so an in-range change in a batch that crosses `u64::MAX -> 0` is reported as `None`. Downstream observers interpret `None` as having no publishable sequence even though the change committed.

Use wrapping sequence arithmetic for in-range changes and retain the existing bounds check. Add a regression for a two-change batch with `sequence_base == u64::MAX`.

## Scope

This is an intentionally atomic first slice of #704. It fixes the consumer-side lookup only. The owner-side `Mempool::finish_mutation` rollover underflow in `pool.rs` remains and should land separately with its owner-level regression. `MPL-02` is therefore not updated here; the contract should move only with that end-to-end owner fix, as #704 requests.

## Verification

- Static diff review: one expression changes from checked to wrapping addition after the existing in-bounds guard.
- Regression test asserts `sequence_of(0) == Some(u64::MAX)`, `sequence_of(1) == Some(0)`, and an out-of-range index remains `None`.
- Repository CI is the execution source because this host cannot obtain a local Git checkout; CI status will be checked on this PR.

Refs #704.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `MutationResult::sequence_of` so in-range changes that cross `u64::MAX` return a valid sequence instead of `None`.

- The existing bounds check for out-of-range indexes stays; only the arithmetic changes from checked to wrapping addition.
- Adds a regression test for a two-change batch starting at `sequence_base == u64::MAX`.
- This is a consumer-side fix only; the owner-side `Mempool::finish_mutation` rollover underflow remains to be addressed separately, and the `MPL-02` contract is not updated here.

<sup>Written for commit 7c6a01058ae637990c90c532b295920fd97c7ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

