### PR TITLE
fix(qa): reject directories and other nonregular fixture cache entries

### DIFF
--- a/scripts/fetch-golden.sh
+++ b/scripts/fetch-golden.sh
@@ -16,7 +16,7 @@ for height in "${heights[@]}"; do
   bin_path="${out_dir}/${height}.bin"
   txids_path="${out_dir}/${height}.txids.txt"
   for cache_path in "${bin_path}" "${txids_path}"; do
-    if [[ -e "${cache_path}" && ! -f "${cache_path}" ]]; then
+    if [[ -L "${cache_path}" || ( -e "${cache_path}" && ! -f "${cache_path}" ) ]]; then
       printf 'Not a regular fixture file: %s\n' "${cache_path}" >&2
       exit 1
     fi

--- a/scripts/fetch-golden.sh
+++ b/scripts/fetch-golden.sh
@@ -15,6 +15,12 @@ trap 'exit 143' TERM
 for height in "${heights[@]}"; do
   bin_path="${out_dir}/${height}.bin"
   txids_path="${out_dir}/${height}.txids.txt"
+  for cache_path in "${bin_path}" "${txids_path}"; do
+    if [[ -e "${cache_path}" && ! -f "${cache_path}" ]]; then
+      printf 'Not a regular fixture file: %s\n' "${cache_path}" >&2
+      exit 1
+    fi
+  done
   if [[ -s "${bin_path}" && -s "${txids_path}" ]]; then
     continue
   fi

--- a/scripts/tests/test_fetch_golden.py
+++ b/scripts/tests/test_fetch_golden.py
@@ -8,6 +8,16 @@ and offline reuse. Heights come from the script, not a second inventory.
 Response bytes are synthetic transport fixtures, not Bitcoin validity vectors:
 expected file contents are the stub's input bytes, never downloader output.
 
+Cache-path admission contract: PR #757 requires regular cache artifacts and
+rejects directories and symbolic links, including dangling links, without
+changing them or starting HTTP/staging work:
+https://github.com/gosuda/bitcoin-rs/pull/757
+Bash -e/-f follow links, while -L tests the link itself. The independent
+reference for the filesystem predicates is:
+https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html
+The tests construct these path types directly rather than deriving expected
+admission decisions from the downloader.
+
 Run from the repository root: python3 -m unittest discover -s scripts/tests -v
 """
 
@@ -117,13 +127,43 @@ class FetchGoldenTests(unittest.TestCase):
                 original = path.read_bytes()
                 path.unlink()
                 path.mkdir()
-                result = self.run_fetch("offline")
-                self.assertNotEqual(result.returncode, 0)
-                self.assertIn(path.name, result.stderr)
-                self.assertEqual(self.requests(), [])
-                self.assertEqual(list(path.iterdir()), [])
-                path.rmdir()
-                path.write_bytes(original)
+                try:
+                    result = self.run_fetch("offline")
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(path.name, result.stderr)
+                    self.assertEqual(self.requests(), [])
+                    self.assertEqual(list(path.iterdir()), [])
+                finally:
+                    path.rmdir()
+                    path.write_bytes(original)
+
+    def test_symlink_cache_entries_are_rejected_and_preserved(self):
+        self.seed_cache()
+        for target_kind in ("nonempty", "empty", "dangling"):
+            target = self.root / f"target-{target_kind}"
+            contents = b"target bytes" if target_kind == "nonempty" else b""
+            if target_kind != "dangling":
+                target.write_bytes(contents)
+            for path in (self.block_path, self.txids_path):
+                with self.subTest(path=path.name, target=target_kind):
+                    original = path.read_bytes()
+                    path.unlink()
+                    path.symlink_to(target)
+                    try:
+                        result = self.run_fetch("offline")
+                        self.assertNotEqual(result.returncode, 0)
+                        self.assertIn(path.name, result.stderr)
+                        self.assertEqual(self.requests(), [])
+                        self.assertTrue(path.is_symlink())
+                        self.assertEqual(os.readlink(path), str(target))
+                        if target_kind == "dangling":
+                            self.assertFalse(target.exists())
+                        else:
+                            self.assertEqual(target.read_bytes(), contents)
+                    finally:
+                        path.unlink(missing_ok=True)
+                        path.write_bytes(original)
+
 
     def test_complete_cache_needs_no_staging_directory(self):
         self.seed_cache()

--- a/scripts/tests/test_fetch_golden.py
+++ b/scripts/tests/test_fetch_golden.py
@@ -110,6 +110,21 @@ class FetchGoldenTests(unittest.TestCase):
         self.assertEqual(self.requests(), [])
         self.assertEqual(self.block_path.read_bytes(), b"existing block")
 
+    def test_nonregular_cache_entries_fail_before_network(self):
+        self.seed_cache()
+        for path in (self.block_path, self.txids_path):
+            with self.subTest(path=path.name):
+                original = path.read_bytes()
+                path.unlink()
+                path.mkdir()
+                result = self.run_fetch("offline")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(path.name, result.stderr)
+                self.assertEqual(self.requests(), [])
+                self.assertEqual(list(path.iterdir()), [])
+                path.rmdir()
+                path.write_bytes(original)
+
     def test_complete_cache_needs_no_staging_directory(self):
         self.seed_cache()
         mktemp = self.bin / "mktemp"


### PR DESCRIPTION
## Reproduced defect

Follow-up to merged #740. Bash `-s` is true for a nonempty directory, so a directory named `<height>.bin` or `<height>.txids.txt` could be accepted as a complete fixture. The downloader then returned success without producing a usable file.

## Change

Reject existing nonregular cache paths before the cache-hit check, network requests, or staging. Preserve the path instead of deleting or resetting it. Regular-file cache reuse and the existing per-artifact atomic publication remain unchanged.

Add one subprocess-level regression with subcases for both artifact paths. Each subcase requires a nonzero exit, a diagnostic identifying the path, no HTTP requests, and no directory writes.

## Verification

- Baseline script blob `c21ba3d4117f896da3ccbe89a8c45e05723f8089`: both new directory subcases failed because the script returned success.
- `/usr/bin/python3 -m unittest discover -s scripts/tests -p test_fetch_golden.py -v`: **9 passed**; Python 3.13.5, Linux, offline curl stub.
- `bash -n scripts/fetch-golden.sh`: passed.
- Python compilation and `git diff --check`: passed.
- Locally tested final blobs: script `19a7a544c9b609395a9d5bb404ebd5218de20a43`; tests `4ec562ef957f9070e69554b02c7455e152f4e9f3`.

## Scope

One commit, two files, independently based on main `76baf086b861057f5700da34c4ad0d4f5aab5966`. #740 was merged by another actor while this follow-up was being tested, so this is a new PR rather than a write to its closed branch. No Rust, consensus, dependencies, workflow policy, or operator data changes. This guard does not claim protection against arbitrary concurrent filesystem replacement.

The dedicated fixture-tools workflow already on main runs these tests. Final-head CI/review is not yet verified. The attempted Cargo/Clippy invocation could not start (`cargo: command not found`, rc 127); no Rust lint success is claimed. No merge, force-push, auto-merge, or direct main write was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects directories and symlinks named like golden-fixture cache files so the downloader no longer accepts them as complete fixtures. Bash `-s` treats a nonempty directory as valid and `-f` follows links, which previously let the script succeed without a usable file; now non-regular cache paths fail with a diagnostic before the cache-hit check, network requests, or staging.

- Existing non-regular paths are preserved, not deleted or reset.
- Adds subprocess regression tests covering directory, symlink, empty, and dangling-link cases for both artifact paths, verifying a nonzero exit, a path-naming diagnostic, no HTTP requests, and no directory writes.

<sup>Written for commit 26a4901a39dde3325c651d1a2bf035799756211d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

