### PR TITLE
fix(script): preserve raw SegWit v0 sighash types

### DIFF
--- a/crates/primitives/src/sighash.rs
+++ b/crates/primitives/src/sighash.rs
@@ -302,7 +302,26 @@ impl<'t> SighashCache<'t> {
         value: u64,
         sighash_type: Sighash,
     ) -> Result<Hash256, SighashError> {
-        let ty = sighash_type.to_ecdsa()?;
+        let raw = sighash_type.to_ecdsa()?.to_u32();
+        self.segwit_v0_signature_hash_raw(input_index, script_code, value, raw)
+    }
+
+    /// Computes the BIP143 digest for a raw ECDSA hash type.
+    ///
+    /// Field selection uses the low five bits and `SIGHASH_ANYONECANPAY`,
+    /// while all 32 bits are serialized into the digest. Undefined ECDSA hash
+    /// types remain valid without `STRICTENC`; enforcing that policy belongs
+    /// to the script checker, not the digest engine. Raw zero is valid here,
+    /// unlike the typed API's taproot-only [`Sighash::Default`].
+    /// The caller supplies the selected script-code suffix verbatim.
+    pub fn segwit_v0_signature_hash_raw(
+        &mut self,
+        input_index: usize,
+        script_code: &[u8],
+        value: u64,
+        sighash_type: u32,
+    ) -> Result<Hash256, SighashError> {
+        let ty = EcdsaType::from_consensus(sighash_type);
         let total = self.tx.inputs.len();
         let input = self
             .tx
@@ -339,9 +358,9 @@ impl<'t> SighashCache<'t> {
                         });
                     finalize_double_sha256(single)
                 }
-                // BIP143 leaves this case undefined; Core rejects the signature while the
-                // rust-bitcoin oracle emits the zero hash. Either way no signature can
-                // verify, so we mirror the oracle's zero hash.
+                // BIP143 uses zero hashOutputs when SINGLE has no matching
+                // output. The complete preimage is still hashed and a signature
+                // over that digest can verify; this is not the legacy ONE bug.
                 None => zero,
             }
         } else {
@@ -360,7 +379,7 @@ impl<'t> SighashCache<'t> {
             .and_then(|()| writer.write_all(&input.sequence.to_le_bytes()))
             .and_then(|()| writer.write_all(outputs_hash.as_byte_array()))
             .and_then(|()| writer.write_all(&self.tx.lock_time.to_le_bytes()))
-            .and_then(|()| writer.write_all(&ty.to_u32().to_le_bytes()))
+            .and_then(|()| writer.write_all(&sighash_type.to_le_bytes()))
             .unwrap_or_else(|error| unreachable!("sha256 writer is infallible: {error}"));
 
         Ok(finalize_double_sha256(engine))

--- a/crates/script/src/checker.rs
+++ b/crates/script/src/checker.rs
@@ -199,13 +199,14 @@ impl<'a> TxSignatureChecker<'a> {
                     .map_err(|e| sighash_to_script_error(&e))?
             }
             SigVersion::WitnessV0 => {
-                let sighash_type = ecdsa_hashtype_from_byte(*hashtype_byte)?;
+                // STRICTENC alone restricts ECDSA hashtypes. BIP143 must
+                // classify, but still commit to, the original signature byte.
                 self.cache
-                    .segwit_v0_signature_hash(
+                    .segwit_v0_signature_hash_raw(
                         self.input_index,
                         script_code,
                         self.amount,
-                        sighash_type,
+                        u32::from(*hashtype_byte),
                     )
                     .map_err(|e| sighash_to_script_error(&e))?
             }
@@ -649,21 +650,6 @@ fn is_compressed_or_uncompressed_pubkey(pubkey: &[u8]) -> bool {
 /// Core's `IsCompressedPubKey`.
 fn is_compressed_pubkey(pubkey: &[u8]) -> bool {
     pubkey.len() == 33 && (pubkey[0] == 0x02 || pubkey[0] == 0x03)
-}
-
-/// Converts a legacy hashtype byte to a [`Sighash`] for segwit v0.
-fn ecdsa_hashtype_from_byte(byte: u8) -> Result<Sighash, ScriptError> {
-    match byte {
-        0x01 => Ok(Sighash::All),
-        0x02 => Ok(Sighash::None),
-        0x03 => Ok(Sighash::Single),
-        0x81 => Ok(Sighash::AllAnyoneCanPay),
-        0x82 => Ok(Sighash::NoneAnyoneCanPay),
-        0x83 => Ok(Sighash::SingleAnyoneCanPay),
-        _ => Err(ScriptError::Invalid {
-            code: ScriptErrCode::SigHashtype,
-        }),
-    }
 }
 
 /// Converts a [`SighashError`] to a [`ScriptError`].

--- a/crates/script/tests/segwit_v0_sighash_edges.rs
+++ b/crates/script/tests/segwit_v0_sighash_edges.rs
@@ -1,0 +1,330 @@
+//! SegWit-v0 ECDSA sighash regressions against BIP143 and Bitcoin Core.
+//!
+//! The reference preimage uses rust-bitcoin's wire encoders and the BIP143
+//! field-selection rules, never the native sighash implementation. The published
+//! BIP143 P2WPKH digest and signature independently anchor that reference.
+//! Sources: bitcoin/bips bip-0143.mediawiki blob
+//! 5d451c221fa9ef052325c42086b8a7097b942556; bitcoin/bitcoin
+//! src/script/interpreter.cpp blob 98b16eca6bcdfb5c98b5f51f6afc42062efb5f01.
+
+#![expect(clippy::expect_used, reason = "fixed regression fixtures")]
+
+use bitcoin::consensus::{deserialize as oracle_decode, encode::VarInt, serialize};
+use bitcoin_rs_primitives::{Sighash, SighashCache, SighashError, Tx, TxOut, deserialize};
+use bitcoin_rs_script::{Interpreter, ScriptErrCode, ScriptError, VerifyFlags};
+use secp256k1::{Message, PublicKey, SECP256K1, SecretKey};
+use sha2::{Digest, Sha256};
+
+// Public test key and unsigned transaction from the BIP143 native-P2WPKH example.
+const TX_HEX: &str = concat!(
+    "0100000002fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f",
+    "0000000000eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57",
+    "b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85",
+    "c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2",
+    "f0167faa815988ac11000000",
+);
+const TEST_KEY: &str = "619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9";
+const SCRIPT_CODE: &str = "76a9141d0f172a0ecb48aee1be1f2687d2963ae33f71a188ac";
+const PROGRAM: &str = "00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1";
+const VALUE: u64 = 600_000_000;
+const INPUT: usize = 1;
+
+fn hex(text: &str) -> Vec<u8> {
+    assert!(text.len().is_multiple_of(2));
+    text.as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            u8::from_str_radix(std::str::from_utf8(pair).expect("ASCII hex"), 16)
+                .expect("hex byte")
+        })
+        .collect()
+}
+
+fn fixture(outputs: usize) -> (Tx, bitcoin::Transaction) {
+    let bytes = hex(TX_HEX);
+    let mut native: Tx = deserialize(&bytes).expect("native fixture decode");
+    let mut oracle: bitcoin::Transaction = oracle_decode(&bytes).expect("oracle fixture decode");
+    native.outputs.truncate(outputs);
+    oracle.output.truncate(outputs);
+    (native, oracle)
+}
+
+fn double_sha256(bytes: &[u8]) -> [u8; 32] {
+    Sha256::digest(Sha256::digest(bytes)).into()
+}
+
+/// BIP143 reference serialization. Raw hash-type bits select fields using the
+/// low five bits and bit 7, but ALL 32 bits are appended to the preimage.
+fn reference_bip143(
+    tx: &bitcoin::Transaction,
+    input: usize,
+    script: &[u8],
+    value: u64,
+    raw: u32,
+) -> [u8; 32] {
+    let anyone = raw & 0x80 != 0;
+    let base = raw & 0x1f;
+    let mut prevouts = [0_u8; 32];
+    let mut sequences = [0_u8; 32];
+    let mut outputs = [0_u8; 32];
+    if !anyone {
+        let bytes: Vec<u8> = tx
+            .input
+            .iter()
+            .flat_map(|input| serialize(&input.previous_output))
+            .collect();
+        prevouts = double_sha256(&bytes);
+    }
+    if !anyone && base != 2 && base != 3 {
+        let bytes: Vec<u8> = tx
+            .input
+            .iter()
+            .flat_map(|input| serialize(&input.sequence))
+            .collect();
+        sequences = double_sha256(&bytes);
+    }
+    if base != 2 && base != 3 {
+        let bytes: Vec<u8> = tx.output.iter().flat_map(serialize).collect();
+        outputs = double_sha256(&bytes);
+    } else if base == 3 {
+        if let Some(output) = tx.output.get(input) {
+            outputs = double_sha256(&serialize(output));
+        }
+    }
+    let selected = &tx.input[input];
+    let mut preimage = serialize(&tx.version);
+    preimage.extend_from_slice(&prevouts);
+    preimage.extend_from_slice(&sequences);
+    preimage.extend(serialize(&selected.previous_output));
+    let script_len = u64::try_from(script.len()).expect("script length");
+    preimage.extend(serialize(&VarInt(script_len)));
+    preimage.extend_from_slice(script);
+    preimage.extend_from_slice(&value.to_le_bytes());
+    preimage.extend(serialize(&selected.sequence));
+    preimage.extend_from_slice(&outputs);
+    preimage.extend(serialize(&tx.lock_time));
+    preimage.extend_from_slice(&raw.to_le_bytes());
+    double_sha256(&preimage)
+}
+
+fn test_key() -> SecretKey {
+    SecretKey::from_slice(&hex(TEST_KEY)).expect("public BIP143 test key")
+}
+
+fn p2wpkh_prevout() -> TxOut {
+    TxOut {
+        value: VALUE,
+        script_pubkey: hex(PROGRAM),
+    }
+}
+
+fn verify_witness(
+    tx: &Tx,
+    prevout: &TxOut,
+    witness: &[Vec<u8>],
+    flags: VerifyFlags,
+) -> Result<bool, ScriptError> {
+    Interpreter.execute(
+        &prevout.script_pubkey,
+        &[],
+        witness,
+        flags,
+        prevout,
+        tx,
+        INPUT,
+    )
+}
+
+// The optional oracle is a real kernel call, not an availability-based skip.
+// Failure to parse or prepare the transaction fails the positive assertion.
+// Policy-only flags are intentionally excluded: the wrapper masks them off.
+#[cfg(feature = "kernel")]
+fn kernel_witness_parity(tx: &Tx, prevout: &TxOut, witness: &[Vec<u8>]) {
+    use bitcoin_rs_consensus::{ConsensusError, kernel::verify_tx_scripts};
+
+    let mut signed = tx.clone();
+    signed.inputs[INPUT].witness = witness.to_vec();
+    // The other input has a synthetic OP_TRUE prevout. This is script-verdict
+    // parity, not contextual block validation or a claim about historical UTXOs.
+    let mut spent: Vec<_> = signed
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(index, input)| {
+            let output = if index == INPUT {
+                prevout.clone()
+            } else {
+                TxOut {
+                    value: VALUE,
+                    script_pubkey: vec![0x51],
+                }
+            };
+            (input.previous_output, output)
+        })
+        .collect();
+    verify_tx_scripts(&signed, &spent, VerifyFlags::MANDATORY)
+        .expect("kernel accepts independently signed BIP143 input");
+    // Every BIP143 mode commits to this amount. Ensure the oracle is not
+    // vacuously accepting, and require a script rejection, not an engine error.
+    spent[INPUT].1.value += 1;
+    assert!(matches!(
+        verify_tx_scripts(&signed, &spent, VerifyFlags::MANDATORY),
+        Err(ConsensusError::Script {
+            input_index: INPUT,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn published_bip143_digest_and_signature_anchor_reference() {
+    let (tx, oracle) = fixture(2);
+    let script = hex(SCRIPT_CODE);
+    let expected = hex("c37af31116d1b27caf68aae9e3ac82f1477929014d5b917657d0eb49478cb670");
+    assert_eq!(
+        reference_bip143(&oracle, INPUT, &script, VALUE, 1).as_slice(),
+        expected,
+    );
+    let mut cache = SighashCache::new(&tx);
+    assert_eq!(
+        cache
+            .segwit_v0_signature_hash_raw(INPUT, &script, VALUE, 1)
+            .expect("BIP143 digest")
+            .as_byte_array()
+            .as_slice(),
+        expected,
+    );
+    let witness = vec![
+        hex(concat!(
+            "304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a",
+            "0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee01",
+        )),
+        hex("025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357"),
+    ];
+    assert_eq!(
+        verify_witness(&tx, &p2wpkh_prevout(), &witness, VerifyFlags::MANDATORY),
+        Ok(true),
+    );
+}
+
+#[test]
+fn every_segwit_hashtype_byte_matches_reference_and_verifies() {
+    let key = test_key();
+    let pubkey = PublicKey::from_secret_key(SECP256K1, &key)
+        .serialize()
+        .to_vec();
+    let script = hex(SCRIPT_CODE);
+    let prevout = p2wpkh_prevout();
+    for output_count in [1, 2] {
+        // input 1 has no matching output in the one-output fixture. SINGLE
+        // must still hash a complete BIP143 preimage and allow a valid signature.
+        let (tx, oracle) = fixture(output_count);
+        let mut cache = SighashCache::new(&tx);
+        for byte in 0_u8..=u8::MAX {
+            let raw = u32::from(byte);
+            let expected = reference_bip143(&oracle, INPUT, &script, VALUE, raw);
+            assert_eq!(
+                cache
+                    .segwit_v0_signature_hash_raw(INPUT, &script, VALUE, raw)
+                    .expect("raw BIP143 digest")
+                    .as_byte_array(),
+                &expected,
+                "outputs={output_count}, raw={raw:#x}",
+            );
+            let message = Message::from_digest(expected);
+            let mut signature = SECP256K1
+                .sign_ecdsa(&message, &key)
+                .serialize_der()
+                .to_vec();
+            signature.push(byte);
+            let witness = vec![signature, pubkey.clone()];
+            assert_eq!(
+                verify_witness(&tx, &prevout, &witness, VerifyFlags::MANDATORY),
+                Ok(true),
+                "consensus: outputs={output_count}, raw={raw:#x}",
+            );
+            let mut wrong_amount = prevout.clone();
+            wrong_amount.value += 1;
+            assert_eq!(
+                verify_witness(&tx, &wrong_amount, &witness, VerifyFlags::MANDATORY),
+                Err(ScriptError::Invalid {
+                    code: ScriptErrCode::EvalFalse,
+                }),
+                "amount commitment: outputs={output_count}, raw={raw:#x}",
+            );
+            #[cfg(feature = "kernel")]
+            kernel_witness_parity(&tx, &prevout, &witness);
+            let strict = VerifyFlags::MANDATORY.union(VerifyFlags::STRICTENC);
+            let result = verify_witness(&tx, &prevout, &witness, strict);
+            if matches!(byte, 1 | 2 | 3 | 0x81 | 0x82 | 0x83) {
+                assert_eq!(result, Ok(true));
+            } else {
+                assert_eq!(
+                    result,
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::SigHashtype,
+                    }),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn raw_segwit_hash_commits_all_32_bits_and_checks_input_bounds() {
+    let script = hex(SCRIPT_CODE);
+    for output_count in [1, 2] {
+        let (tx, oracle) = fixture(output_count);
+        let mut cache = SighashCache::new(&tx);
+        for raw in [0x100, 0x101, 0x1234_5682, 0x8000_0083, u32::MAX] {
+            let expected = reference_bip143(&oracle, INPUT, &script, VALUE, raw);
+            let actual = cache
+                .segwit_v0_signature_hash_raw(INPUT, &script, VALUE, raw)
+                .expect("raw u32 digest");
+            assert_eq!(actual.as_byte_array(), &expected);
+            assert_ne!(
+                actual.as_byte_array(),
+                &reference_bip143(&oracle, INPUT, &script, VALUE, raw & 0xff),
+            );
+        }
+        assert_eq!(
+            cache.segwit_v0_signature_hash_raw(tx.inputs.len(), &script, VALUE, 0),
+            Err(SighashError::InputOutOfRange {
+                index: tx.inputs.len(),
+                total: tx.inputs.len(),
+            }),
+        );
+    }
+}
+
+#[test]
+fn typed_segwit_api_preserves_named_modes_and_default_rejection() {
+    let script = hex(SCRIPT_CODE);
+    let modes = [
+        (Sighash::All, 1),
+        (Sighash::None, 2),
+        (Sighash::Single, 3),
+        (Sighash::AllAnyoneCanPay, 0x81),
+        (Sighash::NoneAnyoneCanPay, 0x82),
+        (Sighash::SingleAnyoneCanPay, 0x83),
+    ];
+    for output_count in [1, 2] {
+        let (tx, oracle) = fixture(output_count);
+        let mut cache = SighashCache::new(&tx);
+        for (mode, raw) in modes {
+            assert_eq!(
+                cache
+                    .segwit_v0_signature_hash(INPUT, &script, VALUE, mode)
+                    .expect("named mode")
+                    .as_byte_array(),
+                &reference_bip143(&oracle, INPUT, &script, VALUE, raw),
+            );
+        }
+        for input in [INPUT, tx.inputs.len()] {
+            assert_eq!(
+                cache.segwit_v0_signature_hash(input, &script, VALUE, Sighash::Default),
+                Err(SighashError::DefaultOnlyTaproot),
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a raw BIP143 sighash entry point that classifies field-selection bits without canonicalizing the committed hash-type value
- route SegWit-v0 ECDSA verification through the raw signature byte
- keep `STRICTENC` as the policy gate for defined hashtypes
- correct `SIGHASH_SINGLE` / missing-output documentation and add independent BIP143 regressions

## Why
The current WitnessV0 checker converts the trailing ECDSA hash-type byte through a six-value enum before computing BIP143. That rejects undefined hash-type bytes even when `STRICTENC` is not active and loses the original byte that BIP143 commits to. Bitcoin Core classifies the field-selection bits while serializing the original hash type into the preimage.

## Regression coverage
The new test independently reconstructs BIP143 using rust-bitcoin wire encoding, anchors it to the published BIP143 P2WPKH digest/signature, exercises all 256 one-byte hash types across two output-count scenarios, checks wrong-amount rejection, raw `u32` commitment, typed API preservation, and optional kernel parity.

## Verification performed
Local reference verification before publication:
- 512 independently signed BIP143 cases verified
- 512 wrong-amount cases rejected
- published BIP143 digest/signature verified
- split unified-diff syntax and final GitHub source-file diff statistics verified

This environment did not have Cargo/rustc available, so the Rust regression target and Clippy were not executed locally. This PR is intentionally a draft pending repository CI. No performance or full native-kernel equivalence claim is made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves raw SegWit v0 hash type bytes during BIP143 digest computation so undefined hash types are no longer rejected unless STRICTENC is set, matching Bitcoin Core.

- The digest now commits to the original signature byte instead of a canonicalized value; field selection still uses the low five bits and the `ANYONECANPAY` flag.
- Added regression tests that reconstruct BIP143 independently and cover all 256 one-byte hash types, plus raw `u32` commitment, typed API preservation, and wrong-amount rejection.
- Corrected the `SIGHASH_SINGLE` missing-output behavior to mirror Bitcoin Core's zero-hash-output handling.

<sup>Written for commit 37176948fc24826293ee7ebfba9f8cfaf43b488a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

