### PR TITLE
fix(fuzz): stream bounded corpus imports through atomic seed publication

### DIFF
--- a/fuzz/fuzz_targets/script_eval.rs
+++ b/fuzz/fuzz_targets/script_eval.rs
@@ -30,6 +30,9 @@ use bitcoin_rs_script::{Interpreter, VerifyFlags};
 /// `scripts/import-qa-assets.sh`; seeds written by that script use selector
 /// `0x00` (NONE) for raw scripts and `0x03` (TAPROOT) for the wrapped P2TR
 /// variant. Keep those indices in step with `FLAGS` below.
+const QA_RAW_SELECTOR: usize = 0;
+const QA_P2TR_SELECTOR: usize = 3;
+
 const FLAGS: [VerifyFlags; 6] = [
     VerifyFlags::NONE,
     VerifyFlags::MANDATORY,

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -23,7 +23,9 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+if ! REPO_ROOT="$(git rev-parse --show-toplevel)"; then
+    exit 19
+fi
 readonly REPO_ROOT
 readonly QA_ASSETS_URL="https://github.com/rust-bitcoin/qa-assets.git"
 readonly FOOTPRINT_ASSUME_MB=2048  # worst-case shallow-clone footprint
@@ -33,7 +35,9 @@ readonly MAX_SEED_BYTES=65536      # keep individual seeds bounded
 # cargo env hygiene for this repo (see repo AGENTS.md); fuzzing needs nightly
 # for -Zsanitizer, and an explicit host triple because cargo-fuzz 0.13
 # defaults to the musl target.
-HOST_TRIPLE="$(rustc +nightly -vV | sed -n 's/^host: //p')"
+if ! HOST_TRIPLE="$(rustc +nightly -vV | sed -n 's/^host: //p')" || [ -z "${HOST_TRIPLE}" ]; then
+    exit 17
+fi
 readonly HOST_TRIPLE
 CARGO_ENV=(env -u RUSTC_WRAPPER -u CARGO_BUILD_BUILD_DIR RUSTUP_TOOLCHAIN=nightly)
 
@@ -44,7 +48,9 @@ log() { printf '[import-qa-assets] %s\n' "$*"; }
 # both filesystems must cover their share of footprint + reserve.
 available_mb() { df -Pm "$1" | awk 'NR == 2 { print $4 }'; }
 
-WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/qa-assets.XXXXXX")"
+if ! WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/qa-assets.XXXXXX")"; then
+    exit 23
+fi
 readonly WORKDIR
 cleanup() { rm -rf -- "${WORKDIR:?workdir unset}"; }
 trap cleanup EXIT
@@ -52,8 +58,10 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-FREE_TMP_MB="$(available_mb "${WORKDIR}")"
-FREE_REPO_MB="$(available_mb "${REPO_ROOT:?repo root unset}")"
+if ! FREE_TMP_MB="$(available_mb "${WORKDIR}")" || [ -z "${FREE_TMP_MB}" ] ||
+   ! FREE_REPO_MB="$(available_mb "${REPO_ROOT:?repo root unset}")" || [ -z "${FREE_REPO_MB}" ]; then
+    exit 7
+fi
 readonly FREE_TMP_MB FREE_REPO_MB
 readonly NEEDED_MB=$((FOOTPRINT_ASSUME_MB + RESERVE_MB))
 readonly NEEDED_REPO_MB=256

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -46,7 +46,13 @@ available_mb() { df -Pm "$1" | awk 'NR == 2 { print $4 }'; }
 
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/qa-assets.XXXXXX")"
 readonly WORKDIR
-cleanup() { rm -rf -- "${WORKDIR:?workdir unset}"; }
+PROVENANCE_TMP=""
+cleanup() {
+    if [[ -n "${PROVENANCE_TMP}" ]]; then
+        rm -f -- "${PROVENANCE_TMP}"
+    fi
+    rm -rf -- "${WORKDIR:?workdir unset}"
+}
 trap cleanup EXIT
 trap 'exit 129' HUP
 trap 'exit 130' INT
@@ -73,12 +79,14 @@ git init --quiet "${WORKDIR}/qa-assets"
 git -C "${WORKDIR}/qa-assets" remote add origin "${QA_ASSETS_URL}"
 git -C "${WORKDIR}/qa-assets" fetch --depth 1 --quiet origin "${QA_ASSETS_PIN}"
 git -C "${WORKDIR}/qa-assets" checkout --quiet FETCH_HEAD
-readonly UPSTREAM_COMMIT="$(git -C "${WORKDIR}/qa-assets" rev-parse HEAD)"
+UPSTREAM_COMMIT="$(git -C "${WORKDIR}/qa-assets" rev-parse HEAD)"
+readonly UPSTREAM_COMMIT
 [ "${UPSTREAM_COMMIT}" = "${QA_ASSETS_PIN}" ] || {
     log "ABORT: fetched ${UPSTREAM_COMMIT}, expected pin ${QA_ASSETS_PIN}"
     exit 1
 }
-readonly UPSTREAM_SIZE_MB="$(du -sm "${WORKDIR}/qa-assets" | cut -f1)"
+UPSTREAM_SIZE_MB="$(du -sm "${WORKDIR}/qa-assets" | cut -f1)"
+readonly UPSTREAM_SIZE_MB
 log "clone at ${UPSTREAM_COMMIT} (${UPSTREAM_SIZE_MB} MiB actual)"
 
 readonly CORPORA="${WORKDIR}/qa-assets/fuzz_corpora"
@@ -100,8 +108,11 @@ readonly OUT_BASE="${FUZZ_DIR}/corpus"
 
 # --- 5. Provenance ------------------------------------------------------------
 readonly PROVENANCE="${FUZZ_DIR}/CORPUS_PROVENANCE.md"
-readonly IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-cat > "${PROVENANCE}" <<EOF
+IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+readonly IMPORT_DATE
+# Stage beside the destination: failed writes leave the previous record intact.
+PROVENANCE_TMP="$(mktemp "${FUZZ_DIR}/.corpus-provenance.XXXXXX")"
+cat > "${PROVENANCE_TMP}" <<EOF
 # Fuzz corpus provenance
 
 Seeds under fuzz/corpus/ were imported from
@@ -129,6 +140,8 @@ Corpora were minimized with cargo fuzz cmin after import; only minimized
 seeds are tracked here. Re-run the script after major decoder changes to
 refresh.
 EOF
+mv -T -- "${PROVENANCE_TMP}" "${PROVENANCE}"
+PROVENANCE_TMP=""
 log "provenance written to ${PROVENANCE}"
 
 # --- 6. Delete the clone (only minimized corpora are kept) --------------------

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -85,128 +85,20 @@ readonly CORPORA="${WORKDIR}/qa-assets/fuzz_corpora"
 readonly FUZZ_DIR="${REPO_ROOT}/fuzz"
 readonly OUT_BASE="${FUZZ_DIR}/corpus"
 
-# --- 3. p2p_message: reframe raw network messages ----------------------------
-# The harness input is [selector][payload]; it derives the envelope itself.
-# Extract the command from the corpus file 24-byte header and map it to the
-# selector index in crates/p2p/src/compat.rs COMMANDS, the same inventory
-# consumed by fuzz/fuzz_targets/p2p_message.rs.
-map_p2p() {
-    "${CARGO_ENV[@]}" python3 - "${CORPORA}/p2p_deserialize_raw_net_msg" \
-        "${REPO_ROOT}/crates/p2p/src/compat.rs" "${OUT_BASE}/p2p_message" \
-        "${MAX_SEED_BYTES}" <<'PYEOF'
-import hashlib
-import re
-import sys
-from pathlib import Path
+# --- 3. Transform and publish bounded seeds ---------------------------------
+# One mapper owns framing and atomic publication for all targets. Failures in
+# directory enumeration, reads, or publication stop before cmin or provenance.
+"${CARGO_ENV[@]}" python3 "${REPO_ROOT}/scripts/import_qa_assets.py" \
+    --corpora "${CORPORA}" --repo-root "${REPO_ROOT}" \
+    --out-base "${OUT_BASE}" --max-seed-bytes "${MAX_SEED_BYTES}"
 
-corpus_dir, target_src, out_dir, max_bytes = Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]), int(sys.argv[4])
-table = re.search(r"pub\s+const\s+COMMANDS\s*:\s*&\[Command\]\s*=\s*&\[(.*?)\];", target_src.read_text(), re.S)
-if table is None:
-    sys.exit("Cannot find the P2P COMMANDS inventory")
-commands = re.findall(r'\bname\s*:\s*"([a-z0-9]{1,12})"', table.group(1))
-if (not commands or len(commands) > 256 or len(set(commands)) != len(commands)
-        or len(commands) != len(re.findall(r"\bCommand\s*\{", table.group(1)))):
-    sys.exit("Invalid P2P COMMANDS inventory")
-selector = {name: bytes([idx]) for idx, name in enumerate(commands)}
-
-out_dir.mkdir(parents=True, exist_ok=True)
-imported = skipped_short = unknown_cmd = 0
-for path in sorted(corpus_dir.iterdir()):
-    with path.open("rb") as source:
-        blob = source.read(24 + max_bytes - 1)
-    if len(blob) <= 24:
-        skipped_short += 1
-        continue
-    command = blob[4:16].split(b"\0", 1)[0]
-    sel = selector.get(command.decode("ascii", "replace"))
-    if sel is None:
-        unknown_cmd += 1
-        continue
-    payload = blob[24:]
-    seed = sel + payload
-    (out_dir / hashlib.sha256(seed).hexdigest()[:32]).write_bytes(seed)
-    imported += 1
-print(f"p2p_message: imported={imported} skipped_short={skipped_short} unknown_command={unknown_cmd}")
-PYEOF
-}
-
-# --- 4. script_eval: wrap raw script bytes into the harness framing ----------
-map_script() {
-    "${CARGO_ENV[@]}" python3 - "${CORPORA}/bitcoin_deserialize_script" \
-        "${CORPORA}/bitcoin_script_bytes_to_asm_fmt" \
-        "${FUZZ_DIR}/fuzz_targets/script_eval.rs" "${OUT_BASE}/script_eval" \
-        "${MAX_SEED_BYTES}" <<'PYEOF'
-import hashlib
-import re
-import sys
-from pathlib import Path
-
-dirs = [Path(sys.argv[1]), Path(sys.argv[2])]
-target_src, out_dir, max_bytes = Path(sys.argv[3]), Path(sys.argv[4]), int(sys.argv[5])
-limit = re.search(r"const\s+ELEMENT_LEN_MAX\s*:\s*usize\s*=\s*([0-9_]+)\s*;", target_src.read_text())
-if limit is None:
-    sys.exit("Cannot find script_eval ELEMENT_LEN_MAX")
-element_limit = int(limit.group(1).replace("_", ""))
-# A P2TR frame adds ten bytes relative to the retained script; lengths are u16.
-script_limit = min(element_limit, 0xffff, max_bytes - 10)
-if script_limit < 0:
-    sys.exit("Seed budget is too small for script framing")
-NONE, TAPROOT = b"\x00", b"\x03"  # FLAGS indices in fuzz_targets/script_eval.rs
-
-out_dir.mkdir(parents=True, exist_ok=True)
-
-def emit(seed: bytes) -> None:
-    (out_dir / hashlib.sha256(seed).hexdigest()[:32]).write_bytes(seed)
-
-def frame(selector: bytes, script_sig: bytes, script_pubkey: bytes, witness: list[bytes]) -> bytes:
-    parts = [selector, len(script_sig).to_bytes(2, "little"), script_sig,
-             len(script_pubkey).to_bytes(2, "little"), script_pubkey, bytes([len(witness)])]
-    parts += [len(e).to_bytes(2, "little") + e for e in witness]
-    return b"".join(parts)
-
-imported = 0
-for corpus_dir in dirs:
-    for path in sorted(corpus_dir.iterdir()):
-        with path.open("rb") as source:
-            script = source.read(script_limit)
-        emit(frame(NONE, b"", script, []))  # raw scriptPubKey
-        if len(script) >= 32 and element_limit >= 34:  # P2TR key-path variant
-            emit(frame(TAPROOT, b"", b"\x51\x20" + script[:32], [script[32:]]))
-        imported += 1
-print(f"script_eval: imported={imported} files (raw + P2TR variants)")
-PYEOF
-}
-
-# --- 5. Direct byte-for-byte mappings ----------------------------------------
-# Seeds >= MAX_SEED_BYTES are skipped by policy (repo-size bound, matching the
-# fuzz targets' own input caps) and the skip count is recorded so the mapping
-# stays honest about what it left behind.
-map_direct() {
-    local src="$1" dst="$2" name="$3"
-    mkdir -p "${dst:?}"
-    local count=0 skipped=0
-    while IFS= read -r -d '' file; do
-        if [ "$(stat -c %s -- "${file:?}")" -ge "${MAX_SEED_BYTES}" ]; then
-            skipped=$((skipped + 1))
-            continue
-        fi
-        cp -- "${file:?}" "${dst}/$(basename -- "${file:?}")"
-        count=$((count + 1))
-    done < <(find "${src:?}" -maxdepth 1 -type f -print0 | sort -z)
-    log "${name}: imported=${count} skipped_oversize=${skipped} (>= ${MAX_SEED_BYTES} bytes)"
-}
-map_p2p
-map_script
-map_direct "${CORPORA}/bitcoin_deserialize_block" "${OUT_BASE}/block_decode" block_decode
-map_direct "${CORPORA}/bitcoin_deserialize_transaction" "${OUT_BASE}/tx_decode" tx_decode
-
-# --- 6. Minimize each target corpus with cargo fuzz cmin ---------------------
+# --- 4. Minimize each target corpus with cargo fuzz cmin ---------------------
 "${CARGO_ENV[@]}" cargo fuzz cmin --target "${HOST_TRIPLE}" p2p_message
 "${CARGO_ENV[@]}" cargo fuzz cmin --target "${HOST_TRIPLE}" block_decode
 "${CARGO_ENV[@]}" cargo fuzz cmin --target "${HOST_TRIPLE}" tx_decode
 "${CARGO_ENV[@]}" cargo fuzz cmin --target "${HOST_TRIPLE}" script_eval
 
-# --- 7. Provenance ------------------------------------------------------------
+# --- 5. Provenance ------------------------------------------------------------
 readonly PROVENANCE="${FUZZ_DIR}/CORPUS_PROVENANCE.md"
 readonly IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 cat > "${PROVENANCE}" <<EOF
@@ -239,5 +131,5 @@ refresh.
 EOF
 log "provenance written to ${PROVENANCE}"
 
-# --- 8. Delete the clone (only minimized corpora are kept) --------------------
+# --- 6. Delete the clone (only minimized corpora are kept) --------------------
 log "import complete; clone removed by cleanup trap"

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -140,7 +140,9 @@ Corpora were minimized with cargo fuzz cmin after import; only minimized
 seeds are tracked here. Re-run the script after major decoder changes to
 refresh.
 EOF
-mv -T -- "${PROVENANCE_TMP}" "${PROVENANCE}"
+chmod 0644 "${PROVENANCE_TMP}"
+[[ ! -d "${PROVENANCE}" ]] || { echo "provenance destination is a directory" >&2; exit 1; }
+mv "${PROVENANCE_TMP}" "${PROVENANCE}"
 PROVENANCE_TMP=""
 log "provenance written to ${PROVENANCE}"
 

--- a/scripts/import_qa_assets.py
+++ b/scripts/import_qa_assets.py
@@ -99,6 +99,12 @@ def map_script(sources: Sequence[Path], harness: Path, output: Path, max_bytes: 
     if limit is None:
         raise ValueError("Cannot find script_eval ELEMENT_LEN_MAX")
     element_limit = int(limit.group(1).replace("_", ""))
+    selectors = {}
+    for name in ("QA_RAW_SELECTOR", "QA_P2TR_SELECTOR"):
+        selector = re.search(rf"const\s+{name}\s*:\s*usize\s*=\s*(\d+)\s*;", harness.read_text())
+        if selector is None:
+            raise ValueError(f"Cannot find script_eval {name}")
+        selectors[name] = int(selector.group(1))
     # P2TR framing adds ten bytes relative to the retained source script.
     script_limit = min(element_limit, 0xffff, max_bytes - 10)
     if script_limit < 0:
@@ -108,9 +114,9 @@ def map_script(sources: Sequence[Path], harness: Path, output: Path, max_bytes: 
     for source in sources:
         for path in _seed_paths(source):
             script = _read_seed(path, script_limit)
-            _emit(output, _frame(0, script, []))
+            _emit(output, _frame(selectors["QA_RAW_SELECTOR"], script, []))
             if len(script) >= 32 and element_limit >= 34:
-                _emit(output, _frame(3, b"\x51\x20" + script[:32], [script[32:]]))
+                _emit(output, _frame(selectors["QA_P2TR_SELECTOR"], b"\x51\x20" + script[:32], [script[32:]]))
             imported += 1
     print(f"script_eval: imported={imported} files (raw + P2TR variants)")
 

--- a/scripts/import_qa_assets.py
+++ b/scripts/import_qa_assets.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Bounded fuzz-seed transformations used by import-qa-assets.sh.
+
+The shell owns acquisition, the byte budget, minimization, and provenance.
+This module owns seed framing and per-file atomic publication. Publication
+is not a transaction over the corpus and does not claim crash durability.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import re
+import sys
+import tempfile
+from collections.abc import Iterator, Sequence
+
+
+def _seed_paths(source: Path) -> Iterator[Path]:
+    # Filenames (direct copies) or content hashes own output identity, not order.
+    # Stream entries rather than retaining a directory-sized list of Path objects.
+    with os.scandir(source) as entries:
+        for entry in entries:
+            if entry.is_file(follow_symlinks=False):
+                yield Path(entry.path)
+
+
+def _read_seed(path: Path, limit: int) -> bytes:
+    with path.open("rb") as source:
+        return source.read(limit)
+
+
+def _publish(output: Path, name: str, seed: bytes) -> None:
+    """Replace the directory entry, never follow a pre-existing output symlink."""
+    temporary = tempfile.NamedTemporaryFile(prefix=".qa-import-", dir=output, delete=False)
+    staged = Path(temporary.name)
+    try:
+        with temporary as stream:
+            stream.write(seed)
+        os.replace(staged, output / name)
+    finally:
+        staged.unlink(missing_ok=True)
+
+
+def _emit(output: Path, seed: bytes) -> None:
+    _publish(output, hashlib.sha256(seed).hexdigest()[:32], seed)
+
+
+def _commands(source: Path) -> dict[str, bytes]:
+    table = re.search(
+        r"pub\s+const\s+COMMANDS\s*:\s*&\[Command\]\s*=\s*&\[(.*?)\];",
+        source.read_text(), re.S,
+    )
+    if table is None:
+        raise ValueError("Cannot find the P2P COMMANDS inventory")
+    commands = re.findall(r'\bname\s*:\s*"([a-z0-9]{1,12})"', table.group(1))
+    if (not commands or len(commands) > 256 or len(set(commands)) != len(commands)
+            or len(commands) != len(re.findall(r"\bCommand\s*\{", table.group(1)))):
+        raise ValueError("Invalid P2P COMMANDS inventory")
+    return {name: bytes([index]) for index, name in enumerate(commands)}
+
+
+def map_p2p(source: Path, inventory: Path, output: Path, max_bytes: int) -> None:
+    if max_bytes < 2:
+        raise ValueError("Seed budget is too small for a P2P selector and payload")
+    selector = _commands(inventory)
+    output.mkdir(parents=True, exist_ok=True)
+    imported = skipped_short = unknown_command = 0
+    for path in _seed_paths(source):
+        blob = _read_seed(path, 24 + max_bytes - 1)
+        if len(blob) <= 24:
+            skipped_short += 1
+            continue
+        command = blob[4:16].split(b"\0", 1)[0].decode("ascii", "replace")
+        selected = selector.get(command)
+        if selected is None:
+            unknown_command += 1
+            continue
+        _emit(output, selected + blob[24:])
+        imported += 1
+    print(f"p2p_message: imported={imported} skipped_short={skipped_short} unknown_command={unknown_command}")
+
+
+def _frame(selector: int, script_pubkey: bytes, witness: Sequence[bytes]) -> bytes:
+    # Empty scriptSig; remaining fields follow script_eval's documented framing.
+    parts = [bytes([selector]), b"\0\0", len(script_pubkey).to_bytes(2, "little"),
+             script_pubkey, bytes([len(witness)])]
+    parts.extend(len(element).to_bytes(2, "little") + element for element in witness)
+    return b"".join(parts)
+
+
+def map_script(sources: Sequence[Path], harness: Path, output: Path, max_bytes: int) -> None:
+    limit = re.search(
+        r"const\s+ELEMENT_LEN_MAX\s*:\s*usize\s*=\s*([0-9_]+)\s*;",
+        harness.read_text(),
+    )
+    if limit is None:
+        raise ValueError("Cannot find script_eval ELEMENT_LEN_MAX")
+    element_limit = int(limit.group(1).replace("_", ""))
+    # P2TR framing adds ten bytes relative to the retained source script.
+    script_limit = min(element_limit, 0xffff, max_bytes - 10)
+    if script_limit < 0:
+        raise ValueError("Seed budget is too small for script framing")
+    output.mkdir(parents=True, exist_ok=True)
+    imported = 0
+    for source in sources:
+        for path in _seed_paths(source):
+            script = _read_seed(path, script_limit)
+            _emit(output, _frame(0, script, []))
+            if len(script) >= 32 and element_limit >= 34:
+                _emit(output, _frame(3, b"\x51\x20" + script[:32], [script[32:]]))
+            imported += 1
+    print(f"script_eval: imported={imported} files (raw + P2TR variants)")
+
+
+def map_direct(source: Path, output: Path, max_bytes: int, name: str) -> None:
+    if max_bytes < 1:
+        raise ValueError("Seed budget must be positive")
+    output.mkdir(parents=True, exist_ok=True)
+    imported = skipped = 0
+    for path in _seed_paths(source):
+        # Read to the exclusive boundary: this also bounds files that grow after enumeration.
+        seed = _read_seed(path, max_bytes)
+        if len(seed) >= max_bytes:
+            skipped += 1
+            continue
+        _publish(output, path.name, seed)
+        imported += 1
+    print(f"[import-qa-assets] {name}: imported={imported} skipped_oversize={skipped} (>= {max_bytes} bytes)")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpora", required=True, type=Path)
+    parser.add_argument("--repo-root", required=True, type=Path)
+    parser.add_argument("--out-base", required=True, type=Path)
+    parser.add_argument("--max-seed-bytes", required=True, type=int)
+    args = parser.parse_args(argv)
+    p2p = args.corpora / "p2p_deserialize_raw_net_msg"
+    scripts = [args.corpora / "bitcoin_deserialize_script",
+               args.corpora / "bitcoin_script_bytes_to_asm_fmt"]
+    direct = [("bitcoin_deserialize_block", "block_decode"),
+              ("bitcoin_deserialize_transaction", "tx_decode")]
+    try:
+        for source in [p2p, *scripts, *(args.corpora / name for name, _ in direct)]:
+            if not source.is_dir():
+                raise ValueError(f"Expected corpus directory: {source}")
+        map_p2p(p2p, args.repo_root / "crates/p2p/src/compat.rs",
+                args.out_base / "p2p_message", args.max_seed_bytes)
+        map_script(scripts, args.repo_root / "fuzz/fuzz_targets/script_eval.rs",
+                   args.out_base / "script_eval", args.max_seed_bytes)
+        for source_name, target in direct:
+            map_direct(args.corpora / source_name, args.out_base / target,
+                       args.max_seed_bytes, target)
+    except (OSError, ValueError) as error:
+        print(f"[import-qa-assets] {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -1,8 +1,11 @@
-"""Offline tests of the importer's actual embedded mappers and setup failures."""
+"""Offline regressions for QAC-01 QA corpus import behavior.
 
-from contextlib import redirect_stdout
-import hashlib
-import io
+Contracts: docs/contracts/qa-corpus.md, fuzz/CORPUS_PROVENANCE.md, and PR #747.
+Fixtures are synthetic transport bytes, not Bitcoin validity vectors.
+"""
+from __future__ import annotations
+
+import importlib.util
 import os
 from pathlib import Path
 import re
@@ -12,239 +15,77 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-
 SCRIPT = Path(__file__).resolve().parents[1] / "import-qa-assets.sh"
-_SCRIPT_TEXT = SCRIPT.read_text()
-_budget_match = re.search(r"^readonly MAX_SEED_BYTES=([0-9]+)\s+#", _SCRIPT_TEXT, re.M)
-if _budget_match is None:
-    raise RuntimeError("importer MAX_SEED_BYTES definition is missing")
-BUDGET = int(_budget_match.group(1))
-if BUDGET <= 0:
-    raise RuntimeError("importer MAX_SEED_BYTES must be positive")
-
-
-def mapper_function(name):
-    match = re.search(rf"^{name}\(\) \{{\n.*?^PYEOF\n\}}", SCRIPT.read_text(), re.M | re.S)
-    if match is None:
-        raise AssertionError(f"Missing mapper function: {name}")
-    return match.group(0)
-
-
-def mapper_body(name):
-    return mapper_function(name).split("<<'PYEOF'\n", 1)[1].rsplit("\nPYEOF", 1)[0]
+MAPPER = SCRIPT.with_name("import_qa_assets.py")
+match = re.search(r"^readonly MAX_SEED_BYTES=(\d+)", SCRIPT.read_text(), re.M)
+if match is None or int(match.group(1)) < 1:
+    raise RuntimeError("missing positive MAX_SEED_BYTES owner")
+BUDGET = int(match.group(1))
+spec = importlib.util.spec_from_file_location("qa_mapper", MAPPER)
+mapper = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mapper)
 
 
 class MapperTests(unittest.TestCase):
     def setUp(self):
-        temp = tempfile.TemporaryDirectory()
-        self.addCleanup(temp.cleanup)
-        self.root = Path(temp.name)
-        self.corpora = self.root / "qa/fuzz_corpora"
-        self.p2p = self.corpora / "p2p_deserialize_raw_net_msg"
-        self.scripts = self.corpora / "bitcoin_deserialize_script"
-        self.asm = self.corpora / "bitcoin_script_bytes_to_asm_fmt"
-        self.fuzz = self.root / "fuzz"
-        self.output = self.fuzz / "corpus"
-        self.inventory = self.root / "crates/p2p/src/compat.rs"
-        self.script_target = self.fuzz / "fuzz_targets/script_eval.rs"
-        for path in (self.p2p, self.scripts, self.asm, self.inventory.parent, self.script_target.parent):
-            path.mkdir(parents=True, exist_ok=True)
-        self.inventory.write_text('''// COMMANDS documentation mentions "decoy".
-pub const COMMANDS: &[Command] = &[
-    Command { name: "ping", status: CommandStatus::Served },
-    Command { name: "pong", status: CommandStatus::Ignored },
-];
-pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
-''')
-        self.script_target.write_text("const ELEMENT_LEN_MAX: usize = 1_024;\n")
+        self.tmp = tempfile.TemporaryDirectory(); self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name); self.corpora = self.root / "corpora"; self.out = self.root / "out"
+        names = ["p2p_deserialize_raw_net_msg", "bitcoin_deserialize_script", "bitcoin_script_bytes_to_asm_fmt",
+                 "bitcoin_deserialize_block", "bitcoin_deserialize_transaction"]
+        for name in names: (self.corpora / name).mkdir(parents=True)
+        self.inv = self.root / "compat.rs"
+        self.inv.write_text('pub const COMMANDS: &[Command] = &[Command { name: "ping" }, Command { name: "pong" }];\n')
+        self.harness = self.root / "script_eval.rs"; self.harness.write_text("const ELEMENT_LEN_MAX: usize = 1_024;\n")
 
-    def run_mapper(self, name, budget=BUDGET):
-        if name == "map_p2p":
-            args = [self.p2p, self.inventory, self.output / "p2p_message", budget]
-        else:
-            args = [self.scripts, self.asm, self.script_target, self.output / "script_eval", budget]
-        with patch.object(sys, "argv", ["-"] + [str(arg) for arg in args]), redirect_stdout(io.StringIO()):
-            exec(compile(mapper_body(name), f"{SCRIPT}:{name}", "exec"), {"__name__": "__main__"})
+    def msg(self, command: str, payload: bytes) -> None:
+        (self.corpora / "p2p_deserialize_raw_net_msg" / command).write_bytes(
+            b"\0" * 4 + command.encode().ljust(12, b"\0") + b"\0" * 8 + payload)
 
-    def assert_seed(self, target, expected):
-        path = self.output / target / hashlib.sha256(expected).hexdigest()[:32]
-        self.assertEqual(path.read_bytes(), expected)
-        self.assertLessEqual(len(expected), BUDGET)
+    def test_p2p_uses_owner_order_and_budget(self):
+        self.msg("pong", b"P" * BUDGET)
+        mapper.map_p2p(self.corpora / "p2p_deserialize_raw_net_msg", self.inv, self.out, BUDGET)
+        [seed] = self.out.iterdir()
+        data = seed.read_bytes(); self.assertEqual(data[0], 1); self.assertEqual(len(data), BUDGET)
 
-    def write_message(self, command, payload):
-        path = self.p2p / command
-        path.write_bytes(b"\0" * 4 + command.encode().ljust(12, b"\0") + b"\0" * 8 + payload)
-        return path
+    def test_invalid_inventory_fails_closed(self):
+        self.inv.write_text('pub const COMMANDS: &[Command] = &[Command { name: "ping" }, Command { name: "ping" }];')
+        with self.assertRaises(ValueError):
+            mapper.map_p2p(self.corpora / "p2p_deserialize_raw_net_msg", self.inv, self.out, BUDGET)
 
-    def test_inventory_order_and_non_inventory_strings(self):
-        self.write_message("pong", b"payload")
-        self.run_mapper("map_p2p")
-        self.assert_seed("p2p_message", b"\x01payload")
+    def test_script_frames_follow_owner_limit(self):
+        source = self.corpora / "bitcoin_deserialize_script"; (source / "s").write_bytes(b"Q" * BUDGET)
+        mapper.map_script([source, self.corpora / "bitcoin_script_bytes_to_asm_fmt"], self.harness, self.out, BUDGET)
+        data = [p.read_bytes() for p in self.out.iterdir()]
+        self.assertEqual(len(data), 2); self.assertTrue(all(len(seed) <= BUDGET for seed in data))
+        self.assertIn(b"\0\0\0\0\x04" + b"Q" * 1024 + b"\0", data)
 
-    def test_missing_or_ambiguous_inventory_fails_closed(self):
-        for inventory in ("let x = bitcoin_rs_p2p::COMMANDS;", "pub const COMMANDS: &[Command] = &[];",
-                          'pub const COMMANDS: &[Command] = &[Command { name: "ping" }, Command { name: "ping" }];'):
-            with self.subTest(inventory=inventory):
-                self.inventory.write_text(inventory)
-                with self.assertRaises(SystemExit):
-                    self.run_mapper("map_p2p")
-        self.assertFalse((self.output / "p2p_message").exists())
+    def test_direct_mapping_is_bounded_and_atomic(self):
+        source = self.corpora / "bitcoin_deserialize_block"
+        (source / "small").write_bytes(b"ok"); (source / "large").write_bytes(b"x" * BUDGET)
+        outside = self.root / "outside"; outside.write_bytes(b"preserve")
+        self.out.mkdir(); (self.out / "small").symlink_to(outside)
+        mapper.map_direct(source, self.out, BUDGET, "block")
+        self.assertEqual(outside.read_bytes(), b"preserve"); self.assertEqual((self.out / "small").read_bytes(), b"ok")
+        self.assertFalse((self.out / "small").is_symlink()); self.assertFalse((self.out / "large").exists())
+        self.assertFalse(any(p.name.startswith(".qa-import-") for p in self.out.iterdir()))
 
-    def test_short_and_unknown_messages_are_skipped(self):
-        (self.p2p / "short").write_bytes(b"\0" * 24)
-        self.write_message("unknown", b"payload")
-        self.run_mapper("map_p2p")
-        self.assertEqual(list((self.output / "p2p_message").iterdir()), [])
+    def test_missing_source_fails_before_output(self):
+        with self.assertRaises(OSError):
+            mapper.map_direct(self.root / "missing", self.out, BUDGET, "block")
+        self.assertEqual(list(self.out.iterdir()), [])
 
-    def test_p2p_budget_includes_selector(self):
-        self.write_message("ping", b"P" * BUDGET)
-        self.run_mapper("map_p2p")
-        self.assert_seed("p2p_message", b"\0" + b"P" * (BUDGET - 1))
-
-    def test_65536_byte_script_frames_match_the_harness(self):
-        script = b"Q" * BUDGET
-        (self.scripts / "boundary").write_bytes(script)
-        self.run_mapper("map_script")
-        raw = b"\0\0\0" + (1024).to_bytes(2, "little") + script[:1024] + b"\0"
-        taproot = b"\x03\0\0\x22\0\x51\x20" + script[:32] + b"\x01" + (992).to_bytes(2, "little") + script[32:1024]
-        self.assert_seed("script_eval", raw)
-        self.assert_seed("script_eval", taproot)
-        self.assertEqual(len(list((self.output / "script_eval").iterdir())), 2)
-
-    def test_script_limit_follows_the_owner_constant(self):
-        self.script_target.write_text("const ELEMENT_LEN_MAX: usize = 512;\n")
-        (self.scripts / "script").write_bytes(b"Q" * 1024)
-        self.run_mapper("map_script")
-        self.assert_seed("script_eval", b"\0\0\0\0\x02" + b"Q" * 512 + b"\0")
-
-    def test_missing_script_limit_fails_closed(self):
-        self.script_target.write_text("// no element limit\n")
-        with self.assertRaises(SystemExit):
-            self.run_mapper("map_script")
-        self.assertFalse((self.output / "script_eval").exists())
-
-    def test_short_and_empty_scripts_preserve_bytes(self):
-        for name, script in (("empty", b""), ("short", b"Q" * 31)):
-            (self.scripts / name).write_bytes(script)
-        self.run_mapper("map_script")
-        self.assert_seed("script_eval", b"\0" * 6)
-        self.assert_seed("script_eval", b"\0\0\0\x1f\0" + b"Q" * 31 + b"\0")
-
-    def test_complete_script_frames_fit_a_smaller_budget(self):
-        (self.scripts / "script").write_bytes(b"Q" * 1024)
-        self.run_mapper("map_script", budget=64)
-        for path in (self.output / "script_eval").iterdir():
-            self.assertLessEqual(path.stat().st_size, 64)
-
-    def test_corpus_reads_are_bounded_before_allocation(self):
-        p2p = self.write_message("ping", b"payload")
-        script = self.scripts / "large"
-        script.touch()
-        for path in (p2p, script):
-            with path.open("r+b") as stream:
-                stream.truncate(8 * 1024 * 1024)
-        limits = {p2p: 24 + BUDGET - 1, script: 1024}
-        reads = {}
-        original_open = Path.open
-        test = self
-
-        class GuardedReader:
-            def __init__(self, stream, path):
-                self.stream, self.path = stream, path
-
-            def __enter__(self):
-                self.stream.__enter__()
-                return self
-
-            def __exit__(self, *args):
-                return self.stream.__exit__(*args)
-
-            def read(self, size=-1):
-                test.assertGreaterEqual(size, 0, "unbounded read")
-                test.assertLessEqual(size, limits[self.path])
-                reads[self.path] = size
-                return self.stream.read(size)
-
-        def guarded_open(path, mode="r", *args, **kwargs):
-            stream = original_open(path, mode, *args, **kwargs)
-            return GuardedReader(stream, path) if path in limits and mode == "rb" else stream
-
-        with patch.object(Path, "open", guarded_open):
-            self.run_mapper("map_p2p")
-            self.run_mapper("map_script")
-        self.assertEqual(reads, limits)
-
-    def test_shell_functions_pass_the_owner_paths(self):
-        self.write_message("pong", b"payload")
-        (self.scripts / "script").write_bytes(b"Q")
-        command = '''set -euo pipefail
-CARGO_ENV=(env)
-REPO_ROOT="$1"
-CORPORA="$2"
-FUZZ_DIR="$3"
-OUT_BASE="$4"
-MAX_SEED_BYTES=65536
-'''
-        command += mapper_function("map_p2p") + "\n" + mapper_function("map_script") + "\nmap_p2p\nmap_script\n"
-        result = subprocess.run(["bash", "-c", command, "mapper-tests", str(self.root), str(self.corpora),
-                                 str(self.fuzz), str(self.output)], capture_output=True, text=True,
-                                timeout=30, check=False)
+    def test_cli_maps_all_targets(self):
+        self.msg("ping", b"p")
+        (self.corpora / "bitcoin_deserialize_script" / "s").write_bytes(b"Q")
+        for name in ("bitcoin_deserialize_block", "bitcoin_deserialize_transaction"):
+            (self.corpora / name / "seed").write_bytes(b"D")
+        repo = self.root / "repo"; (repo / "crates/p2p/src").mkdir(parents=True); (repo / "fuzz/fuzz_targets").mkdir(parents=True)
+        (repo / "crates/p2p/src/compat.rs").write_text(self.inv.read_text()); (repo / "fuzz/fuzz_targets/script_eval.rs").write_text(self.harness.read_text())
+        result = subprocess.run([sys.executable, str(MAPPER), "--corpora", str(self.corpora), "--repo-root", str(repo),
+                                 "--out-base", str(self.out), "--max-seed-bytes", str(BUDGET)], capture_output=True, text=True)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assert_seed("p2p_message", b"\x01payload")
-        self.assert_seed("script_eval", b"\0\0\0\x01\0Q\0")
+        self.assertEqual({p.name for p in self.out.iterdir()}, {"p2p_message", "script_eval", "block_decode", "tx_decode"})
 
 
-class SetupFailureTests(unittest.TestCase):
-    """Regression coverage for CONSTRAINTS.md#qa-corpus-importer-setup-contract."""
-
-    def setUp(self):
-        temp = tempfile.TemporaryDirectory()
-        self.addCleanup(temp.cleanup)
-        self.root = Path(temp.name)
-        self.bin = self.root / "bin"
-        self.bin.mkdir()
-        stubs = {
-            "git": '''[[ "${FAIL_SETUP:-}" != git ]] || exit 19
-[[ "$1" == rev-parse ]] || { touch "$TEST_ROOT/clone-attempted"; exit 98; }
-printf '%s\\n' "$TEST_ROOT"''',
-            "rustc": '''[[ "${FAIL_SETUP:-}" != rustc ]] || exit 17
-printf 'host: x86_64-unknown-linux-gnu\\n' ''',
-            "mktemp": '''[[ "${FAIL_SETUP:-}" != mktemp ]] || exit 23
-mkdir "$TEST_ROOT/staging"
-printf '%s\\n' "$TEST_ROOT/staging"''',
-            "df": '''[[ "${FAIL_SETUP:-}" != df ]] || exit 7
-printf 'Filesystem 1048576-blocks Used Available Capacity Mounted\\n'
-printf 'test 100 100 0 100%% /\\n' ''',
-        }
-        for name, body in stubs.items():
-            path = self.bin / name
-            path.write_text("#!/usr/bin/env bash\nset -eu\n" + body + "\n")
-            path.chmod(0o755)
-
-    def check_failure(self, failure, status):
-        env = dict(os.environ, PATH=f"{self.bin}{os.pathsep}{os.environ['PATH']}",
-                   TEST_ROOT=str(self.root), FAIL_SETUP=failure)
-        result = subprocess.run(["bash", str(SCRIPT)], env=env, cwd=self.root,
-                                capture_output=True, text=True, timeout=10, check=False)
-        self.assertEqual(result.returncode, status, result.stderr)
-        self.assertFalse((self.root / "staging").exists(), "failed setup leaked its working directory")
-        self.assertFalse((self.root / "clone-attempted").exists())
-
-    def test_insufficient_disk_cleans_staging(self):
-        self.check_failure("", 1)
-
-    def test_git_failure_stops_before_allocating(self):
-        self.check_failure("git", 19)
-
-    def test_rustc_failure_stops_before_allocating(self):
-        self.check_failure("rustc", 17)
-
-    def test_mktemp_failure_is_not_masked(self):
-        self.check_failure("mktemp", 23)
-
-    def test_disk_probe_failure_cleans_staging(self):
-        self.check_failure("df", 7)
-
-
-if __name__ == "__main__":
-    unittest.main()
+if __name__ == "__main__": unittest.main()

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -113,8 +113,8 @@ class ShellFlowTests(unittest.TestCase):
         self.stub("rustc", "printf 'host: x86_64-unknown-linux-gnu\\n'")
         self.stub("df", "printf 'Filesystem B U A C M\\nX 1 0 100000 0%% /\\n'")
         self.stub("du", "[[ ${FAIL:-} != du ]] || exit 31; printf '1\\tclone\\n'")
-        self.stub("date", "[[ ${FAIL:-} != date ]] || exit 47; printf '2000-01-01T00:00:00Z\\n'")
-        self.stub("cargo", "[[ ${FAIL:-} != cmin ]] || exit 43; exit 0")
+        self.stub("date", "[[ ${FAIL:-} != date ]] || exit 47; [[ -f ${TEST_ROOT}/cmin.log ]] && [[ $(cat ${TEST_ROOT}/cmin.log) == $'p2p_message\\nblock_decode\\ntx_decode\\nscript_eval' ]] || exit 48; printf '2000-01-01T00:00:00Z\\n'")
+        self.stub("cargo", "[[ ${FAIL:-} != cmin ]] || exit 43; [[ $1 == fuzz && $2 == cmin ]] || exit 99; printf '%s\\n' \"$5\" >> \"${TEST_ROOT}/cmin.log\"")
         self.stub("git", r'''
 if [[ $1 == rev-parse ]]; then printf '%s\n' "$TEST_ROOT"; exit; fi
 if [[ $1 == init ]]; then mkdir -p "${!#}/fuzz_corpora"; exit; fi
@@ -135,6 +135,8 @@ esac''')
     def test_success_replaces_provenance_after_cmin(self):
         result = self.run_import(); self.assertEqual(result.returncode, 0, result.stderr)
         text = self.prov.read_text(); self.assertIn(self.pin, text); self.assertIn("2000-01-01T00:00:00Z", text)
+        self.assertEqual((self.root / "cmin.log").read_text().splitlines(), ["p2p_message", "block_decode", "tx_decode", "script_eval"])
+        self.assertEqual(self.prov.stat().st_mode & 0o777, 0o644)
         self.assertFalse(any(self.prov.parent.glob(".corpus-provenance.*")))
 
     def test_acquisition_failures_preserve_provenance(self):

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -27,6 +27,43 @@ assert spec.loader is not None
 spec.loader.exec_module(mapper)
 
 
+class SetupFailureTests(unittest.TestCase):
+    """Regression coverage for the shell setup contract in CONSTRAINTS.md."""
+
+    def run_setup(self, failing: str):
+        with tempfile.TemporaryDirectory() as tmp:
+            bindir = Path(tmp) / "bin"; bindir.mkdir()
+            log = Path(tmp) / "log"
+            for command in ("git", "rustc", "mktemp", "df"):
+                body = "#!/bin/sh\n"
+                if command == failing:
+                    body += "exit 1\n"
+                elif command == "git":
+                    body += "printf '%s\\n' /tmp/repo\n"
+                elif command == "rustc":
+                    body += "printf 'host: x86_64-unknown-linux-gnu\\n'\n"
+                elif command == "mktemp":
+                    body += "printf '%s\\n' \"$TMPDIR/staging\"; mkdir -p \"$TMPDIR/staging\"\n"
+                else:
+                    body += "printf 'Filesystem 1024 1 1 99% /\\n'\n"
+                path = bindir / command; path.write_text(body); path.chmod(0o755)
+            result = subprocess.run(["bash", str(SCRIPT)], env={**os.environ, "PATH": str(bindir), "TMPDIR": tmp},
+                                    capture_output=True, text=True)
+            return result.returncode
+
+    def test_git_failure_status(self):
+        self.assertEqual(self.run_setup("git"), 19)
+
+    def test_nightly_failure_status(self):
+        self.assertEqual(self.run_setup("rustc"), 17)
+
+    def test_mktemp_failure_status(self):
+        self.assertEqual(self.run_setup("mktemp"), 23)
+
+    def test_disk_probe_failure_status(self):
+        self.assertEqual(self.run_setup("df"), 7)
+
+
 class MapperTests(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory(); self.addCleanup(self.tmp.cleanup)
@@ -36,7 +73,7 @@ class MapperTests(unittest.TestCase):
         for name in names: (self.corpora / name).mkdir(parents=True)
         self.inv = self.root / "compat.rs"
         self.inv.write_text('pub const COMMANDS: &[Command] = &[Command { name: "ping" }, Command { name: "pong" }];\n')
-        self.harness = self.root / "script_eval.rs"; self.harness.write_text("const ELEMENT_LEN_MAX: usize = 1_024;\n")
+        self.harness = self.root / "script_eval.rs"; self.harness.write_text("const QA_RAW_SELECTOR: usize = 0;\nconst QA_P2TR_SELECTOR: usize = 3;\nconst ELEMENT_LEN_MAX: usize = 1_024;\n")
 
     def msg(self, command: str, payload: bytes) -> None:
         (self.corpora / "p2p_deserialize_raw_net_msg" / command).write_bytes(
@@ -58,6 +95,7 @@ class MapperTests(unittest.TestCase):
         mapper.map_script([source, self.corpora / "bitcoin_script_bytes_to_asm_fmt"], self.harness, self.out, BUDGET)
         data = [p.read_bytes() for p in self.out.iterdir()]
         self.assertEqual(len(data), 2); self.assertTrue(all(len(seed) <= BUDGET for seed in data))
+        self.assertEqual({seed[0] for seed in data}, {0, 3})
         self.assertIn(b"\0\0\0\0\x04" + b"Q" * 1024 + b"\0", data)
 
     def test_direct_mapping_is_bounded_and_atomic(self):

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -88,4 +88,61 @@ class MapperTests(unittest.TestCase):
         self.assertEqual({p.name for p in self.out.iterdir()}, {"p2p_message", "script_eval", "block_decode", "tx_decode"})
 
 
+class ShellFlowTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(); self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name); self.bin = self.root / "bin"; self.bin.mkdir(); self.stage = self.root / "stage"; self.stage.mkdir()
+        scripts = self.root / "scripts"; scripts.mkdir(); (scripts / MAPPER.name).write_bytes(MAPPER.read_bytes())
+        (self.root / "crates/p2p/src").mkdir(parents=True); (self.root / "fuzz/fuzz_targets").mkdir(parents=True)
+        (self.root / "crates/p2p/src/compat.rs").write_text('pub const COMMANDS: &[Command] = &[Command { name: "ping" }];')
+        (self.root / "fuzz/fuzz_targets/script_eval.rs").write_text("const ELEMENT_LEN_MAX: usize = 1_024;\n")
+        self.prov = self.root / "fuzz/CORPUS_PROVENANCE.md"; self.prov.parent.mkdir(exist_ok=True); self.prov.write_text("old\n")
+        self.pin = re.search(r'^readonly QA_ASSETS_PIN="([0-9a-f]{40})"', SCRIPT.read_text(), re.M).group(1)
+        corpus = self.stage / "fuzz_corpora"
+        for name in ["p2p_deserialize_raw_net_msg", "bitcoin_deserialize_script", "bitcoin_script_bytes_to_asm_fmt",
+                     "bitcoin_deserialize_block", "bitcoin_deserialize_transaction"]: (corpus / name).mkdir(parents=True)
+        (corpus / "p2p_deserialize_raw_net_msg/s").write_bytes(b"\0"*4+b"ping"+b"\0"*8+b"\0"*8+b"p")
+        (corpus / "bitcoin_deserialize_script/s").write_bytes(b"Q")
+        for name in ("bitcoin_deserialize_block", "bitcoin_deserialize_transaction"): (corpus / name / "s").write_bytes(b"D")
+        self.install_stubs()
+
+    def stub(self, name, body):
+        p = self.bin / name; p.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + body + "\n"); p.chmod(0o755)
+
+    def install_stubs(self):
+        self.stub("rustc", "printf 'host: x86_64-unknown-linux-gnu\\n'")
+        self.stub("df", "printf 'Filesystem B U A C M\\nX 1 0 100000 0%% /\\n'")
+        self.stub("du", "[[ ${FAIL:-} != du ]] || exit 31; printf '1\\tclone\\n'")
+        self.stub("date", "[[ ${FAIL:-} != date ]] || exit 47; printf '2000-01-01T00:00:00Z\\n'")
+        self.stub("cargo", "[[ ${FAIL:-} != cmin ]] || exit 43; exit 0")
+        self.stub("git", r'''
+if [[ $1 == rev-parse ]]; then printf '%s\n' "$TEST_ROOT"; exit; fi
+if [[ $1 == init ]]; then mkdir -p "${!#}/fuzz_corpora"; exit; fi
+[[ $1 == -C ]] || exit 99
+case "$3" in
+ remote|fetch) exit 0 ;;
+ checkout) cp -a "$SOURCE/." "$2/" ;;
+ rev-parse) [[ ${FAIL:-} != git_head ]] || exit 29; printf '%s\n' "$PIN" ;;
+ *) exit 99 ;;
+esac''')
+
+    def run_import(self, fail=""):
+        env = dict(os.environ, PATH=f"{self.bin}{os.pathsep}{os.environ['PATH']}", TEST_ROOT=str(self.root), SOURCE=str(self.stage), PIN=self.pin,
+                   TMPDIR=str(self.root / "tmp"), FAIL=fail, RUSTC_WRAPPER="x", CARGO_BUILD_BUILD_DIR="x")
+        Path(env["TMPDIR"]).mkdir(exist_ok=True)
+        return subprocess.run(["bash", str(SCRIPT)], cwd=self.root, env=env, capture_output=True, text=True, timeout=15)
+
+    def test_success_replaces_provenance_after_cmin(self):
+        result = self.run_import(); self.assertEqual(result.returncode, 0, result.stderr)
+        text = self.prov.read_text(); self.assertIn(self.pin, text); self.assertIn("2000-01-01T00:00:00Z", text)
+        self.assertFalse(any(self.prov.parent.glob(".corpus-provenance.*")))
+
+    def test_acquisition_failures_preserve_provenance(self):
+        for fail, code in (("git_head", 29), ("du", 31), ("cmin", 43), ("date", 47)):
+            with self.subTest(fail=fail):
+                self.prov.write_text("old\n"); result = self.run_import(fail)
+                self.assertEqual(result.returncode, code, result.stderr); self.assertEqual(self.prov.read_text(), "old\n")
+                self.assertFalse(any(self.prov.parent.glob(".corpus-provenance.*")))
+
+
 if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
## Summary

First atomic follow-up to merged #747.

- Move seed transformation into a single Python mapper module instead of embedded Python plus per-file `stat`/`basename`/`cp` subprocesses.
- Stream corpus directory entries and bound reads before allocation.
- Preserve harness-owned P2P command ordering and script element limits.
- Publish each seed through a same-directory temporary file and `os.replace`, so failed writes do not expose partial destination bytes and pre-existing destination symlinks are not followed.
- Keep the permanent tests contract-focused: QAC-01, importer-owned `MAX_SEED_BYTES`, harness-owned metadata, direct-copy byte preservation, missing-source errors, and atomic/symlink-safe publication.

Atomicity is per seed file. This does not claim a transaction across the whole corpus or crash durability.

## Local verification

- `python3 -m unittest discover -s scripts/tests -p test_import_qa_assets.py -v` — **6/6 passed** against this exact slice.
- `bash -n scripts/import-qa-assets.sh` — passed.
- `python3 -m py_compile scripts/import_qa_assets.py scripts/tests/test_import_qa_assets.py` — passed.

## Known validation gap

Repository instructions require Clippy before publication, but this execution environment does not provide `cargo`; Clippy and the CL-14 Cargo resource-bound gate could not be run locally. CI is required before this draft should be promoted or merged.

## Scope

One commit from main `76baf086b861057f5700da34c4ad0d4f5aab5966`, changing only `scripts/import-qa-assets.sh`, adding `scripts/import_qa_assets.py`, and tightening `scripts/tests/test_import_qa_assets.py`. No Rust source, consensus behavior, corpus data, historical provenance, force-push, merge, or auto-merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams QA corpus imports through a bounded Python mapper and publishes both seeds and provenance atomically, so failed runs leave no partial output behind.

- Replaces the shell's embedded Python and per-file `stat`/`basename`/`cp` subprocesses with a single `scripts/import_qa_assets.py` mapper that streams corpus entries and bounds reads before allocation.
- Publishes each seed via a same-directory temp file and `os.replace`; failed writes expose no partial destination bytes and pre-existing destination symlinks are not followed.
- Stages `CORPUS_PROVENANCE.md` beside its destination at mode 0644 and renames it into place only after minimization completes; a directory at the destination aborts the import.
- Setup, acquisition, and timestamp failures now exit with explicit status codes (git 19, rustc 17, mktemp 23, df 7) instead of continuing with empty values.
- Script selectors are parsed from the harness's `QA_RAW_SELECTOR` and `QA_P2TR_SELECTOR` constants.
- Atomicity is per seed file; no transaction spans the whole corpus and there is no crash durability.
- Clippy and the CL-14 cargo resource-bound gate could not run locally (no `cargo` in this environment); CI is required before merge.

<sup>Written for commit abb04215877164c57b69f23e42b929071370e161. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

