### PR TITLE
fix(consensus): enforce BIP141 witness activation rules

### DIFF
--- a/crates/consensus/src/verify_block.rs
+++ b/crates/consensus/src/verify_block.rs
@@ -65,13 +65,24 @@ pub fn verify_block_rules_precomputed(
         return Err(ConsensusError::MerkleMutation);
     }
 
-    if context.segwit_active && facts.has_witness() {
+    // BIP141/Core select a coinbase commitment independently of witness
+    // presence. A selected commitment requires its reserved-value proof even
+    // when every input witness is empty. Without an active commitment, witness
+    // data is forbidden (including before SegWit activation).
+    let has_witness_commitment = context.segwit_active
+        && txdata[0].outputs.iter().rev().any(|output| {
+            output.script_pubkey.len() >= 38
+                && output.script_pubkey[..6] == [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed]
+        });
+    if has_witness_commitment {
         let Some(wtxids) = facts.wtxids() else {
             return Err(ConsensusError::WitnessCommitment);
         };
         if wtxids.len() != txdata.len() || !block_witness_commitment_matches(block, wtxids) {
             return Err(ConsensusError::WitnessCommitment);
         }
+    } else if facts.has_witness() {
+        return Err(ConsensusError::WitnessCommitment);
     }
 
     let weight = facts.weight();

--- a/crates/consensus/src/verify_block.rs
+++ b/crates/consensus/src/verify_block.rs
@@ -13,7 +13,7 @@ mod legacy {
 pub(crate) use legacy::merkle_root_and_mutation_borrowed;
 pub use legacy::{
     BlockRuleContext, block_has_witness, block_merkle_root_matches_txids,
-    block_witness_commitment_matches, verify_merkle_root_with_txids,
+    block_witness_commitment_matches, verify_merkle_root_with_txids, witness_commitment,
 };
 
 /// BIP141 maximum block weight in weight units.
@@ -69,11 +69,8 @@ pub fn verify_block_rules_precomputed(
     // presence. A selected commitment requires its reserved-value proof even
     // when every input witness is empty. Without an active commitment, witness
     // data is forbidden (including before SegWit activation).
-    let has_witness_commitment = context.segwit_active
-        && txdata[0].outputs.iter().rev().any(|output| {
-            output.script_pubkey.len() >= 38
-                && output.script_pubkey[..6] == [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed]
-        });
+    let has_witness_commitment =
+        context.segwit_active && witness_commitment(block).is_some();
     if has_witness_commitment {
         let Some(wtxids) = facts.wtxids() else {
             return Err(ConsensusError::WitnessCommitment);

--- a/crates/consensus/src/verify_block.rs
+++ b/crates/consensus/src/verify_block.rs
@@ -10,10 +10,10 @@ mod legacy {
     include!("verify_block_impl.rs");
 }
 
-pub(crate) use legacy::merkle_root_and_mutation_borrowed;
+pub(crate) use legacy::{merkle_root_and_mutation_borrowed, witness_commitment};
 pub use legacy::{
     BlockRuleContext, block_has_witness, block_merkle_root_matches_txids,
-    block_witness_commitment_matches, verify_merkle_root_with_txids, witness_commitment,
+    block_witness_commitment_matches, verify_merkle_root_with_txids,
 };
 
 /// BIP141 maximum block weight in weight units.
@@ -69,8 +69,7 @@ pub fn verify_block_rules_precomputed(
     // presence. A selected commitment requires its reserved-value proof even
     // when every input witness is empty. Without an active commitment, witness
     // data is forbidden (including before SegWit activation).
-    let has_witness_commitment =
-        context.segwit_active && witness_commitment(block).is_some();
+    let has_witness_commitment = context.segwit_active && witness_commitment(block).is_some();
     if has_witness_commitment {
         let Some(wtxids) = facts.wtxids() else {
             return Err(ConsensusError::WitnessCommitment);

--- a/crates/consensus/src/verify_block_impl.rs
+++ b/crates/consensus/src/verify_block_impl.rs
@@ -319,18 +319,13 @@ fn hash_avx2_parent_batches<T: Copy>(
 /// computing them here would re-serialize and re-hash every transaction on a
 /// path the node can already serve from its parse-once view.
 pub(crate) fn witness_commitment(block: &Block) -> Option<&[u8]> {
-    block.txs.first()?.outputs.iter().rev().find_map(|output| {
-        (output.script_pubkey.len() >= 38
-            && output.script_pubkey[..6] == WITNESS_COMMITMENT_PREFIX)
-            .then_some(&output.script_pubkey[6..38])
-    })
+    block.txs.first()?.outputs.iter().rev().find(|output| {
+        output.script_pubkey.len() >= 38
+            && output.script_pubkey[..6] == WITNESS_COMMITMENT_PREFIX
+    }).map(|output| &output.script_pubkey[6..38])
 }
 
 pub fn block_witness_commitment_matches(block: &Block, wtxids: &[Wtxid]) -> bool {
-    let Some(coinbase) = block.txs.first() else {
-        return false;
-    };;
-    // Highest matching output: iterate in reverse to find the last one.
     let Some(commitment) = witness_commitment(block) else {
         return false;
     };

--- a/crates/consensus/src/verify_block_impl.rs
+++ b/crates/consensus/src/verify_block_impl.rs
@@ -318,21 +318,20 @@ fn hash_avx2_parent_batches<T: Copy>(
 /// `wtxids` must contain one witness ID per block transaction in block order;
 /// computing them here would re-serialize and re-hash every transaction on a
 /// path the node can already serve from its parse-once view.
+pub(crate) fn witness_commitment(block: &Block) -> Option<&[u8]> {
+    block.txs.first()?.outputs.iter().rev().find_map(|output| {
+        (output.script_pubkey.len() >= 38
+            && output.script_pubkey[..6] == WITNESS_COMMITMENT_PREFIX)
+            .then_some(&output.script_pubkey[6..38])
+    })
+}
+
 pub fn block_witness_commitment_matches(block: &Block, wtxids: &[Wtxid]) -> bool {
     let Some(coinbase) = block.txs.first() else {
         return false;
-    };
+    };;
     // Highest matching output: iterate in reverse to find the last one.
-    let Some(commitment) = coinbase
-        .outputs
-        .iter()
-        .rev()
-        .find(|output| {
-            output.script_pubkey.len() >= 38
-                && output.script_pubkey[..6] == WITNESS_COMMITMENT_PREFIX
-        })
-        .map(|output| &output.script_pubkey[6..38])
-    else {
+    let Some(commitment) = witness_commitment(block) else {
         return false;
     };
     // BIP141: coinbase witness must have exactly one 32-byte element (the reserved value).

--- a/crates/consensus/tests/witness_activation_rules.rs
+++ b/crates/consensus/tests/witness_activation_rules.rs
@@ -9,7 +9,7 @@ use bitcoin_rs_consensus::verify_block::{
     BlockRuleContext, verify_block_rules, verify_block_rules_precomputed,
 };
 use bitcoin_rs_consensus::ConsensusError;
-use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_primitives::{Block, BlockHash, Header, OutPoint, Tx, TxIn, TxOut, Txid};
 
 const PREFIX: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
 // SHA256d(00*32 || 00*32): coinbase-only witness root and zero reserved value.

--- a/crates/consensus/tests/witness_activation_rules.rs
+++ b/crates/consensus/tests/witness_activation_rules.rs
@@ -1,0 +1,120 @@
+//! BIP141 activation/commitment regressions at the exported block-rule boundary.
+//!
+//! Independent references: BIP141 commitment structure and Bitcoin Core v31.0
+//! `CheckWitnessMalleation`. These fixtures isolate block witness rules; they
+//! are not mined or UTXO-valid chain fixtures.
+
+use bitcoin_rs_consensus::block_view::BlockView;
+use bitcoin_rs_consensus::verify_block::{
+    BlockRuleContext, verify_block_rules, verify_block_rules_precomputed,
+};
+use bitcoin_rs_consensus::ConsensusError;
+use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+
+const PREFIX: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+// SHA256d(00*32 || 00*32): coinbase-only witness root and zero reserved value.
+const ZERO_RESERVED_COMMITMENT: [u8; 32] = [
+    0xe2, 0xf6, 0x1c, 0x3f, 0x71, 0xd1, 0xde, 0xfd, 0x3f, 0xa9, 0x99, 0xdf, 0xa3, 0x69,
+    0x53, 0x75, 0x5c, 0x69, 0x06, 0x89, 0x79, 0x99, 0x62, 0xb4, 0x8b, 0xeb, 0xd8, 0x36,
+    0x97, 0x4e, 0x8c, 0xf9,
+];
+
+fn commitment_output() -> TxOut {
+    let mut script_pubkey = PREFIX.to_vec();
+    script_pubkey.extend_from_slice(&ZERO_RESERVED_COMMITMENT);
+    TxOut {
+        value: 0,
+        script_pubkey,
+    }
+}
+
+fn coinbase(with_witness: bool, with_commitment: bool) -> Tx {
+    let mut tx = Tx {
+        version: 1,
+        inputs: vec![TxIn {
+            previous_output: OutPoint::new(Txid::default(), u32::MAX),
+            script_sig: vec![1, 1],
+            sequence: u32::MAX,
+            witness: if with_witness {
+                vec![vec![0; 32]]
+            } else {
+                Vec::new()
+            },
+        }],
+        outputs: vec![TxOut {
+            value: 50,
+            script_pubkey: Vec::new(),
+        }],
+        lock_time: 0,
+    };
+    if with_commitment {
+        tx.outputs.push(commitment_output());
+    }
+    tx
+}
+
+fn block(tx: Tx) -> Block {
+    let merkle_root = tx.txid().into();
+    Block {
+        header: Header {
+            version: 1,
+            prev_blockhash: BlockHash::default(),
+            merkle_root,
+            time: 0,
+            bits: 0,
+            nonce: 0,
+        },
+        txs: vec![tx],
+    }
+}
+
+fn verify_with_activation(block: &Block, segwit_active: bool) -> Result<(), ConsensusError> {
+    let txids = block.txs.iter().map(Tx::txid).collect();
+    let mut view = BlockView::new(&block.txs, txids);
+    if view.facts().has_witness() {
+        let _ = view.witness_ids();
+    }
+    verify_block_rules_precomputed(block, BlockRuleContext { segwit_active }, view.facts())
+}
+
+#[test]
+fn active_commitment_without_reserved_value_is_rejected() {
+    let block = block(coinbase(false, true));
+    assert_eq!(verify_block_rules(&block), Err(ConsensusError::WitnessCommitment));
+}
+
+#[test]
+fn active_witness_free_block_without_commitment_is_valid_at_this_stage() {
+    let block = block(coinbase(false, false));
+    assert_eq!(verify_block_rules(&block), Ok(()));
+}
+
+#[test]
+fn preactivation_witness_without_commitment_is_rejected() {
+    let block = block(coinbase(true, false));
+    assert_eq!(
+        verify_with_activation(&block, false),
+        Err(ConsensusError::WitnessCommitment)
+    );
+}
+
+#[test]
+fn preactivation_commitment_like_output_does_not_authorize_witness() {
+    let block = block(coinbase(true, true));
+    assert_eq!(
+        verify_with_activation(&block, false),
+        Err(ConsensusError::WitnessCommitment)
+    );
+}
+
+#[test]
+fn active_commitment_with_exact_reserved_value_is_valid_at_this_stage() {
+    let block = block(coinbase(true, true));
+    assert_eq!(verify_block_rules(&block), Ok(()));
+}
+
+#[test]
+fn active_witness_without_commitment_is_rejected() {
+    let block = block(coinbase(true, false));
+    assert_eq!(verify_block_rules(&block), Err(ConsensusError::WitnessCommitment));
+}


### PR DESCRIPTION
## Why

`verify_block_rules_precomputed` currently verifies the BIP141 coinbase witness commitment only when both SegWit is active **and** the block already reports witness data. That differs from Bitcoin Core's `CheckWitnessMalleation` boundary in two consensus-relevant cases:

1. After SegWit activation, a coinbase output matching the BIP141 commitment pattern must validate the coinbase witness reserved value even when all transaction witnesses are otherwise empty.
2. When no active commitment authorizes witness data — including before SegWit activation — witness data is forbidden.

The existing condition could therefore accept a commitment-bearing block without its reserved-value proof and could skip the pre-activation unexpected-witness rejection.

## Changes

- Select the BIP141 coinbase commitment independently of `facts.has_witness()`.
- Require cached witness IDs and the existing commitment verifier whenever an active matching commitment is present.
- Reject witness data when there is no active commitment, including before activation.
- Preserve existing Merkle/structural error precedence and block-weight ordering.
- Add six exported-boundary regressions covering:
  - active commitment without reserved value,
  - active witness-free/no-commitment block,
  - pre-activation witness without commitment,
  - pre-activation commitment-like output with witness,
  - active valid coinbase-only commitment,
  - active witness without commitment.

## Independent references

- BIP141 commitment structure: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
- Bitcoin Core v31.0 `CheckWitnessMalleation`: https://github.com/bitcoin/bitcoin/blob/v31.0/src/validation.cpp
- Core source blob reviewed for this change: `5c02ec2341cd50c28c717e011cb61a0fcae9a91d`

The coinbase-only fixture uses the independently derived value `SHA256d(00*32 || 00*32) = e2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9`; it was cross-checked outside bitcoin-rs before publication.

## Publication evidence

Base: `ff96503212be41acc10252ebdbc8b97eaccf42a2`

Candidate commit: `39be9892037cc3ec244fc3acca47e7021d442618`

Git compare confirms one commit, two changed files, and no unrelated paths. Local `git diff --check` produced no errors.

### Not executed locally

This environment has no `cargo`, `rustc`, `rustfmt`, or `clippy-driver`, so compiler-backed tests, formatting, Clippy, and the applicable repository constraint gates were **not** executed here. This PR is intentionally draft until CI supplies that evidence. No full-repository clean verdict, replay result, fuzz result, performance claim, or native-default promotion is claimed.

## Scope

No dependency, feature-default, storage-format, kernel-oracle, operator-data, or validation-default change. This is a focused BIP141 block-rule correction; the larger implementation cleanup is deliberately kept out of this correctness PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes BIP141 witness activation enforcement so coinbase commitment validation matches Bitcoin Core's behavior: a block with an active commitment must prove the witness reserved value even when all witnesses are empty, and witness data is rejected when no active commitment authorizes it. Previously, a commitment-bearing block without witness data could skip the reserved-value check, and pre-activation witness data could pass.

**Refactor**
- Extracted coinbase commitment selection into a shared `witness_commitment` helper now reused by the match check.
- Removed the unused hash import.

Six regression tests cover the activation-boundary cases.

<sup>Written for commit b3a2d672a6d7a0411b93f7c9ad049f01a873ab7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

