### PR TITLE
Clean staged recovery evidence after publish failures

### DIFF
--- a/crates/node/src/recovery_evidence.rs
+++ b/crates/node/src/recovery_evidence.rs
@@ -234,7 +234,7 @@ pub(crate) fn write_bounded(
         Err(e) => return Err(EvidenceError::Io(e)),
     }
 
-    // 2-4. Create temp, write, fsync.
+    // 2-7. Stage and publish the replacement.
     let result = (|| -> Result<(), EvidenceError> {
         use std::io::Write;
         let mut file = std::fs::OpenOptions::new()
@@ -245,39 +245,38 @@ pub(crate) fn write_bounded(
         file.write_all(b"\n")?;
         file.sync_all()?;
         drop(file);
+
+        // 5. Validate current; rotate valid current to `.prev`.
+        // Never overwrite a known-valid `.prev` with an invalid current.
+        if current_path.exists() {
+            match std::fs::read(&current_path) {
+                Ok(data) if data.len() <= MAX_FILE_BYTES && validate(&data) => {
+                    // Current is valid; rotate to .prev.
+                    let _ = std::fs::remove_file(&prev_path);
+                    std::fs::rename(&current_path, &prev_path)?;
+                }
+                _ => {
+                    // Current is invalid or oversized; remove it.
+                    // Keep existing .prev (never overwrite valid .prev with invalid current).
+                    let _ = std::fs::remove_file(&current_path);
+                }
+            }
+        }
+
+        // 6. Rename temp to current.
+        std::fs::rename(&tmp_path, &current_path)?;
+
+        // 7. Fsync the data-dir root.
+        sync_dir(dir)?;
+
         Ok(())
     })();
 
-    if let Err(e) = result {
-        // 8. Best-effort temp cleanup on error.
+    if result.is_err() {
+        // 8. Best-effort temp cleanup on every returned failure.
         let _ = std::fs::remove_file(&tmp_path);
-        return Err(e);
     }
-
-    // 5. Validate current; rotate valid current to `.prev`.
-    // Never overwrite a known-valid `.prev` with an invalid current.
-    if current_path.exists() {
-        match std::fs::read(&current_path) {
-            Ok(data) if data.len() <= MAX_FILE_BYTES && validate(&data) => {
-                // Current is valid; rotate to .prev.
-                let _ = std::fs::remove_file(&prev_path);
-                std::fs::rename(&current_path, &prev_path)?;
-            }
-            _ => {
-                // Current is invalid or oversized; remove it.
-                // Keep existing .prev (never overwrite valid .prev with invalid current).
-                let _ = std::fs::remove_file(&current_path);
-            }
-        }
-    }
-
-    // 6. Rename temp to current.
-    std::fs::rename(&tmp_path, &current_path)?;
-
-    // 7. Fsync the data-dir root.
-    sync_dir(dir)?;
-
-    Ok(())
+    result
 }
 /// missing or invalid (oversized or unreadable). Never selects by greater
 /// height or newer time.
@@ -733,6 +732,34 @@ mod tests {
     // -----------------------------------------------------------------------
     // A2.1: Bounded file protocol tests
     // -----------------------------------------------------------------------
+
+    // `write_bounded` protocol step 8 and recovery contract RCV-03 require
+    // staged, non-authoritative tails not to survive a returned failure.
+    #[test]
+    fn witness_rotation_failure_removes_staged_temp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let genesis = "aaaa";
+        let w1 = AppliedTipWitness::new(genesis, 1, 100, "aaa", 1000);
+        write_witness(dir.path(), &w1).expect("write current");
+
+        // A directory at the .prev path makes current -> .prev rotation fail
+        // after the replacement has already been staged and fsynced.
+        std::fs::create_dir(dir.path().join(WITNESS_PREV)).expect("block prev rotation");
+        let w2 = AppliedTipWitness::new(genesis, 2, 200, "bbb", 2000);
+        assert!(
+            write_witness(dir.path(), &w2).is_err(),
+            "rotation failure must propagate"
+        );
+        assert!(
+            !dir.path().join(WITNESS_TMP).exists(),
+            "returned failure must remove staged temp"
+        );
+        assert_eq!(
+            read_witness(dir.path(), genesis),
+            Some(w1),
+            "failed rotation keeps the current witness readable"
+        );
+    }
 
     #[test]
     fn witness_stage_failure_preserves_bounded_current_prev() {


### PR DESCRIPTION
## Summary

Make `recovery_evidence::write_bounded` honor its own step-8 failure protocol across the full publication sequence, not only temp creation/write/fsync.

Previously, failures while rotating current to `.prev`, renaming staged temp to current, or syncing the directory could return after staging without running the best-effort temp cleanup path. The implementation now treats steps 2–7 as one fallible publication operation and performs step-8 temp cleanup for every returned failure.

## Regression

The new unit regression reaches the post-stage rotation failure without synthetic hooks:

1. publish a valid witness,
2. create a directory at the `.prev` path,
3. attempt a second publication,
4. observe current → `.prev` rotation fail after temp write/fsync,
5. require the error to propagate, `.tmp` to be absent, and the prior current witness to remain readable.

The test cites the local `write_bounded` protocol step 8 and `docs/contracts/recovery.md` `RCV-03` for non-authoritative staged tails.

## Scope

One file only: `crates/node/src/recovery_evidence.rs`, containing both implementation and its private unit regression. No file format, schema, public API, recovery authority, or success-path ordering change.

## Verification

- Based on `main` at `ec43331f871d9457d26f1b21799d1bb6048977c4`.
- Exactly one commit ahead / zero behind that base at construction.
- GitHub commit diff shows only the intended publication-error scope change and one regression test in the same file.
- No duplicate open PR was found for this defect.

Local Cargo, rustfmt, Clippy, and Rust tests are unavailable in this execution host because the Rust toolchain is not installed. GitHub PR CI remains the executable verification source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `recovery_evidence::write_bounded` clean up the staged temporary file on every publish failure. Previously, failures after staging — during current-to-`.prev` rotation, temp-to-current rename, or directory sync — returned an error but left the `.tmp` file behind.

**Regression**
- Adds a unit test that forces rotation to fail by creating a directory at the `.prev` path, then verifies the error propagates, the temp file is removed, and the prior current witness stays readable.

<sup>Written for commit 350aa309bee7559e4b6265c8c32caf0873afb3e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

