### PR TITLE
perf(rpc): select mempool pages before full ordering and repeated cursor formatting

### DIFF
--- a/crates/rpc/src/esplora/backend.rs
+++ b/crates/rpc/src/esplora/backend.rs
@@ -9,7 +9,7 @@ use core::str::FromStr as _;
 use bitcoin_rs_primitives::{OutPoint, Txid};
 
 use super::http::{bad, dispatch_error, json_response, query_limit};
-use super::model::Outspend;
+use super::model::{Outspend, TransactionValue};
 use super::projection::Projection;
 use super::public::{block_transaction_values, outspend, outspends_for_transaction};
 use crate::context::Context;
@@ -51,30 +51,42 @@ fn internal_block_txs(ctx: &Context, hash: &str) -> Response {
 
 fn internal_mempool_txs(ctx: &Context, last: Option<&str>, query: &str) -> Response {
     let max_txs = query_limit(query, "max_txs").unwrap_or(usize::MAX);
-    // Ordering needs every entry, the answer needs `max_txs` of them. The pool
-    // payload stays behind its `Arc` until the page is cut, so a one-transaction
-    // request no longer copies the whole mempool under the read lock.
+    if max_txs == 0 {
+        return json_response(Vec::<TransactionValue>::new());
+    }
+    // A cursor previously matched the exact lowercase Display text. Parse
+    // once, but keep malformed, noncanonical, and absent cursors restarting
+    // at the beginning instead of silently broadening the accepted syntax.
+    let last = last.and_then(|text| {
+        let txid = Txid::from_str(text).ok()?;
+        (txid.to_string() == text).then_some(txid)
+    });
     let transactions = {
         let pool = ctx.mempool.read();
+        // Resolve the cursor in the same snapshot as the entries. Filtering
+        // before cloning avoids retaining transactions before this page.
+        let after = last
+            .and_then(|txid| pool.entry_by_txid(&txid))
+            .map(|entry| (entry.time, entry.txid));
         let mut ordered = pool
             .iter_entries()
+            .filter(|entry| after.is_none_or(|key| (entry.time, entry.txid) > key))
             .map(|entry| (entry.time, entry.txid, Arc::clone(&entry.tx)))
             .collect::<Vec<_>>();
         drop(pool);
+        // Partition outside the lock, then sort only the requested prefix.
+        // The strict bound also handles empty snapshots and usize::MAX.
+        if max_txs < ordered.len() {
+            ordered.select_nth_unstable_by(max_txs, |left, right| {
+                left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1))
+            });
+            ordered.truncate(max_txs);
+        }
         ordered.sort_unstable_by(|left, right| {
             left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1))
         });
-        let start = last
-            .and_then(|last| {
-                ordered
-                    .iter()
-                    .position(|(_, txid, _)| txid.to_string() == last)
-            })
-            .map_or(0, |position| position.saturating_add(1));
         ordered
             .into_iter()
-            .skip(start)
-            .take(max_txs)
             .map(|(_, _, transaction)| transaction)
             .collect::<Vec<_>>()
     };
@@ -180,4 +192,168 @@ fn block_template(handler: &Handler) -> Response {
     handler
         .dispatch("getblocktemplate", &sonic_json!([]))
         .map_or_else(dispatch_error, json_response)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod pagination_tests {
+    use alloc::sync::Arc;
+
+    use bitcoin_rs_mempool::MempoolEntry;
+    use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
+    use serde_json::Value;
+
+    use super::internal_mempool_txs;
+    use crate::context::Context;
+
+    fn fixture(times: &[u64]) -> (Context, Vec<(u64, Txid)>) {
+        let ctx = Context::new();
+        let mut expected = Vec::new();
+        for (index, &time) in times.iter().enumerate() {
+            // No-input fixtures isolate the projection/pagination owner;
+            // they do not claim to exercise consensus or admission validity.
+            let tx = Tx {
+                version: 2,
+                inputs: Vec::new(),
+                outputs: vec![TxOut {
+                    value: 1_000,
+                    script_pubkey: vec![0x51],
+                }],
+                lock_time: u32::try_from(index).expect("small fixture index"),
+            };
+            let entry = MempoolEntry::new(Arc::new(tx), 100, 1_000, time, 0);
+            expected.push((time, entry.txid));
+            ctx.mempool
+                .pool()
+                .write()
+                .insert_entry(entry)
+                .expect("insert independent fixture entry");
+        }
+        // Independent reference: fully order all admission keys, then slice.
+        expected.sort_unstable();
+        (ctx, expected)
+    }
+
+    fn page(ctx: &Context, cursor: Option<&str>, query: &str) -> Vec<Txid> {
+        let response = internal_mempool_txs(ctx, cursor, query);
+        assert_eq!(
+            response.status,
+            200,
+            "{}",
+            String::from_utf8_lossy(&response.body)
+        );
+        let values: Value = serde_json::from_slice(&response.body).expect("response JSON");
+        values
+            .as_array()
+            .expect("transaction array")
+            .iter()
+            .map(|value| {
+                value["txid"]
+                    .as_str()
+                    .expect("text txid")
+                    .parse()
+                    .expect("valid txid")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn bounded_pages_match_full_sort_for_every_cursor() {
+        for times in [
+            Vec::new(),
+            vec![0],
+            vec![u64::MAX],
+            vec![7; 18],
+            vec![8, 0, u64::MAX, 8, 1, 8, 1, 0, 9, 8, 1, 0, 9, 4, 4, 8, 2, 9],
+        ] {
+            let (ctx, expected) = fixture(&times);
+            let cursors = std::iter::once(None)
+                .chain(expected.iter().map(|(_, txid)| Some(txid.to_string())));
+            for (start, cursor) in cursors.enumerate() {
+                for limit in [0, 1, 2, 3, 8, 17, 18, 19, usize::MAX] {
+                    let want: Vec<_> = expected
+                        .iter()
+                        .skip(start)
+                        .take(limit)
+                        .map(|(_, txid)| *txid)
+                        .collect();
+                    assert_eq!(
+                        page(&ctx, cursor.as_deref(), &format!("max_txs={limit}")),
+                        want,
+                        "cursor {cursor:?}, limit {limit}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn noncanonical_and_missing_cursors_keep_restart_behavior() {
+        let (ctx, expected) = fixture(&[4, 1, 4, 2, 4, 3]);
+        let lower = expected[2].1.to_string();
+        let upper = lower.to_ascii_uppercase();
+        assert_ne!(lower, upper, "fixture must exercise alphabetic hex");
+        let unknown = Txid(Hash256::from_le_bytes(&[0xff; 32]));
+        assert!(expected.iter().all(|(_, txid)| *txid != unknown));
+        let want: Vec<_> = expected.iter().take(3).map(|(_, txid)| *txid).collect();
+        for cursor in [
+            String::new(),
+            "00".to_owned(),
+            "g".repeat(64),
+            "é".repeat(32),
+            format!(" {lower}"),
+            format!("0x{lower}"),
+            upper,
+            unknown.to_string(),
+        ] {
+            assert_eq!(page(&ctx, Some(&cursor), "max_txs=3"), want);
+        }
+    }
+
+    #[test]
+    fn absent_invalid_and_duplicate_limits_keep_query_semantics() {
+        let (ctx, expected) = fixture(&[2, 0, 1, 2]);
+        let all: Vec<_> = expected.iter().map(|(_, txid)| *txid).collect();
+        for query in [
+            "",
+            "max_txs=invalid",
+            "max_txs=-1",
+            "max_txs=184467440737095516160",
+            "other=1",
+        ] {
+            assert_eq!(page(&ctx, None, query), all);
+        }
+        assert_eq!(page(&ctx, None, "max_txs=invalid&max_txs=2"), all[..2]);
+        assert_eq!(page(&ctx, None, "max_txs=1&max_txs=2"), all[..1]);
+        assert!(page(&ctx, None, "max_txs=0&max_txs=2").is_empty());
+    }
+
+    #[test]
+    fn unselected_transactions_are_not_projected() {
+        let (ctx, expected) = fixture(&[2, 3]);
+        let tx = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0xaa; 32])), 0),
+                script_sig: Vec::new(),
+                sequence: u32::MAX,
+                witness: Vec::new(),
+            }],
+            outputs: vec![TxOut {
+                value: 1,
+                script_pubkey: vec![0x51],
+            }],
+            lock_time: 99,
+        };
+        let entry = MempoolEntry::new(Arc::new(tx), 100, 1_000, 1, 0);
+        let cursor = entry.txid.to_string();
+        ctx.mempool
+            .pool()
+            .write()
+            .insert_entry(entry)
+            .expect("insert unresolved-prevout fixture");
+        assert_eq!(internal_mempool_txs(&ctx, None, "max_txs=1").status, 503);
+        assert_eq!(page(&ctx, Some(&cursor), "max_txs=1"), vec![expected[0].1]);
+        assert!(page(&ctx, None, "max_txs=0").is_empty());
+    }
 }

--- a/crates/rpc/src/esplora/backend.rs
+++ b/crates/rpc/src/esplora/backend.rs
@@ -287,6 +287,9 @@ mod pagination_tests {
         }
     }
 
+    // Contract: docs/contracts/external-api.md, API-09 (Esplora dialects),
+    // which defines exact lowercase txid cursors and restart behavior for
+    // malformed, noncanonical, unknown, and missing values.
     #[test]
     fn noncanonical_and_missing_cursors_keep_restart_behavior() {
         let (ctx, expected) = fixture(&[4, 1, 4, 2, 4, 3]);

--- a/docs/contracts/external-api.md
+++ b/docs/contracts/external-api.md
@@ -183,7 +183,12 @@ Owners:
   Only declared backend-dialect routes exist; each backend route is marked
   as such.
 - History reads use bounded pages and cursors that preserve public
-  Esplora cursor semantics. A richer internal revision token stays
+    Esplora cursor semantics. Cursor values
+   are the exact lowercase `txid` display text: malformed, noncanonical
+   (including uppercase or prefixed), unknown, and missing cursors restart from
+   the beginning; a valid known cursor strictly excludes that transaction and
+   earlier entries.
+  A richer internal revision token stays
   internal or is a documented extension. Lag, reorg, or a disabled
   capability returns the declared unavailable response, never an empty
   successful history.


### PR DESCRIPTION
## Scope

One atomic source-file change against `ff96503212be41acc10252ebdbc8b97eaccf42a2`: `crates/rpc/src/esplora/backend.rs`.

Parse the cursor once outside the pool guard while preserving exact lowercase Display matching. Resolve the cursor key and snapshot entries under one read guard, filter before Arc cloning, release the guard, partition to the requested prefix, then sort only that prefix. Return an empty JSON array without a pool snapshot for a zero limit. Projection and outer chain-generation checks are unchanged. No cache, public API, dependency, unsafe code, default, or persistence change. No dependency on the separate Hash256 formatting candidate.

## Compatibility and regression coverage

Preserve ascending `(time, txid)` order, strict cursor exclusion, restart behavior for uppercase/malformed/missing cursors, and existing query-limit handling. Keep nth selection behind a strict index `< len` guard. Four native test functions cover boundary/tied/extreme-time fixtures, every fixture cursor, limit parsing, and avoiding unselected transaction projection. These owner tests use the existing raw test-seam insertion, not production transaction admission.

## Preparation evidence

- Base source Git blob: `6e4495da7b19c168a39e22fbd6d513b736bc5895`
- Candidate Git blob: `57df6abbd06f0de87e72baf8b4a17bee0085b361`
- Independent full-sort vs partition model: 274,770 comparisons, no mismatches
- Four deliberately faulty variants were rejected
- Patch application/reversal and whitespace checks passed on the exact reviewed baseline

This does not establish native RPC behavior, allocation/lock performance, Clippy, owner gates, or any measured speedup.

## Performance hypothesis and pending gates

Selection/sorting work becomes `O(R + K log K)` for `R` entries after the cursor and `K` returned entries, plus the initial pool traversal. Memory remains `O(R)`, not `O(K)`, and a nearly full page may regress due to extra partition work. Filtering adds comparisons under the read lock while saving pre-cursor Arc clones; contention must be measured. Existing code already used Arc snapshots and sorted outside the lock, so neither is claimed as newly introduced.

Before ready/merge, run pinned Rust 1.95.0 locked RPC tests, rustfmt, Clippy, CL-07 coherent-view and CL-14 resource gates, actual public-route/concurrent-mutation tests, and paired native latency/allocation/RSS/lock benchmarks.

The preparation environment lacked Cargo/rustc, so AGENTS.md's pre-publication Clippy requirement could not be fulfilled there. This PR is intentionally a draft pending GitHub CI/native validation and measurement; it is not a performance-promotion claim.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes mempool page selection in the esplora RPC backend so a page request no longer sorts the full pool. The cursor is parsed once outside the lock, entries are filtered before Arc cloning, and only the requested prefix is sorted after selection; zero-limit requests return an empty array without a pool snapshot.

- Preserves existing `(time, txid)` ordering, strict cursor exclusion, and restart behavior for noncanonical or missing cursors.
- Documents the cursor contract in `docs/contracts/external-api.md`: cursors are exact lowercase `txid` text, and malformed, noncanonical, unknown, or missing cursors restart from the beginning.
- Adds tests for boundary and tied-time fixtures, cursor parsing, limit handling, and that unselected transactions are not projected.
- No API, cache, dependency, or public behavior changes.

<sup>Written for commit 9c6a3904fbec2fd3ec16add2abc2d0b2826697f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

