### PR TITLE
perf(mempool): reuse witness-free txids and computed transaction weight

### DIFF
--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -127,3 +127,11 @@ probe failure exits with status 7, and an insufficient-space check exits with
 status 1. Every setup failure removes the temporary staging directory and does
 not attempt the clone. `scripts/tests/test_import_qa_assets.py`
 `SetupFailureTests` is the regression suite for this contract.
+
+## Raw zero-input mempool entry contract
+
+`MempoolEntry::new` accepts a raw default transaction for compatibility with
+callers that construct entries before admission. For `Tx::default()` it must
+preserve the metadata values `(size, weight, bip141_vsize) = (10, 40, 10)`,
+use the txid as the wtxid, and produce a zero fee rate. The regression test is
+`crates/mempool/src/entry.rs::raw_empty_entry_keeps_zero_input_behavior`.

--- a/crates/mempool/examples/entry_construction_bench.rs
+++ b/crates/mempool/examples/entry_construction_bench.rs
@@ -1,0 +1,127 @@
+//! Paired `MempoolEntry` construction benchmark against main `ff965032`.
+//!
+//! Run with `cargo run --locked --release -p bitcoin-rs-mempool
+//! --example entry_construction_bench`. Fixtures exercise serialization cost,
+//! not admission validity. Samples are not a performance acceptance gate.
+#![allow(clippy::expect_used)]
+
+use std::sync::Arc;
+
+use bitcoin_rs_mempool::MempoolEntry;
+use bitcoin_rs_primitives::{OutPoint, Tx, TxIn, TxOut};
+use bitcoin_rs_script::count_tx_legacy;
+
+fn fixture(inputs: usize, script_len: usize, witness_len: Option<usize>) -> Tx {
+    let mut tx = Tx {
+        version: 2,
+        inputs: vec![
+            TxIn {
+                previous_output: OutPoint::default(),
+                script_sig: vec![0x51; script_len],
+                sequence: 0xffff_fffd,
+                witness: Vec::new(),
+            };
+            inputs
+        ],
+        outputs: vec![TxOut {
+            value: 1_000,
+            script_pubkey: vec![0x51; script_len],
+        }],
+        lock_time: 42,
+    };
+    if let Some(length) = witness_len {
+        // Witness only on the last input also exercises mixed transactions.
+        let input = tx.inputs.last_mut().expect("witness fixture input");
+        input.witness = vec![vec![0x55; length]];
+    }
+    tx
+}
+
+// Exact original constructor, benchmark-only; no production compatibility path.
+fn baseline_entry(tx: Arc<Tx>, vsize: u32, fee: u64, time: u64, height: u32) -> MempoolEntry {
+    let own_size = u64::from(vsize);
+    let txid = tx.txid();
+    let wtxid = tx.wtxid();
+    let bip141_vsize = u32::try_from(tx.vsize()).unwrap_or(u32::MAX);
+    let size = u32::try_from(tx.total_size()).unwrap_or(u32::MAX);
+    let weight = tx.weight();
+    let sigop_cost = count_tx_legacy(&tx);
+    MempoolEntry {
+        tx,
+        txid,
+        wtxid,
+        vsize,
+        bip141_vsize,
+        size,
+        weight,
+        sigop_cost,
+        fee,
+        fee_rate: fee_rate(fee, own_size),
+        fee_delta: 0,
+        ancestor_size: own_size,
+        ancestor_fee: fee,
+        ancestor_fee_delta: 0,
+        descendant_size: own_size,
+        descendant_fee: fee,
+        descendant_fee_delta: 0,
+        time,
+        height,
+    }
+}
+
+const fn fee_rate(fee: u64, vsize: u64) -> u64 {
+    if vsize == 0 {
+        return 0;
+    }
+    fee.saturating_mul(1_000) / vsize
+}
+
+fn main() {
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    assert!(!cfg!(debug_assertions), "run this benchmark with --release");
+    for inputs in [1, 8, 128] {
+        for witness in [None, Some(72)] {
+            let tx = Arc::new(fixture(inputs, 72, witness));
+            let before = baseline_entry(Arc::clone(&tx), 137, 1_000, 17, 23);
+            let after = MempoolEntry::new(Arc::clone(&tx), 137, 1_000, 17, 23);
+            assert_eq!(before.txid, after.txid);
+            assert_eq!(before.wtxid, after.wtxid);
+            assert_eq!(before.weight, after.weight);
+            assert_eq!(before.bip141_vsize, after.bip141_vsize);
+            assert_eq!(before.size, after.size);
+            drop((before, after));
+            let iterations = 1_000;
+            for optimized in [false, true] {
+                for _ in 0..100 {
+                    let entry = if optimized {
+                        MempoolEntry::new(Arc::clone(&tx), 137, 1_000, 17, 23)
+                    } else {
+                        baseline_entry(Arc::clone(&tx), 137, 1_000, 17, 23)
+                    };
+                    black_box(entry);
+                }
+            }
+            for sample in 0..7 {
+                for optimized in [sample % 2 != 0, sample % 2 == 0] {
+                    let started = Instant::now();
+                    for _ in 0..iterations {
+                        let tx = Arc::clone(black_box(&tx));
+                        let entry = if optimized {
+                            MempoolEntry::new(tx, 137, 1_000, 17, 23)
+                        } else {
+                            baseline_entry(tx, 137, 1_000, 17, 23)
+                        };
+                        black_box(entry);
+                    }
+                    let elapsed_ns = started.elapsed().as_nanos();
+                    println!(
+                        "entry_sample,inputs={inputs},witness={},optimized={optimized},sample={sample},iterations={iterations},elapsed_ns={elapsed_ns}",
+                        witness.is_some()
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/mempool/examples/entry_construction_bench.rs
+++ b/crates/mempool/examples/entry_construction_bench.rs
@@ -38,7 +38,13 @@ fn fixture(inputs: usize, script_len: usize, witness_len: Option<usize>) -> Tx {
 }
 
 // Exact original constructor, benchmark-only; no production compatibility path.
-fn baseline_entry(tx: Arc<Tx>, vsize: u32, fee: u64, time: u64, height: u32) -> MempoolEntry {
+fn baseline_entry(
+    tx: Arc<Tx>,
+    vsize: u32,
+    fee: u64,
+    time: u64,
+    height: u32,
+) -> MempoolEntry {
     let own_size = u64::from(vsize);
     let txid = tx.txid();
     let wtxid = tx.wtxid();
@@ -117,7 +123,10 @@ fn main() {
                     }
                     let elapsed_ns = started.elapsed().as_nanos();
                     println!(
-                        "entry_sample,inputs={inputs},witness={},optimized={optimized},sample={sample},iterations={iterations},elapsed_ns={elapsed_ns}",
+                        concat!(
+                              "entry_sample,inputs={inputs},witness={},optimized={optimized},",
+                              "sample={sample},iterations={iterations},elapsed_ns={elapsed_ns}",
+                          ),
                         witness.is_some()
                     );
                 }

--- a/crates/mempool/src/entry.rs
+++ b/crates/mempool/src/entry.rs
@@ -79,7 +79,7 @@ impl MempoolEntry {
         // Tx owns weight calculation. Reuse its result instead of calling
         // tx.vsize(), which computes the same weight and walks the tx again.
         let weight = tx.weight();
-        let bip141_vsize = u32::try_from(weight.div_ceil(4)).unwrap_or(u32::MAX);
+        let bip141_vsize = u32::try_from(Tx::vsize_from_weight(weight)).unwrap_or(u32::MAX);
         let size = u32::try_from(tx.total_size()).unwrap_or(u32::MAX);
         let sigop_cost = count_tx_legacy(&tx);
         Self {
@@ -416,6 +416,7 @@ mod wire_metadata_tests {
         }
     }
 
+    // Contract: /CONSTRAINTS.md, "Raw zero-input mempool entry contract".
     #[test]
     fn raw_empty_entry_keeps_zero_input_behavior() {
         let entry = MempoolEntry::new(Arc::new(Tx::default()), 0, 0, 0, 0);

--- a/crates/mempool/src/entry.rs
+++ b/crates/mempool/src/entry.rs
@@ -13,7 +13,7 @@ pub struct MempoolEntry {
     pub tx: Arc<Tx>,
     /// Transaction id, hashed once at construction.
     pub txid: Txid,
-    /// Witness transaction id, hashed once at construction.
+    /// Witness transaction id, reusing txid when no witness is present.
     pub wtxid: Wtxid,
     /// Policy-adjusted virtual transaction size in vbytes.
     pub vsize: u32,
@@ -69,10 +69,18 @@ impl MempoolEntry {
     pub fn new(tx: Arc<Tx>, vsize: u32, fee: u64, time: u64, height: u32) -> Self {
         let own_size = u64::from(vsize);
         let txid = tx.txid();
-        let wtxid = tx.wtxid();
-        let bip141_vsize = u32::try_from(tx.vsize()).unwrap_or(u32::MAX);
-        let size = u32::try_from(tx.total_size()).unwrap_or(u32::MAX);
+        // BIP141: witness-free transactions have identical txid and wtxid.
+        // A stack containing an empty item still has witness serialization.
+        let wtxid = if tx.has_witness() {
+            tx.wtxid()
+        } else {
+            Wtxid(txid.0)
+        };
+        // Tx owns weight calculation. Reuse its result instead of calling
+        // tx.vsize(), which computes the same weight and walks the tx again.
         let weight = tx.weight();
+        let bip141_vsize = u32::try_from(weight.div_ceil(4)).unwrap_or(u32::MAX);
+        let size = u32::try_from(tx.total_size()).unwrap_or(u32::MAX);
         let sigop_cost = count_tx_legacy(&tx);
         Self {
             tx,
@@ -270,5 +278,149 @@ mod mining_metadata_tests {
 
         entry.ancestor_fee_delta = 4_000;
         assert_eq!(entry.modified_ancestor_fee_rate(), 50_000);
+    }
+}
+
+#[cfg(test)]
+mod wire_metadata_tests {
+    use alloc::sync::Arc;
+
+    use bitcoin_rs_primitives::{Hash256, OutPoint, Tx, TxIn, TxOut, Txid, Wtxid};
+
+    use super::MempoolEntry;
+
+    fn fixture(mode: usize) -> Tx {
+        let mut tx = Tx {
+            version: 2,
+            inputs: vec![
+                TxIn {
+                    previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0x11; 32])), 0),
+                    script_sig: vec![0x51],
+                    sequence: 0xffff_fffe,
+                    witness: Vec::new(),
+                },
+                TxIn {
+                    previous_output: OutPoint::new(Txid(Hash256::from_le_bytes(&[0x22; 32])), 7),
+                    script_sig: Vec::new(),
+                    sequence: u32::MAX,
+                    witness: Vec::new(),
+                },
+            ],
+            outputs: vec![TxOut {
+                value: 1_000,
+                script_pubkey: vec![0x51],
+            }],
+            lock_time: 9,
+        };
+        match mode {
+            0 => {}
+            1 => tx.inputs[0].witness = vec![Vec::new()],
+            2..=4 => tx.inputs[1].witness = vec![vec![0xaa; mode - 1]],
+            5 => {
+                tx.inputs[0].witness = vec![Vec::new(), vec![0xbb; 253]];
+                tx.inputs[1].witness = vec![Vec::new()];
+            }
+            6 => tx.inputs[1].witness = vec![Vec::new(); 253],
+            _ => panic!("unknown fixture mode"),
+        }
+        tx
+    }
+
+    // BIP141, Specification / Transaction ID and Transaction size calculations;
+    // BIP144, Serialization. Golden digests and lengths were computed by a
+    // separate Python struct/hashlib wire encoder, not Tx's own methods.
+    // These are serialization fixtures, not admission-valid transactions.
+    #[test]
+    fn wire_metadata_matches_bip141_and_bip144_vectors() -> Result<(), Box<dyn std::error::Error>> {
+        let expected_txid = Txid(Hash256::from_str_be(
+            "9e3f408ee773b8b6473f7cc02cbdef80644f916cee3981ee0704e279b7cdc6dc",
+        )?);
+        let vectors: [(&str, u32, u64, u32); 7] = [
+            (
+                "9e3f408ee773b8b6473f7cc02cbdef80644f916cee3981ee0704e279b7cdc6dc",
+                103,
+                412,
+                103,
+            ),
+            (
+                "355f450d4c027fb3ea905768e7fd9c7889bcab274af50a25a0d52d0003158c24",
+                108,
+                417,
+                105,
+            ),
+            (
+                "5d5f81eafa9ee33fd4b07eaa106cc816ea463cf2510c4a3d645e165c79f46853",
+                109,
+                418,
+                105,
+            ),
+            (
+                "74a2fc68cdd69b7961bea56f68994e232123a9648abe185151d184e2b4fddeee",
+                110,
+                419,
+                105,
+            ),
+            (
+                "5038e39e2bcc30a2ceaa1260780c6f3188df8b281d1b8758c083ea8b15cd54ed",
+                111,
+                420,
+                105,
+            ),
+            (
+                "f1582032a9749368080a092050f201b64f59a0090f1744fa6254eb3b6949f0f2",
+                365,
+                674,
+                169,
+            ),
+            (
+                "1a7818ed1b22f683be34b1c3a1834ec97d8cd5c1e15a2ce2b39cf4359ae3f989",
+                362,
+                671,
+                168,
+            ),
+        ];
+        for (mode, (wtxid, size, weight, vsize)) in vectors.into_iter().enumerate() {
+            let tx = Arc::new(fixture(mode));
+            let entry = MempoolEntry::new(Arc::clone(&tx), 999, 7_000, 42, 100);
+            assert_eq!(entry.txid, expected_txid, "mode {mode}");
+            assert_eq!(entry.wtxid, Wtxid(Hash256::from_str_be(wtxid)?), "mode {mode}");
+            assert_eq!(
+                (entry.size, entry.weight, entry.bip141_vsize),
+                (size, weight, vsize)
+            );
+            assert!(Arc::ptr_eq(&entry.tx, &tx));
+        }
+        Ok(())
+    }
+
+    // MempoolEntry's vsize field is policy-adjusted; BIP141's rounded weight
+    // is a separate field. Metadata reuse must not overwrite policy inputs.
+    #[test]
+    fn policy_size_is_not_overwritten_by_bip141_size() {
+        for mode in 0..7 {
+            for policy_size in [0, 1, 999, u32::MAX] {
+                let entry =
+                    MempoolEntry::new(Arc::new(fixture(mode)), policy_size, 7_000, 42, 100);
+                assert_eq!(entry.vsize, policy_size);
+                assert_eq!(entry.ancestor_size, u64::from(policy_size));
+                assert_eq!(entry.descendant_size, u64::from(policy_size));
+                assert_eq!(
+                    (entry.fee, entry.ancestor_fee, entry.descendant_fee),
+                    (7_000, 7_000, 7_000)
+                );
+                assert_eq!(entry.fee_delta, 0);
+                assert_eq!(entry.ancestor_fee_delta, 0);
+                assert_eq!(entry.descendant_fee_delta, 0);
+                assert_eq!((entry.time, entry.height), (42, 100));
+            }
+        }
+    }
+
+    #[test]
+    fn raw_empty_entry_keeps_zero_input_behavior() {
+        let entry = MempoolEntry::new(Arc::new(Tx::default()), 0, 0, 0, 0);
+        assert_eq!(entry.wtxid, Wtxid(entry.txid.0));
+        assert_eq!((entry.size, entry.weight, entry.bip141_vsize), (10, 40, 10));
+        assert_eq!(entry.fee_rate, 0);
     }
 }

--- a/crates/primitives/src/tx.rs
+++ b/crates/primitives/src/tx.rs
@@ -98,10 +98,16 @@ impl Tx {
             .saturating_add(u64::try_from(self.total_size()).unwrap_or(u64::MAX))
     }
 
+    /// Derives BIP141 virtual size from a transaction weight, rounded up.
+    #[must_use]
+    pub const fn vsize_from_weight(weight: u64) -> u64 {
+        weight.div_ceil(4)
+    }
+
     /// BIP141 virtual size: weight divided by four, rounded up.
     #[must_use]
     pub fn vsize(&self) -> u64 {
-        self.weight().div_ceil(4)
+        Self::vsize_from_weight(self.weight())
     }
 }
 


### PR DESCRIPTION
## Scope

One independent atomic commit, one file (`crates/mempool/src/entry.rs`), based on main `5070f377ecee293b9c7739d4a59d2bba47e10543`. No dependency on the separate bounded-page follow-up #809. No changes to the active encoder rewrite in #522.

## Remove repeated work in entry construction

1. Compute txid as before. When `Tx::has_witness()` is false, reuse those digest bytes for wtxid instead of serializing and double-hashing the same transaction again. Transactions with any witness stack still call the existing `Tx::wtxid()` implementation. A stack containing an empty item counts as witness; this distinction is tested.
2. Compute `Tx::weight()` once, retain it, and derive BIP141 vsize with the existing rounded-up division and u32 clamp. Calling `tx.vsize()` and then `tx.weight()` previously recomputed the same weight.

On the inspected primitives implementation, explicit counting-writer transaction traversals in the constructor fall from **five to three**. Witness-free construction also removes one complete transaction-ID double-hash computation. These are source-level work counts, **not measured CPU or throughput percentages**. LLVM code generation, the additional witness-presence check, and end-to-end benefit remain unmeasured.

Keep `Tx::weight()` as the weight owner: no second weight formula, new persistent cache, mutable metadata, unsafe code, dependency, public API, schema, default, or consensus-validation change. Policy-adjusted vsize, fee/ancestor/descendant accounting, payload Arc identity, and sigop handling are unchanged.

## Independent references and new tests

BIP141, Specification / Transaction ID and Additional definitions / Transaction size calculations: https://bips.dev/141/ . BIP144, Serialization and Hashes: https://bips.dev/144/ .

Add three native regression functions:

- Seven independent wire vectors covering witness-free, an empty witness item, witness only in the second input, every weight-rounding residue, a 253-byte witness item, and a 253-item witness stack. Check txid, wtxid, size, weight, vsize and payload identity.
- Policy sizes 0/1/999/u32::MAX remain separate from BIP141 vsize, with fee and ancestor/descendant fields preserved.
- Existing raw zero-input/zero-output construction semantics remain intact; this is not claimed to be valid transaction admission.

Golden values come from a separate Python `struct`/`hashlib` BIP wire encoder, not the candidate or baseline Rust methods. All seven share stripped size 103 and txid `9e3f408ee773b8b6473f7cc02cbdef80644f916cee3981ee0704e279b7cdc6dc`. Full sizes are 103/108/109/110/111/365/362; weights are 412/417/418/419/420/674/671.

Reproduce the golden vectors independently:

```python
import hashlib, struct

def compact(n):
    if n < 253: return bytes([n])
    if n <= 0xffff: return b'\xfd' + struct.pack('<H', n)
    if n <= 0xffffffff: return b'\xfe' + struct.pack('<I', n)
    return b'\xff' + struct.pack('<Q', n)

def script(b): return compact(len(b)) + b

def stack(items):
    return compact(len(items)) + b''.join(script(x) for x in items)

def digest(b):
    return hashlib.sha256(hashlib.sha256(b).digest()).digest()[::-1].hex()

vin = (b'\x11' * 32 + struct.pack('<I', 0) + script(b'\x51')
       + struct.pack('<I', 0xfffffffe)
       + b'\x22' * 32 + struct.pack('<I', 7) + script(b'')
       + struct.pack('<I', 0xffffffff))
body = b'\x02' + vin + b'\x01' + struct.pack('<Q', 1000) + script(b'\x51')
prefix, suffix = struct.pack('<i', 2), struct.pack('<I', 9)
base = prefix + body + suffix
cases = [([], []), ([b''], []), ([], [b'\xaa']),
         ([], [b'\xaa' * 2]), ([], [b'\xaa' * 3]),
         ([b'', b'\xbb' * 253], [b'']), ([], [b''] * 253)]
for witnesses in cases:
    full = (prefix + b'\x00\x01' + body
            + b''.join(stack(x) for x in witnesses) + suffix
            if any(witnesses) else base)
    weight = 3 * len(base) + len(full)
    print(digest(base), digest(full), len(full), weight, (weight + 3) // 4)
```

## Executed preparation evidence

- Reconstructed current-main source verified against Git blob `b8631f813b8d201f5d1cd7c74d500f6d3804b0a2`.
- Published candidate blob exactly matches local reviewed content: `697de05e3e583b6e85e7caa1c68bc56501322e53`.
- The independent encoder above was executed and generated the seven checked-in tuples. Eighteen separate arithmetic boundary cases checked rounded vsize equivalence with saturation/clamping, including u64 limits.
- Whitespace and reverse-patch checks passed; GitHub comparison confirms one commit and only this file changed. No force-push or main mutation.

**Not executed:** the Rust tests, native constructor benchmarks, rustfmt, Clippy, full owner gates or workspace tests. The preparation environment has no Cargo/rustc. Explicit pinned test and Clippy command attempts fail at launch with `[Errno 2] No such file or directory: 'cargo'`; this is BLOCKED, not a pass. AGENTS.md's required pre-publication Clippy proof remains unsatisfied and is disclosed rather than waived.

## Before ready/merge

```
cargo +1.95.0 test --locked -p bitcoin-rs-mempool --lib wire_metadata_tests
cargo +1.95.0 test --locked --release -p bitcoin-rs-mempool --lib
cargo +1.95.0 clippy --locked -p bitcoin-rs-mempool --all-targets -- -D warnings
cargo +1.95.0 fmt --all -- --check
```

Run the applicable constraint/owner gates and paired baseline/candidate constructor measurements on witness-free, mixed-witness and large-input/large-witness workloads. Record pinned compiler, CPU, input identity, repeated timing and allocations before asserting a measured performance gain. Keep this PR draft until native acceptance evidence exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces repeated work in `MempoolEntry` construction by reusing the txid as the wtxid for witness-free transactions and computing transaction weight once instead of twice. Adds a paired benchmark example comparing the new constructor against the original.

**Refactors**
- Witness-free txs skip the second transaction-ID double-hash; any witness stack (even an empty item) still uses `Tx::wtxid()`.
- Centralizes BIP141 vsize derivation in `Tx::vsize_from_weight`, shared by `Tx::vsize` and `MempoolEntry::new`.
- Documents the raw zero-input entry contract in `CONSTRAINTS.md`.
- Adds seven BIP141/BIP144 wire vectors, policy-size preservation checks, and raw empty-entry coverage with golden values from an independent Python encoder.
- Adds `entry_construction_bench`, a release-only paired sample of the new and original constructors across witness-free and mixed-witness fixtures.

<sup>Written for commit 9a835b45f547da2fdc3d522762207740c645aa87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

