### PR TITLE
fix(qa): repair merged raw-string and owner-documentation regressions

### DIFF
--- a/scripts/import_qa_assets.py
+++ b/scripts/import_qa_assets.py
@@ -108,6 +108,7 @@ def _frame(selector: int, script_pubkey: bytes, witness: Sequence[bytes]) -> byt
 
 def _strip_rust_comments(text: str) -> str:
     """Remove Rust line/nested-block comments without touching string contents."""
+    raw_start = re.compile(r'r(#{0,255})"')
     out: list[str] = []
     index = block_depth = 0
     in_string = False
@@ -133,11 +134,11 @@ def _strip_rust_comments(text: str) -> str:
             elif char == '"':
                 in_string = False
             continue
-        raw = re.match(r'r(#{0,255})"', text[index:])
+        raw = raw_start.match(text, index)
         if raw:
             hashes = raw.group(1)
-            terminator = '"' + hashes + '"'
-            end = text.find(terminator, index + len(raw.group(0)))
+            terminator = '"' + hashes
+            end = text.find(terminator, raw.end())
             if end < 0:
                 raise ValueError("Unterminated Rust raw string in script_eval contract")
             out.append(text[index:end + len(terminator)])

--- a/scripts/import_qa_assets.py
+++ b/scripts/import_qa_assets.py
@@ -62,8 +62,30 @@ def _emit(output: Path, seed: bytes) -> None:
     _publish(output, hashlib.sha256(seed).hexdigest()[:32], seed)
 
 
+def _mask_rust_raw_strings(text: str) -> str:
+    """Hide raw-string bodies from regexes that locate Rust declarations."""
+    raw_start = re.compile(r'(?:b|c)?r(#{0,255})"')
+    out: list[str] = []
+    index = 0
+    while index < len(text):
+        raw = raw_start.match(text, index)
+        if raw is None:
+            out.append(text[index])
+            index += 1
+            continue
+        hashes = raw.group(1)
+        terminator = '"' + hashes
+        end = text.find(terminator, raw.end())
+        if end < 0:
+            raise ValueError("Unterminated Rust raw string in script_eval contract")
+        literal = text[index:end + len(terminator)]
+        out.append("".join("\n" if char == "\n" else " " for char in literal))
+        index = end + len(terminator)
+    return "".join(out)
+
+
 def _commands(source: Path) -> dict[str, bytes]:
-    text = _strip_rust_comments(source.read_text())
+    text = _mask_rust_raw_strings(_strip_rust_comments(source.read_text()))
     table = re.search(
         r"pub\s+const\s+COMMANDS\s*:\s*&\[Command\]\s*=\s*&\[(.*?)\];",
         text, re.S,
@@ -190,7 +212,7 @@ def _split_flags(body: str) -> list[str]:
 
 
 def _script_contract(harness: Path) -> tuple[int, int, int]:
-    text = _strip_rust_comments(harness.read_text())
+    text = _mask_rust_raw_strings(_strip_rust_comments(harness.read_text()))
     limit = re.search(r"const\s+ELEMENT_LEN_MAX\s*:\s*usize\s*=\s*([0-9_]+)\s*;", text)
     flags = re.search(
         r"const\s+FLAGS\s*:\s*\[VerifyFlags\s*;\s*([0-9_]+)\s*\]\s*=\s*\[(.*?)\]\s*;",

--- a/scripts/tests/test_import_qa_assets_boundaries.py
+++ b/scripts/tests/test_import_qa_assets_boundaries.py
@@ -63,6 +63,39 @@ class SeedBoundaryTests(unittest.TestCase):
         self.map_p2p()
         self.assertEqual([path.read_bytes() for path in self.output.iterdir()], [b"\0payload"])
 
+    def test_raw_string_delimiters_preserve_live_command_selection(self):
+        # Rust Reference raw-string grammar (matching hash-delimited terminators):
+        # https://doc.rust-lang.org/reference/tokens.html#raw-string-literals
+        # Strings before COMMANDS are fixture data, not inventory or comments.
+        table = ('pub const COMMANDS: &[Command] = &['
+                 'Command { name: "ping" }, Command { name: "verack" }];')
+        self.write_message("verack")
+        for prefix in ("r", "br", "cr"):
+            for count in (0, 1, 2, 3, 255):
+                with self.subTest(prefix=prefix, hashes=count):
+                    hashes = "#" * count
+                    body = '/* // backslash \\'
+                    if count:
+                        body += ' embedded " /* quote'
+                    if count > 1:
+                        body += ' "' + "#" * (count - 1) + ' not the terminator'
+                    literal = prefix + hashes + '"' + body + '"' + hashes
+                    kind = {'r': '&str', 'br': '&[u8]', 'cr': '&core::ffi::CStr'}[prefix]
+                    text = 'const EXAMPLE: ' + kind + ' = ' + literal + ';\n' + table
+                    self.inventory.write_text(text)
+                    self.assertIn(literal, mapper._strip_rust_comments(text))
+                    self.map_p2p()
+                    self.assertEqual([path.read_bytes() for path in self.output.iterdir()],
+                                     [b"\x01"])
+
+    def test_unterminated_raw_literal_is_rejected(self):
+        self.inventory.write_text('const BAD: &str = r##"not terminated;\n'
+                                  'pub const COMMANDS: &[Command] = &['
+                                  'Command { name: "verack" }];')
+        with self.assertRaisesRegex(ValueError, "raw string"):
+            self.map_p2p()
+        self.assertFalse(self.output.exists())
+
     def test_header_only_command_becomes_a_selector_only_seed(self):
         self.inventory.write_text('pub const COMMANDS: &[Command] = &[Command { name: "verack" }];')
         self.write_message("verack")

--- a/scripts/tests/test_import_qa_assets_provenance.py
+++ b/scripts/tests/test_import_qa_assets_provenance.py
@@ -235,9 +235,9 @@ printf '%s\\n' "${{!#}}" >> "$TEST_ROOT/cmin.log"
         self.assertIn("TAPROOT", record)
         self.assertIn("FLAGS", record)
 
-        documentation = (self.root / "scripts/import-qa-assets.sh").read_text()
-        self.assertNotIn("selector 0x00", documentation)
-        self.assertNotIn("selector 0x03", documentation)
+        documentation = OWNER_HARNESS.read_text()
+        self.assertNotIn("`0x00`", documentation)
+        self.assertNotIn("`0x03`", documentation)
 
 
 


### PR DESCRIPTION
## Why this follow-up exists

#783 and #784 received concurrent automated-review changes and were merged outside this session. Re-read those changes instead of overwriting them, then reproduced **two failures in the existing importer suite on merged main `800c97db1df509e0e8ccbc3905139d478fccf357`**.

1. The raw-string scanner searches for a quote, matching hashes, **and an extra trailing quote**. Rust's terminator has only the first quote plus the matching hashes. The newly merged `test_raw_strings_before_commands_do_not_stop_inventory_scan` therefore raises `ValueError` on its valid fixture.
2. The provenance test reads `self.root/scripts/import-qa-assets.sh`, which its temporary repository never creates. It fails with `FileNotFoundError`. Its intended documentation owner is the existing `OWNER_HARNESS`, whose comment was changed by the concurrent fix.

## Changes

- Correct the raw-string terminator and use the regex match's absolute end position.
- Compile the raw-string prefix pattern once per scan and match at the cursor, avoiding a full remaining-source slice at every character.
- Read `OWNER_HARNESS` for the documentation assertion and reject its obsolete backtick-quoted selector literals.
- Preserve the concurrent QAC-04 permissions contract, its regression references, the existing raw-string regression, and the updated Rust harness comment. No duplicate contract is added.
- Add two regressions: a 15-case delimiter matrix (`r`, `br`, `cr`; 0/1/2/3/255 hashes; embedded quotes, backslashes, comment markers, and shorter nonterminating delimiters) plus unterminated-raw-string rejection.

Independent lexical reference: https://doc.rust-lang.org/reference/tokens.html#raw-string-literals . The fixtures test that token grammar; they are not claimed to have been compiled with Rust in this environment.

## Executed verification

The relevant merged files were reconstructed locally and verified against their immutable remote Git blobs before execution:

- merged mapper: `b0da9db35aeb57e8d08fcca82c11745f59941df6`
- merged boundary tests: `e17e31c3bbf0f17703a3f77959dc9fd779e68cab`
- merged provenance tests: `92bb11833c794a30bf39a0e9257033588af11fac`
- real Rust harness fixture: `144893379f1cb5bb14f8b80fd5bc31d713435cba`

Command: `python3 -m unittest discover -s scripts/tests -p 'test_import_qa_assets*.py' -v`

- Verified merged baseline: **60 tests, 2 errors** (the exact failures above).
- Final candidate: **62 passed**, including both previously failing regressions; rerun on the exact published blobs also passed.
- Bash syntax, Python compile checks, and whitespace checks passed.
- Published candidate blobs match locally tested mapper `4550b606`, boundary tests `bc07917a`, and provenance tests `fa75380c`.

## Scope and limits

One commit, three Python files, based on the merged state. No Rust source, production validation behavior, dependency, live corpus, historical provenance, or main-branch mutation. No force-push and no merge is requested.

Draft pending final-head CI. This environment still lacks Cargo: Clippy and the locked CL-14 gate returned 127 when attempted. No full-repository clean verdict, compiler-backed gate pass, end-to-end fuzz minimization, or performance-promotion result is claimed. The separate setup-contract/test-sentinel discrepancy recorded on #784 remains outside this focused repair.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two regressions in the QA importer suite that appeared on merged main: raw-string bodies are now masked before declaration scanning so they can't cause false matches, and the provenance test reads `OWNER_HARNESS` instead of a script file the temporary repo never creates.

Adds regression coverage for raw-string delimiter edge cases and unterminated literals, and updates the provenance assertion to reject obsolete backtick-quoted selector literals.

- Masks raw-string contents so regexes locating `COMMANDS`, `ELEMENT_LEN_MAX`, and `FLAGS` only see real declarations.
- Corrects the raw-string terminator and matches at the cursor instead of slicing the remaining source.
- Preserves the concurrent permissions contract and existing regression references.
- Adds a 15-case delimiter matrix covering `r`, `br`, `cr` prefixes and 0–255 hashes.

<sup>Written for commit c227048488f29f009cb7201b7915c9af04c73359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

