### PR TITLE
fix(fuzz): fail closed on incomplete imports and remove per-seed subprocesses

### DIFF
--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -120,10 +120,16 @@ candidate baselines before production edits; owner gates append final values.
 
 ## QA corpus importer setup contract
 
-The versioned setup contract for `scripts/import-qa-assets.sh` is: a failure of
-`git rev-parse` exits with status 19, a failure of the nightly `rustc` host
-probe exits with status 17, a failure of `mktemp` exits with status 23, a disk
-probe failure exits with status 7, and an insufficient-space check exits with
-status 1. Every setup failure removes the temporary staging directory and does
-not attempt the clone. `scripts/tests/test_import_qa_assets.py`
-`SetupFailureTests` is the regression suite for this contract.
+The setup commands in `scripts/import-qa-assets.sh` preserve the failing
+command or pipeline's nonzero exit status; they do not remap external errors
+to fixed importer codes. `SetupFailureTests` in
+`scripts/tests/test_import_qa_assets.py` injects statuses such as 19, 17, 23,
+and 7 to verify propagation. Those numbers are fixture inputs, not a public
+exit-code inventory. Bash assignment and `pipefail` semantics are the
+independent reference for propagation.
+
+An absent host triple or a failed disk-capacity comparison exits with status
+1 before cloning. Setup failure cleans any successfully acquired staging
+directory and does not attempt the clone. Corpus mapping and successful-import
+provenance remain owned by `fuzz/CORPUS_PROVENANCE.md` under `QAC-01`; this
+section does not define a second corpus policy.

--- a/docs/contracts/qa-corpus.md
+++ b/docs/contracts/qa-corpus.md
@@ -18,6 +18,8 @@ end-state evidence roles.
   `script_eval.rs`.
 - Provenance rows must be updated in the same commit as any corpus re-import via
   `scripts/import-qa-assets.sh`.
+- Import scope is limited to regular files directly inside each named source
+  directory: nested-directory entries and symbolic links are not imported.
 
 ### `QAC-02`: End-state evidence roles
 

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -35,6 +35,10 @@ readonly MAX_SEED_BYTES=65536      # keep individual seeds bounded
 # defaults to the musl target.
 HOST_TRIPLE="$(rustc +nightly -vV | sed -n 's/^host: //p')"
 readonly HOST_TRIPLE
+if [[ -z "${HOST_TRIPLE}" ]]; then
+    printf 'Cannot determine the nightly Rust host triple\n' >&2
+    exit 1
+fi
 CARGO_ENV=(env -u RUSTC_WRAPPER -u CARGO_BUILD_BUILD_DIR RUSTUP_TOOLCHAIN=nightly)
 
 log() { printf '[import-qa-assets] %s\n' "$*"; }
@@ -57,8 +61,10 @@ FREE_REPO_MB="$(available_mb "${REPO_ROOT:?repo root unset}")"
 readonly FREE_TMP_MB FREE_REPO_MB
 readonly NEEDED_MB=$((FOOTPRINT_ASSUME_MB + RESERVE_MB))
 readonly NEEDED_REPO_MB=256
-if [ "${FREE_TMP_MB:?free space unknown}" -lt "${NEEDED_MB}" ] ||
-    [ "${FREE_REPO_MB:?free space unknown}" -lt "${NEEDED_REPO_MB}" ]; then
+# Failure to establish either lower bound is an abort, including malformed
+# or out-of-range readings. A failed -lt comparison must not grant permission.
+if ! [ "${FREE_TMP_MB:?free space unknown}" -ge "${NEEDED_MB}" ] ||
+    ! [ "${FREE_REPO_MB:?free space unknown}" -ge "${NEEDED_REPO_MB}" ]; then
     log "ABORT: free ${FREE_TMP_MB} MiB (tmp) / ${FREE_REPO_MB} MiB (repo) < needed ${NEEDED_MB} / ${NEEDED_REPO_MB} MiB (footprint ${FOOTPRINT_ASSUME_MB} + reserve ${RESERVE_MB})"
     exit 1
 fi
@@ -73,12 +79,14 @@ git init --quiet "${WORKDIR}/qa-assets"
 git -C "${WORKDIR}/qa-assets" remote add origin "${QA_ASSETS_URL}"
 git -C "${WORKDIR}/qa-assets" fetch --depth 1 --quiet origin "${QA_ASSETS_PIN}"
 git -C "${WORKDIR}/qa-assets" checkout --quiet FETCH_HEAD
-readonly UPSTREAM_COMMIT="$(git -C "${WORKDIR}/qa-assets" rev-parse HEAD)"
+UPSTREAM_COMMIT="$(git -C "${WORKDIR}/qa-assets" rev-parse HEAD)"
+readonly UPSTREAM_COMMIT
 [ "${UPSTREAM_COMMIT}" = "${QA_ASSETS_PIN}" ] || {
     log "ABORT: fetched ${UPSTREAM_COMMIT}, expected pin ${QA_ASSETS_PIN}"
     exit 1
 }
-readonly UPSTREAM_SIZE_MB="$(du -sm "${WORKDIR}/qa-assets" | cut -f1)"
+UPSTREAM_SIZE_MB="$(du -sm "${WORKDIR}/qa-assets" | cut -f1)"
+readonly UPSTREAM_SIZE_MB
 log "clone at ${UPSTREAM_COMMIT} (${UPSTREAM_SIZE_MB} MiB actual)"
 
 readonly CORPORA="${WORKDIR}/qa-assets/fuzz_corpora"
@@ -114,7 +122,7 @@ imported = skipped_short = unknown_cmd = 0
 for path in sorted(corpus_dir.iterdir()):
     with path.open("rb") as source:
         blob = source.read(24 + max_bytes - 1)
-    if len(blob) <= 24:
+    if len(blob) < 24:
         skipped_short += 1
         continue
     command = blob[4:16].split(b"\0", 1)[0]
@@ -182,18 +190,33 @@ PYEOF
 # fuzz targets' own input caps) and the skip count is recorded so the mapping
 # stays honest about what it left behind.
 map_direct() {
-    local src="$1" dst="$2" name="$3"
-    mkdir -p "${dst:?}"
-    local count=0 skipped=0
-    while IFS= read -r -d '' file; do
-        if [ "$(stat -c %s -- "${file:?}")" -ge "${MAX_SEED_BYTES}" ]; then
-            skipped=$((skipped + 1))
-            continue
-        fi
-        cp -- "${file:?}" "${dst}/$(basename -- "${file:?}")"
-        count=$((count + 1))
-    done < <(find "${src:?}" -maxdepth 1 -type f -print0 | sort -z)
-    log "${name}: imported=${count} skipped_oversize=${skipped} (>= ${MAX_SEED_BYTES} bytes)"
+    "${CARGO_ENV[@]}" python3 - "$1" "$2" "$3" "${MAX_SEED_BYTES}" <<'PYEOF'
+import os
+import sys
+from pathlib import Path
+
+src, dst, name, max_bytes = Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3], int(sys.argv[4])
+# Opening the directory must succeed before an empty import can be reported.
+with os.scandir(src) as entries:
+    files = sorted(entries, key=lambda entry: entry.name)
+dst.mkdir(parents=True, exist_ok=True)
+imported = skipped = 0
+for entry in files:
+    if not entry.is_file(follow_symlinks=False):
+        continue
+    if entry.stat(follow_symlinks=False).st_size >= max_bytes:
+        skipped += 1
+        continue
+    with open(entry.path, "rb") as source:
+        seed = source.read(max_bytes)
+    # Recheck the bytes actually read in case a file grew after stat.
+    if len(seed) >= max_bytes:
+        skipped += 1
+        continue
+    (dst / entry.name).write_bytes(seed)
+    imported += 1
+print(f"[import-qa-assets] {name}: imported={imported} skipped_oversize={skipped} (>= {max_bytes} bytes)")
+PYEOF
 }
 map_p2p
 map_script
@@ -208,7 +231,8 @@ map_direct "${CORPORA}/bitcoin_deserialize_transaction" "${OUT_BASE}/tx_decode" 
 
 # --- 7. Provenance ------------------------------------------------------------
 readonly PROVENANCE="${FUZZ_DIR}/CORPUS_PROVENANCE.md"
-readonly IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+IMPORT_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+readonly IMPORT_DATE
 cat > "${PROVENANCE}" <<EOF
 # Fuzz corpus provenance
 

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -1,4 +1,17 @@
-"""Offline tests of the importer's actual embedded mappers and setup failures."""
+"""Offline tests of the importer's actual mappers and setup failures.
+
+Contract: docs/contracts/qa-corpus.md QAC-01 and fuzz/CORPUS_PROVENANCE.md
+own the corpus mapping and successful-import provenance. The P2P harness
+accepts a selector with an empty payload. Seed budgets come from the importer.
+Fixture metadata and byte strings below are independent synthetic inputs,
+not consensus vectors or candidate-derived expected outputs.
+
+Setup failures must abort before cloning and clean acquired staging storage.
+The injected command statuses (for example, 7, 17, 19, 23) are test sentinels, not a public
+exit-code inventory. Bash assignment/errexit behavior is the external reference:
+https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
+Regression context: https://github.com/gosuda/bitcoin-rs/pull/747
+"""
 
 from contextlib import redirect_stdout
 import hashlib
@@ -23,8 +36,9 @@ if BUDGET <= 0:
     raise RuntimeError("importer MAX_SEED_BYTES must be positive")
 
 
+
 def mapper_function(name):
-    match = re.search(rf"^{name}\(\) \{{\n.*?^PYEOF\n\}}", SCRIPT.read_text(), re.M | re.S)
+    match = re.search(rf"^{name}\(\) \{{\n.*?^\}}", SCRIPT.read_text(), re.M | re.S)
     if match is None:
         raise AssertionError(f"Missing mapper function: {name}")
     return match.group(0)
@@ -81,6 +95,12 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
         self.run_mapper("map_p2p")
         self.assert_seed("p2p_message", b"\x01payload")
 
+    def test_header_only_known_message_preserves_empty_payload(self):
+        self.inventory.write_text('pub const COMMANDS: &[Command] = &[Command { name: "verack" }];')
+        self.write_message("verack", b"")
+        self.run_mapper("map_p2p")
+        self.assert_seed("p2p_message", b"\0")
+
     def test_missing_or_ambiguous_inventory_fails_closed(self):
         for inventory in ("let x = bitcoin_rs_p2p::COMMANDS;", "pub const COMMANDS: &[Command] = &[];",
                           'pub const COMMANDS: &[Command] = &[Command { name: "ping" }, Command { name: "ping" }];'):
@@ -102,7 +122,7 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
         self.assert_seed("p2p_message", b"\0" + b"P" * (BUDGET - 1))
 
     def test_65536_byte_script_frames_match_the_harness(self):
-        script = b"Q" * BUDGET
+        script = b"Q" * (1 << 16)  # u16 framing boundary, independent of the seed budget
         (self.scripts / "boundary").write_bytes(script)
         self.run_mapper("map_script")
         raw = b"\0\0\0" + (1024).to_bytes(2, "little") + script[:1024] + b"\0"
@@ -183,11 +203,11 @@ REPO_ROOT="$1"
 CORPORA="$2"
 FUZZ_DIR="$3"
 OUT_BASE="$4"
-MAX_SEED_BYTES=65536
+MAX_SEED_BYTES="$5"
 '''
         command += mapper_function("map_p2p") + "\n" + mapper_function("map_script") + "\nmap_p2p\nmap_script\n"
         result = subprocess.run(["bash", "-c", command, "mapper-tests", str(self.root), str(self.corpora),
-                                 str(self.fuzz), str(self.output)], capture_output=True, text=True,
+                                 str(self.fuzz), str(self.output), str(BUDGET)], capture_output=True, text=True,
                                 timeout=30, check=False)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_seed("p2p_message", b"\x01payload")
@@ -208,13 +228,19 @@ class SetupFailureTests(unittest.TestCase):
 [[ "$1" == rev-parse ]] || { touch "$TEST_ROOT/clone-attempted"; exit 98; }
 printf '%s\\n' "$TEST_ROOT"''',
             "rustc": '''[[ "${FAIL_SETUP:-}" != rustc ]] || exit 17
+[[ "${FAIL_SETUP:-}" != missing_host ]] || exit 0
 printf 'host: x86_64-unknown-linux-gnu\\n' ''',
-            "mktemp": '''[[ "${FAIL_SETUP:-}" != mktemp ]] || exit 23
+            "mktemp": '''touch "$TEST_ROOT/mktemp-called"
+[[ "${FAIL_SETUP:-}" != mktemp ]] || exit 23
 mkdir "$TEST_ROOT/staging"
 printf '%s\\n' "$TEST_ROOT/staging"''',
             "df": '''[[ "${FAIL_SETUP:-}" != df ]] || exit 7
 printf 'Filesystem 1048576-blocks Used Available Capacity Mounted\\n'
-printf 'test 100 100 0 100%% /\\n' ''',
+if [[ "${FAIL_SETUP:-}" == invalid_disk ]]; then
+    printf 'test 100 0 invalid 0%% /\\n'
+else
+    printf 'test 100 100 0 100%% /\\n'
+fi ''',
         }
         for name, body in stubs.items():
             path = self.bin / name
@@ -229,6 +255,8 @@ printf 'test 100 100 0 100%% /\\n' ''',
         self.assertEqual(result.returncode, status, result.stderr)
         self.assertFalse((self.root / "staging").exists(), "failed setup leaked its working directory")
         self.assertFalse((self.root / "clone-attempted").exists())
+        if failure in ("git", "rustc", "missing_host"):
+            self.assertFalse((self.root / "mktemp-called").exists())
 
     def test_insufficient_disk_cleans_staging(self):
         self.check_failure("", 1)
@@ -242,8 +270,201 @@ printf 'test 100 100 0 100%% /\\n' ''',
     def test_mktemp_failure_is_not_masked(self):
         self.check_failure("mktemp", 23)
 
+    def test_missing_host_stops_before_allocating(self):
+        self.check_failure("missing_host", 1)
+
+    def test_malformed_disk_probe_fails_closed(self):
+        self.check_failure("invalid_disk", 1)
+
     def test_disk_probe_failure_cleans_staging(self):
         self.check_failure("df", 7)
+
+    def test_external_failure_statuses_are_not_remapped(self):
+        for command, old_status, status in (("git", 19, 61), ("rustc", 17, 62),
+                                             ("mktemp", 23, 63), ("df", 7, 64)):
+            with self.subTest(command=command):
+                stub = self.bin / command
+                stub.write_text(stub.read_text().replace(f"exit {old_status}", f"exit {status}"))
+                self.check_failure(command, status)
+
+
+class DirectMappingTests(unittest.TestCase):
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        self.source = self.root / "source"
+        self.source.mkdir()
+        self.output = self.root / "output"
+
+    def run_direct(self):
+        command = """set -euo pipefail
+CARGO_ENV=(env)
+MAX_SEED_BYTES="$3"
+log() { printf '[import-qa-assets] %s\\n' "$*"; }
+"""
+        command += mapper_function("map_direct") + '\nmap_direct "$1" "$2" block_decode\n'
+        return subprocess.run(
+            ["bash", "-c", command, "direct-tests", str(self.source), str(self.output), str(BUDGET)],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+
+    def test_missing_source_cannot_report_success(self):
+        self.source.rmdir()
+        result = self.run_direct()
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertNotIn("imported=", result.stdout)
+
+    def test_exact_byte_mapping_and_size_boundary(self):
+        (self.source / "empty").touch()
+        retained = bytes(range(256)) * ((BUDGET - 1) // 256) + b"x" * ((BUDGET - 1) % 256)
+        (self.source / "last accepted").write_bytes(retained)
+        for name, size in (("at-limit", BUDGET), ("over-limit", BUDGET + 1)):
+            with (self.source / name).open("wb") as output:
+                output.truncate(size)
+        result = self.run_direct()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual({p.name for p in self.output.iterdir()}, {"empty", "last accepted"})
+        self.assertEqual((self.output / "last accepted").read_bytes(), retained)
+        self.assertEqual((self.output / "empty").read_bytes(), b"")
+        self.assertIn("imported=2 skipped_oversize=2", result.stdout)
+
+    def test_nested_directories_and_symlinks_are_not_imported(self):
+        nested = self.source / "nested"
+        nested.mkdir()
+        (nested / "seed").write_bytes(b"nested bytes")
+        (self.source / "link").symlink_to(nested / "seed")
+        (self.source / "broken").symlink_to(self.source / "absent")
+        result = self.run_direct()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(list(self.output.iterdir()), [])
+        self.assertIn("imported=0 skipped_oversize=0", result.stdout)
+
+    def test_filenames_are_not_interpreted_as_shell_syntax(self):
+        names = ("line\nbreak", "-option", "white space", "semi;colon", "$(touch injected)")
+        for name in names:
+            (self.source / name).write_bytes(name.encode())
+        result = self.run_direct()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual({p.name for p in self.output.iterdir()}, set(names))
+        for name in names:
+            self.assertEqual((self.output / name).read_bytes(), name.encode())
+
+
+class ImportFlowTests(unittest.TestCase):
+    """Execute the entry point, replacing only Git/Rust and failure probes.
+
+    QAC-01 provenance is a success record: failed acquisition, measurement,
+    or minimization must not replace the previous provenance document.
+    The four target names below come from that contract's explicit scope.
+    """
+
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory(prefix="qa import flow ")
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.upstream = self.root / "upstream"
+        self.tmp = self.root / "tmp"
+        self.tmp.mkdir()
+        self.provenance = self.root / "fuzz/CORPUS_PROVENANCE.md"
+        self.provenance.parent.mkdir()
+        self.provenance.write_text("previous provenance\n")
+        self.log = self.root / "minimize.log"
+        self.pin = re.search(r'^readonly QA_ASSETS_PIN="([0-9a-f]{40})"', SCRIPT.read_text(), re.M).group(1)
+        for corpus in ("p2p_deserialize_raw_net_msg", "bitcoin_deserialize_script",
+                       "bitcoin_script_bytes_to_asm_fmt", "bitcoin_deserialize_block",
+                       "bitcoin_deserialize_transaction"):
+            (self.upstream / "fuzz_corpora" / corpus).mkdir(parents=True)
+        (self.upstream / "fuzz_corpora/p2p_deserialize_raw_net_msg/verack").write_bytes(
+            b"\0" * 4 + b"verack" + b"\0" * 14)
+        (self.upstream / "fuzz_corpora/bitcoin_deserialize_script/script").write_bytes(b"Q" * 32)
+        (self.upstream / "fuzz_corpora/bitcoin_deserialize_block/block").write_bytes(b"block bytes")
+        (self.upstream / "fuzz_corpora/bitcoin_deserialize_transaction/tx").write_bytes(b"tx bytes")
+        inventory = self.root / "crates/p2p/src/compat.rs"
+        inventory.parent.mkdir(parents=True)
+        inventory.write_text('pub const COMMANDS: &[Command] = &[Command { name: "verack" }];')
+        harness = self.root / "fuzz/fuzz_targets/script_eval.rs"
+        harness.parent.mkdir()
+        harness.write_text("const ELEMENT_LEN_MAX: usize = 1024;\n")
+        stubs = {
+            "git": r"""case "$1" in
+rev-parse) printf '%s\n' "$TEST_ROOT" ;;
+init) mkdir -p "$3"; cp -R "$UPSTREAM/." "$3/" ;;
+-C)
+    case "$3" in
+        remote|checkout) : ;;
+        fetch) [[ "$FAIL_FLOW" != fetch ]] || exit 31 ;;
+        rev-parse) [[ "$FAIL_FLOW" != identity ]] || exit 44; printf '%s\n' "$PIN" ;;
+        *) exit 99 ;;
+    esac ;;
+*) exit 99 ;;
+esac""",
+            "rustc": "printf 'host: x86_64-unknown-linux-gnu\\n'",
+            "df": "printf 'Filesystem 1048576-blocks Used Available Capacity Mounted\\ntest 9999 0 9999 0%% /\\n'",
+            "du": '[[ "$FAIL_FLOW" != size ]] || exit 42\nexec /usr/bin/du "$@"',
+            "date": '[[ "$FAIL_FLOW" != date ]] || exit 43\nexec /usr/bin/date "$@"',
+            "cargo": r"""printf '%s\n' "$*" >> "$MINIMIZE_LOG"
+[[ "$FAIL_FLOW" != minimize || "${!#}" != tx_decode ]] || exit 37
+if [[ "$FAIL_FLOW" == terminate ]]; then kill -TERM "$PPID"; fi""",
+        }
+        for name, body in stubs.items():
+            path = self.bin / name
+            path.write_text("#!/usr/bin/env bash\nset -eu\n" + body + "\n")
+            path.chmod(0o755)
+
+    def run_import(self, failure=""):
+        env = dict(os.environ, PATH=f"{self.bin}{os.pathsep}{os.environ['PATH']}",
+                   TEST_ROOT=str(self.root), UPSTREAM=str(self.upstream), TMPDIR=str(self.tmp),
+                   PIN=self.pin, MINIMIZE_LOG=str(self.log), FAIL_FLOW=failure)
+        result = subprocess.run(["bash", str(SCRIPT)], cwd=self.root, env=env,
+                                capture_output=True, text=True, timeout=30, check=False)
+        self.assertEqual(list(self.tmp.iterdir()), [], "import leaked its clone")
+        return result
+
+    def assert_failure(self, failure, status):
+        result = self.run_import(failure)
+        self.assertEqual(result.returncode, status, result.stderr)
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+        self.assertNotIn("import complete", result.stdout)
+
+    def test_success_minimizes_all_targets_before_provenance(self):
+        result = self.run_import()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.log.read_text().splitlines(), [
+            f"fuzz cmin --target x86_64-unknown-linux-gnu {target}"
+            for target in ("p2p_message", "block_decode", "tx_decode", "script_eval")])
+        self.assertIn(self.pin, self.provenance.read_text())
+        self.assertEqual((self.root / "fuzz/corpus/block_decode/block").read_bytes(), b"block bytes")
+        self.assertEqual((self.root / "fuzz/corpus/tx_decode/tx").read_bytes(), b"tx bytes")
+        self.assertEqual([p.read_bytes() for p in (self.root / "fuzz/corpus/p2p_message").iterdir()], [b"\0"])
+
+    def test_missing_direct_corpus_cannot_publish_provenance(self):
+        directory = self.upstream / "fuzz_corpora/bitcoin_deserialize_block"
+        (directory / "block").unlink()
+        directory.rmdir()
+        self.assert_failure("", 1)
+        self.assertFalse(self.log.exists())
+
+    def test_fetch_failure_preserves_status_and_provenance(self):
+        self.assert_failure("fetch", 31)
+
+    def test_identity_failure_preserves_status_and_provenance(self):
+        self.assert_failure("identity", 44)
+
+    def test_size_probe_failure_preserves_status_and_provenance(self):
+        self.assert_failure("size", 42)
+
+    def test_date_failure_preserves_status_and_provenance(self):
+        self.assert_failure("date", 43)
+
+    def test_minimizer_failure_preserves_status_and_provenance(self):
+        self.assert_failure("minimize", 37)
+        self.assertEqual(len(self.log.read_text().splitlines()), 3)
+
+    def test_termination_cleans_clone_and_preserves_provenance(self):
+        self.assert_failure("terminate", 143)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -329,6 +329,7 @@ log() { printf '[import-qa-assets] %s\\n' "$*"; }
         self.assertEqual((self.output / "empty").read_bytes(), b"")
         self.assertIn("imported=2 skipped_oversize=2", result.stdout)
 
+    # Contract: docs/contracts/qa-corpus.md QAC-01, import-scope bullet.
     def test_nested_directories_and_symlinks_are_not_imported(self):
         nested = self.source / "nested"
         nested.mkdir()
@@ -403,8 +404,8 @@ init) mkdir -p "$3"; cp -R "$UPSTREAM/." "$3/" ;;
 esac""",
             "rustc": "printf 'host: x86_64-unknown-linux-gnu\\n'",
             "df": "printf 'Filesystem 1048576-blocks Used Available Capacity Mounted\\ntest 9999 0 9999 0%% /\\n'",
-            "du": '[[ "$FAIL_FLOW" != size ]] || exit 42\nexec /usr/bin/du "$@"',
-            "date": '[[ "$FAIL_FLOW" != date ]] || exit 43\nexec /usr/bin/date "$@"',
+            "du": '[[ "$FAIL_FLOW" != size ]] || exit 42\nprintf "1\\t%s\\n" "$2"',
+            "date": '[[ "$FAIL_FLOW" != date ]] || exit 43\nprintf "2025-01-02T03:04:05Z\\n"',
             "cargo": r"""printf '%s\n' "$*" >> "$MINIMIZE_LOG"
 [[ "$FAIL_FLOW" != minimize || "${!#}" != tx_decode ]] || exit 37
 if [[ "$FAIL_FLOW" == terminate ]]; then kill -TERM "$PPID"; fi""",


### PR DESCRIPTION
## Follow-up to merged #747

The broader failure-injection pass found defects outside the original mapper unit tests. This PR is independently based on main `76baf086b861057f5700da34c4ad0d4f5aab5966`, preserving the external #747/#753 merges and their budget-owner extraction and contract link.

## Reproduced failures and fixes

- A missing direct corpus was hidden by `find | sort` process substitution: the importer reported `imported=0` and could publish successful provenance. Replace that loop with one Python mapper whose directory-open/read/write failures propagate normally.
- The direct path spawned `stat`, `basename`, and `cp` per seed. The replacement uses one process, preserves exact filenames/bytes and the strict `< MAX_SEED_BYTES` policy, ignores nested directories/symlinks as before, bounds each read, and rechecks the bytes read in case a file grows after stat.
- Recognized 24-byte/header-only P2P messages were silently discarded. The actual harness accepts a selector with empty payload; retain those seeds.
- Malformed disk readings could make the old negative comparisons fail without aborting. Require both lower-bound comparisons to succeed, and reject an absent Rust host triple before allocating staging.
- Three remaining `readonly VAR="$(command)"` assignments masked failures: upstream identity, size measurement, and timestamp generation. Separate assignment from readonly declaration. Baseline full-flow tests reproduced wrong statuses or false success for all three.
- Correct the newly merged setup-contract wording: injected test statuses are not fixed public error mappings. An additional test varies four subprocess statuses and verifies verbatim propagation. No CL row, proof inventory, target, or measurement verdict is changed.

## Executable QA

`/usr/bin/python3 -m unittest discover -s scripts/tests -p test_import_qa_assets.py -v` — **32 passed** on Python 3.13.5 / Linux; final run 25.353 seconds.

The suite now includes eight full-entrypoint cases: successful four-target minimization dispatch, fetch/identity/size/date failures, missing corpus, minimizer failure, and TERM cleanup. They run the actual shell entry point and embedded mappers with synthetic files and stub external Git/Rust tools; they do **not** execute a real clone or `cargo fuzz cmin`. Failure cases verify existing provenance survives and the clone is cleaned. Direct-copy tests check exact bytes, size boundaries, odd filenames, symlinks, and missing directories.

`bash -n`, Python syntax compilation, and whitespace checks passed. The independent downloader follow-up #757 has **9 passing tests**, for **41 passing tests across the two separately completed suites**. Combined attempts hit this environment's execution timeout and are not counted as passing combined runs.

## Measurements, not promotion claims

Command: `/usr/bin/python3 evidence/measure_import.py` in the downloadable acceptance bundle. The script executes extracted actual mapper bodies/functions, alternates before/after order, and records source identities and raw samples. Environment: Python 3.13.5, GNU Bash 5.2.37, Linux 6.18.35 x86_64 / glibc 2.41.

Direct mapping, 250 synthetic 1,024-byte seeds, six runs per version:

- Before median **2.330523 s**; after **1.113582 s**; observed ratio **2.0928x**.
- Every output filename-and-byte manifest matches the input and both versions.
- Maximum deviation from each arm's median is approximately **38.1%**. This is noisy local evidence, **not** a CL-19 stability pass or a production speedup claim.

P2P memory, fresh subprocesses, three repeats per input size at 1/8/64 MiB; original pre-#747 mapper versus this PR's mapper. For the 64-MiB input:

| Metric | Original | Current |
|---|---:|---:|
| Retained traced Python bytes | 67,787,932–67,788,033 | 748,955–749,084 |
| Peak traced Python bytes | 134,831,406–134,831,462 | 754,591–754,720 |
| Process RSS high-water, KiB | 143,232 | 14,080 |
| Emitted seed bytes | 65,537 (old budget bug) | 65,536 |

RSS includes the interpreter/instrumentation, not just payload allocations. The current P2P mapper reads at most 65,559 bytes including the discarded envelope. These measurements supplement #747's read-bound evidence; they do not prove node-wide resource closure, constant total corpus memory, or live corpus throughput.

## Source identities

All three uploaded blobs equal the locally tested files:

- importer `5b9bfb8dcd0631ce689acf1e6de42547d94e6b2b`
- tests `6658dbb62ed6ba69242ec3b48f666a6ae6ab8207`
- constraints `6e7334380422864a0f6720b786ef3f05e330261d`

The current-main importer baseline remains `723896b3f419c6a4504561286b28024610cabae3`. The original memory-control source is blob `22a14e444732dd71913bc5043feed231f4a53d03`. The original current-main constraints copy was hash-verified against `b484f18c3ed9cc893e7d82c6688bc9fc166d34b4` before the setup-only wording edit.

## Unverified gates and scope

The CL-14 command was attempted exactly:

```sh
cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test overhaul_resource_bounds -- --nocapture
```

It could not start (`cargo: command not found`, rc 127). Clippy likewise could not start. Terminal DNS prevents toolchain/CodeRabbit installation and live acquisition. Final-head CI, independent review, native CL-14/CL-19, actual minimization, and full-repository correctness remain **unverified**, not waived or passed.

One commit, three related files. No Rust code, dependencies, workflows, corpus, historical provenance, operator data, or defaults change. A real re-import must update corpus and provenance together under QAC-01. Failure does not roll back already written seed files; the tested guarantee is abort/no false success and preservation of the previous provenance before publication. No merge, force-push, auto-merge, or direct main write was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the QA corpus importer fail closed on incomplete imports, removes per-seed subprocesses from the direct mapping path, and documents the eligible import scope.

Previously, a missing corpus directory could report `imported=0` and publish successful provenance; the importer now aborts before publishing. The direct mapper also spawned `stat`, `basename`, and `cp` per seed; it now uses a single Python process that preserves exact filenames and bytes.

**Bug Fixes**
- Fail closed on absent host triple, malformed disk readings, and missing corpus directories.
- Require both disk-capacity comparisons to succeed instead of failing open.
- Preserve header-only P2P messages with empty payloads.
- Separate `readonly` from assignment so upstream identity, size, and date failures propagate.

**Refactors**
- Replace per-seed shell subprocesses with one Python mapper that bounds reads and rechecks bytes read after stat.
- Document that only regular files directly inside each source directory are imported; nested directories and symlinks are skipped.
- Remove fixed exit-code remapping in the setup contract; injected statuses are now documented as test fixtures, not a public inventory.
- Expand tests to cover full entry-point flows with location-independent stubs, including fetch, identity, size, date, minimizer, and TERM cleanup failures.

<sup>Written for commit fe7ae095335d48fc61b1810b9982b0b84fd9baa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

