### PR TITLE
fix(fuzz): stream bounded corpus imports through atomic seed publication

### DIFF
--- a/.github/workflows/fuzz-corpus-tools.yml
+++ b/.github/workflows/fuzz-corpus-tools.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Check importer syntax
         run: bash -n scripts/import-qa-assets.sh
       - name: Run offline corpus-import regressions
-        run: python3 -m unittest discover -s scripts/tests -p test_import_qa_assets.py -v
+        run: python3 -m unittest discover -s scripts/tests -p 'test_import_qa_assets*.py' -v

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -85,128 +85,20 @@ readonly CORPORA="${WORKDIR}/qa-assets/fuzz_corpora"
 readonly FUZZ_DIR="${REPO_ROOT}/fuzz"
 readonly OUT_BASE="${FUZZ_DIR}/corpus"
 
-# --- 3. p2p_message: reframe raw network messages ----------------------------
-# The harness input is [selector][payload]; it derives the envelope itself.
-# Extract the command from the corpus file 24-byte header and map it to the
-# selector index in crates/p2p/src/compat.rs COMMANDS, the same inventory
-# consumed by fuzz/fuzz_targets/p2p_message.rs.
-map_p2p() {
-    "${CARGO_ENV[@]}" python3 - "${CORPORA}/p2p_deserialize_raw_net_msg" \
-        "${REPO_ROOT}/crates/p2p/src/compat.rs" "${OUT_BASE}/p2p_message" \
-        "${MAX_SEED_BYTES}" <<'PYEOF'
-import hashlib
-import re
-import sys
-from pathlib import Path
+# --- 3. Transform and publish bounded seeds ---------------------------------
+# One mapper owns framing and atomic publication for all targets. Failures in
+# directory enumeration, reads, or publication stop before cmin or provenance.
+"${CARGO_ENV[@]}" python3 "${REPO_ROOT}/scripts/import_qa_assets.py" \
+    --corpora "${CORPORA}" --repo-root "${REPO_ROOT}" \
+    --out-base "${OUT_BASE}" --max-seed-bytes "${MAX_SEED_BYTES}"
 
-corpus_dir, target_src, out_dir, max_bytes = Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]), int(sys.argv[4])
-table = re.search(r"pub\s+const\s+COMMANDS\s*:\s*&\[Command\]\s*=\s*&\[(.*?)\];", target_src.read_text(), re.S)
-if table is None:
-    sys.exit("Cannot find the P2P COMMANDS inventory")
-commands = re.findall(r'\bname\s*:\s*"([a-z0-9]{1,12})"', table.group(1))
-if (not commands or len(commands) > 256 or len(set(commands)) != len(commands)
-        or len(commands) != len(re.findall(r"\bCommand\s*\{", table.group(1)))):
-    sys.exit("Invalid P2P COMMANDS inventory")
-selector = {name: bytes([idx]) for idx, name in enumerate(commands)}
-
-out_dir.mkdir(parents=True, exist_ok=True)
-imported = skipped_short = unknown_cmd = 0
-for path in sorted(corpus_dir.iterdir()):
-    with path.open("rb") as source:
-        blob = source.read(24 + max_bytes - 1)
-    if len(blob) <= 24:
-        skipped_short += 1
-        continue
-    command = blob[4:16].split(b"\0", 1)[0]
-    sel = selector.get(command.decode("ascii", "replace"))
-    if sel is None:
-        unknown_cmd += 1
-        continue
-    payload = blob[24:]
-    seed = sel + payload
-    (out_dir / hashlib.sha256(seed).hexdigest()[:32]).write_bytes(seed)
-    imported += 1
-print(f"p2p_message: imported={imported} skipped_short={skipped_short} unknown_command={unknown_cmd}")
-PYEOF
-}
-
-# --- 4. script_eval: wrap raw script bytes into the harness framing ----------
-map_script() {
-    "${CARGO_ENV[@]}" python3 - "${CORPORA}/bitcoin_deserialize_script" \
-        "${CORPORA}/bitcoin_script_bytes_to_asm_fmt" \
-        "${FUZZ_DIR}/fuzz_targets/script_eval.rs" "${OUT_BASE}/script_eval" \
-        "${MAX_SEED_BYTES}" <<'PYEOF'
-import hashlib
-import re
-import sys
-from pathlib import Path
-
-dirs = [Path(sys.argv[1]), Path(sys.argv[2])]
-target_src, out_dir, max_bytes = Path(sys.argv[3]), Path(sys.argv[4]), int(sys.argv[5])
-limit = re.search(r"const\s+ELEMENT_LEN_MAX\s*:\s*usize\s*=\s*([0-9_]+)\s*;", target_src.read_text())
-if limit is None:
-    sys.exit("Cannot find script_eval ELEMENT_LEN_MAX")
-element_limit = int(limit.group(1).replace("_", ""))
-# A P2TR frame adds ten bytes relative to the retained script; lengths are u16.
-script_limit = min(element_limit, 0xffff, max_bytes - 10)
-if script_limit < 0:
-    sys.exit("Seed budget is too small for script framing")
-NONE, TAPROOT = b"\x00", b"\x03"  # FLAGS indices in fuzz_targets/script_eval.rs
-
-out_dir.mkdir(parents=True, exist_ok=True)
-
-def emit(seed: bytes) -> None:
-    (out_dir / hashlib.sha256(seed).hexdigest()[:32]).write_bytes(seed)
-
-def frame(selector: bytes, script_sig: bytes, script_pubkey: bytes, witness: list[bytes]) -> bytes:
-    parts = [selector, len(script_sig).to_bytes(2, "little"), script_sig,
-             len(script_pubkey).to_bytes(2, "little"), script_pubkey, bytes([len(witness)])]
-    parts += [len(e).to_bytes(2, "little") + e for e in witness]
-    return b"".join(parts)
-
-imported = 0
-for corpus_dir in dirs:
-    for path in sorted(corpus_dir.iterdir()):
-        with path.open("rb") as source:
-            script = source.read(script_limit)
-        emit(frame(NONE, b"", script, []))  # raw scriptPubKey
-        if len(script) >= 32 and element_limit >= 34:  # P2TR key-path variant
-            emit(frame(TAPROOT, b"", b"\x51\x20" + script[:32], [script[32:]]))
-        imported += 1
-print(f"script_eval: imported={imported} files (raw + P2TR variants)")
-PYEOF
-}
-
-# --- 5. Direct byte-for-byte mappings ----------------------------------------
-# Seeds >= MAX_SEED_BYTES are skipped by policy (repo-size bound, matching the
-# fuzz targets' own input caps) and the skip count is recorded so the mapping
-# stays honest about what it left behind.
-map_direct() {
-    local src="$1" dst="$2" name="$3"
-    mkdir -p "${dst:?}"
-    local count=0 skipped=0
-    while IFS= read -r -d '' file; do
-        if [ "$(stat -c %s -- "${file:?}")" -ge "${MAX_SEED_BYTES}" ]; then
-            skipped=$((skipped + 1))
-            continue
-        fi
-        cp -- "${file:?}" "${dst}/$(basename -- "${file:?}")"
-        count=$((count + 1))
-    done < <(find "${src:?}" -maxdepth 1 -type f -print0 | sort -z)
-    log "${name}: imported=${count} skipped_oversize=${skipped} (>= ${MAX_SEED_BYTES} bytes)"
-}
-map_p2p
-map_script
-map_direct "${CORPORA}/bitcoin_deserialize_block" "${OUT_BASE}/block_decode" block_decode
-map_direct "${CORPORA}/bitcoin_deserialize_transaction" "${OUT_BASE}/tx_decode" tx_decode
-
-# --- 6. Minimize each target corpus with cargo fuzz cmin ---------------------
+# --- 4. Minimize each target corpus with cargo fuzz cmin ---------------------
 "${CARGO_ENV[@]}" cargo fuzz cmin --target "${HOST_TRIPLE}" p2p_message
 "${CARGO_ENV[@]}" cargo fuzz cmin --target "${HOST_TRIPLE}" block_decode
 "${CARGO_ENV[@]}" cargo fuzz cmin --target "${HOST_TRIPLE}" tx_decode
 "${CARGO_ENV[@]}" cargo fuzz cmin --target "${HOST_TRIPLE}" script_eval
 
-# --- 7. Provenance ------------------------------------------------------------
+# --- 5. Provenance ------------------------------------------------------------
 readonly PROVENANCE="${FUZZ_DIR}/CORPUS_PROVENANCE.md"
 readonly IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 cat > "${PROVENANCE}" <<EOF
@@ -239,5 +131,5 @@ refresh.
 EOF
 log "provenance written to ${PROVENANCE}"
 
-# --- 8. Delete the clone (only minimized corpora are kept) --------------------
+# --- 6. Delete the clone (only minimized corpora are kept) --------------------
 log "import complete; clone removed by cleanup trap"

--- a/scripts/import_qa_assets.py
+++ b/scripts/import_qa_assets.py
@@ -91,6 +91,52 @@ def _frame(selector: int, script_pubkey: bytes, witness: Sequence[bytes]) -> byt
     return b"".join(parts)
 
 
+def _strip_rust_comments(text: str) -> str:
+    """Remove Rust line/nested-block comments without touching string contents."""
+    out: list[str] = []
+    index = block_depth = 0
+    in_string = False
+    while index < len(text):
+        if block_depth:
+            if text.startswith("/*", index):
+                block_depth += 1
+                index += 2
+            elif text.startswith("*/", index):
+                block_depth -= 1
+                index += 2
+            else:
+                out.append("\n" if text[index] == "\n" else " ")
+                index += 1
+            continue
+        if in_string:
+            char = text[index]
+            out.append(char)
+            index += 1
+            if char == "\\" and index < len(text):
+                out.append(text[index])
+                index += 1
+            elif char == '"':
+                in_string = False
+            continue
+        if text.startswith("//", index):
+            newline = text.find("\n", index + 2)
+            if newline < 0:
+                break
+            out.append("\n")
+            index = newline + 1
+        elif text.startswith("/*", index):
+            block_depth = 1
+            index += 2
+        else:
+            char = text[index]
+            out.append(char)
+            in_string = char == '"'
+            index += 1
+    if block_depth:
+        raise ValueError("Unterminated Rust block comment in script_eval contract")
+    return "".join(out)
+
+
 def _split_flags(body: str) -> list[str]:
     entries: list[str] = []
     start = depth = 0
@@ -118,7 +164,7 @@ def _split_flags(body: str) -> list[str]:
 
 
 def _script_contract(harness: Path) -> tuple[int, int, int]:
-    text = harness.read_text()
+    text = _strip_rust_comments(harness.read_text())
     limit = re.search(r"const\s+ELEMENT_LEN_MAX\s*:\s*usize\s*=\s*([0-9_]+)\s*;", text)
     flags = re.search(
         r"const\s+FLAGS\s*:\s*\[VerifyFlags\s*;\s*([0-9_]+)\s*\]\s*=\s*\[(.*?)\]\s*;",

--- a/scripts/import_qa_assets.py
+++ b/scripts/import_qa_assets.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Bounded fuzz-seed transformations used by import-qa-assets.sh.
+
+The shell owns acquisition, the byte budget, minimization, and provenance.
+This module owns seed framing and per-file atomic publication. Publication
+is not a transaction over the corpus and does not claim crash durability.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import re
+import sys
+import tempfile
+from collections.abc import Iterator, Sequence
+
+
+def _seed_paths(source: Path) -> Iterator[Path]:
+    # Filenames (direct copies) or content hashes own output identity, not order.
+    # Stream entries rather than retaining a directory-sized list of Path objects.
+    with os.scandir(source) as entries:
+        for entry in entries:
+            if entry.is_file(follow_symlinks=False):
+                yield Path(entry.path)
+
+
+def _read_seed(path: Path, limit: int) -> bytes:
+    with path.open("rb") as source:
+        return source.read(limit)
+
+
+def _publish(output: Path, name: str, seed: bytes) -> None:
+    """Replace the directory entry, never follow a pre-existing output symlink."""
+    temporary = tempfile.NamedTemporaryFile(prefix=".qa-import-", dir=output, delete=False)
+    staged = Path(temporary.name)
+    try:
+        with temporary as stream:
+            stream.write(seed)
+        os.replace(staged, output / name)
+    finally:
+        staged.unlink(missing_ok=True)
+
+
+def _emit(output: Path, seed: bytes) -> None:
+    _publish(output, hashlib.sha256(seed).hexdigest()[:32], seed)
+
+
+def _commands(source: Path) -> dict[str, bytes]:
+    table = re.search(
+        r"pub\s+const\s+COMMANDS\s*:\s*&\[Command\]\s*=\s*&\[(.*?)\];",
+        source.read_text(), re.S,
+    )
+    if table is None:
+        raise ValueError("Cannot find the P2P COMMANDS inventory")
+    commands = re.findall(r'\bname\s*:\s*"([a-z0-9]{1,12})"', table.group(1))
+    if (not commands or len(commands) > 256 or len(set(commands)) != len(commands)
+            or len(commands) != len(re.findall(r"\bCommand\s*\{", table.group(1)))):
+        raise ValueError("Invalid P2P COMMANDS inventory")
+    return {name: bytes([index]) for index, name in enumerate(commands)}
+
+
+def map_p2p(source: Path, inventory: Path, output: Path, max_bytes: int) -> None:
+    if max_bytes < 2:
+        raise ValueError("Seed budget is too small for a P2P selector and payload")
+    selector = _commands(inventory)
+    output.mkdir(parents=True, exist_ok=True)
+    imported = skipped_short = unknown_command = 0
+    for path in _seed_paths(source):
+        blob = _read_seed(path, 24 + max_bytes - 1)
+        if len(blob) <= 24:
+            skipped_short += 1
+            continue
+        command = blob[4:16].split(b"\0", 1)[0].decode("ascii", "replace")
+        selected = selector.get(command)
+        if selected is None:
+            unknown_command += 1
+            continue
+        _emit(output, selected + blob[24:])
+        imported += 1
+    print(f"p2p_message: imported={imported} skipped_short={skipped_short} unknown_command={unknown_command}")
+
+
+def _frame(selector: int, script_pubkey: bytes, witness: Sequence[bytes]) -> bytes:
+    # Empty scriptSig; remaining fields follow script_eval's documented framing.
+    parts = [bytes([selector]), b"\0\0", len(script_pubkey).to_bytes(2, "little"),
+             script_pubkey, bytes([len(witness)])]
+    parts.extend(len(element).to_bytes(2, "little") + element for element in witness)
+    return b"".join(parts)
+
+
+def map_script(sources: Sequence[Path], harness: Path, output: Path, max_bytes: int) -> None:
+    limit = re.search(
+        r"const\s+ELEMENT_LEN_MAX\s*:\s*usize\s*=\s*([0-9_]+)\s*;",
+        harness.read_text(),
+    )
+    if limit is None:
+        raise ValueError("Cannot find script_eval ELEMENT_LEN_MAX")
+    element_limit = int(limit.group(1).replace("_", ""))
+    # P2TR framing adds ten bytes relative to the retained source script.
+    script_limit = min(element_limit, 0xffff, max_bytes - 10)
+    if script_limit < 0:
+        raise ValueError("Seed budget is too small for script framing")
+    output.mkdir(parents=True, exist_ok=True)
+    imported = 0
+    for source in sources:
+        for path in _seed_paths(source):
+            script = _read_seed(path, script_limit)
+            _emit(output, _frame(0, script, []))
+            if len(script) >= 32 and element_limit >= 34:
+                _emit(output, _frame(3, b"\x51\x20" + script[:32], [script[32:]]))
+            imported += 1
+    print(f"script_eval: imported={imported} files (raw + P2TR variants)")
+
+
+def map_direct(source: Path, output: Path, max_bytes: int, name: str) -> None:
+    if max_bytes < 1:
+        raise ValueError("Seed budget must be positive")
+    output.mkdir(parents=True, exist_ok=True)
+    imported = skipped = 0
+    for path in _seed_paths(source):
+        # Read to the exclusive boundary: this also bounds files that grow after enumeration.
+        seed = _read_seed(path, max_bytes)
+        if len(seed) >= max_bytes:
+            skipped += 1
+            continue
+        _publish(output, path.name, seed)
+        imported += 1
+    print(f"[import-qa-assets] {name}: imported={imported} skipped_oversize={skipped} (>= {max_bytes} bytes)")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpora", required=True, type=Path)
+    parser.add_argument("--repo-root", required=True, type=Path)
+    parser.add_argument("--out-base", required=True, type=Path)
+    parser.add_argument("--max-seed-bytes", required=True, type=int)
+    args = parser.parse_args(argv)
+    p2p = args.corpora / "p2p_deserialize_raw_net_msg"
+    scripts = [args.corpora / "bitcoin_deserialize_script",
+               args.corpora / "bitcoin_script_bytes_to_asm_fmt"]
+    direct = [("bitcoin_deserialize_block", "block_decode"),
+              ("bitcoin_deserialize_transaction", "tx_decode")]
+    try:
+        for source in [p2p, *scripts, *(args.corpora / name for name, _ in direct)]:
+            if not source.is_dir():
+                raise ValueError(f"Expected corpus directory: {source}")
+        map_p2p(p2p, args.repo_root / "crates/p2p/src/compat.rs",
+                args.out_base / "p2p_message", args.max_seed_bytes)
+        map_script(scripts, args.repo_root / "fuzz/fuzz_targets/script_eval.rs",
+                   args.out_base / "script_eval", args.max_seed_bytes)
+        for source_name, target in direct:
+            map_direct(args.corpora / source_name, args.out_base / target,
+                       args.max_seed_bytes, target)
+    except (OSError, ValueError) as error:
+        print(f"[import-qa-assets] {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import_qa_assets.py
+++ b/scripts/import_qa_assets.py
@@ -91,14 +91,60 @@ def _frame(selector: int, script_pubkey: bytes, witness: Sequence[bytes]) -> byt
     return b"".join(parts)
 
 
-def map_script(sources: Sequence[Path], harness: Path, output: Path, max_bytes: int) -> None:
-    limit = re.search(
-        r"const\s+ELEMENT_LEN_MAX\s*:\s*usize\s*=\s*([0-9_]+)\s*;",
-        harness.read_text(),
+def _split_flags(body: str) -> list[str]:
+    entries: list[str] = []
+    start = depth = 0
+    pairs = {")": "(", "]": "[", "}": "{"}
+    stack: list[str] = []
+    for index, char in enumerate(body):
+        if char in "([{":
+            stack.append(char)
+            depth += 1
+        elif char in pairs:
+            if not stack or stack.pop() != pairs[char]:
+                raise ValueError("Invalid script_eval FLAGS inventory")
+            depth -= 1
+        elif char == "," and depth == 0:
+            entry = body[start:index].strip()
+            if entry:
+                entries.append(entry)
+            start = index + 1
+    if stack:
+        raise ValueError("Invalid script_eval FLAGS inventory")
+    tail = body[start:].strip()
+    if tail:
+        entries.append(tail)
+    return entries
+
+
+def _script_contract(harness: Path) -> tuple[int, int, int]:
+    text = harness.read_text()
+    limit = re.search(r"const\s+ELEMENT_LEN_MAX\s*:\s*usize\s*=\s*([0-9_]+)\s*;", text)
+    flags = re.search(
+        r"const\s+FLAGS\s*:\s*\[VerifyFlags\s*;\s*([0-9_]+)\s*\]\s*=\s*\[(.*?)\]\s*;",
+        text, re.S,
     )
     if limit is None:
         raise ValueError("Cannot find script_eval ELEMENT_LEN_MAX")
-    element_limit = int(limit.group(1).replace("_", ""))
+    if flags is None:
+        raise ValueError("Cannot find script_eval FLAGS inventory")
+    entries = _split_flags(flags.group(2))
+    declared = int(flags.group(1).replace("_", ""))
+    if not entries or len(entries) != declared or len(entries) > 256:
+        raise ValueError("Invalid script_eval FLAGS inventory")
+    normalized = [re.sub(r"\s+", "", entry) for entry in entries]
+    try:
+        none = normalized.index("VerifyFlags::NONE")
+        taproot = normalized.index("VerifyFlags::TAPROOT")
+    except ValueError as error:
+        raise ValueError("script_eval FLAGS must contain NONE and TAPROOT exactly once") from error
+    if normalized.count("VerifyFlags::NONE") != 1 or normalized.count("VerifyFlags::TAPROOT") != 1:
+        raise ValueError("script_eval FLAGS must contain NONE and TAPROOT exactly once")
+    return int(limit.group(1).replace("_", "")), none, taproot
+
+
+def map_script(sources: Sequence[Path], harness: Path, output: Path, max_bytes: int) -> None:
+    element_limit, none_selector, taproot_selector = _script_contract(harness)
     # P2TR framing adds ten bytes relative to the retained source script.
     script_limit = min(element_limit, 0xffff, max_bytes - 10)
     if script_limit < 0:
@@ -108,9 +154,9 @@ def map_script(sources: Sequence[Path], harness: Path, output: Path, max_bytes: 
     for source in sources:
         for path in _seed_paths(source):
             script = _read_seed(path, script_limit)
-            _emit(output, _frame(0, script, []))
+            _emit(output, _frame(none_selector, script, []))
             if len(script) >= 32 and element_limit >= 34:
-                _emit(output, _frame(3, b"\x51\x20" + script[:32], [script[32:]]))
+                _emit(output, _frame(taproot_selector, b"\x51\x20" + script[:32], [script[32:]]))
             imported += 1
     print(f"script_eval: imported={imported} files (raw + P2TR variants)")
 

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -56,7 +56,15 @@ pub const COMMANDS: &[Command] = &[
 ];
 pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
 ''')
-        self.script_target.write_text("const ELEMENT_LEN_MAX: usize = 1_024;\n")
+        self.script_target.write_text(
+            "const FLAGS: [VerifyFlags; 4] = [\n"
+            "    VerifyFlags::NONE,\n"
+            "    VerifyFlags::MANDATORY,\n"
+            "    VerifyFlags::STANDARD,\n"
+            "    VerifyFlags::TAPROOT,\n"
+            "];\n"
+            "const ELEMENT_LEN_MAX: usize = 1_024;\n"
+        )
 
     def run_mapper(self, name, budget=BUDGET):
         with redirect_stdout(io.StringIO()):
@@ -112,14 +120,43 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
         self.assertEqual(len(list((self.output / "script_eval").iterdir())), 2)
 
     def test_script_limit_follows_the_owner_constant(self):
-        self.script_target.write_text("const ELEMENT_LEN_MAX: usize = 512;\n")
+        self.script_target.write_text(
+            self.script_target.read_text().replace("1_024", "512")
+        )
         (self.scripts / "script").write_bytes(b"Q" * 1024)
         self.run_mapper("map_script")
         self.assert_seed("script_eval", b"\0\0\0\0\x02" + b"Q" * 512 + b"\0")
 
     def test_missing_script_limit_fails_closed(self):
-        self.script_target.write_text("// no element limit\n")
+        self.script_target.write_text(
+            self.script_target.read_text().replace("const ELEMENT_LEN_MAX: usize = 1_024;\n", "")
+        )
         with self.assertRaises(ValueError):
+            self.run_mapper("map_script")
+        self.assertFalse((self.output / "script_eval").exists())
+
+
+    def test_script_selectors_follow_the_owner_inventory_order(self):
+        self.script_target.write_text(
+            "const FLAGS: [VerifyFlags; 4] = [\n"
+            "    VerifyFlags::TAPROOT,\n"
+            "    VerifyFlags::MANDATORY,\n"
+            "    VerifyFlags::NONE,\n"
+            "    VerifyFlags::STANDARD,\n"
+            "];\n"
+            "const ELEMENT_LEN_MAX: usize = 1_024;\n"
+        )
+        script = b"Q" * 64
+        (self.scripts / "script").write_bytes(script)
+        self.run_mapper("map_script")
+        raw = b"\x02\0\0\x40\0" + script + b"\0"
+        taproot = b"\x00\0\0\x22\0\x51\x20" + script[:32] + b"\x01\x20\0" + script[32:]
+        self.assert_seed("script_eval", raw)
+        self.assert_seed("script_eval", taproot)
+
+    def test_missing_script_flags_fail_closed(self):
+        self.script_target.write_text("const ELEMENT_LEN_MAX: usize = 1_024;\n")
+        with self.assertRaisesRegex(ValueError, "FLAGS"):
             self.run_mapper("map_script")
         self.assertFalse((self.output / "script_eval").exists())
 

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -1,6 +1,14 @@
-"""Offline tests of the importer's actual embedded mappers and setup failures."""
+"""Offline QA import regressions for QAC-01 and the harness input contracts.
 
-from contextlib import redirect_stdout
+See docs/contracts/qa-corpus.md, fuzz/CORPUS_PROVENANCE.md, and the framing
+comments in fuzz/fuzz_targets/{p2p_message,script_eval}.rs. Fixtures here are
+synthetic wire bytes with hand-written expected frames, not Bitcoin validity
+vectors. The importer owns MAX_SEED_BYTES; Rust owners supply the inventories
+and element limits. Failure publication cases are documented in PR #747.
+"""
+
+from contextlib import contextmanager, redirect_stdout
+import importlib.util
 import hashlib
 import io
 import os
@@ -14,24 +22,16 @@ from unittest.mock import patch
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "import-qa-assets.sh"
-_SCRIPT_TEXT = SCRIPT.read_text()
-_budget_match = re.search(r"^readonly MAX_SEED_BYTES=([0-9]+)\s+#", _SCRIPT_TEXT, re.M)
-if _budget_match is None:
-    raise RuntimeError("importer MAX_SEED_BYTES definition is missing")
-BUDGET = int(_budget_match.group(1))
-if BUDGET <= 0:
-    raise RuntimeError("importer MAX_SEED_BYTES must be positive")
+_budget = re.search(r"^readonly MAX_SEED_BYTES=([0-9]+)\s*(?:#.*)?$", SCRIPT.read_text(), re.M)
+if _budget is None or int(_budget.group(1)) < 1:
+    raise RuntimeError("Cannot read the importer's positive MAX_SEED_BYTES limit")
+BUDGET = int(_budget.group(1))
 
 
-def mapper_function(name):
-    match = re.search(rf"^{name}\(\) \{{\n.*?^PYEOF\n\}}", SCRIPT.read_text(), re.M | re.S)
-    if match is None:
-        raise AssertionError(f"Missing mapper function: {name}")
-    return match.group(0)
-
-
-def mapper_body(name):
-    return mapper_function(name).split("<<'PYEOF'\n", 1)[1].rsplit("\nPYEOF", 1)[0]
+MAPPER = SCRIPT.with_name("import_qa_assets.py")
+_spec = importlib.util.spec_from_file_location("qa_assets_mapper", MAPPER)
+mapper = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mapper)
 
 
 class MapperTests(unittest.TestCase):
@@ -59,12 +59,12 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
         self.script_target.write_text("const ELEMENT_LEN_MAX: usize = 1_024;\n")
 
     def run_mapper(self, name, budget=BUDGET):
-        if name == "map_p2p":
-            args = [self.p2p, self.inventory, self.output / "p2p_message", budget]
-        else:
-            args = [self.scripts, self.asm, self.script_target, self.output / "script_eval", budget]
-        with patch.object(sys, "argv", ["-"] + [str(arg) for arg in args]), redirect_stdout(io.StringIO()):
-            exec(compile(mapper_body(name), f"{SCRIPT}:{name}", "exec"), {"__name__": "__main__"})
+        with redirect_stdout(io.StringIO()):
+            if name == "map_p2p":
+                mapper.map_p2p(self.p2p, self.inventory, self.output / "p2p_message", budget)
+            else:
+                mapper.map_script([self.scripts, self.asm], self.script_target,
+                                  self.output / "script_eval", budget)
 
     def assert_seed(self, target, expected):
         path = self.output / target / hashlib.sha256(expected).hexdigest()[:32]
@@ -86,7 +86,7 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
                           'pub const COMMANDS: &[Command] = &[Command { name: "ping" }, Command { name: "ping" }];'):
             with self.subTest(inventory=inventory):
                 self.inventory.write_text(inventory)
-                with self.assertRaises(SystemExit):
+                with self.assertRaises(ValueError):
                     self.run_mapper("map_p2p")
         self.assertFalse((self.output / "p2p_message").exists())
 
@@ -102,7 +102,7 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
         self.assert_seed("p2p_message", b"\0" + b"P" * (BUDGET - 1))
 
     def test_65536_byte_script_frames_match_the_harness(self):
-        script = b"Q" * BUDGET
+        script = b"Q" * (1 << 16)
         (self.scripts / "boundary").write_bytes(script)
         self.run_mapper("map_script")
         raw = b"\0\0\0" + (1024).to_bytes(2, "little") + script[:1024] + b"\0"
@@ -119,7 +119,7 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
 
     def test_missing_script_limit_fails_closed(self):
         self.script_target.write_text("// no element limit\n")
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ValueError):
             self.run_mapper("map_script")
         self.assertFalse((self.output / "script_eval").exists())
 
@@ -174,28 +174,55 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
             self.run_mapper("map_script")
         self.assertEqual(reads, limits)
 
-    def test_shell_functions_pass_the_owner_paths(self):
+    def test_cli_maps_all_targets_using_the_owner_paths(self):
         self.write_message("pong", b"payload")
         (self.scripts / "script").write_bytes(b"Q")
-        command = '''set -euo pipefail
-CARGO_ENV=(env)
-REPO_ROOT="$1"
-CORPORA="$2"
-FUZZ_DIR="$3"
-OUT_BASE="$4"
-MAX_SEED_BYTES=65536
-'''
-        command += mapper_function("map_p2p") + "\n" + mapper_function("map_script") + "\nmap_p2p\nmap_script\n"
-        result = subprocess.run(["bash", "-c", command, "mapper-tests", str(self.root), str(self.corpora),
-                                 str(self.fuzz), str(self.output)], capture_output=True, text=True,
-                                timeout=30, check=False)
+        for source in ("bitcoin_deserialize_block", "bitcoin_deserialize_transaction"):
+            (self.corpora / source).mkdir()
+            (self.corpora / source / "seed").write_bytes(b"direct")
+        result = subprocess.run(
+            [sys.executable, str(MAPPER), "--corpora", str(self.corpora),
+             "--repo-root", str(self.root), "--out-base", str(self.output),
+             "--max-seed-bytes", str(BUDGET)],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_seed("p2p_message", b"\x01payload")
         self.assert_seed("script_eval", b"\0\0\0\x01\0Q\0")
+        for target in ("block_decode", "tx_decode"):
+            self.assertEqual((self.output / target / "seed").read_bytes(), b"direct")
+
+
+    def test_directory_order_does_not_change_seed_names_or_bytes(self):
+        self.write_message("ping", b"A")
+        self.write_message("pong", b"B")
+        for directory in (self.scripts, self.asm):
+            (directory / "one").write_bytes(b"Q" * 64)
+            (directory / "two").write_bytes(b"R")
+        self.run_mapper("map_p2p")
+        self.run_mapper("map_script")
+        expected = {str(path.relative_to(self.output)): path.read_bytes()
+                    for path in self.output.rglob("*") if path.is_file()}
+        self.output = self.root / "reversed"
+        original_paths = mapper._seed_paths
+
+        def reversed_paths(source):
+            return iter(reversed(list(original_paths(source))))
+
+        with patch.object(mapper, "_seed_paths", reversed_paths):
+            self.run_mapper("map_p2p")
+            self.run_mapper("map_script")
+        actual = {str(path.relative_to(self.output)): path.read_bytes()
+                  for path in self.output.rglob("*") if path.is_file()}
+        self.assertEqual(actual, expected)
 
 
 class SetupFailureTests(unittest.TestCase):
-    """Regression coverage for CONSTRAINTS.md#qa-corpus-importer-setup-contract."""
+    """Regression coverage for CONSTRAINTS.md#qa-corpus-importer-setup-contract.
+
+    QAC-01 names the corpus/provenance owner; the setup section in
+    CONSTRAINTS.md owns the exit-status and cleanup behavior asserted below.
+    """
 
     def setUp(self):
         temp = tempfile.TemporaryDirectory()
@@ -244,6 +271,220 @@ printf 'test 100 100 0 100%% /\\n' ''',
 
     def test_disk_probe_failure_cleans_staging(self):
         self.check_failure("df", 7)
+
+
+class DirectMappingTests(unittest.TestCase):
+    """Direct mappings preserve exact bytes/names and never report a failed scan as success."""
+
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        self.source = self.root / "source"
+        self.source.mkdir()
+        self.output = self.root / "output"
+        self.output.mkdir()
+
+    def run_direct(self, source=None, env=None):
+        return subprocess.run(
+            [sys.executable, "-c",
+             "from pathlib import Path; import sys; from import_qa_assets import map_direct; "
+             "map_direct(Path(sys.argv[1]), Path(sys.argv[2]), int(sys.argv[3]), 'test-direct')",
+             str(source or self.source), str(self.output), str(BUDGET)],
+            cwd=MAPPER.parent, env=env, capture_output=True,
+            text=True, timeout=10, check=False,
+        )
+
+    def test_exact_bytes_and_unusual_names_are_preserved(self):
+        seeds = {"empty": b"", "space and\nnewline": b"\x00\xff\n", "-option": b"abc"}
+        for name, data in seeds.items():
+            (self.source / name).write_bytes(data)
+        result = self.run_direct()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual({p.name: p.read_bytes() for p in self.output.iterdir()}, seeds)
+
+    def test_limit_is_exclusive(self):
+        for name, length in (("under", BUDGET - 1), ("equal", BUDGET), ("over", BUDGET + 1)):
+            (self.source / name).write_bytes(b"x" * length)
+        result = self.run_direct()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([p.name for p in self.output.iterdir()], ["under"])
+        self.assertEqual((self.output / "under").read_bytes(), b"x" * (BUDGET - 1))
+        self.assertIn("skipped_oversize=2", result.stdout)
+
+    def test_missing_source_is_an_error(self):
+        result = self.run_direct(self.root / "missing")
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(list(self.output.iterdir()), [])
+
+    def test_non_directory_source_is_an_error(self):
+        source = self.root / "not-a-directory"
+        source.write_bytes(b"seed")
+        result = self.run_direct(source)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(list(self.output.iterdir()), [])
+
+    def test_non_regular_entries_are_not_followed(self):
+        (self.source / "directory").mkdir()
+        (self.source / "link").symlink_to(self.root / "external")
+        (self.root / "external").write_bytes(b"external")
+        result = self.run_direct()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(list(self.output.iterdir()), [])
+
+    def test_conflicting_output_directory_is_not_a_copy_destination(self):
+        (self.source / "seed").write_bytes(b"new")
+        (self.output / "seed").mkdir()
+        result = self.run_direct()
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(list((self.output / "seed").iterdir()), [])
+
+    def test_existing_output_symlink_does_not_overwrite_its_target(self):
+        external = self.root / "external"
+        external.write_bytes(b"preserve")
+        (self.output / "seed").symlink_to(external)
+        (self.source / "seed").write_bytes(b"new")
+        result = self.run_direct()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(external.read_bytes(), b"preserve")
+        self.assertFalse((self.output / "seed").is_symlink())
+        self.assertEqual((self.output / "seed").read_bytes(), b"new")
+
+
+class PublicationTests(unittest.TestCase):
+    """Failed publication preserves old bytes and cleans temporary files."""
+
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.output = Path(temp.name)
+        self.destination = self.output / "seed"
+        self.destination.write_bytes(b"old")
+
+    def assert_preserved(self):
+        self.assertEqual(self.destination.read_bytes(), b"old")
+        self.assertEqual(list(self.output.iterdir()), [self.destination])
+
+    def test_replace_failure_preserves_old_file(self):
+        with patch.object(mapper.os, "replace", side_effect=OSError("injected rename failure")):
+            with self.assertRaisesRegex(OSError, "rename failure"):
+                mapper._publish(self.output, "seed", b"new")
+        self.assert_preserved()
+
+    def test_partial_write_failure_preserves_old_file(self):
+        real_temporary = mapper.tempfile.NamedTemporaryFile
+
+        def failing_temporary(*args, **kwargs):
+            temporary = real_temporary(*args, **kwargs)
+            write = temporary.write
+
+            def fail_after_prefix(data):
+                write(data[:2])
+                raise OSError("injected partial write")
+
+            temporary.write = fail_after_prefix
+            return temporary
+
+        with patch.object(mapper.tempfile, "NamedTemporaryFile", failing_temporary):
+            with self.assertRaisesRegex(OSError, "partial write"):
+                mapper._publish(self.output, "seed", b"new")
+        self.assert_preserved()
+
+    def test_staging_failure_preserves_old_file(self):
+        with patch.object(mapper.tempfile, "NamedTemporaryFile", side_effect=OSError("no space")):
+            with self.assertRaisesRegex(OSError, "no space"):
+                mapper._publish(self.output, "seed", b"new")
+        self.assert_preserved()
+
+    def test_old_file_remains_visible_until_replace(self):
+        replace = mapper.os.replace
+        observations = []
+
+        def observe(staged, destination):
+            observations.append((self.destination.read_bytes(), Path(staged).read_bytes()))
+            replace(staged, destination)
+
+        with patch.object(mapper.os, "replace", observe):
+            mapper._publish(self.output, "seed", b"complete new bytes")
+        self.assertEqual(observations, [(b"old", b"complete new bytes")])
+        self.assertEqual(self.destination.read_bytes(), b"complete new bytes")
+        self.assertEqual(list(self.output.iterdir()), [self.destination])
+
+    def test_directory_scan_is_lazy_and_closes(self):
+        class Entry:
+            path = "synthetic/seed"
+
+            def is_file(self, *, follow_symlinks):
+                self.follow_symlinks = follow_symlinks
+                return True
+
+        entry = Entry()
+        requested = []
+        closed = []
+
+        @contextmanager
+        def entries(_source):
+            def iterator():
+                requested.append(1)
+                yield entry
+                raise AssertionError("directory was eagerly consumed")
+            try:
+                yield iterator()
+            finally:
+                closed.append(True)
+
+        with patch.object(mapper.os, "scandir", entries):
+            paths = mapper._seed_paths(Path("synthetic"))
+            self.assertEqual(next(paths), Path(entry.path))
+            self.assertEqual(requested, [1])
+            self.assertFalse(entry.follow_symlinks)
+            paths.close()
+        self.assertEqual(closed, [True])
+
+    def test_scanning_failure_is_not_swallowed(self):
+        with patch.object(mapper.os, "scandir", side_effect=OSError("scan failed")):
+            with self.assertRaisesRegex(OSError, "scan failed"):
+                list(mapper._seed_paths(self.output))
+
+    def test_direct_reads_stop_at_the_budget_without_trusting_metadata(self):
+        source = self.output / "source"
+        source.mkdir()
+        seed = source / "large"
+        with seed.open("wb") as stream:
+            stream.truncate(8 * 1024 * 1024)
+        destination = self.output / "mapped"
+        real_open = Path.open
+        requested = []
+
+        @contextmanager
+        def bounded_open(path, mode="r", *args, **kwargs):
+            with real_open(path, mode, *args, **kwargs) as stream:
+                if path != seed or mode != "rb":
+                    yield stream
+                    return
+
+                class Bounded:
+                    def read(self, size=-1):
+                        requested.append(size)
+                        if not 0 <= size <= BUDGET:
+                            raise AssertionError("unbounded corpus read")
+                        return stream.read(size)
+
+                yield Bounded()
+
+        with patch.object(Path, "open", bounded_open), redirect_stdout(io.StringIO()):
+            mapper.map_direct(source, destination, BUDGET, "direct")
+        self.assertEqual(requested, [BUDGET])
+        self.assertEqual(list(destination.iterdir()), [])
+
+    def test_invalid_budgets_fail_before_reads_or_publication(self):
+        with patch.object(mapper, "_read_seed", side_effect=AssertionError("read too early")):
+            for budget in (0, -1):
+                with self.subTest(budget=budget):
+                    with self.assertRaises(ValueError):
+                        mapper.map_direct(self.output, self.output, budget, "direct")
+                    with self.assertRaises(ValueError):
+                        mapper.map_p2p(self.output, self.output, self.output, budget)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_import_qa_assets_flags.py
+++ b/scripts/tests/test_import_qa_assets_flags.py
@@ -1,4 +1,11 @@
-"""Regression for Rust comments in the script_eval FLAGS owner inventory."""
+"""Regression for Rust comments in the script_eval FLAGS owner inventory.
+
+Contract: `fuzz/fuzz_targets/script_eval.rs` owns the selector-indexed input framing
+and `FLAGS` order; `docs/contracts/qa-corpus.md` QAC-01 requires imported script
+seeds to feed that harness. This test mutates only owner syntax (order/comments),
+then derives selector indices from the parsed owner contract before independently
+constructing the documented byte frame.
+"""
 
 import importlib.util
 from pathlib import Path
@@ -32,10 +39,12 @@ class FlagCommentTests(unittest.TestCase):
                 "];\n"
                 "const ELEMENT_LEN_MAX: usize = 1_024;\n"
             )
+            _, none_selector, taproot_selector = mapper._script_contract(harness)
             mapper.map_script([source], harness, output, 65_536)
             seeds = {path.read_bytes() for path in output.iterdir()}
-            raw = b"\x02\0\0\x40\0" + script + b"\0"
-            taproot = b"\x00\0\0\x22\0\x51\x20" + script[:32] + b"\x01\x20\0" + script[32:]
+            raw = bytes([none_selector]) + b"\0\0\x40\0" + script + b"\0"
+            taproot = (bytes([taproot_selector]) + b"\0\0\x22\0\x51\x20" + script[:32]
+                       + b"\x01\x20\0" + script[32:])
             self.assertEqual(seeds, {raw, taproot})
 
 

--- a/scripts/tests/test_import_qa_assets_flags.py
+++ b/scripts/tests/test_import_qa_assets_flags.py
@@ -1,0 +1,43 @@
+"""Regression for Rust comments in the script_eval FLAGS owner inventory."""
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+MAPPER = Path(__file__).resolve().parents[1] / "import_qa_assets.py"
+_SPEC = importlib.util.spec_from_file_location("qa_flags_mapper", MAPPER)
+mapper = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mapper)
+
+
+class FlagCommentTests(unittest.TestCase):
+    def test_comments_with_commas_do_not_change_owned_selectors(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source = root / "source"
+            output = root / "output"
+            source.mkdir()
+            script = b"Q" * 64
+            (source / "script").write_bytes(script)
+            harness = root / "script_eval.rs"
+            harness.write_text(
+                "const FLAGS: [VerifyFlags; 4] = [\n"
+                "    VerifyFlags::TAPROOT, // taproot, selector owner\n"
+                "    /* mandatory, nested /* comment, comma */ still comment */\n"
+                "    VerifyFlags::MANDATORY,\n"
+                "    VerifyFlags::NONE, // none, selector owner\n"
+                "    VerifyFlags::STANDARD,\n"
+                "];\n"
+                "const ELEMENT_LEN_MAX: usize = 1_024;\n"
+            )
+            mapper.map_script([source], harness, output, 65_536)
+            seeds = {path.read_bytes() for path in output.iterdir()}
+            raw = b"\x02\0\0\x40\0" + script + b"\0"
+            taproot = b"\x00\0\0\x22\0\x51\x20" + script[:32] + b"\x01\x20\0" + script[32:]
+            self.assertEqual(seeds, {raw, taproot})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Follow-up hardening after #747/#753. Move fuzz-seed transformation/publication into one bounded Python mapper and make per-seed publication atomic.

- Stream corpus directory entries instead of retaining a sorted path list.
- Bound reads before allocation for direct, P2P, and script inputs.
- Preserve the owner-derived `MAX_SEED_BYTES` and P2P command inventory.
- Derive `NONE`/`TAPROOT` selectors and `ELEMENT_LEN_MAX` from the Rust-owned `fuzz/fuzz_targets/script_eval.rs` contract; Rust line and nested block comments are ignored when reading the `FLAGS` inventory.
- Replace per-file `stat`/`basename`/`cp` subprocesses with direct Python I/O.
- Publish each seed through a same-directory temporary file + `os.replace`, so failed writes/replaces preserve the previous file and pre-existing destination symlinks are not followed.
- Reject missing/non-directory corpus sources before minimization/provenance.

This is atomic **per seed file**, not a transaction across the whole corpus and not a crash-durability claim.

## Scope

Rebased onto main after #747/#753 merged. The #753 review changes remain preserved: tests derive the seed budget from the importer, and setup-failure assertions remain tied to `CONSTRAINTS.md#qa-corpus-importer-setup-contract`.

Changed files:

- `.github/workflows/fuzz-corpus-tools.yml`
- `scripts/import-qa-assets.sh`
- `scripts/import_qa_assets.py`
- `scripts/tests/test_import_qa_assets.py`
- `scripts/tests/test_import_qa_assets_flags.py`

No Rust source, dependency, corpus, historical provenance, or consensus behavior changes.

## Validation

Final local validation for this layer:

- `bash -n scripts/import-qa-assets.sh` — passed
- Python compile checks for mapper/tests — passed
- `python3 -m unittest discover -s scripts/tests -p 'test_import_qa_assets*.py' -v` with this layer's tests — **35 passed**
- Regression coverage includes owner-inventory reordering and Rust line/nested-block comments containing commas.

Synthetic direct-copy benchmark from the prepared evidence bundle: 500 identical seeds, five alternating-order samples; median **3.199 s before vs 0.099 s after (32.46×)**, with output bytes/names identical. This is a copy-only diagnostic result, not an end-to-end importer or node benchmark and **does not satisfy the repository CL-14 promotion evidence requirement**.

The repository CL-14/Cargo gate and Clippy could not run in the local execution environment because `cargo` is unavailable. This is not a pass. The related performance-evidence review thread intentionally remains open pending supported Cargo/qualified benchmark evidence.

## Stack

#762 is the dependent second layer for acquisition-error propagation and atomic provenance publication.