### PR TITLE
perf(node): avoid block reserialization in stager size checks

### DIFF
--- a/crates/node/src/sync/stage.rs
+++ b/crates/node/src/sync/stage.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bitcoin_rs_primitives::{Block, Hash256, consensus_bytes};
+use bitcoin_rs_primitives::{Block, Hash256};
 use hashbrown::{HashMap, hash_map::Entry};
 
 use bitcoin_rs_p2p::SyncBudget;
@@ -87,7 +87,7 @@ impl BlockStager {
         self.received_blocks_high_water
     }
 
-    /// Highest staged-byte total ever observed this run.
+    /// Highest staged-byte total observed; feeds the high-water gauge.
     pub(super) const fn received_bytes_high_water(&self) -> usize {
         self.received_bytes_high_water
     }
@@ -369,7 +369,7 @@ fn received_deadline(received_at: Instant, timeout: Duration) -> Instant {
 }
 
 fn block_size(block: &Block) -> usize {
-    consensus_bytes(block).len()
+    block.total_size()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Scope

Remove a debug/test-path full-block allocation and copy from inbound staging without weakening the size invariant.

## Change

`BlockStager::insert` compares the preserved P2P payload length against the decoded block's consensus size under `debug_assert_eq!`. The helper previously called `consensus_bytes(block).len()`, which allocates a `Vec` and serializes the full block solely to count bytes.

Use the existing native `Block::total_size()` helper instead. That helper routes through `consensus_len` / `CountWriter`, so it executes the same consensus encoder while counting bytes without allocating the encoded buffer. The existing `block_size_matches_consensus_serialized_len` test remains as the independent equality oracle.

Also removes the now-unused production import and tightens the high-water accessor comment.

## Expected effect / evidence boundary

This removes one full serialized-block allocation/copy for every staged insert when `debug_assertions` are enabled (notably ordinary tests and debug-node runs). It does not change release behavior where the debug assertion is compiled out, so no release-IBD wall-time claim is made.

## Verification

Source-level verification pins `Block::total_size()` to the repository's allocation-free `consensus_len` implementation, and the existing regression test compares it against real consensus serialization. Full compiler/test verification is delegated to PR CI because this execution environment has no runnable Cargo checkout.

One commit, one file, no protocol, budget, validation, storage, or persistence semantic change. No merge requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids reserializing staged blocks just to check their size when debug assertions are on.

In `BlockStager::insert`, the size check now calls `Block::total_size()` instead of `consensus_bytes(block).len()`, so checking the size invariants no longer allocates a full encoded copy of every staged block. This affects only `debug_assertions` builds; release behavior is unchanged.

<sup>Written for commit 7cbf97f4d41fe2cf16f4b5b8440fe1410ed0ad4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

