### PR TITLE
fix(fuzz): preserve acquisition failures and atomically publish provenance

### DIFF
--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -46,7 +46,13 @@ available_mb() { df -Pm "$1" | awk 'NR == 2 { print $4 }'; }
 
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/qa-assets.XXXXXX")"
 readonly WORKDIR
-cleanup() { rm -rf -- "${WORKDIR:?workdir unset}"; }
+PROVENANCE_TMP=""
+cleanup() {
+    if [[ -n "${PROVENANCE_TMP}" ]]; then
+        rm -f -- "${PROVENANCE_TMP}"
+    fi
+    rm -rf -- "${WORKDIR:?workdir unset}"
+}
 trap cleanup EXIT
 trap 'exit 129' HUP
 trap 'exit 130' INT
@@ -73,12 +79,14 @@ git init --quiet "${WORKDIR}/qa-assets"
 git -C "${WORKDIR}/qa-assets" remote add origin "${QA_ASSETS_URL}"
 git -C "${WORKDIR}/qa-assets" fetch --depth 1 --quiet origin "${QA_ASSETS_PIN}"
 git -C "${WORKDIR}/qa-assets" checkout --quiet FETCH_HEAD
-readonly UPSTREAM_COMMIT="$(git -C "${WORKDIR}/qa-assets" rev-parse HEAD)"
+UPSTREAM_COMMIT="$(git -C "${WORKDIR}/qa-assets" rev-parse HEAD)"
+readonly UPSTREAM_COMMIT
 [ "${UPSTREAM_COMMIT}" = "${QA_ASSETS_PIN}" ] || {
     log "ABORT: fetched ${UPSTREAM_COMMIT}, expected pin ${QA_ASSETS_PIN}"
     exit 1
 }
-readonly UPSTREAM_SIZE_MB="$(du -sm "${WORKDIR}/qa-assets" | cut -f1)"
+UPSTREAM_SIZE_MB="$(du -sm "${WORKDIR}/qa-assets" | cut -f1)"
+readonly UPSTREAM_SIZE_MB
 log "clone at ${UPSTREAM_COMMIT} (${UPSTREAM_SIZE_MB} MiB actual)"
 
 readonly CORPORA="${WORKDIR}/qa-assets/fuzz_corpora"
@@ -100,8 +108,11 @@ readonly OUT_BASE="${FUZZ_DIR}/corpus"
 
 # --- 5. Provenance ------------------------------------------------------------
 readonly PROVENANCE="${FUZZ_DIR}/CORPUS_PROVENANCE.md"
-readonly IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-cat > "${PROVENANCE}" <<EOF
+IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+readonly IMPORT_DATE
+# Stage beside the destination: failed writes leave the previous record intact.
+PROVENANCE_TMP="$(mktemp "${FUZZ_DIR}/.corpus-provenance.XXXXXX")"
+cat > "${PROVENANCE_TMP}" <<EOF
 # Fuzz corpus provenance
 
 Seeds under fuzz/corpus/ were imported from
@@ -129,6 +140,8 @@ Corpora were minimized with cargo fuzz cmin after import; only minimized
 seeds are tracked here. Re-run the script after major decoder changes to
 refresh.
 EOF
+mv -T -- "${PROVENANCE_TMP}" "${PROVENANCE}"
+PROVENANCE_TMP=""
 log "provenance written to ${PROVENANCE}"
 
 # --- 6. Delete the clone (only minimized corpora are kept) --------------------

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -140,7 +140,9 @@ Corpora were minimized with cargo fuzz cmin after import; only minimized
 seeds are tracked here. Re-run the script after major decoder changes to
 refresh.
 EOF
-mv -T -- "${PROVENANCE_TMP}" "${PROVENANCE}"
+chmod 0644 "${PROVENANCE_TMP}"
+[[ ! -d "${PROVENANCE}" ]] || { echo "provenance destination is a directory" >&2; exit 1; }
+mv "${PROVENANCE_TMP}" "${PROVENANCE}"
 PROVENANCE_TMP=""
 log "provenance written to ${PROVENANCE}"
 

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -113,8 +113,8 @@ class ShellFlowTests(unittest.TestCase):
         self.stub("rustc", "printf 'host: x86_64-unknown-linux-gnu\\n'")
         self.stub("df", "printf 'Filesystem B U A C M\\nX 1 0 100000 0%% /\\n'")
         self.stub("du", "[[ ${FAIL:-} != du ]] || exit 31; printf '1\\tclone\\n'")
-        self.stub("date", "[[ ${FAIL:-} != date ]] || exit 47; printf '2000-01-01T00:00:00Z\\n'")
-        self.stub("cargo", "[[ ${FAIL:-} != cmin ]] || exit 43; exit 0")
+        self.stub("date", "[[ ${FAIL:-} != date ]] || exit 47; [[ -f ${TEST_ROOT}/cmin.log ]] && [[ $(cat ${TEST_ROOT}/cmin.log) == $'p2p_message\\nblock_decode\\ntx_decode\\nscript_eval' ]] || exit 48; printf '2000-01-01T00:00:00Z\\n'")
+        self.stub("cargo", "[[ ${FAIL:-} != cmin ]] || exit 43; [[ $1 == fuzz && $2 == cmin ]] || exit 99; printf '%s\\n' \"$5\" >> \"${TEST_ROOT}/cmin.log\"")
         self.stub("git", r'''
 if [[ $1 == rev-parse ]]; then printf '%s\n' "$TEST_ROOT"; exit; fi
 if [[ $1 == init ]]; then mkdir -p "${!#}/fuzz_corpora"; exit; fi
@@ -135,6 +135,8 @@ esac''')
     def test_success_replaces_provenance_after_cmin(self):
         result = self.run_import(); self.assertEqual(result.returncode, 0, result.stderr)
         text = self.prov.read_text(); self.assertIn(self.pin, text); self.assertIn("2000-01-01T00:00:00Z", text)
+        self.assertEqual((self.root / "cmin.log").read_text().splitlines(), ["p2p_message", "block_decode", "tx_decode", "script_eval"])
+        self.assertEqual(self.prov.stat().st_mode & 0o777, 0o644)
         self.assertFalse(any(self.prov.parent.glob(".corpus-provenance.*")))
 
     def test_acquisition_failures_preserve_provenance(self):

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -88,4 +88,61 @@ class MapperTests(unittest.TestCase):
         self.assertEqual({p.name for p in self.out.iterdir()}, {"p2p_message", "script_eval", "block_decode", "tx_decode"})
 
 
+class ShellFlowTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(); self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name); self.bin = self.root / "bin"; self.bin.mkdir(); self.stage = self.root / "stage"; self.stage.mkdir()
+        scripts = self.root / "scripts"; scripts.mkdir(); (scripts / MAPPER.name).write_bytes(MAPPER.read_bytes())
+        (self.root / "crates/p2p/src").mkdir(parents=True); (self.root / "fuzz/fuzz_targets").mkdir(parents=True)
+        (self.root / "crates/p2p/src/compat.rs").write_text('pub const COMMANDS: &[Command] = &[Command { name: "ping" }];')
+        (self.root / "fuzz/fuzz_targets/script_eval.rs").write_text("const ELEMENT_LEN_MAX: usize = 1_024;\n")
+        self.prov = self.root / "fuzz/CORPUS_PROVENANCE.md"; self.prov.parent.mkdir(exist_ok=True); self.prov.write_text("old\n")
+        self.pin = re.search(r'^readonly QA_ASSETS_PIN="([0-9a-f]{40})"', SCRIPT.read_text(), re.M).group(1)
+        corpus = self.stage / "fuzz_corpora"
+        for name in ["p2p_deserialize_raw_net_msg", "bitcoin_deserialize_script", "bitcoin_script_bytes_to_asm_fmt",
+                     "bitcoin_deserialize_block", "bitcoin_deserialize_transaction"]: (corpus / name).mkdir(parents=True)
+        (corpus / "p2p_deserialize_raw_net_msg/s").write_bytes(b"\0"*4+b"ping"+b"\0"*8+b"\0"*8+b"p")
+        (corpus / "bitcoin_deserialize_script/s").write_bytes(b"Q")
+        for name in ("bitcoin_deserialize_block", "bitcoin_deserialize_transaction"): (corpus / name / "s").write_bytes(b"D")
+        self.install_stubs()
+
+    def stub(self, name, body):
+        p = self.bin / name; p.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + body + "\n"); p.chmod(0o755)
+
+    def install_stubs(self):
+        self.stub("rustc", "printf 'host: x86_64-unknown-linux-gnu\\n'")
+        self.stub("df", "printf 'Filesystem B U A C M\\nX 1 0 100000 0%% /\\n'")
+        self.stub("du", "[[ ${FAIL:-} != du ]] || exit 31; printf '1\\tclone\\n'")
+        self.stub("date", "[[ ${FAIL:-} != date ]] || exit 47; printf '2000-01-01T00:00:00Z\\n'")
+        self.stub("cargo", "[[ ${FAIL:-} != cmin ]] || exit 43; exit 0")
+        self.stub("git", r'''
+if [[ $1 == rev-parse ]]; then printf '%s\n' "$TEST_ROOT"; exit; fi
+if [[ $1 == init ]]; then mkdir -p "${!#}/fuzz_corpora"; exit; fi
+[[ $1 == -C ]] || exit 99
+case "$3" in
+ remote|fetch) exit 0 ;;
+ checkout) cp -a "$SOURCE/." "$2/" ;;
+ rev-parse) [[ ${FAIL:-} != git_head ]] || exit 29; printf '%s\n' "$PIN" ;;
+ *) exit 99 ;;
+esac''')
+
+    def run_import(self, fail=""):
+        env = dict(os.environ, PATH=f"{self.bin}{os.pathsep}{os.environ['PATH']}", TEST_ROOT=str(self.root), SOURCE=str(self.stage), PIN=self.pin,
+                   TMPDIR=str(self.root / "tmp"), FAIL=fail, RUSTC_WRAPPER="x", CARGO_BUILD_BUILD_DIR="x")
+        Path(env["TMPDIR"]).mkdir(exist_ok=True)
+        return subprocess.run(["bash", str(SCRIPT)], cwd=self.root, env=env, capture_output=True, text=True, timeout=15)
+
+    def test_success_replaces_provenance_after_cmin(self):
+        result = self.run_import(); self.assertEqual(result.returncode, 0, result.stderr)
+        text = self.prov.read_text(); self.assertIn(self.pin, text); self.assertIn("2000-01-01T00:00:00Z", text)
+        self.assertFalse(any(self.prov.parent.glob(".corpus-provenance.*")))
+
+    def test_acquisition_failures_preserve_provenance(self):
+        for fail, code in (("git_head", 29), ("du", 31), ("cmin", 43), ("date", 47)):
+            with self.subTest(fail=fail):
+                self.prov.write_text("old\n"); result = self.run_import(fail)
+                self.assertEqual(result.returncode, code, result.stderr); self.assertEqual(self.prov.read_text(), "old\n")
+                self.assertFalse(any(self.prov.parent.glob(".corpus-provenance.*")))
+
+
 if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
## Summary

Second atomic follow-up, stacked on #763.

- Preserve failures from upstream commit lookup and clone-size measurement instead of allowing `readonly VAR="$(...)"` to mask command status.
- Preserve timestamp-generation failures for provenance.
- Stage `CORPUS_PROVENANCE.md` beside its destination and publish with a single rename only after the complete record is written.
- Clean provenance staging on normal failure and termination.
- Add shell-flow regressions proving successful publication happens after minimization and acquisition/minimization/timestamp failures preserve the previous provenance file.

This PR intentionally depends on #763's mapper extraction and seed-publication work. After #763 merges, this branch can be retargeted to `main` without changing its single logical commit.

## Local verification

- Importer suite at the stacked final state — **8/8 passed**.
- Combined downloader/importer discovery printed **16/16 `OK`** before the host wrapper reported its timeout boundary.
- `bash -n scripts/import-qa-assets.sh` — passed.
- `python3 -m py_compile scripts/import_qa_assets.py scripts/tests/test_import_qa_assets.py` — passed.
- `git diff --check` — passed.

## Known validation gap

`cargo` is unavailable in this execution environment, so the repository-required Clippy run and CL-14 Cargo resource-bound gate remain locally blocked. CI must complete before promotion or merge.

## Scope

One commit on top of #763. Only `scripts/import-qa-assets.sh` and its importer regression test change in this slice. No Rust source, consensus behavior, corpus regeneration, historical provenance rewrite, force-push, merge, or auto-merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `readonly VAR="$(...)"` substitutions in the import script from masking command failures, and publishes provenance atomically so failed runs preserve the last good `CORPUS_PROVENANCE.md`.

- `UPSTREAM_COMMIT`, `UPSTREAM_SIZE_MB`, and `IMPORT_DATE` are computed before `readonly`; commit lookup, clone-size, and timestamp failures now abort with their original exit codes.
- Provenance is written to a staged temp file beside its destination, set to mode 0644, and renamed into place only after the full record is complete; a directory at the destination aborts the import.
- Staging files are removed on normal failure and on HUP, INT, and TERM.
- Regression tests cover successful publication, mode 0644, minimization order, and preservation on `git rev-parse`, `du`, `cmin`, and `date` failures.

<sup>Written for commit 8a15d2146145ad86be26864f2a480f9531be2fc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

