### PR TITLE
perf(rpc): bound mempool page-selection scratch and clone only winners

### DIFF
--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -11,6 +11,17 @@ Every measurement cell below is `UNMEASURED`. Target values are contracts, not
 results. Unknown is not false; a missing measurement blocks the owning task.
 `BLOCKED` is a workflow state, not a verdict.
 
+## Mempool page-selection contracts (v1)
+
+These contracts own the selector's bounded-work and ownership expectations;
+benchmark results remain subject to CL-19 and CL-20 and must not be inferred
+from the unit tests.
+
+| ID | requirement |
+| --- | --- |
+| SEL-01 | Page selection borrows candidate payloads and clones payloads only for the final returned page. |
+| SEL-02 | A page with limit zero returns immediately without polling the pool iterator. |
+
 ## Formal model tool identity
 
 | Field | Value |

--- a/crates/rpc/src/esplora/backend.rs
+++ b/crates/rpc/src/esplora/backend.rs
@@ -435,6 +435,7 @@ mod pagination_tests {
         }
     }
 
+    // Contract: CONSTRAINTS.md, "Mempool page-selection contracts (v1)", SEL-01.
     #[test]
     fn selection_borrows_payloads_and_only_the_final_page_is_cloned() {
         let entries: Vec<_> = (0_u32..129)
@@ -472,6 +473,7 @@ mod pagination_tests {
         assert!(entries.iter().all(|entry| Arc::strong_count(&entry.tx) == 1));
     }
 
+    // Contract: CONSTRAINTS.md, "Mempool page-selection contracts (v1)", SEL-02.
     #[test]
     fn zero_selection_does_not_poll_the_pool_iterator() {
         let entries = std::iter::from_fn(|| -> Option<&MempoolEntry> {

--- a/crates/rpc/src/esplora/backend.rs
+++ b/crates/rpc/src/esplora/backend.rs
@@ -6,6 +6,7 @@
 use alloc::sync::Arc;
 use core::str::FromStr as _;
 
+use bitcoin_rs_mempool::MempoolEntry;
 use bitcoin_rs_primitives::{OutPoint, Txid};
 
 use super::http::{bad, dispatch_error, json_response, query_limit};
@@ -63,25 +64,18 @@ fn internal_mempool_txs(ctx: &Context, last: Option<&str>, query: &str) -> Respo
     });
     let transactions = {
         let pool = ctx.mempool.read();
-        // Resolve the cursor in the same snapshot as the entries. Filtering
-        // before cloning avoids retaining transactions before this page.
+        // Cursor lookup, selection, and Arc capture share one read guard.
+        // Only the selected page escapes the guard; no second lookup can
+        // observe a removal or replacement between selection and capture.
         let after = last
             .and_then(|txid| pool.entry_by_txid(&txid))
             .map(|entry| (entry.time, entry.txid));
-        let mut ordered = pool
-            .iter_entries()
-            .filter(|entry| after.is_none_or(|key| (entry.time, entry.txid) > key))
+        let mut ordered = select_mempool_page(pool.iter_entries(), after, max_txs)
+            .into_iter()
             .map(|entry| (entry.time, entry.txid, Arc::clone(&entry.tx)))
             .collect::<Vec<_>>();
         drop(pool);
-        // Partition outside the lock, then sort only the requested prefix.
-        // The strict bound also handles empty snapshots and usize::MAX.
-        if max_txs < ordered.len() {
-            ordered.select_nth_unstable_by(max_txs, |left, right| {
-                left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1))
-            });
-            ordered.truncate(max_txs);
-        }
+        // Final ordering and transaction projection stay outside the guard.
         ordered.sort_unstable_by(|left, right| {
             left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1))
         });
@@ -96,6 +90,49 @@ fn internal_mempool_txs(ctx: &Context, last: Option<&str>, query: &str) -> Respo
         .map(|transaction| projection.transaction_value(&transaction, None))
         .collect::<Result<Vec<_>, _>>()
         .map_or_else(|r| r, json_response)
+}
+
+/// Selects the API-09 page without retaining the entire eligible suffix.
+///
+/// At most 2K borrowed entries are live for a positive limit K. Every full
+/// batch discards K entries in linear time; only the final page is cloned by
+/// the caller. `Vec` capacity grows with observed entries, not an untrusted
+/// requested limit. Selection holds the caller's read guard; it trades that
+/// work for bounded scratch space and avoids `Arc` churn on rejected entries.
+fn select_mempool_page<'a>(
+    entries: impl Iterator<Item = &'a MempoolEntry>,
+    after: Option<(u64, Txid)>,
+    max_txs: usize,
+) -> Vec<&'a MempoolEntry> {
+    let mut selected = Vec::new();
+    if max_txs == 0 {
+        return selected;
+    }
+    let mut cutoff = None;
+    for entry in entries {
+        let key = (entry.time, entry.txid);
+        if after.is_some_and(|after| key <= after)
+            || cutoff.is_some_and(|cutoff| key >= cutoff)
+        {
+            continue;
+        }
+        selected.push(entry);
+        // This is len >= 2K without multiplying the caller's usize limit.
+        // K > 0 also proves the nth index is strictly below the length.
+        if selected.len() / 2 >= max_txs {
+            let (_, excluded, _) = selected
+                .select_nth_unstable_by_key(max_txs, |entry| (entry.time, entry.txid));
+            // Txids are unique in a pool snapshot. Everything retained is
+            // strictly before this first excluded key; later keys cannot win.
+            cutoff = Some((excluded.time, excluded.txid));
+            selected.truncate(max_txs);
+        }
+    }
+    if max_txs < selected.len() {
+        selected.select_nth_unstable_by_key(max_txs, |entry| (entry.time, entry.txid));
+        selected.truncate(max_txs);
+    }
+    selected
 }
 
 fn internal_transactions(ctx: &Context, body: &[u8], mempool_only: bool) -> Response {
@@ -203,7 +240,7 @@ mod pagination_tests {
     use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid};
     use serde_json::Value;
 
-    use super::internal_mempool_txs;
+    use super::{internal_mempool_txs, select_mempool_page};
     use crate::context::Context;
 
     fn fixture(times: &[u64]) -> (Context, Vec<(u64, Txid)>) {
@@ -358,5 +395,167 @@ mod pagination_tests {
         assert_eq!(internal_mempool_txs(&ctx, None, "max_txs=1").status, 503);
         assert_eq!(page(&ctx, Some(&cursor), "max_txs=1"), vec![expected[0].1]);
         assert!(page(&ctx, None, "max_txs=0").is_empty());
+    }
+
+    // API-09 in docs/contracts/external-api.md owns order and strict cursor
+    // exclusion. Full sorting is the independent selection reference.
+    #[test]
+    fn batched_selection_matches_full_sort_across_flush_boundaries() {
+        let entries: Vec<_> = (0_u32..257)
+            .map(|index| {
+                let tx = Tx {
+                    lock_time: index,
+                    ..Tx::default()
+                };
+                MempoolEntry::new(Arc::new(tx), 100, 1_000, u64::from(index % 7), 0)
+            })
+            .collect();
+        let mut ordered: Vec<_> = entries.iter().collect();
+        ordered.sort_unstable_by_key(|entry| (entry.time, entry.txid));
+        for reverse in [false, true] {
+            let mut traversal = ordered.clone();
+            if reverse {
+                traversal.reverse();
+            }
+            for after in [None, Some((ordered[128].time, ordered[128].txid))] {
+                for limit in [0, 1, 2, 3, 25, 127, 128, 129, 256, 257, usize::MAX] {
+                    let mut actual =
+                        select_mempool_page(traversal.iter().copied(), after, limit);
+                    actual.sort_unstable_by_key(|entry| (entry.time, entry.txid));
+                    let actual: Vec<_> = actual.iter().map(|entry| entry.txid).collect();
+                    let expected: Vec<_> = ordered
+                        .iter()
+                        .filter(|entry| after.is_none_or(|key| (entry.time, entry.txid) > key))
+                        .take(limit)
+                        .map(|entry| entry.txid)
+                        .collect();
+                    assert_eq!(actual, expected, "reverse={reverse}, limit={limit}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn selection_borrows_payloads_and_only_the_final_page_is_cloned() {
+        let entries: Vec<_> = (0_u32..129)
+            .map(|index| {
+                MempoolEntry::new(
+                    Arc::new(Tx {
+                        lock_time: index,
+                        ..Tx::default()
+                    }),
+                    100,
+                    1_000,
+                    u64::from(129 - index),
+                    0,
+                )
+            })
+            .collect();
+        let selected = select_mempool_page(
+            entries.iter().inspect(|_| {
+                assert!(entries.iter().all(|entry| Arc::strong_count(&entry.tx) == 1));
+            }),
+            None,
+            3,
+        );
+        assert_eq!(selected.len(), 3);
+        assert!(entries.iter().all(|entry| Arc::strong_count(&entry.tx) == 1));
+        let captured: Vec<_> = selected.iter().map(|entry| Arc::clone(&entry.tx)).collect();
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|entry| Arc::strong_count(&entry.tx) == 2)
+                .count(),
+            3
+        );
+        drop(captured);
+        assert!(entries.iter().all(|entry| Arc::strong_count(&entry.tx) == 1));
+    }
+
+    #[test]
+    fn zero_selection_does_not_poll_the_pool_iterator() {
+        let entries = std::iter::from_fn(|| -> Option<&MempoolEntry> {
+            panic!("zero-sized pages must not traverse entries")
+        });
+        assert!(select_mempool_page(entries, None, 0).is_empty());
+    }
+
+    /// Paired page-selection microbenchmark, not an HTTP or lock benchmark.
+    /// Run with --release --ignored --nocapture; fixture setup is untimed.
+    #[test]
+    #[ignore = "manual paired release benchmark; no timing threshold in unit tests"]
+    fn benchmark_bounded_page_selection() {
+        use std::hint::black_box;
+        use std::time::Instant;
+
+        fn snapshot(
+            entries: &[MempoolEntry],
+            after: Option<(u64, Txid)>,
+            limit: usize,
+            bounded: bool,
+        ) -> Vec<(u64, Txid, Arc<Tx>)> {
+            let mut page: Vec<_> = if bounded {
+                select_mempool_page(entries.iter(), after, limit)
+                    .into_iter()
+                    .map(|entry| (entry.time, entry.txid, Arc::clone(&entry.tx)))
+                    .collect()
+            } else {
+                // PR #796 at 9c6a3904: capture the entire suffix, partition,
+                // then sort only the retained page. Keep this baseline local.
+                let mut all: Vec<_> = entries
+                    .iter()
+                    .filter(|entry| after.is_none_or(|key| (entry.time, entry.txid) > key))
+                    .map(|entry| (entry.time, entry.txid, Arc::clone(&entry.tx)))
+                    .collect();
+                if limit < all.len() {
+                    all.select_nth_unstable_by_key(limit, |entry| (entry.0, entry.1));
+                    all.truncate(limit);
+                }
+                all
+            };
+            page.sort_unstable_by_key(|entry| (entry.0, entry.1));
+            page
+        }
+
+        let entries: Vec<_> = (0_u32..10_000)
+            .map(|index| {
+                MempoolEntry::new(
+                    Arc::new(Tx {
+                        lock_time: index,
+                        ..Tx::default()
+                    }),
+                    100,
+                    1_000,
+                    u64::from(index.wrapping_mul(2_654_435_761) % 10_000),
+                    0,
+                )
+            })
+            .collect();
+        for after in [None, Some((entries[5_000].time, entries[5_000].txid))] {
+            for limit in [1, 25, 1_000, 9_999, usize::MAX] {
+                let expected = snapshot(&entries, after, limit, false);
+                assert_eq!(snapshot(&entries, after, limit, true), expected);
+                drop(expected);
+                for trial in 0..6 {
+                    // Alternate order to reduce one-sided warm-cache bias.
+                    for bounded in [trial % 2 == 0, trial % 2 != 0] {
+                        let start = Instant::now();
+                        for _ in 0..100 {
+                            drop(black_box(snapshot(
+                                black_box(&entries),
+                                after,
+                                limit,
+                                bounded,
+                            )));
+                        }
+                        eprintln!(
+                            "page_selection n={} after={after:?} k={limit} trial={trial} bounded={bounded} iterations=100 elapsed_ns={}",
+                            entries.len(),
+                            start.elapsed().as_nanos()
+                        );
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Scope

Atomic follow-up to merged #796: one commit, one source file, based directly on `main` at `5070f377ecee293b9c7739d4a59d2bba47e10543`. Preserve the concurrently merged API-09 cursor contract and tests; do not rewrite the earlier PR or its branch.

Replace capture-of-every-eligible-Arc with batched selection over borrowed entries. This closes the O(R) scratch-space limitation documented in #796, where R is the suffix after the cursor.

## Algorithm and bounds

For positive requested page size K, maintain at most 2K live borrowed entries. Each full batch uses nth-element selection, keeps K entries, and records the first excluded `(time, txid)` key. Because pool txids are unique, entries at or beyond that cutoff cannot beat the retained page. Each full batch discards K entries, so total batch-selection work is linear in visited entries. A final partial batch is trimmed before the winning transaction Arcs are cloned.

- Selection scratch: O(min(R, K)), rather than O(R), apart from ordinary Vec capacity rounding. The **2K bound is on live borrowed entries, not exact allocator bytes**.
- Snapshot Arc clones: min(R, K), rather than R; no Arc clone/drop churn for losing entries.
- Selection plus final ordering: O(N + P log P), with N visited pool entries and P returned entries. The full pool traversal remains.
- No request-sized up-front reservation: Vec grows from actual observed entries. `len / 2 >= K` avoids overflow from computing `2 * K`; zero returns before polling the iterator, and final nth selection has an explicit `K < len` guard.
- Cursor lookup, selection, and final Arc capture share one read guard, so no second lookup can observe removal/replacement between selection and capture. Final ordering and transaction projection remain outside the guard.

**Tradeoff:** partition work now runs under the existing read guard. Bounded scratch and fewer atomic reference operations do not prove better writer latency. Read-lock contention and nearly-full/unbounded requests still require native measurement. This is not an unconditional speedup claim or default-promotion result. No new cache/index, persistence, consensus, dependency, public API, or unsafe code.

## Regression and benchmark coverage

Keep all four existing API-09 pagination regressions. Add three tests: ascending/reverse traversal across repeated batch boundaries (257 entries, tied times, cursors and extreme limits); borrowed-payload/no-selection-Arc-clone behavior; zero-limit no-iterator-poll behavior.

Add an ignored paired release microbenchmark comparing the prior #796 capture/partition algorithm against the new selector. It checks equality before timing, keeps setup untimed, alternates execution order across six trials, and covers 10,000 entries with K=1/25/1000/9999/unbounded, with and without a cursor. It measures page selection/Arc capture, **not HTTP, live locks, RSS, or end-to-end node throughput**. No timing assertions in normal tests.

```
cargo +1.95.0 test --locked --release -p bitcoin-rs-rpc --lib benchmark_bounded_page_selection -- --ignored --nocapture
```

## Executed preparation evidence

- Exact merged source blob reconstructed and verified: `a74279986c63c0487cc9f2c0ac87c21cad890591`.
- Published candidate blob matches the locally reviewed source: `09991b399a471d4a5ad4edb4e2bf2f0f6cf05c54`.
- Independent Python full-sort/reference vs batched-selection model: **275,490 comparisons, no mismatches**. Every comparison also checks the live 2K bound and batch-discard work bound. Exhaustive permutations through six entries, randomized snapshots through 16,384 entries, malformed/noncanonical/missing cursors, and size boundaries.
- Five deliberately faulty controls detected, including an incorrectly tightened cutoff that drops a later winning entry.
- Whitespace checks and patch reverse-application checks passed. GitHub compare confirms one commit / one changed file against current main; no force-push or main write.

The model is a separately written Python algorithm, **not execution of the Rust selector or std's implementation**. It does not validate actual allocation behavior, locking, HTTP, or compiler semantics.

## Pending native acceptance — keep draft

Cargo/rustc are absent in the preparation environment; repository cloning also fails DNS resolution. Explicit attempts at pinned RPC tests, Clippy `--all-targets -- -D warnings`, rustfmt, CL-07 `overhaul_core_api`, CL-14 `overhaul_resource_bounds`, and the release microbenchmark all failed at command launch (`[Errno 2] No such file or directory: 'cargo'`). These are BLOCKED, not passes or code-test failures. AGENTS.md's pre-publication Clippy requirement remains unsatisfied and is disclosed here rather than suppressed.

Before ready/merge: compile and run the new and existing Rust tests, fix all changed-line Clippy/rustfmt issues, run the owning gates and real concurrent public-route tests, and collect paired native CPU/allocation/RSS/read-lock/writer-latency evidence. The inherited unlimited-response behavior is unchanged; this does not close the whole API-08/CL-14 resource-budget programme.

Library reference: https://doc.rust-lang.org/std/primitive.slice.html#method.select_nth_unstable_by_key . The API contract supports the algorithm argument; served documentation is not a substitute for the pinned compiler.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds Esplora API-09 mempool pagination scratch to at most 2K live borrowed entries instead of retaining the full eligible suffix, and clones `Arc` payloads only for returned transactions. Cursor lookup, selection, and capture share one read guard; ordering and cursor semantics stay unchanged, while selection work moves inside the guard. Adds `CONSTRAINTS.md` entries SEL-01 and SEL-02 documenting the borrowed-payload and zero-limit contracts, and links the selector tests to them.

**Validation**

- Adds coverage for repeated batch boundaries, reverse traversal, tied timestamps, borrowed payloads, and zero-limit requests.
- Adds an ignored paired release benchmark for bounded and previous page-selection algorithms across several page sizes and cursor states.
- Pinned Rust tests, Clippy, rustfmt, and the benchmark remain blocked because `cargo` and `rustc` are unavailable.

<sup>Written for commit 4a71ef4d2f37ab2da9d7e577ced451ba131937f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

