### PR TITLE
fix(script): enforce pubkey encoding for empty signatures

### DIFF
--- a/.github/workflows/script-parity.yml
+++ b/.github/workflows/script-parity.yml
@@ -1,0 +1,99 @@
+name: script-parity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: script-parity-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  script-parity:
+    name: script-parity (${{ matrix.engine }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [native, kernel]
+    env:
+      CARGO_TERM_COLOR: never
+      CARGO_INCREMENTAL: 0
+      RUST_BACKTRACE: 1
+      ENGINE: ${{ matrix.engine }}
+      CARGO_TARGET_DIR: target/script-parity-${{ matrix.engine }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        id: toolchain
+        with:
+          toolchain: '1.95.0'
+          components: clippy
+      - name: Install kernel build prerequisites
+        if: matrix.engine == 'kernel'
+        run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
+      # Separate runners and target directories keep the native candidate and
+      # kernel-enabled oracle artifacts distinct. No shared build cache here.
+      - name: Record source, toolchain, lockfile, and feature graph
+        id: identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p evidence
+          features=()
+          if [[ "$ENGINE" == kernel ]]; then features=(--features bitcoin-rs-script/kernel); fi
+          {
+            printf 'engine=%s\npr_head=%s\ntarget_dir=%s\n' "$ENGINE" "$PR_HEAD_SHA" "$CARGO_TARGET_DIR"
+            git rev-parse HEAD
+            rustc --version --verbose
+            cargo --version
+            sha256sum Cargo.lock
+          } > evidence/identity.txt
+          cargo tree --locked -p bitcoin-rs-script --no-default-features \
+            "${features[@]}" > evidence/features.txt
+      - name: Lint primitives and script targets
+        if: ${{ !cancelled() && steps.identity.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          features=()
+          if [[ "$ENGINE" == kernel ]]; then features=(--features bitcoin-rs-script/kernel); fi
+          cargo clippy --locked -p bitcoin-rs-primitives -p bitcoin-rs-script \
+            --no-default-features "${features[@]}" --all-targets -- -D warnings \
+            2>&1 | tee evidence/clippy.log
+      # This focused acceptance lane is independent of Apalache provisioning
+      # and the full-workspace test job. Lint failure must not hide test output.
+      - name: Run primitives and script suites
+        if: ${{ !cancelled() && steps.identity.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          features=()
+          if [[ "$ENGINE" == kernel ]]; then features=(--features bitcoin-rs-script/kernel); fi
+          cargo test --locked -p bitcoin-rs-primitives -p bitcoin-rs-script \
+            --no-default-features "${features[@]}" --no-fail-fast -- --nocapture \
+            2>&1 | tee evidence/tests.log
+      - name: Record built artifact identities
+        if: ${{ always() && steps.identity.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -d "$CARGO_TARGET_DIR/debug/deps" ]]; then
+            find "$CARGO_TARGET_DIR/debug/deps" -maxdepth 1 -type f -executable -print0 \
+              | sort -z | xargs -0 -r sha256sum > evidence/executables.sha256
+          fi
+      - name: Preserve acceptance evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: script-parity-${{ matrix.engine }}-${{ github.run_attempt }}
+          path: evidence/
+          if-no-files-found: warn
+          retention-days: 7

--- a/crates/script/src/checker.rs
+++ b/crates/script/src/checker.rs
@@ -154,14 +154,14 @@ impl<'a> TxSignatureChecker<'a> {
         sigversion: SigVersion,
         flags: VerifyFlags,
     ) -> Result<bool, ScriptError> {
-        // NULLFAIL: empty signature is a clean false, not an error.
+        // Core checks both encodings before signature verification. An empty
+        // signature is permitted, but does not waive public-key encoding rules.
+        check_signature_encoding(sig, flags)?;
+        check_pubkey_encoding(pubkey, flags, sigversion)?;
+
         if sig.is_empty() {
             return Ok(false);
         }
-
-        // Encoding checks driven by flags.
-        check_signature_encoding(sig, flags)?;
-        check_pubkey_encoding(pubkey, flags, sigversion)?;
 
         // Parse the pubkey; an invalid pubkey is a clean false (not an error)
         // matching Core's `CPubKey::IsValid()` returning false.

--- a/crates/script/tests/ecdsa_encoding_order.rs
+++ b/crates/script/tests/ecdsa_encoding_order.rs
@@ -1,0 +1,188 @@
+//! ECDSA encoding-order regressions against Bitcoin Core.
+//!
+//! Empty ECDSA signatures are a clean verification failure, but Core still
+//! applies public-key encoding checks before reaching cryptographic verification.
+
+#![expect(clippy::expect_used, reason = "fixed regression fixtures")]
+
+use bitcoin_rs_primitives::{Tx, TxOut, deserialize};
+use bitcoin_rs_script::checker::{SigVersion, TxSignatureChecker};
+use bitcoin_rs_script::{Interpreter, ScriptErrCode, ScriptError, VerifyFlags};
+use secp256k1::{PublicKey, SECP256K1, SecretKey};
+use sha2::{Digest, Sha256};
+
+const TX_HEX: &str = concat!(
+    "0100000002fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f",
+    "0000000000eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57",
+    "b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85",
+    "c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2",
+    "f0167faa815988ac11000000",
+);
+const TEST_KEY: &str = "619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9";
+const PROGRAM: &str = "00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1";
+const VALUE: u64 = 600_000_000;
+const INPUT: usize = 1;
+
+fn hex(text: &str) -> Vec<u8> {
+    assert!(text.len().is_multiple_of(2));
+    text.as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            u8::from_str_radix(std::str::from_utf8(pair).expect("ASCII hex"), 16)
+                .expect("hex byte")
+        })
+        .collect()
+}
+
+fn fixture() -> Tx {
+    deserialize(&hex(TX_HEX)).expect("native fixture decode")
+}
+
+fn test_key() -> SecretKey {
+    SecretKey::from_slice(&hex(TEST_KEY)).expect("public BIP143 test key")
+}
+
+fn p2wpkh_prevout() -> TxOut {
+    TxOut {
+        value: VALUE,
+        script_pubkey: hex(PROGRAM),
+    }
+}
+
+fn negative_check_script(pubkey: &[u8], multisig: bool) -> Vec<u8> {
+    assert!(pubkey.len() <= 75);
+    let mut script = Vec::new();
+    if multisig {
+        script.push(0x51); // one signature
+    }
+    script.push(u8::try_from(pubkey.len()).expect("short test pubkey"));
+    script.extend_from_slice(pubkey);
+    if multisig {
+        script.push(0x51); // one key
+    }
+    script.push(if multisig { 0xae } else { 0xac }); // CHECKMULTISIG / CHECKSIG
+    script.push(0x91); // NOT: clean signature failure succeeds; encoding errors do not.
+    script
+}
+
+#[test]
+fn empty_signature_cannot_bypass_legacy_key_encoding() {
+    let tx = fixture();
+    for multisig in [false, true] {
+        let script = negative_check_script(&[], multisig);
+        let prevout = TxOut {
+            value: VALUE,
+            script_pubkey: script.clone(),
+        };
+        let script_sig = if multisig {
+            vec![0x00, 0x00]
+        } else {
+            vec![0x00]
+        };
+        assert_eq!(
+            Interpreter.execute(
+                &script,
+                &script_sig,
+                &[],
+                VerifyFlags::NONE,
+                &prevout,
+                &tx,
+                INPUT,
+            ),
+            Ok(true),
+        );
+        assert_eq!(
+            Interpreter.execute(
+                &script,
+                &script_sig,
+                &[],
+                VerifyFlags::STRICTENC,
+                &prevout,
+                &tx,
+                INPUT,
+            ),
+            Err(ScriptError::Invalid {
+                code: ScriptErrCode::PubkeyType,
+            }),
+        );
+    }
+}
+
+#[test]
+fn empty_signature_cannot_bypass_witness_compressed_key_policy() {
+    let tx = fixture();
+    let uncompressed =
+        PublicKey::from_secret_key(SECP256K1, &test_key()).serialize_uncompressed();
+    for multisig in [false, true] {
+        let script = negative_check_script(&uncompressed, multisig);
+        let mut program = vec![0x00, 0x20]; // witness v0, 32-byte script hash
+        program.extend_from_slice(&Sha256::digest(&script));
+        let prevout = TxOut {
+            value: VALUE,
+            script_pubkey: program,
+        };
+        let mut witness = vec![Vec::new()];
+        if multisig {
+            witness.push(Vec::new());
+        }
+        witness.push(script);
+        assert_eq!(
+            Interpreter.execute(
+                &prevout.script_pubkey,
+                &[],
+                &witness,
+                VerifyFlags::MANDATORY,
+                &prevout,
+                &tx,
+                INPUT,
+            ),
+            Ok(true),
+        );
+        assert_eq!(
+            Interpreter.execute(
+                &prevout.script_pubkey,
+                &[],
+                &witness,
+                VerifyFlags::MANDATORY.union(VerifyFlags::WITNESS_PUBKEYTYPE),
+                &prevout,
+                &tx,
+                INPUT,
+            ),
+            Err(ScriptError::Invalid {
+                code: ScriptErrCode::WitnessPubkeyType,
+            }),
+        );
+    }
+}
+
+#[test]
+fn encoding_error_precedence_matches_core() {
+    let tx = fixture();
+    let prevouts = vec![p2wpkh_prevout(); tx.inputs.len()];
+    let mut checker = TxSignatureChecker::new(&tx, INPUT, VALUE, &prevouts);
+    for version in [SigVersion::Base, SigVersion::WitnessV0] {
+        assert_eq!(
+            checker.check_ecdsa_signature(&[], &[], &[], version, VerifyFlags::DERSIG),
+            Ok(false),
+        );
+        assert_eq!(
+            checker.check_ecdsa_signature(&[], &[], &[], version, VerifyFlags::STRICTENC),
+            Err(ScriptError::Invalid {
+                code: ScriptErrCode::PubkeyType,
+            }),
+        );
+        assert_eq!(
+            checker.check_ecdsa_signature(&[0], &[], &[], version, VerifyFlags::STRICTENC),
+            Err(ScriptError::Invalid {
+                code: ScriptErrCode::SigDer,
+            }),
+        );
+    }
+    let flags = VerifyFlags::STRICTENC.union(VerifyFlags::WITNESS_PUBKEYTYPE);
+    assert_eq!(
+        checker.check_ecdsa_signature(&[], &[], &[], SigVersion::WitnessV0, flags),
+        Err(ScriptError::Invalid {
+            code: ScriptErrCode::PubkeyType,
+        }),
+    );
+}

--- a/crates/script/tests/ecdsa_encoding_order.rs
+++ b/crates/script/tests/ecdsa_encoding_order.rs
@@ -1,4 +1,10 @@
-//! ECDSA encoding-order regressions against Bitcoin Core.
+//! ECDSA encoding-order regressions against Bitcoin Core v29.0.
+//!
+//! Contract: Bitcoin Core tag `v29.0`, `src/script/interpreter.cpp`,
+//! `EvalChecksig` (and `EvalCheckmultisig`) calls `CheckSignatureEncoding`
+//! followed by `CheckPubKeyEncoding` before cryptographic verification. These
+//! assertions are derived from that pinned reference, including the empty
+//! signature and witness public-key policy behavior.
 //!
 //! Empty ECDSA signatures are a clean verification failure, but Core still
 //! applies public-key encoding checks before reaching cryptographic verification.

--- a/crates/script/tests/ecdsa_encoding_order.rs
+++ b/crates/script/tests/ecdsa_encoding_order.rs
@@ -1,13 +1,14 @@
-//! ECDSA encoding-order regressions against Bitcoin Core v29.0.
+//! ECDSA encoding-order regressions against Bitcoin Core.
 //!
-//! Contract: Bitcoin Core tag `v29.0`, `src/script/interpreter.cpp`,
-//! `EvalChecksig` (and `EvalCheckmultisig`) calls `CheckSignatureEncoding`
-//! followed by `CheckPubKeyEncoding` before cryptographic verification. These
-//! assertions are derived from that pinned reference, including the empty
-//! signature and witness public-key policy behavior.
-//!
+//! Originally anchored to Core v29.0; rechecked against v31.1 below.
 //! Empty ECDSA signatures are a clean verification failure, but Core still
 //! applies public-key encoding checks before reaching cryptographic verification.
+//!
+//! Reference: bitcoin/bitcoin v31.1, src/script/interpreter.cpp, Git blob
+//! 443714ceedaf6b0cc695316882080f79fb50316e: CheckSignatureEncoding,
+//! CheckPubKeyEncoding, EvalChecksigPreTapscript, and EvalScript's
+//! OP_CHECKMULTISIG loop. Assertions follow that reference's ordering and
+//! distinguish structural key policy from elliptic-curve point validity.
 
 #![expect(clippy::expect_used, reason = "fixed regression fixtures")]
 
@@ -191,4 +192,133 @@ fn encoding_error_precedence_matches_core() {
             code: ScriptErrCode::PubkeyType,
         }),
     );
+}
+
+#[test]
+fn empty_signature_key_policy_matrix_preserves_clean_false_and_error_order() {
+    let tx = fixture();
+    let prevouts = vec![p2wpkh_prevout(); tx.inputs.len()];
+    let public = PublicKey::from_secret_key(SECP256K1, &test_key());
+    let mut hybrid = public.serialize_uncompressed().to_vec();
+    hybrid[0] = 0x06 | (hybrid[64] & 1);
+    let mut invalid_point = vec![0xff; 33];
+    invalid_point[0] = 0x02; // structurally compressed; x is outside the curve field
+    // Columns are STRICTENC shape validity and compressed-key shape validity.
+    let keys = [
+        (Vec::new(), false, false),
+        (vec![0x02; 32], false, false),
+        (vec![0x05; 33], false, false),
+        (public.serialize().to_vec(), true, true),
+        (public.serialize_uncompressed().to_vec(), true, false),
+        (hybrid, false, false),
+        (invalid_point, true, true),
+    ];
+    let policy_bits = [
+        VerifyFlags::STRICTENC,
+        VerifyFlags::WITNESS_PUBKEYTYPE,
+        VerifyFlags::DERSIG,
+        VerifyFlags::LOW_S,
+        VerifyFlags::NULLFAIL,
+    ];
+    let mut checked = 0;
+    for version in [SigVersion::Base, SigVersion::WitnessV0] {
+        for mask in 0_u32..32 {
+            let mut flags = VerifyFlags::NONE;
+            for (bit, flag) in policy_bits.iter().enumerate() {
+                if mask & (1 << bit) != 0 {
+                    flags = flags.union(*flag);
+                }
+            }
+            for (key, strict_shape, compressed) in &keys {
+                let expected = if flags.contains(VerifyFlags::STRICTENC) && !*strict_shape {
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::PubkeyType,
+                    })
+                } else if version == SigVersion::WitnessV0
+                    && flags.contains(VerifyFlags::WITNESS_PUBKEYTYPE)
+                    && !*compressed
+                {
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::WitnessPubkeyType,
+                    })
+                } else {
+                    Ok(false)
+                };
+                let mut checker = TxSignatureChecker::new(&tx, INPUT, VALUE, &prevouts);
+                assert_eq!(
+                    checker.check_ecdsa_signature(&[], key, &[], version, flags),
+                    expected,
+                    "version={version:?}, flags={flags:?}, key={key:02x?}",
+                );
+                checked += 1;
+            }
+        }
+    }
+    assert_eq!(checked, 448);
+}
+
+#[test]
+fn undefined_hashtype_precedes_bad_pubkey_encoding() {
+    let tx = fixture();
+    let prevouts = vec![p2wpkh_prevout(); tx.inputs.len()];
+    // DER r=1, s=1 is structurally valid and low-S; 0x05 is undefined.
+    let signature = hex("300602010102010105");
+    let flags = VerifyFlags::STRICTENC
+        .union(VerifyFlags::WITNESS_PUBKEYTYPE)
+        .union(VerifyFlags::LOW_S);
+    for version in [SigVersion::Base, SigVersion::WitnessV0] {
+        let mut checker = TxSignatureChecker::new(&tx, INPUT, VALUE, &prevouts);
+        assert_eq!(
+            checker.check_ecdsa_signature(&signature, &[], &[], version, flags),
+            Err(ScriptError::Invalid {
+                code: ScriptErrCode::SigHashtype,
+            }),
+        );
+    }
+}
+
+#[test]
+fn unvisited_keys_and_unexecuted_sigops_do_not_trigger_encoding_checks() {
+    let tx = fixture();
+    let flags = VerifyFlags::MANDATORY
+        .union(VerifyFlags::STRICTENC)
+        .union(VerifyFlags::WITNESS_PUBKEYTYPE)
+        .union(VerifyFlags::NULLFAIL);
+    // Zero-of-one CHECKMULTISIG never visits the empty pubkey. An inactive
+    // CHECKSIG branch must not check either encoding or stack operands.
+    let cases = [
+        (vec![0x00, 0x00, 0x51, 0xae], vec![Vec::new()]),
+        (vec![0x00, 0x63, 0xac, 0x68, 0x51], Vec::new()),
+    ];
+    for (script, arguments) in cases {
+        let prevout = TxOut {
+            value: VALUE,
+            script_pubkey: script.clone(),
+        };
+        let script_sig = vec![0x00; arguments.len()];
+        assert_eq!(
+            Interpreter.execute(&script, &script_sig, &[], flags, &prevout, &tx, INPUT),
+            Ok(true),
+        );
+        let mut program = vec![0x00, 0x20];
+        program.extend_from_slice(&Sha256::digest(&script));
+        let witness_prevout = TxOut {
+            value: VALUE,
+            script_pubkey: program,
+        };
+        let mut witness = arguments;
+        witness.push(script);
+        assert_eq!(
+            Interpreter.execute(
+                &witness_prevout.script_pubkey,
+                &[],
+                &witness,
+                flags,
+                &witness_prevout,
+                &tx,
+                INPUT,
+            ),
+            Ok(true),
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- run ECDSA signature and public-key encoding checks before the empty-signature clean-false return
- preserve Bitcoin Core's encoding-error precedence
- add `CHECKSIG` / `CHECKMULTISIG` regressions for `STRICTENC` and `WITNESS_PUBKEYTYPE`

## Why
An empty ECDSA signature is permitted as a clean verification failure, but Bitcoin Core still performs public-key encoding checks before cryptographic verification. The current checker returns early and can therefore bypass `STRICTENC` / `WITNESS_PUBKEYTYPE` key-encoding errors.

## Regression coverage
The new tests cover:
- legacy `CHECKSIG` and `CHECKMULTISIG` with `OP_NOT` under `STRICTENC`
- witness-v0 compressed-key policy with empty signatures
- direct checker error precedence for `DERSIG`, `STRICTENC`, and `WITNESS_PUBKEYTYPE`

## Verification performed
The patch was source-compared against Bitcoin Core's check order. The split unified-diff syntax and final GitHub diff statistics were verified, and the published regression-test blob matches the locally prepared test blob exactly.

This environment did not have Cargo/rustc available, so the Rust target and Clippy were not executed locally. This PR is intentionally a draft pending repository CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves ECDSA signature and public-key encoding checks before the empty-signature early return so `STRICTENC` and `WITNESS_PUBKEYTYPE` failures are no longer suppressed, matching Bitcoin Core's error precedence.

- Empty signatures still verify as clean false when their encoding is valid.
- Adds regression coverage for legacy `CHECKSIG`/`CHECKMULTISIG`, witness-v0 compressed-key policy, 448 flag/key combinations, and direct checker precedence for `DERSIG`, `STRICTENC`, and `WITNESS_PUBKEYTYPE`, anchored to Bitcoin Core v29.0/v31.1.
- Adds a pinned Rust 1.95 native/kernel CI workflow running Clippy and the primitives/script suites.

<sup>Written for commit 5d666b38ec5c5d789bc29123bd4c8047c867394c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

