### PR TITLE
bench(primitives): compare Hash256 Display with its bytewise baseline

### DIFF
--- a/crates/primitives/examples/hash_display_bench.rs
+++ b/crates/primitives/examples/hash_display_bench.rs
@@ -1,0 +1,83 @@
+//! Paired `Hash256` `Display` microbenchmark against the pre-PR bytewise formatter.
+//!
+//! Run with `cargo run --locked --release -p bitcoin-rs-primitives
+//! --example hash_display_bench`. Samples are not a performance acceptance gate.
+
+use std::fmt::{self, Write as _};
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use bitcoin_rs_primitives::Hash256;
+
+struct Bytewise<'a>(&'a Hash256);
+
+impl fmt::Display for Bytewise<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Exact Display loop from main ff965032, benchmark-only.
+        for byte in self.0.as_byte_array().iter().rev() {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+fn measure(
+    hashes: &[Hash256],
+    optimized: bool,
+    reuse: bool,
+    iterations: usize,
+) -> Result<Duration, fmt::Error> {
+    let mut output = String::with_capacity(64);
+    let started = Instant::now();
+    for hash in hashes.iter().cycle().take(iterations) {
+        let hash = black_box(hash);
+        if reuse {
+            output.clear();
+            if optimized {
+                write!(&mut output, "{hash}")?;
+            } else {
+                write!(&mut output, "{}", Bytewise(hash))?;
+            }
+            black_box(output.as_str());
+        } else {
+            let text = if optimized {
+                hash.to_string()
+            } else {
+                Bytewise(hash).to_string()
+            };
+            black_box(text);
+        }
+    }
+    Ok(started.elapsed())
+}
+
+fn main() -> fmt::Result {
+    assert!(!cfg!(debug_assertions), "run this benchmark with --release");
+    let hashes: Vec<_> = (0_u8..=u8::MAX)
+        .map(|seed| {
+            let mut bytes = [0_u8; 32];
+            for (offset, byte) in (0_u8..32).zip(&mut bytes) {
+                *byte = seed.wrapping_add(offset);
+            }
+            Hash256::from_le_bytes(&bytes)
+        })
+        .collect();
+    for hash in &hashes {
+        assert_eq!(hash.to_string(), Bytewise(hash).to_string());
+    }
+    for reuse in [true, false] {
+        for optimized in [false, true] {
+            let _ = measure(&hashes, optimized, reuse, 10_000)?;
+        }
+        for sample in 0..7 {
+            for optimized in [sample % 2 != 0, sample % 2 == 0] {
+                let iterations = 100_000;
+                let elapsed_ns = measure(&hashes, optimized, reuse, iterations)?.as_nanos();
+                println!(
+                    "hash_sample,reuse={reuse},optimized={optimized},sample={sample},iterations={iterations},elapsed_ns={elapsed_ns}"
+                );
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Scope

One benchmark-only commit, one new file: `crates/primitives/examples/hash_display_bench.rs`, based on main `5070f377ecee293b9c7739d4a59d2bba47e10543` after #795 merged. No production implementation, default, dependency, public API, or consensus change.

The benchmark compares the production Hash256 Display implementation against the bytewise Display loop from `ff965032`. It tests two caller modes separately: a reused 64-byte-capacity String and an allocating `to_string()` call. It checks equal output for all 256 deterministic hashes before timing, warms both arms, alternates order over seven paired samples, uses black_box, and emits raw elapsed nanoseconds and iteration counts. Setup and printing are outside each timed loop; output destruction is included in the allocating arm. The baseline is confined to this executable, not a production compatibility path.

## Run

```
cargo +1.95.0 run --locked --release -p bitcoin-rs-primitives --example hash_display_bench
cargo +1.95.0 clippy --locked -p bitcoin-rs-primitives --all-targets -- -D warnings
cargo +1.95.0 test --locked -p bitcoin-rs-primitives
cargo +1.95.0 fmt --all -- --check
```

These samples are diagnostic microbenchmarks, not automatic performance-acceptance gates. Record the compiler, CPU, resolved profile and lockfile identity when collecting them. Allocation counts, RSS, production RPC throughput, and independent baseline/candidate binary measurements remain separate requirements. The old Display loop did not itself allocate one heap object per byte; no such allocation-elimination claim is made.

## Verification and limitations

Local whitespace checking passed. The remotely read-back file blob `fa0d1d79db2a967f8b7a8ae9ac749ff2788fb45e` exactly matches the locally prepared UTF-8 source. Commit `ef98e118586cd3a13dc1e0ce7aaf2430ffe89a67` adds only this file.

Pinned run, Clippy, and rustfmt attempts fail before execution because Cargo/rustc are absent (`[Errno 2] No such file or directory: 'cargo'`). Repository cloning also fails DNS resolution. This does not establish compilation, native correctness, Clippy cleanliness, or any timing improvement. AGENTS.md's pre-publication Clippy proof is still unsatisfied and is disclosed here; this PR remains draft pending native validation. No zero-findings or measured-performance verdict is claimed.

Related optimization PRs: #809 (bounded mempool page selection) and #811 (reuse transaction metadata). This PR is independent of both.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a paired microbenchmark comparing the current `Hash256` `Display` implementation against the pre-refactor bytewise formatter.

- Benchmark-only change: no production code, dependencies, or public API changes.
- Tests two caller modes: reusing a 64-byte `String` and allocating via `to_string()`.
- Verifies identical output for all 256 deterministic hashes before timing, warms both arms, and alternates order over seven paired samples.
- The benchmark is diagnostic only and is not a performance acceptance gate; native compilation and results still need validation before this leaves draft.

<sup>Written for commit ef98e118586cd3a13dc1e0ce7aaf2430ffe89a67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

