### PR TITLE
fix(fuzz): preserve acquisition failures and atomically publish provenance

### DIFF
--- a/.github/workflows/fuzz-corpus-tools.yml
+++ b/.github/workflows/fuzz-corpus-tools.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Check importer syntax
         run: bash -n scripts/import-qa-assets.sh
       - name: Run offline corpus-import regressions
-        run: python3 -m unittest discover -s scripts/tests -p test_import_qa_assets.py -v
+        run: python3 -m unittest discover -s scripts/tests -p 'test_import_qa_assets*.py' -v

--- a/docs/contracts/qa-corpus.md
+++ b/docs/contracts/qa-corpus.md
@@ -31,10 +31,37 @@ end-state evidence roles.
 - G6 policy and admission: the `script_eval` and `tx_decode` targets exercise
   standardness and admission edge cases in addition to consensus decoding.
 
+### `QAC-03`: Importer acquisition and provenance publication
+
+After the setup contract in `CONSTRAINTS.md` succeeds, `scripts/import-qa-assets.sh`
+uses fail-closed acquisition and publication semantics:
+
+- the pinned upstream commit check, clone-size measurement, each corpus
+  minimization, and the UTC import timestamp must succeed; a nonzero tool status
+  is not hidden by valid output from that tool;
+- provenance is not replaced until mapping and all four minimization commands
+  have succeeded;
+- a refresh is written to a same-directory staging file, completed successfully,
+  set to repository-document mode `0644`, and then atomically replaces the
+  `fuzz/CORPUS_PROVENANCE.md` directory entry;
+- a failed provenance write, mode change, or replacement preserves the prior
+  destination. A destination symlink is replaced as an entry rather than
+  followed, and a destination directory is not treated as a container;
+- normal exit and `HUP`/`INT`/`TERM` cleanup remove clone/provenance staging.
+  Signal exits use the shell convention `128 + signal`;
+- these guarantees are process-level failure atomicity. They do not claim
+  `fsync`/power-loss durability or one transaction spanning corpus files and
+  provenance.
+
+Injected numeric statuses in regression tests are sentinels used to prove
+nonzero-status propagation; they are not stable public status-code assignments.
+
 ## Proven by
 
 - `fuzz/CORPUS_PROVENANCE.md` (existing): records the upstream identity,
   license, per-target mapping, and refresh rule.
+- `scripts/tests/test_import_qa_assets_provenance.py`: `QAC-03` acquisition,
+  minimization, cleanup, mode, and failure-atomic provenance publication.
 - `bin/bitcoin-rs/tests/overhaul_reference_set.rs` (planned): G0 pin; rejects
   a QA corpus with a missing or mismatched upstream commit.
 - `crates/consensus/tests/overhaul_consensus_matrix.rs` (planned): G5 arm;

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -46,7 +46,13 @@ available_mb() { df -Pm "$1" | awk 'NR == 2 { print $4 }'; }
 
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/qa-assets.XXXXXX")"
 readonly WORKDIR
-cleanup() { rm -rf -- "${WORKDIR:?workdir unset}"; }
+PROVENANCE_TMP=""
+cleanup() {
+    if [[ -n "${PROVENANCE_TMP}" ]]; then
+        rm -f -- "${PROVENANCE_TMP}"
+    fi
+    rm -rf -- "${WORKDIR:?workdir unset}"
+}
 trap cleanup EXIT
 trap 'exit 129' HUP
 trap 'exit 130' INT
@@ -73,12 +79,14 @@ git init --quiet "${WORKDIR}/qa-assets"
 git -C "${WORKDIR}/qa-assets" remote add origin "${QA_ASSETS_URL}"
 git -C "${WORKDIR}/qa-assets" fetch --depth 1 --quiet origin "${QA_ASSETS_PIN}"
 git -C "${WORKDIR}/qa-assets" checkout --quiet FETCH_HEAD
-readonly UPSTREAM_COMMIT="$(git -C "${WORKDIR}/qa-assets" rev-parse HEAD)"
+UPSTREAM_COMMIT="$(git -C "${WORKDIR}/qa-assets" rev-parse HEAD)"
+readonly UPSTREAM_COMMIT
 [ "${UPSTREAM_COMMIT}" = "${QA_ASSETS_PIN}" ] || {
     log "ABORT: fetched ${UPSTREAM_COMMIT}, expected pin ${QA_ASSETS_PIN}"
     exit 1
 }
-readonly UPSTREAM_SIZE_MB="$(du -sm "${WORKDIR}/qa-assets" | cut -f1)"
+UPSTREAM_SIZE_MB="$(du -sm "${WORKDIR}/qa-assets" | cut -f1)"
+readonly UPSTREAM_SIZE_MB
 log "clone at ${UPSTREAM_COMMIT} (${UPSTREAM_SIZE_MB} MiB actual)"
 
 readonly CORPORA="${WORKDIR}/qa-assets/fuzz_corpora"
@@ -100,8 +108,11 @@ readonly OUT_BASE="${FUZZ_DIR}/corpus"
 
 # --- 5. Provenance ------------------------------------------------------------
 readonly PROVENANCE="${FUZZ_DIR}/CORPUS_PROVENANCE.md"
-readonly IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-cat > "${PROVENANCE}" <<EOF
+IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+readonly IMPORT_DATE
+# Stage beside the destination: failed writes leave the previous record intact.
+PROVENANCE_TMP="$(mktemp "${FUZZ_DIR}/.corpus-provenance.XXXXXX")"
+cat > "${PROVENANCE_TMP}" <<EOF
 # Fuzz corpus provenance
 
 Seeds under fuzz/corpus/ were imported from
@@ -129,6 +140,8 @@ Corpora were minimized with cargo fuzz cmin after import; only minimized
 seeds are tracked here. Re-run the script after major decoder changes to
 refresh.
 EOF
+mv -T -- "${PROVENANCE_TMP}" "${PROVENANCE}"
+PROVENANCE_TMP=""
 log "provenance written to ${PROVENANCE}"
 
 # --- 6. Delete the clone (only minimized corpora are kept) --------------------

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -140,6 +140,7 @@ Corpora were minimized with cargo fuzz cmin after import; only minimized
 seeds are tracked here. Re-run the script after major decoder changes to
 refresh.
 EOF
+chmod 0644 -- "${PROVENANCE_TMP}"
 mv -T -- "${PROVENANCE_TMP}" "${PROVENANCE}"
 PROVENANCE_TMP=""
 log "provenance written to ${PROVENANCE}"

--- a/scripts/tests/test_import_qa_assets_provenance.py
+++ b/scripts/tests/test_import_qa_assets_provenance.py
@@ -1,0 +1,178 @@
+"""End-to-end failure and provenance-publication tests for the QA corpus importer."""
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "import-qa-assets.sh"
+MAPPER = SCRIPT.with_name("import_qa_assets.py")
+
+
+class ImportFlowTests(unittest.TestCase):
+    """Run the real shell and mapper, replacing only external acquisition/tools."""
+
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.tmp = self.root / "tmp"
+        self.tmp.mkdir()
+        scripts = self.root / "scripts"
+        scripts.mkdir()
+        (scripts / MAPPER.name).write_bytes(MAPPER.read_bytes())
+        inventory = self.root / "crates/p2p/src/compat.rs"
+        inventory.parent.mkdir(parents=True)
+        inventory.write_text('pub const COMMANDS: &[Command] = &[Command { name: "ping" }];\n')
+        harness = self.root / "fuzz/fuzz_targets/script_eval.rs"
+        harness.parent.mkdir(parents=True)
+        harness.write_text("const ELEMENT_LEN_MAX: usize = 1_024;\n")
+        self.provenance = self.root / "fuzz/CORPUS_PROVENANCE.md"
+        self.provenance.write_text("previous provenance\n")
+        self.source = self.root / "upstream"
+        self.corpora = self.source / "fuzz_corpora"
+        for name in ("p2p_deserialize_raw_net_msg", "bitcoin_deserialize_script",
+                     "bitcoin_script_bytes_to_asm_fmt", "bitcoin_deserialize_block",
+                     "bitcoin_deserialize_transaction"):
+            (self.corpora / name).mkdir(parents=True)
+        message = b"\0" * 4 + b"ping".ljust(12, b"\0") + b"\0" * 8 + b"payload"
+        (self.corpora / "p2p_deserialize_raw_net_msg/seed").write_bytes(message)
+        for name in ("bitcoin_deserialize_script", "bitcoin_deserialize_block",
+                     "bitcoin_deserialize_transaction"):
+            (self.corpora / name / "seed").write_bytes(b"Q")
+        pin = re.search(r'^readonly QA_ASSETS_PIN="([0-9a-f]{40})"$', SCRIPT.read_text(), re.M)
+        self.assertIsNotNone(pin)
+        self.pin = pin.group(1)
+        stubs = {
+            "git": r'''
+if [[ "$1" == rev-parse ]]; then printf '%s\n' "$TEST_ROOT"; exit; fi
+if [[ "$1" == init ]]; then mkdir -p "${!#}"; exit; fi
+[[ "$1" == -C ]] || exit 99
+case "$3" in
+    remote|fetch) ;;
+    checkout) cp -a "$SOURCE_FIXTURE/." "$2/" ;;
+    rev-parse)
+        printf '%s\n' "$EXPECTED_PIN"
+        [[ "${FAIL_STAGE:-}" != git_head ]] || exit 29
+        ;;
+    *) exit 99 ;;
+esac
+''',
+            "rustc": "printf 'host: x86_64-unknown-linux-gnu\\n'",
+            "df": "printf 'Filesystem Blocks Used Available Capacity Mounted\\n'\n"
+                  "printf 'test 100000 0 100000 0%% /\\n'",
+            "du": "printf '1\\tclone\\n'\n[[ \"${FAIL_STAGE:-}\" != du ]] || exit 31",
+            "date": "[[ \"${FAIL_STAGE:-}\" != date ]] || exit 47\n"
+                    "printf '2000-01-01T00:00:00Z\\n'",
+            "cat": "if [[ \"${FAIL_STAGE:-}\" == term ]]; then kill -TERM \"$PPID\"; exit 0; fi\n"
+                   "if [[ \"${FAIL_STAGE:-}\" == provenance_write ]]; then printf partial; exit 51; fi\n"
+                   "exec /usr/bin/cat \"$@\"",
+            "mv": "[[ \"${FAIL_STAGE:-}\" != provenance_publish ]] || exit 53\n"
+                  "exec /usr/bin/mv \"$@\"",
+            "cargo": r'''
+[[ "${RUSTUP_TOOLCHAIN:-}" == nightly ]] || exit 98
+[[ ! -v RUSTC_WRAPPER && ! -v CARGO_BUILD_BUILD_DIR ]] || exit 97
+printf '%s\n' "${!#}" >> "$TEST_ROOT/cmin.log"
+[[ "${FAIL_STAGE:-}" != cmin ]] || exit 43
+''',
+        }
+        for name, body in stubs.items():
+            path = self.bin / name
+            path.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + body + "\n")
+            path.chmod(0o755)
+
+    def run_import(self, fail=""):
+        environment = dict(os.environ, PATH=f"{self.bin}{os.pathsep}{os.environ['PATH']}",
+                           TEST_ROOT=str(self.root), SOURCE_FIXTURE=str(self.source),
+                           EXPECTED_PIN=self.pin, TMPDIR=str(self.tmp), FAIL_STAGE=fail,
+                           RUSTC_WRAPPER="must-be-unset", CARGO_BUILD_BUILD_DIR="must-be-unset")
+        result = subprocess.run(["bash", str(SCRIPT)], cwd=self.root, env=environment,
+                                capture_output=True, text=True, timeout=10, check=False)
+        self.assertEqual(list(self.tmp.iterdir()), [], "clone leaked after importer exit")
+        self.assertEqual(list((self.root / "fuzz").glob(".corpus-provenance.*")), [],
+                         "provenance staging leaked after importer exit")
+        return result
+
+    def test_success_maps_then_minimizes_and_records_provenance(self):
+        result = self.run_import()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.root / "cmin.log").read_text().splitlines(),
+                         ["p2p_message", "block_decode", "tx_decode", "script_eval"])
+        self.assertIn(self.pin, self.provenance.read_text())
+        self.assertIn("2000-01-01T00:00:00Z", self.provenance.read_text())
+        for target in ("block_decode", "tx_decode"):
+            self.assertEqual((self.root / "fuzz/corpus" / target / "seed").read_bytes(), b"Q")
+
+    def test_missing_source_stops_before_minimization_or_provenance(self):
+        (self.corpora / "bitcoin_script_bytes_to_asm_fmt").rmdir()
+        result = self.run_import()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.root / "cmin.log").exists())
+        self.assertFalse((self.root / "fuzz/corpus").exists())
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+    def test_failed_minimization_preserves_provenance(self):
+        result = self.run_import("cmin")
+        self.assertEqual(result.returncode, 43, result.stderr)
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+        self.assertEqual((self.root / "cmin.log").read_text().splitlines(), ["p2p_message"])
+
+    def test_failed_commit_probe_is_not_hidden_by_valid_output(self):
+        result = self.run_import("git_head")
+        self.assertEqual(result.returncode, 29, result.stderr)
+        self.assertFalse((self.root / "cmin.log").exists())
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+    def test_failed_size_probe_stops_before_mapping(self):
+        result = self.run_import("du")
+        self.assertEqual(result.returncode, 31, result.stderr)
+        self.assertFalse((self.root / "cmin.log").exists())
+        self.assertFalse((self.root / "fuzz/corpus").exists())
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+    def test_failed_timestamp_preserves_provenance(self):
+        result = self.run_import("date")
+        self.assertEqual(result.returncode, 47, result.stderr)
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+    def test_failed_provenance_write_preserves_previous_file(self):
+        result = self.run_import("provenance_write")
+        self.assertEqual(result.returncode, 51, result.stderr)
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+    def test_failed_provenance_publish_preserves_previous_file(self):
+        result = self.run_import("provenance_publish")
+        self.assertEqual(result.returncode, 53, result.stderr)
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+    def test_provenance_symlink_is_replaced_without_following_it(self):
+        outside = self.root / "outside.md"
+        outside.write_text("unrelated data\n")
+        self.provenance.unlink()
+        self.provenance.symlink_to(outside)
+        result = self.run_import()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(outside.read_text(), "unrelated data\n")
+        self.assertFalse(self.provenance.is_symlink())
+        self.assertIn(self.pin, self.provenance.read_text())
+
+    def test_provenance_directory_is_not_used_as_a_container(self):
+        self.provenance.unlink()
+        self.provenance.mkdir()
+        result = self.run_import()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(list(self.provenance.iterdir()), [])
+
+    def test_termination_cleans_staging_and_preserves_provenance(self):
+        result = self.run_import("term")
+        self.assertEqual(result.returncode, 143, result.stderr)
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_import_qa_assets_provenance.py
+++ b/scripts/tests/test_import_qa_assets_provenance.py
@@ -1,19 +1,36 @@
-"""End-to-end failure and provenance-publication tests for the QA corpus importer."""
+"""End-to-end failure and provenance-publication tests for the QA corpus importer.
+
+Contract: docs/contracts/qa-corpus.md#qac-03-importer-acquisition-and-provenance-publication.
+Injected nonzero statuses below are test sentinels proving pass-through; the contract owns
+that failures are propagated, not the sentinel numbers themselves.
+"""
 
 import os
 from pathlib import Path
 import re
+import stat
 import subprocess
 import tempfile
 import unittest
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = Path(__file__).resolve().parents[1] / "import-qa-assets.sh"
 MAPPER = SCRIPT.with_name("import_qa_assets.py")
+OWNER_HARNESS = REPO_ROOT / "fuzz/fuzz_targets/script_eval.rs"
+
+GIT_HEAD_STATUS = 29
+SIZE_STATUS = 31
+CMIN_STATUS = 43
+DATE_STATUS = 47
+PROVENANCE_WRITE_STATUS = 51
+PROVENANCE_CHMOD_STATUS = 52
+PROVENANCE_PUBLISH_STATUS = 53
+TERM_STATUS = 128 + 15
 
 
 class ImportFlowTests(unittest.TestCase):
-    """Run the real shell and mapper, replacing only external acquisition/tools."""
+    """Exercise QAC-03 through the real shell and mapper with external tools stubbed."""
 
     def setUp(self):
         temp = tempfile.TemporaryDirectory()
@@ -31,15 +48,7 @@ class ImportFlowTests(unittest.TestCase):
         inventory.write_text('pub const COMMANDS: &[Command] = &[Command { name: "ping" }];\n')
         harness = self.root / "fuzz/fuzz_targets/script_eval.rs"
         harness.parent.mkdir(parents=True)
-        harness.write_text(
-            "const FLAGS: [VerifyFlags; 4] = [\n"
-            "    VerifyFlags::NONE,\n"
-            "    VerifyFlags::MANDATORY,\n"
-            "    VerifyFlags::STANDARD,\n"
-            "    VerifyFlags::TAPROOT,\n"
-            "];\n"
-            "const ELEMENT_LEN_MAX: usize = 1_024;\n"
-        )
+        harness.write_bytes(OWNER_HARNESS.read_bytes())
         self.provenance = self.root / "fuzz/CORPUS_PROVENANCE.md"
         self.provenance.write_text("previous provenance\n")
         self.source = self.root / "upstream"
@@ -57,16 +66,16 @@ class ImportFlowTests(unittest.TestCase):
         self.assertIsNotNone(pin)
         self.pin = pin.group(1)
         stubs = {
-            "git": r'''
-if [[ "$1" == rev-parse ]]; then printf '%s\n' "$TEST_ROOT"; exit; fi
-if [[ "$1" == init ]]; then mkdir -p "${!#}"; exit; fi
+            "git": f'''
+if [[ "$1" == rev-parse ]]; then printf '%s\\n' "$TEST_ROOT"; exit; fi
+if [[ "$1" == init ]]; then mkdir -p "${{!#}}"; exit; fi
 [[ "$1" == -C ]] || exit 99
 case "$3" in
     remote|fetch) ;;
     checkout) cp -a "$SOURCE_FIXTURE/." "$2/" ;;
     rev-parse)
-        printf '%s\n' "$EXPECTED_PIN"
-        [[ "${FAIL_STAGE:-}" != git_head ]] || exit 29
+        printf '%s\\n' "$EXPECTED_PIN"
+        [[ "${{FAIL_STAGE:-}}" != git_head ]] || exit {GIT_HEAD_STATUS}
         ;;
     *) exit 99 ;;
 esac
@@ -74,19 +83,21 @@ esac
             "rustc": "printf 'host: x86_64-unknown-linux-gnu\\n'",
             "df": "printf 'Filesystem Blocks Used Available Capacity Mounted\\n'\n"
                   "printf 'test 100000 0 100000 0%% /\\n'",
-            "du": "printf '1\\tclone\\n'\n[[ \"${FAIL_STAGE:-}\" != du ]] || exit 31",
-            "date": "[[ \"${FAIL_STAGE:-}\" != date ]] || exit 47\n"
+            "du": f"printf '1\\tclone\\n'\n[[ \"${{FAIL_STAGE:-}}\" != du ]] || exit {SIZE_STATUS}",
+            "date": f"[[ \"${{FAIL_STAGE:-}}\" != date ]] || exit {DATE_STATUS}\n"
                     "printf '2000-01-01T00:00:00Z\\n'",
-            "cat": "if [[ \"${FAIL_STAGE:-}\" == term ]]; then kill -TERM \"$PPID\"; exit 0; fi\n"
-                   "if [[ \"${FAIL_STAGE:-}\" == provenance_write ]]; then printf partial; exit 51; fi\n"
+            "cat": f"if [[ \"${{FAIL_STAGE:-}}\" == term ]]; then kill -TERM \"$PPID\"; exit 0; fi\n"
+                   f"if [[ \"${{FAIL_STAGE:-}}\" == provenance_write ]]; then printf partial; exit {PROVENANCE_WRITE_STATUS}; fi\n"
                    "exec /usr/bin/cat \"$@\"",
-            "mv": "[[ \"${FAIL_STAGE:-}\" != provenance_publish ]] || exit 53\n"
+            "chmod": f"[[ \"${{FAIL_STAGE:-}}\" != provenance_chmod ]] || exit {PROVENANCE_CHMOD_STATUS}\n"
+                     "exec /usr/bin/chmod \"$@\"",
+            "mv": f"[[ \"${{FAIL_STAGE:-}}\" != provenance_publish ]] || exit {PROVENANCE_PUBLISH_STATUS}\n"
                   "exec /usr/bin/mv \"$@\"",
-            "cargo": r'''
-[[ "${RUSTUP_TOOLCHAIN:-}" == nightly ]] || exit 98
+            "cargo": f'''
+[[ "${{RUSTUP_TOOLCHAIN:-}}" == nightly ]] || exit 98
 [[ ! -v RUSTC_WRAPPER && ! -v CARGO_BUILD_BUILD_DIR ]] || exit 97
-printf '%s\n' "${!#}" >> "$TEST_ROOT/cmin.log"
-[[ "${FAIL_STAGE:-}" != cmin ]] || exit 43
+printf '%s\\n' "${{!#}}" >> "$TEST_ROOT/cmin.log"
+[[ "${{FAIL_STAGE:-}}" != cmin ]] || exit {CMIN_STATUS}
 ''',
         }
         for name, body in stubs.items():
@@ -113,6 +124,7 @@ printf '%s\n' "${!#}" >> "$TEST_ROOT/cmin.log"
                          ["p2p_message", "block_decode", "tx_decode", "script_eval"])
         self.assertIn(self.pin, self.provenance.read_text())
         self.assertIn("2000-01-01T00:00:00Z", self.provenance.read_text())
+        self.assertEqual(stat.S_IMODE(self.provenance.stat().st_mode), 0o644)
         for target in ("block_decode", "tx_decode"):
             self.assertEqual((self.root / "fuzz/corpus" / target / "seed").read_bytes(), b"Q")
 
@@ -126,37 +138,41 @@ printf '%s\n' "${!#}" >> "$TEST_ROOT/cmin.log"
 
     def test_failed_minimization_preserves_provenance(self):
         result = self.run_import("cmin")
-        self.assertEqual(result.returncode, 43, result.stderr)
+        self.assertEqual(result.returncode, CMIN_STATUS, result.stderr)
         self.assertEqual(self.provenance.read_text(), "previous provenance\n")
         self.assertEqual((self.root / "cmin.log").read_text().splitlines(), ["p2p_message"])
 
     def test_failed_commit_probe_is_not_hidden_by_valid_output(self):
         result = self.run_import("git_head")
-        self.assertEqual(result.returncode, 29, result.stderr)
+        self.assertEqual(result.returncode, GIT_HEAD_STATUS, result.stderr)
         self.assertFalse((self.root / "cmin.log").exists())
         self.assertEqual(self.provenance.read_text(), "previous provenance\n")
 
     def test_failed_size_probe_stops_before_mapping(self):
         result = self.run_import("du")
-        self.assertEqual(result.returncode, 31, result.stderr)
+        self.assertEqual(result.returncode, SIZE_STATUS, result.stderr)
         self.assertFalse((self.root / "cmin.log").exists())
         self.assertFalse((self.root / "fuzz/corpus").exists())
         self.assertEqual(self.provenance.read_text(), "previous provenance\n")
 
     def test_failed_timestamp_preserves_provenance(self):
         result = self.run_import("date")
-        self.assertEqual(result.returncode, 47, result.stderr)
+        self.assertEqual(result.returncode, DATE_STATUS, result.stderr)
         self.assertEqual(self.provenance.read_text(), "previous provenance\n")
-
 
     def test_failed_provenance_write_preserves_previous_file(self):
         result = self.run_import("provenance_write")
-        self.assertEqual(result.returncode, 51, result.stderr)
+        self.assertEqual(result.returncode, PROVENANCE_WRITE_STATUS, result.stderr)
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+    def test_failed_provenance_chmod_preserves_previous_file(self):
+        result = self.run_import("provenance_chmod")
+        self.assertEqual(result.returncode, PROVENANCE_CHMOD_STATUS, result.stderr)
         self.assertEqual(self.provenance.read_text(), "previous provenance\n")
 
     def test_failed_provenance_publish_preserves_previous_file(self):
         result = self.run_import("provenance_publish")
-        self.assertEqual(result.returncode, 53, result.stderr)
+        self.assertEqual(result.returncode, PROVENANCE_PUBLISH_STATUS, result.stderr)
         self.assertEqual(self.provenance.read_text(), "previous provenance\n")
 
     def test_provenance_symlink_is_replaced_without_following_it(self):
@@ -169,6 +185,7 @@ printf '%s\n' "${!#}" >> "$TEST_ROOT/cmin.log"
         self.assertEqual(outside.read_text(), "unrelated data\n")
         self.assertFalse(self.provenance.is_symlink())
         self.assertIn(self.pin, self.provenance.read_text())
+        self.assertEqual(stat.S_IMODE(self.provenance.stat().st_mode), 0o644)
 
     def test_provenance_directory_is_not_used_as_a_container(self):
         self.provenance.unlink()
@@ -177,12 +194,10 @@ printf '%s\n' "${!#}" >> "$TEST_ROOT/cmin.log"
         self.assertNotEqual(result.returncode, 0)
         self.assertEqual(list(self.provenance.iterdir()), [])
 
-
     def test_termination_cleans_staging_and_preserves_provenance(self):
         result = self.run_import("term")
-        self.assertEqual(result.returncode, 143, result.stderr)
+        self.assertEqual(result.returncode, TERM_STATUS, result.stderr)
         self.assertEqual(self.provenance.read_text(), "previous provenance\n")
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Second atomic follow-up after #747/#753, stacked on #758. Harden acquisition and authoritative provenance publication without changing #758's seed mapper.

- Preserve nonzero failures from the pinned-commit probe, clone-size probe, minimization commands, and timestamp command instead of masking them with valid output.
- Stage `fuzz/CORPUS_PROVENANCE.md` beside its destination, finish the record, set ordinary repository mode `0644`, then atomically replace the directory entry.
- Preserve the previous provenance file on failed write, chmod, publication, minimization, acquisition errors, and termination.
- Replace a provenance symlink as a directory entry rather than following it; a destination directory is rejected rather than used as a container.
- Clean provenance staging together with clone staging on exit and signals.
- Document these semantics as `QAC-03` in `docs/contracts/qa-corpus.md`.
- End-to-end tests copy the real `fuzz/fuzz_targets/script_eval.rs` owner into the isolated test repository rather than duplicating its `FLAGS`/element-limit constants.

Publication is process-level atomicity for the provenance-file rename. It does not claim fsync/power-loss durability or a transaction spanning the corpus and provenance together.

## Stack / scope

- Base PR: #758
- Merge #758 first; after it lands, this PR can be retargeted to `main`.

Final diff relative to #758 is limited to:

- `docs/contracts/qa-corpus.md`
- `scripts/import-qa-assets.sh`
- `scripts/tests/test_import_qa_assets_provenance.py`

The CI wildcard needed for the companion tests is already owned by #758 and therefore is not repeated in this diff. No Rust source, dependencies, fuzz corpus contents, historical provenance data, or consensus behavior change.

## Validation

Final local stacked validation:

- `bash -n scripts/import-qa-assets.sh` — passed
- Python compile checks for mapper and all importer test modules — passed
- `python3 -m unittest discover -s scripts/tests -p 'test_import_qa_assets*.py' -v` — **47 passed**
- The QAC-03 companion contributes **12** end-to-end acquisition/minimization/publication regressions, including `0644` mode and failed-chmod preservation.

The repository CL-14/Cargo gate and Clippy were unavailable in the local execution environment because `cargo` is not installed. No gate pass is claimed; GitHub CI remains required before landing.