### PR TITLE
perf(primitives): format Hash256 Display through a stack hex buffer

### DIFF
--- a/crates/primitives/src/hash.rs
+++ b/crates/primitives/src/hash.rs
@@ -4,6 +4,8 @@ use bytemuck::{Pod, Zeroable};
 use thiserror::Error;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
 /// A 256-bit Bitcoin hash stored in consensus little-endian byte order.
 #[derive(
     Copy,
@@ -78,7 +80,6 @@ impl Hash256 {
     /// Formats this hash as conventional big-endian lowercase hexadecimal.
     #[must_use]
     pub fn to_string_be(self) -> String {
-        const HEX: &[u8; 16] = b"0123456789abcdef";
         let mut s = String::with_capacity(64);
         for byte in self.0.iter().rev() {
             s.push(char::from(HEX[usize::from(byte >> 4)]));
@@ -104,10 +105,15 @@ impl Hash256 {
 
 impl fmt::Display for Hash256 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in self.0.iter().rev() {
-            write!(f, "{byte:02x}")?;
+        let mut encoded = [0_u8; 64];
+        for (byte, pair) in self.0.iter().rev().zip(encoded.chunks_exact_mut(2)) {
+            pair[0] = HEX[usize::from(byte >> 4)];
+            pair[1] = HEX[usize::from(byte & 0x0f)];
         }
-        Ok(())
+        // Every byte comes from the ASCII table. Keep this conversion checked
+        // rather than adding unsafe code to a presentation-only path.
+        let text = core::str::from_utf8(&encoded).map_err(|_| fmt::Error)?;
+        f.write_str(text)
     }
 }
 
@@ -130,6 +136,8 @@ const fn decode_nibble(byte: u8, offset: usize) -> Result<u8, HashError> {
 
 #[cfg(test)]
 mod tests {
+    use core::fmt::{self, Write as _};
+
     use super::{Hash256, HashError};
 
     #[test]
@@ -150,10 +158,60 @@ mod tests {
             hash.to_string_be(),
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
         );
+        assert_eq!(
+            hash.to_string(),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+        );
         // `prefix8()` is an internal convenience helper (used only by the
         // chain tree's hash-table key and a benchmark sharder), not a durable
         // consensus/serialization contract, so it is not pinned here.
         Ok(())
+    }
+
+    #[test]
+    fn display_matches_bytewise_reference() -> fmt::Result {
+        for position in 0..32 {
+            for value in 0..=u8::MAX {
+                let mut bytes = [0_u8; 32];
+                bytes[position] = value;
+                let mut expected = String::with_capacity(64);
+                for byte in bytes.iter().rev() {
+                    write!(&mut expected, "{byte:02x}")?;
+                }
+                let hash = Hash256::from_le_bytes(&bytes);
+                assert_eq!(hash.to_string(), expected);
+                assert_eq!(hash.to_string_be(), expected);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn display_preserves_existing_format_options() {
+        let hash = Hash256::from_le_bytes(&[0xab; 32]);
+        let expected = "ab".repeat(32);
+        // The existing Display contract ignores outer width, precision, and
+        // numeric flags; switching to Formatter::pad would change its output.
+        assert_eq!(format!("{hash:>80}"), expected);
+        assert_eq!(format!("{hash:<80}"), expected);
+        assert_eq!(format!("{hash:^80}"), expected);
+        assert_eq!(format!("{hash:.8}"), expected);
+        assert_eq!(format!("{hash:#}"), expected);
+        assert_eq!(format!("{hash:+080}"), expected);
+    }
+
+    #[test]
+    fn display_propagates_writer_errors() {
+        struct Reject;
+
+        impl fmt::Write for Reject {
+            fn write_str(&mut self, _text: &str) -> fmt::Result {
+                Err(fmt::Error)
+            }
+        }
+
+        let hash = Hash256::default();
+        assert!(fmt::write(&mut Reject, format_args!("{hash}")).is_err());
     }
 
     #[test]

--- a/crates/primitives/src/hash.rs
+++ b/crates/primitives/src/hash.rs
@@ -190,8 +190,10 @@ mod tests {
     fn display_preserves_existing_format_options() {
         let hash = Hash256::from_le_bytes(&[0xab; 32]);
         let expected = "ab".repeat(32);
-        // The existing Display contract ignores outer width, precision, and
-        // numeric flags; switching to Formatter::pad would change its output.
+        // Rust Reference, "Formatting parameters": Display receives these
+        // parameters, but `write_str` does not apply outer padding or numeric
+        // formatting; using `Formatter::pad` would change this Display output.
+        // https://doc.rust-lang.org/reference/format-args.html#formatting-parameters
         assert_eq!(format!("{hash:>80}"), expected);
         assert_eq!(format!("{hash:<80}"), expected);
         assert_eq!(format!("{hash:^80}"), expected);


### PR DESCRIPTION
## Scope

One atomic source-file change against `ff96503212be41acc10252ebdbc8b97eaccf42a2`: `crates/primitives/src/hash.rs`.

Replace the 32 per-byte numeric formatting invocations in `Hash256` Display with a 64-byte stack buffer and one formatter write. Reuse the existing hexadecimal alphabet, use checked UTF-8 conversion, and leave `to_string_be()`'s algorithm and hash parsing unchanged. No unsafe code, dependencies, default changes, or public API additions.

## Regression coverage added

Three native tests cover every byte value at every hash position, existing outer format-option behavior, and destination-writer errors. The existing genesis hash golden test also covers Display.

## Preparation evidence

- Base source Git blob: `837eb4d916eabdfb5e0c7712108fadb5b7a81bf4`
- Candidate Git blob: `18d00677417a9cde97439b87a968c59ec3ce06be`
- Independent Python encoding models: 12,545 cases, no mismatches
- Patch application/reversal and whitespace checks passed on the exact reviewed baseline

These results are algorithm/model evidence, not Rust compilation or a measured performance result.

## Pending before ready/merge

Run the pinned Rust 1.95.0 rustfmt, locked primitives tests including release, and Clippy with warnings denied. Run paired baseline/candidate production formatting benchmarks with output, allocation, and latency evidence. The old Display does not itself allocate a heap buffer, so this PR makes no per-byte allocation-elimination claim. Checked UTF-8 overhead and actual caller allocation effects remain unmeasured.

The preparation environment lacked Cargo/rustc, so AGENTS.md's pre-publication Clippy requirement could not be fulfilled there. This PR is intentionally a draft pending GitHub CI/native validation and performance evidence; it is not a performance-promotion claim.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `Hash256` Display formatting by writing the hex output from a stack buffer in one call instead of 32 per-byte writes.

- Moves the shared hex alphabet to module scope for reuse by `to_string_be()`.
- Adds tests covering all byte values at every position, format-option behavior, and writer error propagation.
- No unsafe code, dependency changes, or public API additions; output is identical.

<sup>Written for commit b53bc217436b6798d9d15f2e9bf068f872759080. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

