### PR TITLE
Unify script stack transfer contract

### DIFF
--- a/crates/script/README.md
+++ b/crates/script/README.md
@@ -18,21 +18,15 @@ see [`docs/contracts/validation-default.md`](../../docs/contracts/validation-def
 ## Stack transfer contract
 
 `Stack::move_to` and `Stack::move_from` transfer exactly one top `ScriptItem`
-between bounded stacks. Source underflow is checked before destination capacity.
-Either error leaves both stacks unchanged. A successful transfer moves ownership
-of the existing item; the transfer helper does not duplicate that item. This is
-an ownership and correctness contract, not a product performance claim.
+by ownership between bounded stacks. Source underflow is checked before
+destination capacity; `Stack::MAX_DEPTH` is that capacity bound. Either error
+leaves both stacks unchanged. A successful transfer preserves item identity
+and stack order without duplicating the item. This is an ownership and
+correctness contract, not a product performance claim.
 
 ## Features
 
 - `rocksdb`, `fjall`, `redb`: no-op in this crate — this crate has no backend code; the names exist so the shared storage-backend features can be enabled uniformly across the workspace.
-
-## Bounded stack transfer contract
-
-`Stack::move_to` and `Stack::move_from` transfer the top `ScriptItem` by
-ownership. They check source underflow before destination capacity, leave both
-stacks unchanged on either error, and preserve the item's identity and stack
-order on success. `Stack::MAX_DEPTH` is the destination capacity bound.
 
 Part of [`bitcoin-rs`](../../README.md); see [`CONCEPTS.md`](../../CONCEPTS.md) for the
 project vocabulary.

--- a/crates/script/tests/stack_transfer.rs
+++ b/crates/script/tests/stack_transfer.rs
@@ -1,14 +1,13 @@
 //! Ownership-preserving transfers between bounded script stacks.
 //!
-//! Contract: `crates/script/README.md#stack-transfer-contract` requires one-item
+//! Contract: `crates/script/README.md#stack-transfer-contract` owns one-item
 //! ownership transfer, source-underflow-before-destination-overflow precedence,
-//! unchanged stacks on failure, and no duplication of the transferred item.
+//! unchanged stacks on failure, identity, ordering, and the capacity bound.
 use bitcoin_rs_script::{ScriptItem, Stack, StackError};
 use smallvec::SmallVec;
 
-// Contract: crates/script/README.md, “Bounded stack transfer contract”.
-// The 520-byte fixture is deliberately above SmallVec's inline capacity so
-// the contract's ownership/identity guarantee is exercised on heap storage.
+// `crates/script/README.md#stack-transfer-contract`: 520 bytes exceeds the
+// SmallVec inline capacity, so pointer identity exercises ownership transfer.
 #[test]
 fn transfers_move_heap_backed_bytes_without_cloning() -> Result<(), StackError> {
     let mut source = Stack::new();
@@ -38,9 +37,8 @@ fn transfers_move_heap_backed_bytes_without_cloning() -> Result<(), StackError> 
     Ok(())
 }
 
-// Contract: crates/script/README.md, “Bounded stack transfer contract”.
-// The four lengths cover the documented empty, non-full, and MAX_DEPTH
-// capacity boundaries; underflow must still win when the source is empty.
+// `crates/script/README.md#stack-transfer-contract`: cover empty,
+// spare-capacity, and full-destination boundaries; source underflow wins.
 #[test]
 fn transfers_preserve_error_precedence_and_capacity() -> Result<(), StackError> {
     for len in [0, 1, Stack::MAX_DEPTH - 1, Stack::MAX_DEPTH] {


### PR DESCRIPTION
## Summary

Follow-up to merged #772. Collapse two overlapping stack-transfer contract sections into one canonical owner-local contract and point the permanent transfer regression rationale at that single anchor.

The retained contract covers the union of the prior text: one top-item ownership transfer, source-underflow-before-destination-capacity error ordering, `Stack::MAX_DEPTH` capacity, unchanged stacks on failure, identity/order preservation on success, and no product-performance claim.

## Scope

Documentation/comment cleanup only:

- `crates/script/README.md`
- `crates/script/tests/stack_transfer.rs`

No executable Rust, public API, consensus behavior, dependency, feature, or persistence change.

## Why

Automated review on #772 identified that concurrent remediation left both `Stack transfer contract` and `Bounded stack transfer contract` as competing owners, while test comments referenced different headings. #772 was merged before that live finding could be repaired, so this is a separate atomic follow-up rather than a history rewrite.

## Verification

- Based on `main` at `64b9c73a8c8b8de6d43918e343e2e4b4e4d3bbf5`.
- Exactly one commit ahead / zero behind that base at construction.
- GitHub compare reports only the two intended files.
- The change deletes duplicate policy text and normalizes all test references to `crates/script/README.md#stack-transfer-contract`.

Local Cargo/Clippy/Rust tests are unavailable in this execution host because the Rust toolchain is not installed. GitHub PR CI remains the executable verification source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the two overlapping stack-transfer contract sections in `crates/script/README.md` into one canonical contract and updates test comments in `crates/script/tests/stack_transfer.rs` to reference that single anchor.

No executable code or behavior changes; docs and test comments only.

<sup>Written for commit 44e5ee58e2c1b54ce1eaf9728d587f34a4f2cd45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

