### PR TITLE
perf(storage): coalesce flat-file block appends

### DIFF
--- a/crates/storage/src/block_file.rs
+++ b/crates/storage/src/block_file.rs
@@ -850,14 +850,75 @@ fn open_new_block_file(blocks_dir: &Path, file_no: u32) -> Result<File, StorageE
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::OpenOptions, io::Write as _};
+    use std::{
+        fs::OpenOptions,
+        io::{self, Write as _},
+    };
 
     use tempfile::tempdir;
 
-    use super::{BLOCK_FILE_MAGIC, BlockFilePosition, FlatFileBlockStore, RECORD_HEADER_LEN_U64};
+    use super::{
+        write_record, BLOCK_FILE_MAGIC, BlockFilePosition, FlatFileBlockStore, RECORD_HEADER_LEN_U64,
+    };
 
     fn hash(byte: u8) -> [u8; 32] {
         [byte; 32]
+    }
+
+    struct VectoredTestWriter {
+        bytes: Vec<u8>,
+        max_write: usize,
+        interrupt_once: bool,
+    }
+
+    impl io::Write for VectoredTestWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            let written = bytes.len().min(self.max_write);
+            self.bytes.extend_from_slice(&bytes[..written]);
+            Ok(written)
+        }
+
+        fn write_vectored(&mut self, slices: &[io::IoSlice<'_>]) -> io::Result<usize> {
+            if self.interrupt_once {
+                self.interrupt_once = false;
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "try again"));
+            }
+            let requested = slices.iter().map(|slice| slice.len()).sum::<usize>();
+            let written = requested.min(self.max_write);
+            let mut remaining = written;
+            for slice in slices {
+                let count = remaining.min(slice.len());
+                self.bytes.extend_from_slice(&slice[..count]);
+                remaining -= count;
+                if remaining == 0 {
+                    break;
+                }
+            }
+            Ok(written)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_record_handles_short_interrupted_and_zero_writes() {
+        let mut writer = VectoredTestWriter {
+            bytes: Vec::new(),
+            max_write: 1,
+            interrupt_once: true,
+        };
+        write_record(&mut writer, b"header", b"body").expect("short writes must be retried");
+        assert_eq!(writer.bytes, b"headerbody");
+
+        let mut writer = VectoredTestWriter {
+            bytes: Vec::new(),
+            max_write: 0,
+            interrupt_once: false,
+        };
+        let error = write_record(&mut writer, b"header", b"body").expect_err("zero write");
+        assert_eq!(error.kind(), io::ErrorKind::WriteZero);
     }
 
     /// `disk_usage` reports bytes that are there, and stops reporting them when

--- a/crates/storage/src/block_file.rs
+++ b/crates/storage/src/block_file.rs
@@ -215,15 +215,15 @@ impl FlatFileBlockStore {
         header[8..12].copy_from_slice(&height.to_le_bytes());
         header[12..].copy_from_slice(&hash);
 
-        writer.file.seek(SeekFrom::Start(position.offset))?;
         let next_offset = position
             .offset
             .checked_add(record_len)
             .ok_or(StorageError::InvalidOperation("block file offset overflow"))?;
-        let append_result = writer
-            .file
-            .write_all(&header)
-            .and_then(|()| writer.file.write_all(body))
+        // The writer cursor is established at `append_offset` when the store
+        // opens or recovers, starts at zero on rollover, and advances by the
+        // exact record length after every successful write. Keep that invariant
+        // instead of issuing an unconditional seek for every block.
+        let append_result = write_record(&mut writer.file, &header, body)
             .and_then(|()| writer.file.flush());
         if let Err(append_error) = append_result {
             writer.rollback_offset = Some(position.offset);
@@ -708,6 +708,25 @@ fn body_offset(offset: u64) -> Option<u64> {
 
 fn record_end(position: BlockFilePosition) -> Option<u64> {
     body_offset(position.offset)?.checked_add(u64::from(position.len))
+}
+
+fn write_record(writer: &mut impl io::Write, header: &[u8], body: &[u8]) -> io::Result<()> {
+    let mut slices: &mut [io::IoSlice<'_>] =
+        &mut [io::IoSlice::new(header), io::IoSlice::new(body)];
+    while !slices.is_empty() {
+        match writer.write_vectored(slices) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write whole block record",
+                ));
+            }
+            Ok(written) => io::IoSlice::advance_slices(&mut slices, written),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
 }
 
 /// Complete framed record count and byte length in an already-open block file.


### PR DESCRIPTION
## Scope

Reduce kernel transitions in the ranked `apply.body_persist` hot path without changing durability or recovery semantics.

## Change

- Drop the unconditional `seek(append_offset)` before every block-body append. The writer cursor is already established at the recovered append offset on open/recovery, starts at zero after rollover, and advances by the exact record length on successful writes.
- Emit the 44-byte frame header and borrowed block body through one vectored-write loop instead of two independent `write_all` calls.
- Preserve `flush`, rollover `sync_data`, directory sync, append rollback/truncation, dirty-usage recovery, and framed-body format exactly.
- Handle short vectored writes, `Interrupted`, and `WriteZero` explicitly.

## Expected effect / evidence boundary

The source path removes one unconditional seek operation and can collapse header+body emission to one vectored write per successful record. This PR does **not** claim a wall-time or IBD speedup: the repository's performance contract requires matched-product measurements before promoting such a number.

Historical hot-path attribution ranks block-body persistence first among unresolved candidates, so this is deliberately narrower than changing flush/durability policy.

## Verification

This branch is based on `main` `ff96503212be41acc10252ebdbc8b97eaccf42a2`. The environment used to prepare the patch has no runnable Cargo checkout, so compiler-backed verification is delegated to the repository's PR CI before this is marked ready. Existing block-file tests cover rollover, reopen/torn-tail recovery, failed rollback recovery, persisted-position idempotence, range reads, and disk-usage accounting.

No force push, schema change, durability weakening, or merge requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces kernel transitions in the block-file append path by removing the unconditional seek before each body append and emitting the header and body in a single vectored write. The writer cursor already tracks the correct offset, durability and recovery semantics are unchanged, and new unit tests cover short, interrupted, and zero-length writes.

<sup>Written for commit 62b22f549acefcc016008c1744e1b69de1fe0952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

