### PR TITLE
fix(fuzz): reject invalid disk probes and keep provenance owner-derived

### DIFF
--- a/fuzz/fuzz_targets/script_eval.rs
+++ b/fuzz/fuzz_targets/script_eval.rs
@@ -27,9 +27,9 @@ use bitcoin_rs_script::{Interpreter, VerifyFlags};
 /// ```
 ///
 /// Scripts from the qa-assets corpus are wrapped into this framing by
-/// `scripts/import-qa-assets.sh`; seeds written by that script use selector
-/// `0x00` (NONE) for raw scripts and `0x03` (TAPROOT) for the wrapped P2TR
-/// variant. Keep those indices in step with `FLAGS` below.
+/// `scripts/import-qa-assets.sh`; seeds written by that script use the harness
+/// `FLAGS` entry `NONE` for raw scripts and, for files >= 32 bytes, a P2TR
+/// variant using its `TAPROOT` entry.
 const FLAGS: [VerifyFlags; 6] = [
     VerifyFlags::NONE,
     VerifyFlags::MANDATORY,

--- a/scripts/import-qa-assets.sh
+++ b/scripts/import-qa-assets.sh
@@ -11,8 +11,8 @@
 #   tx_decode     <- bitcoin_deserialize_transaction (raw consensus bytes, direct)
 #   script_eval   <- bitcoin_deserialize_script + bitcoin_script_bytes_to_asm_fmt
 #                    (raw script bytes, wrapped into the script_eval framing:
-#                    selector 0x00 = NONE, and for files >= 32 bytes a P2TR
-#                    variant with selector 0x03 = TAPROOT)
+#                    the harness FLAGS entry NONE, and for files >= 32 bytes
+#                    a P2TR variant using its TAPROOT entry)
 #
 # Disk discipline (repo AGENTS.md): the worst-case footprint of the clone is
 # declared below (shallow clone ~= corpus size, assumed <= 2 GiB); free space
@@ -42,7 +42,16 @@ log() { printf '[import-qa-assets] %s\n' "$*"; }
 # --- 1. Disk discipline: declare footprint, verify free space ---------------
 # The clone lands under TMPDIR and the minimized corpora under fuzz/corpus/;
 # both filesystems must cover their share of footprint + reserve.
-available_mb() { df -Pm "$1" | awk 'NR == 2 { print $4 }'; }
+available_mb() {
+    local available
+    available="$(df -Pm "$1" | awk 'NR == 2 { print $4 }')" || return
+    # A failed numeric comparison is not proof that there is enough space.
+    if [[ ! "${available}" =~ ^[0-9]+$ ]] || ! [ "${available}" -ge 0 ] 2>/dev/null; then
+        log "ABORT: invalid available-space result for $1" >&2
+        return 1
+    fi
+    printf '%s\n' "${available}"
+}
 
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/qa-assets.XXXXXX")"
 readonly WORKDIR
@@ -134,7 +143,7 @@ Seeds under fuzz/corpus/ were imported from
 | p2p_message | fuzz_corpora/p2p_deserialize_raw_net_msg | 24-byte envelope stripped; header command mapped to the harness selector byte; payload bounded so the selector plus payload fits ${MAX_SEED_BYTES} bytes (harness rebuilds magic/length/checksum) |
 | block_decode | fuzz_corpora/bitcoin_deserialize_block | direct copy (raw consensus bytes) |
 | tx_decode | fuzz_corpora/bitcoin_deserialize_transaction | direct copy (raw consensus bytes) |
-| script_eval | fuzz_corpora/bitcoin_deserialize_script, fuzz_corpora/bitcoin_script_bytes_to_asm_fmt | raw script bytes bounded by the harness ELEMENT_LEN_MAX and seed budget, then wrapped into the script_eval framing (selector 0x00 = NONE); files >= 32 bytes also emit a P2TR key-path variant (selector 0x03 = TAPROOT) |
+| script_eval | fuzz_corpora/bitcoin_deserialize_script, fuzz_corpora/bitcoin_script_bytes_to_asm_fmt | raw script bytes bounded by the harness ELEMENT_LEN_MAX and seed budget, then wrapped into the script_eval framing (selector from the harness FLAGS entry NONE); files >= 32 bytes also emit a P2TR key-path variant (selector from its TAPROOT entry) |
 
 Corpora were minimized with cargo fuzz cmin after import; only minimized
 seeds are tracked here. Re-run the script after major decoder changes to

--- a/scripts/tests/test_import_qa_assets_provenance.py
+++ b/scripts/tests/test_import_qa_assets_provenance.py
@@ -199,6 +199,43 @@ printf '%s\\n' "${{!#}}" >> "$TEST_ROOT/cmin.log"
         self.assertEqual(result.returncode, TERM_STATUS, result.stderr)
         self.assertEqual(self.provenance.read_text(), "previous provenance\n")
 
+    def test_nonnumeric_disk_probe_cannot_authorize_an_import(self):
+        probe = self.bin / "df"
+        probe.write_text("#!/usr/bin/env bash\nprintf 'Filesystem Blocks Used Available Capacity Mounted\\n'\n"
+                         "printf 'test 100000 0 unknown 0%% /\\n'\n")
+        result = self.run_import()
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertFalse((self.root / "fuzz/corpus").exists())
+        self.assertFalse((self.root / "cmin.log").exists())
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+    def test_overflowing_disk_probe_cannot_authorize_an_import(self):
+        probe = self.bin / "df"
+        probe.write_text("#!/usr/bin/env bash\nprintf 'Filesystem Blocks Used Available Capacity Mounted\\n'\n"
+                         "printf 'test 100000 0 999999999999999999999999999999999999 0%% /\\n'\n")
+        result = self.run_import()
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertFalse((self.root / "fuzz/corpus").exists())
+        self.assertFalse((self.root / "cmin.log").exists())
+        self.assertEqual(self.provenance.read_text(), "previous provenance\n")
+
+    def test_provenance_does_not_claim_fixed_selectors_after_owner_reordering(self):
+        harness = self.root / "fuzz/fuzz_targets/script_eval.rs"
+        text = harness.read_text()
+        text = text.replace("    VerifyFlags::NONE,", "    SWAP_NONE,")
+        text = text.replace("    VerifyFlags::TAPROOT,", "    VerifyFlags::NONE,")
+        text = text.replace("    SWAP_NONE,", "    VerifyFlags::TAPROOT,")
+        harness.write_text(text)
+        result = self.run_import()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        record = self.provenance.read_text()
+        self.assertNotIn("selector 0x00", record)
+        self.assertNotIn("selector 0x03", record)
+        self.assertIn("NONE", record)
+        self.assertIn("TAPROOT", record)
+        self.assertIn("FLAGS", record)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_import_qa_assets_provenance.py
+++ b/scripts/tests/test_import_qa_assets_provenance.py
@@ -235,6 +235,10 @@ printf '%s\\n' "${{!#}}" >> "$TEST_ROOT/cmin.log"
         self.assertIn("TAPROOT", record)
         self.assertIn("FLAGS", record)
 
+        documentation = (self.root / "scripts/import-qa-assets.sh").read_text()
+        self.assertNotIn("selector 0x00", documentation)
+        self.assertNotIn("selector 0x03", documentation)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope

Independent follow-up to #762, which merged during the deeper review. One commit based on main `ec43331f871d9457d26f1b21799d1bb6048977c4`, changing only `scripts/import-qa-assets.sh` and its existing provenance-flow test module. This does not depend on #783.

## Reproduced defects

1. A successful `df` command with a nonnumeric or out-of-range available-space field causes both shell `-lt` checks to error inside a conditional. The script treats those errors as false comparisons, logs `disk ok`, and continues through mapping, minimization, and provenance replacement. Reject missing, nondecimal, negative, and unrepresentable available-space values before the disk guard. Preserve real command/pipeline failure status explicitly.
2. The mapper derives script selectors from Rust-owned `FLAGS`, but the generated provenance still claims fixed `0x00` and `0x03`. Reordering the owner inventory makes the record false even when the imported frames are correct. Remove the duplicated numbers from shell documentation and generated provenance; describe `NONE` and `TAPROOT` through their owning `FLAGS` entries.

No new limits, target defaults, dependencies, Rust source, live corpus files, historical provenance data, or main-branch writes.

## Verification

- Original hash-verified importer suite: **47 passed**.
- Three added full-shell regressions against original code: **3 failed**, reproducing the two disk-result cases and the stale selector claims.
- This PR independently, with the merged mapper unchanged: `python3 -m unittest discover -s scripts/tests -p 'test_import_qa_assets*.py' -v` — **50 passed**.
- This PR combined locally with #783 — **59 passed**; the change sets have disjoint files and neither requires the other.
- `bash -n scripts/import-qa-assets.sh`, Python compilation, and staged whitespace checks passed.
- Remote blobs match tested files: script `9f2b6b83e40e2041e7cb3c2c54e05d3bfa56529c`, tests `60adf32392a04c632e777c5b5382f52b01e7ecd8`.

Tests use disposable directories and injected external tools; the real shell and mapper run, but no actual clone, Cargo build, or minimization was performed. The three new regressions remain in the existing QAC-03-linked test suite, which now has 15 methods.

## Limits / gates

The disk check remains a preflight free-space observation, not a reservation or a whole-import disk budget guarantee. Per-file publication is not a transaction spanning corpus and provenance and does not establish power-loss durability.

The locked CL-14 Cargo gate and `cargo clippy --locked --workspace --all-targets -- -D warnings` were attempted locally and returned **127: cargo not found**. No gate pass or performance gain is claimed. Draft pending supported CI and independent review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects invalid disk probe results in the QA asset import script so a failed or malformed `df` call cannot be mistaken for enough free space. Also makes provenance and harness documentation describe selectors by their owning FLAGS entry instead of hardcoded `0x00` and `0x03` values, so the record stays accurate after flag reordering.

- Disk probe now aborts on missing, nonnumeric, negative, or overflowing available-space values.
- Provenance, the shell documentation, and the `script_eval` harness comment now reference the FLAGS entries `NONE` and `TAPROOT` instead of fixed selector bytes.
- Added regression tests for invalid disk probes and for docs not regressing to fixed selector claims.

<sup>Written for commit 19618c040412bcb9ae1be4a5ee961a47e697520e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

