### PR TITLE
fix(fuzz): validate seed descriptors and preserve P2P selector contracts

### DIFF
--- a/docs/contracts/qa-corpus.md
+++ b/docs/contracts/qa-corpus.md
@@ -19,6 +19,13 @@ end-state evidence roles.
 - Provenance rows must be updated in the same commit as any corpus re-import via
   `scripts/import-qa-assets.sh`.
 
+### `QAC-04`: Published seed-file permissions
+
+- Published corpus seed files created by the importer use repository-readable
+  mode `0644`, independent of the caller's umask.
+- This mode is a publication contract for shared checkouts; it does not claim
+  crash durability or define permissions for unrelated generated files.
+
 ### `QAC-02`: End-state evidence roles
 
 - G0 pins: the pinned `rust-bitcoin/qa-assets` commit and the minimized seed

--- a/scripts/import_qa_assets.py
+++ b/scripts/import_qa_assets.py
@@ -13,6 +13,7 @@ import hashlib
 import os
 from pathlib import Path
 import re
+import stat
 import sys
 import tempfile
 from collections.abc import Iterator, Sequence
@@ -28,7 +29,19 @@ def _seed_paths(source: Path) -> Iterator[Path]:
 
 
 def _read_seed(path: Path, limit: int) -> bytes:
-    with path.open("rb") as source:
+    # Revalidate the opened object: the directory entry may change after scandir.
+    # NONBLOCK avoids hanging on a raced FIFO before fstat can reject it.
+    def open_regular(name: str, flags: int) -> int:
+        descriptor = os.open(name, flags | os.O_NOFOLLOW | os.O_NONBLOCK)
+        try:
+            if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                raise ValueError(f"Expected regular seed file: {path}")
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    with open(path, "rb", opener=open_regular) as source:
         return source.read(limit)
 
 
@@ -39,6 +52,7 @@ def _publish(output: Path, name: str, seed: bytes) -> None:
     try:
         with temporary as stream:
             stream.write(seed)
+            os.fchmod(stream.fileno(), 0o644)
         os.replace(staged, output / name)
     finally:
         staged.unlink(missing_ok=True)
@@ -49,9 +63,10 @@ def _emit(output: Path, seed: bytes) -> None:
 
 
 def _commands(source: Path) -> dict[str, bytes]:
+    text = _strip_rust_comments(source.read_text())
     table = re.search(
         r"pub\s+const\s+COMMANDS\s*:\s*&\[Command\]\s*=\s*&\[(.*?)\];",
-        source.read_text(), re.S,
+        text, re.S,
     )
     if table is None:
         raise ValueError("Cannot find the P2P COMMANDS inventory")
@@ -63,14 +78,14 @@ def _commands(source: Path) -> dict[str, bytes]:
 
 
 def map_p2p(source: Path, inventory: Path, output: Path, max_bytes: int) -> None:
-    if max_bytes < 2:
-        raise ValueError("Seed budget is too small for a P2P selector and payload")
+    if max_bytes < 1:
+        raise ValueError("Seed budget is too small for a P2P selector")
     selector = _commands(inventory)
     output.mkdir(parents=True, exist_ok=True)
     imported = skipped_short = unknown_command = 0
     for path in _seed_paths(source):
         blob = _read_seed(path, 24 + max_bytes - 1)
-        if len(blob) <= 24:
+        if len(blob) < 24:
             skipped_short += 1
             continue
         command = blob[4:16].split(b"\0", 1)[0].decode("ascii", "replace")

--- a/scripts/import_qa_assets.py
+++ b/scripts/import_qa_assets.py
@@ -133,6 +133,16 @@ def _strip_rust_comments(text: str) -> str:
             elif char == '"':
                 in_string = False
             continue
+        raw = re.match(r'r(#{0,255})"', text[index:])
+        if raw:
+            hashes = raw.group(1)
+            terminator = '"' + hashes + '"'
+            end = text.find(terminator, index + len(raw.group(0)))
+            if end < 0:
+                raise ValueError("Unterminated Rust raw string in script_eval contract")
+            out.append(text[index:end + len(terminator)])
+            index = end + len(terminator)
+            continue
         if text.startswith("//", index):
             newline = text.find("\n", index + 2)
             if newline < 0:

--- a/scripts/tests/test_import_qa_assets.py
+++ b/scripts/tests/test_import_qa_assets.py
@@ -182,7 +182,7 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
                 stream.truncate(8 * 1024 * 1024)
         limits = {p2p: 24 + BUDGET - 1, script: 1024}
         reads = {}
-        original_open = Path.open
+        original_open = open
         test = self
 
         class GuardedReader:
@@ -206,7 +206,7 @@ pub const CORE_UNTYPED_COMMANDS: &[&str] = &["outside"];
             stream = original_open(path, mode, *args, **kwargs)
             return GuardedReader(stream, path) if path in limits and mode == "rb" else stream
 
-        with patch.object(Path, "open", guarded_open):
+        with patch.object(mapper, "open", guarded_open, create=True):
             self.run_mapper("map_p2p")
             self.run_mapper("map_script")
         self.assertEqual(reads, limits)
@@ -490,7 +490,7 @@ class PublicationTests(unittest.TestCase):
         with seed.open("wb") as stream:
             stream.truncate(8 * 1024 * 1024)
         destination = self.output / "mapped"
-        real_open = Path.open
+        real_open = open
         requested = []
 
         @contextmanager
@@ -509,7 +509,7 @@ class PublicationTests(unittest.TestCase):
 
                 yield Bounded()
 
-        with patch.object(Path, "open", bounded_open), redirect_stdout(io.StringIO()):
+        with patch.object(mapper, "open", bounded_open, create=True), redirect_stdout(io.StringIO()):
             mapper.map_direct(source, destination, BUDGET, "direct")
         self.assertEqual(requested, [BUDGET])
         self.assertEqual(list(destination.iterdir()), [])

--- a/scripts/tests/test_import_qa_assets_boundaries.py
+++ b/scripts/tests/test_import_qa_assets_boundaries.py
@@ -1,6 +1,6 @@
 """QAC-01 boundary regressions for seed ingress and publication.
 
-`docs/contracts/qa-corpus.md` QAC-01 and the framing in
+`docs/contracts/qa-corpus.md` QAC-01 and QAC-04 and the framing in
 `fuzz/fuzz_targets/p2p_message.rs` require a selector followed by the payload,
 which may be empty. `crates/p2p/src/compat.rs` owns selector order; comments
 are not inventory entries. AGENTS.md's data-preservation rule applies to
@@ -54,6 +54,14 @@ class SeedBoundaryTests(unittest.TestCase):
         # Only two live entries exist; ping is independently the second entry.
         self.assertEqual([path.read_bytes() for path in self.output.iterdir()],
                          [b"\x01payload"])
+
+    def test_raw_strings_before_commands_do_not_stop_inventory_scan(self):
+        self.inventory.write_text('''const NOTE: &str = r#""/*"#;
+    pub const COMMANDS: &[Command] = &[Command { name: "ping" }];
+''')
+        self.write_message("ping", b"payload")
+        self.map_p2p()
+        self.assertEqual([path.read_bytes() for path in self.output.iterdir()], [b"\0payload"])
 
     def test_header_only_command_becomes_a_selector_only_seed(self):
         self.inventory.write_text('pub const COMMANDS: &[Command] = &[Command { name: "verack" }];')
@@ -137,6 +145,7 @@ class SeedBoundaryTests(unittest.TestCase):
             mapper._publish(self.output, "seed", b"public corpus bytes")
         finally:
             os.umask(previous_umask)
+        # QAC-04 requires repository-readable mode for published corpus seeds.
         self.assertEqual(stat.S_IMODE((self.output / "seed").stat().st_mode), 0o644)
 
     def test_failed_seed_mode_change_preserves_previous_bytes(self):

--- a/scripts/tests/test_import_qa_assets_boundaries.py
+++ b/scripts/tests/test_import_qa_assets_boundaries.py
@@ -1,0 +1,154 @@
+"""QAC-01 boundary regressions for seed ingress and publication.
+
+`docs/contracts/qa-corpus.md` QAC-01 and the framing in
+`fuzz/fuzz_targets/p2p_message.rs` require a selector followed by the payload,
+which may be empty. `crates/p2p/src/compat.rs` owns selector order; comments
+are not inventory entries. AGENTS.md's data-preservation rule applies to
+publication, and CONSTRAINTS.md CL-14 requires bounded ingress. File races
+below are injected in disposable directories, not an operator checkout.
+"""
+
+from contextlib import redirect_stdout
+import io
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from test_import_qa_assets import BUDGET, MAPPER, mapper
+
+
+class SeedBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.source = self.root / "source"
+        self.source.mkdir()
+        self.output = self.root / "output"
+        self.inventory = self.root / "compat.rs"
+
+    def map_p2p(self, budget=BUDGET):
+        with redirect_stdout(io.StringIO()):
+            mapper.map_p2p(self.source, self.inventory, self.output, budget)
+
+    def write_message(self, name, payload=b""):
+        self.assertLessEqual(len(name), 12)
+        message = b"\0" * 4 + name.encode().ljust(12, b"\0") + b"\0" * 8 + payload
+        (self.source / name).write_bytes(message)
+
+    def test_commented_commands_do_not_shift_decoder_selection(self):
+        self.inventory.write_text('''pub const COMMANDS: &[Command] = &[
+    // Command { name: "ghost" },
+    Command { name: "verack" },
+    /* nested /* Command { name: "phantom" }, */ ]; still a comment */
+    Command { name: "ping" },
+];
+''')
+        self.write_message("ping", b"payload")
+        self.map_p2p()
+        # Only two live entries exist; ping is independently the second entry.
+        self.assertEqual([path.read_bytes() for path in self.output.iterdir()],
+                         [b"\x01payload"])
+
+    def test_header_only_command_becomes_a_selector_only_seed(self):
+        self.inventory.write_text('pub const COMMANDS: &[Command] = &[Command { name: "verack" }];')
+        self.write_message("verack")
+        self.map_p2p()
+        self.assertEqual([path.read_bytes() for path in self.output.iterdir()], [b"\0"])
+
+    def test_one_byte_budget_supports_a_selector_only_seed(self):
+        self.inventory.write_text('pub const COMMANDS: &[Command] = &[Command { name: "verack" }];')
+        self.write_message("verack")
+        self.map_p2p(budget=1)
+        self.assertEqual([path.read_bytes() for path in self.output.iterdir()], [b"\0"])
+
+    def test_truncated_envelopes_never_become_selector_only_seeds(self):
+        self.inventory.write_text('pub const COMMANDS: &[Command] = &[Command { name: "verack" }];')
+        message = b"\0" * 4 + b"verack".ljust(12, b"\0") + b"\0" * 8
+        for length in range(len(message)):
+            (self.source / str(length)).write_bytes(message[:length])
+        self.map_p2p()
+        self.assertEqual(list(self.output.iterdir()), [])
+
+    def test_source_changed_to_symlink_after_scan_is_rejected(self):
+        seed = self.source / "seed"
+        seed.write_bytes(b"expected")
+        unrelated = self.root / "unrelated"
+        unrelated.write_bytes(b"must not enter corpus")
+        original_paths = mapper._seed_paths
+
+        def raced_paths(source):
+            for path in original_paths(source):
+                path.unlink()
+                path.symlink_to(unrelated)
+                yield path
+
+        with patch.object(mapper, "_seed_paths", raced_paths), redirect_stdout(io.StringIO()):
+            with self.assertRaises(OSError):
+                mapper.map_direct(self.source, self.output, BUDGET, "test")
+        self.assertEqual(list(self.output.iterdir()), [])
+        self.assertEqual(unrelated.read_bytes(), b"must not enter corpus")
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "requires POSIX FIFOs")
+    def test_fifo_read_is_rejected_without_waiting_for_a_writer(self):
+        fifo = self.source / "fifo"
+        os.mkfifo(fifo)
+        command = [sys.executable, "-c",
+                   "from pathlib import Path; import sys; "
+                   "from import_qa_assets import _read_seed; "
+                   "_read_seed(Path(sys.argv[1]), int(sys.argv[2]))",
+                   str(fifo), str(BUDGET)]
+        try:
+            result = subprocess.run(command, cwd=MAPPER.parent, capture_output=True,
+                                    text=True, timeout=2, check=False)
+        except subprocess.TimeoutExpired:
+            self.fail("seed ingress blocked on a FIFO despite its byte budget")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("regular", result.stderr)
+
+    def test_failed_descriptor_validation_closes_the_descriptor(self):
+        seed = self.source / "seed"
+        seed.write_bytes(b"data")
+        opened = []
+        real_open = os.open
+
+        def observe_open(*args, **kwargs):
+            descriptor = real_open(*args, **kwargs)
+            opened.append(descriptor)
+            return descriptor
+
+        with patch.object(mapper.os, "open", observe_open):
+            with patch.object(mapper.os, "fstat", side_effect=OSError("injected fstat failure")):
+                with self.assertRaisesRegex(OSError, "fstat failure"):
+                    mapper._read_seed(seed, BUDGET)
+        self.assertEqual(len(opened), 1)
+        with self.assertRaises(OSError):
+            os.fstat(opened[0])
+
+    def test_published_seed_remains_readable_in_a_shared_checkout(self):
+        self.output.mkdir()
+        previous_umask = os.umask(0o022)
+        try:
+            mapper._publish(self.output, "seed", b"public corpus bytes")
+        finally:
+            os.umask(previous_umask)
+        self.assertEqual(stat.S_IMODE((self.output / "seed").stat().st_mode), 0o644)
+
+    def test_failed_seed_mode_change_preserves_previous_bytes(self):
+        self.output.mkdir()
+        destination = self.output / "seed"
+        destination.write_bytes(b"old")
+        with patch.object(mapper.os, "fchmod", side_effect=OSError("injected chmod failure")):
+            with self.assertRaisesRegex(OSError, "chmod failure"):
+                mapper._publish(self.output, "seed", b"new")
+        self.assertEqual(destination.read_bytes(), b"old")
+        self.assertEqual(list(self.output.iterdir()), [destination])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_import_qa_assets_flags.py
+++ b/scripts/tests/test_import_qa_assets_flags.py
@@ -3,8 +3,8 @@
 Contract: `fuzz/fuzz_targets/script_eval.rs` owns the selector-indexed input framing
 and `FLAGS` order; `docs/contracts/qa-corpus.md` QAC-01 requires imported script
 seeds to feed that harness. This test mutates only owner syntax (order/comments),
-then derives selector indices from the parsed owner contract before independently
-constructing the documented byte frame.
+then derives expected selectors from the independently declared fixture order,
+not from the parser under test, before constructing the documented byte frame.
 """
 
 import importlib.util
@@ -29,17 +29,19 @@ class FlagCommentTests(unittest.TestCase):
             script = b"Q" * 64
             (source / "script").write_bytes(script)
             harness = root / "script_eval.rs"
+            flag_names = ("TAPROOT", "MANDATORY", "NONE", "STANDARD")
             harness.write_text(
                 "const FLAGS: [VerifyFlags; 4] = [\n"
-                "    VerifyFlags::TAPROOT, // taproot, selector owner\n"
+                f"    VerifyFlags::{flag_names[0]}, // taproot, selector owner\n"
                 "    /* mandatory, nested /* comment, comma */ still comment */\n"
-                "    VerifyFlags::MANDATORY,\n"
-                "    VerifyFlags::NONE, // none, selector owner\n"
-                "    VerifyFlags::STANDARD,\n"
+                f"    VerifyFlags::{flag_names[1]},\n"
+                f"    VerifyFlags::{flag_names[2]}, // none, selector owner\n"
+                f"    VerifyFlags::{flag_names[3]},\n"
                 "];\n"
                 "const ELEMENT_LEN_MAX: usize = 1_024;\n"
             )
-            _, none_selector, taproot_selector = mapper._script_contract(harness)
+            none_selector = flag_names.index("NONE")
+            taproot_selector = flag_names.index("TAPROOT")
             mapper.map_script([source], harness, output, 65_536)
             seeds = {path.read_bytes() for path in output.iterdir()}
             raw = bytes([none_selector]) + b"\0\0\x40\0" + script + b"\0"


### PR DESCRIPTION
## Scope

Follow-up to #758, which merged while its deeper review was in progress. One commit on main `ec43331f871d9457d26f1b21799d1bb6048977c4`; four related Python source/test files. No Rust source, dependency, live corpus, historical provenance, or main-branch write.

## Reproduced defects

- Commented-out P2P `Command` entries change selector indices; a `];` inside a nested comment can terminate extraction early. This also addresses CodeRabbit's still-valid review comment on #758 (`discussion_r3974976894`). Reuse the existing Rust-comment stripper before reading the inventory.
- A complete 24-byte envelope with an empty payload is discarded. The actual P2P harness accepts a selector followed by an empty payload. Preserve that case, allow the one-byte seed budget, and continue rejecting every truncated envelope length.
- A source switched from a regular file to a symlink after enumeration is read into the corpus. A FIFO can block ingress despite the byte budget. Open with POSIX `O_NOFOLLOW | O_NONBLOCK`, validate the opened descriptor with `fstat`, and close it on failed validation before bounded reads.
- Temporary-file publication turns ordinary corpus files into mode 0600. Set staged seed mode 0644 before replacement; chmod failure preserves previous bytes and cleans the temporary file.
- The FLAGS-comment regression gets expected selectors from the same parser it tests. A deliberately wrong parser returned `(1024, 0, 3)` for a fixture whose actual indices are `(2, 0)`, and the old regression passed. Build expected selectors from the independently declared fixture order; the same mutation now fails.

## Verification

Local execution used hash-verified copies of the relevant repository files, not a full Cargo checkout. GitHub comparison confirms these files and the Rust harness fixture are unchanged between the inspected #762 head and the current main base.

- Original importer suite: **47 passed**.
- New seed-boundary suite against original code: **7 failures and 1 error across 9 tests** (the truncation negative control already passed).
- Fixed new seed-boundary suite: **9 passed**.
- This PR independently, including the previously merged provenance tests: `python3 -m unittest discover -s scripts/tests -p 'test_import_qa_assets*.py' -v` — **56 passed**.
- Bash syntax, Python compilation, and staged whitespace checks passed.
- Published blob identities match the tested files: mapper `90dc889f`, main tests `33d92ffe`, FLAGS regression `eb24603a`, boundary regressions `1819cee2`.

The source-race tests operate only in disposable fixtures. The FIFO check uses a subprocess timeout to safely detect the original hang. The bound-instrumentation tests now observe the new open path rather than accidentally bypassing it.

## Limits / required review

The descriptor defense covers the final path component on POSIX; parent directories remain trusted. This is not a hostile-filesystem sandbox, a whole-corpus transaction, or fsync/power-loss durability. Corpus writes are still atomic per file.

`cargo clippy --locked --workspace --all-targets -- -D warnings` and the locked CL-14 `overhaul_resource_bounds` gate were attempted and returned **127: cargo not found**. No compiler-backed or performance-promotion pass is claimed. The prior 32.46x copy diagnostic was not rerun for this revised head and is not current-head performance evidence. Draft pending supported CI and independent review.

A separate, independent follow-up addresses malformed disk-probe results and provenance text; neither change set depends on the other.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seed-validation and selector-index bugs in the QA asset importer (`scripts/import_qa_assets.py`). The importer now rejects symlinks and FIFOs before reading, allows empty payloads (selector-only seeds) with a one-byte budget, strips Rust comments and raw-string literals before extracting P2P commands, and publishes seeds with mode 0644 per the new QAC-04 contract. Adds a boundary regression suite and makes the FLAGS parser test derive expected selectors from fixture order, not the parser under test.

<sup>Written for commit 988d3b10641fe19b5b9647e2111429ba94eb52d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

