### PR TITLE
perf(consensus): remove block-fact reserialization and redundant witness hashing

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -40,3 +40,7 @@ sonic-rs.workspace = true
 [[bench]]
 name = "merkle"
 harness = false
+
+[[bench]]
+name = "block_facts"
+harness = false

--- a/crates/consensus/benches/block_facts.rs
+++ b/crates/consensus/benches/block_facts.rs
@@ -1,0 +1,86 @@
+//! Parse-once fact derivation and decoded lazy witness-ID benchmarks.
+//! Run the identical harness at its introduction commit and the optimized
+//! descendant in separate target directories. No historical-chain fixture is
+//! needed. This microbenchmark is not an apply-path or full-replay verdict.
+#![allow(missing_docs)]
+
+#[path = "../tests/support/block_facts_fixture.rs"]
+mod fixtures;
+
+use std::hint::black_box;
+
+use bitcoin_rs_consensus::{BlockView, block_view::BlockFacts};
+use bitcoin_rs_primitives::layout::ParsedBlock;
+use bitcoin_rs_primitives::{Tx, consensus_bytes};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+fn block_facts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("block_facts");
+    // name, tx count, inputs, outputs, script bytes, witness modulus.
+    // Each fixture isolates a relevant source of copying or metadata work.
+    for (name, txs, inputs, outputs, script, witness) in [
+        ("legacy_small", 1, 1, 2, 25, 0),
+        ("legacy_1024", 1024, 1, 2, 25, 0),
+        ("segwit_1024", 1024, 1, 2, 25, 1),
+        ("mixed_1024", 1024, 1, 2, 25, 2),
+        ("legacy_large_script", 1, 1, 1, 65_536, 0),
+        ("segwit_large_script", 1, 1, 1, 65_536, 1),
+        ("segwit_253_inputs", 8, 253, 2, 0, 1),
+        ("segwit_253_outputs", 8, 1, 253, 0, 1),
+    ] {
+        let block = fixtures::fixture(txs, inputs, outputs, script, witness);
+        let bytes = consensus_bytes(&block);
+        let parsed = ParsedBlock::parse_exact(&bytes)
+            .unwrap_or_else(|error| panic!("benchmark layout: {error}"));
+        let checked = BlockFacts::from_parsed(&parsed);
+        fixtures::assert_oracle(&bytes, &checked);
+        assert!(!checked.merkle_mutated());
+        group.throughput(Throughput::Bytes(
+            u64::try_from(bytes.len()).unwrap_or_else(|error| panic!("fixture size: {error}")),
+        ));
+        group.bench_function(BenchmarkId::new("derive", name), |b| {
+            b.iter(|| black_box(BlockFacts::from_parsed(black_box(&parsed))));
+        });
+        group.bench_function(BenchmarkId::new("parse_and_derive", name), |b| {
+            b.iter(|| {
+                let layout = ParsedBlock::parse_exact(black_box(&bytes))
+                    .unwrap_or_else(|error| panic!("benchmark layout: {error}"));
+                black_box(BlockFacts::from_parsed(&layout))
+            });
+        });
+    }
+    group.finish();
+}
+
+fn lazy_witness_ids(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lazy_witness_ids");
+    for (name, witness) in [("legacy", 0), ("segwit", 1), ("mixed", 2)] {
+        let block = fixtures::fixture(1024, 1, 2, 25, witness);
+        let txids = block.txs.iter().map(Tx::txid).collect();
+        let baseline = BlockFacts::from_txids(&block.txs, txids);
+        let mut checked = BlockView::from_facts(&block.txs, baseline.clone());
+        let bytes = consensus_bytes(&block);
+        let oracle: bitcoin::Block = bitcoin::consensus::deserialize(&bytes)
+            .unwrap_or_else(|error| panic!("benchmark oracle: {error}"));
+        assert_eq!(checked.witness_ids().len(), oracle.txdata.len());
+        for (actual, expected) in checked.witness_ids().iter().zip(&oracle.txdata) {
+            assert_eq!(actual.to_string(), expected.compute_wtxid().to_string());
+        }
+        group.throughput(Throughput::Elements(1024));
+        group.bench_function(name, |b| {
+            // Reset the lazy cache outside timing. Each iteration measures a
+            // genuine first fill, not the already-populated fast return.
+            b.iter_batched_ref(
+                || BlockView::from_facts(&block.txs, baseline.clone()),
+                |view| {
+                    black_box(view.witness_ids());
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, block_facts, lazy_witness_ids);
+criterion_main!(benches);

--- a/crates/consensus/src/block_view.rs
+++ b/crates/consensus/src/block_view.rs
@@ -4,10 +4,12 @@
 //! the Merkle result so later validation stages do not derive them again.
 
 use bitcoin_rs_primitives::{
-    Tx, TxOut, Txid, Wtxid,
+    Hash256, Tx, TxOut, Txid, Wtxid,
     encode::double_sha256,
     layout::{ByteSpan, ParsedBlock, ParsedTransaction},
 };
+
+use sha2::{Digest, Sha256};
 
 use crate::verify_block::merkle_root_and_mutation_borrowed;
 
@@ -34,10 +36,9 @@ impl BlockFacts {
         let mut wtxids: Option<Vec<Wtxid>> = None;
         let mut base_sizes = 0_u64;
         let mut has_witness = false;
-        let mut scratch = Vec::new();
 
         for tx in parsed.transactions() {
-            let txid = txid_from_spans(tx, &mut scratch);
+            let (txid, base_size) = txid_and_base_size(tx);
             if tx.is_segwit() {
                 has_witness = true;
                 let ids = wtxids.get_or_insert_with(|| {
@@ -49,7 +50,7 @@ impl BlockFacts {
             } else if let Some(ids) = wtxids.as_mut() {
                 ids.push(Wtxid(txid.0));
             }
-            base_sizes = base_sizes.saturating_add(base_size_from_spans(tx));
+            base_sizes = base_sizes.saturating_add(base_size);
             txids.push(txid);
         }
 
@@ -158,7 +159,22 @@ impl BlockFacts {
 
     pub(crate) fn or_insert_wtxids_from(&mut self, txs: &[Tx]) {
         if self.wtxids.is_none() {
-            self.wtxids = Some(txs.iter().map(Tx::wtxid).collect());
+            // BIP141: a witness-free transaction's wtxid is its txid. Reuse
+            // the identity already owned by these facts instead of encoding
+            // and hashing the same transaction again. Iterate over txs, not
+            // a zip: even malformed caller-supplied identity counts must not
+            // silently truncate the witness-ID matrix.
+            self.wtxids = Some(
+                txs.iter()
+                    .enumerate()
+                    .map(|(index, tx)| {
+                        self.txids
+                            .get(index)
+                            .filter(|_| !tx.has_witness())
+                            .map_or_else(|| tx.wtxid(), |txid| Wtxid(txid.0))
+                    })
+                    .collect(),
+            );
         }
     }
 }
@@ -280,24 +296,49 @@ fn merkle_root_and_mutation(txids: &[Txid]) -> (Option<Txid>, bool) {
         .map_or((None, false), |(root, mutated)| (Some(root), mutated))
 }
 
-fn txid_from_spans(tx: &ParsedTransaction<'_>, scratch: &mut Vec<u8>) -> Txid {
-    scratch.clear();
-    extend_span(scratch, tx, tx.version_span());
-    extend_span(scratch, tx, tx.input_count_span());
-    for input in tx.inputs() {
-        extend_span(scratch, tx, input.outpoint());
-        push_compact(scratch, span_len(input.script_sig()));
-        extend_span(scratch, tx, input.script_sig());
-        extend_span(scratch, tx, input.sequence());
+/// Hash the canonical base serialization without reconstructing its fields.
+///
+/// The layout parser has already checked `CompactSize` canonicality and wire
+/// order. Legacy bytes are contiguous; `SegWit` removes exactly the marker/flag
+/// and witness section, leaving version, the input/output range, and lock time.
+/// The same borrowed ranges own the stripped-size calculation, so there is no
+/// second traversal of input/output metadata and no transaction-sized scratch.
+fn txid_and_base_size(tx: &ParsedTransaction<'_>) -> (Txid, u64) {
+    let bytes = tx
+        .span_bytes(tx.span())
+        .unwrap_or_else(|| unreachable!("span belongs to the parsed image"));
+    if !tx.is_segwit() {
+        return (Txid(double_sha256(bytes)), u64::from(tx.span().len()));
     }
-    extend_span(scratch, tx, tx.output_count_span());
-    for output in tx.outputs() {
-        extend_span(scratch, tx, output.value());
-        push_compact(scratch, span_len(output.script_pubkey()));
-        extend_span(scratch, tx, output.script_pubkey());
-    }
-    extend_span(scratch, tx, tx.lock_time_span());
-    Txid(double_sha256(scratch))
+
+    // An empty final script still ends after its CompactSize prefix. With no
+    // outputs, the output-count prefix itself is the end of the base body.
+    let body_end = tx.outputs().last().map_or_else(
+        || tx.output_count_span().end(),
+        |output| output.script_pubkey().end(),
+    );
+    // Layout offsets are image-relative, not transaction-relative. Subtract
+    // the transaction origin before indexing its borrowed byte slice.
+    let origin = u64::from(tx.span().start());
+    let start = usize::try_from(u64::from(tx.input_count_span().start()) - origin)
+        .unwrap_or_else(|_| unreachable!("body start is inside the transaction"));
+    let end = usize::try_from(body_end - origin)
+        .unwrap_or_else(|_| unreachable!("body end is inside the transaction"));
+    let body = &bytes[start..end];
+    let version = tx
+        .span_bytes(tx.version_span())
+        .unwrap_or_else(|| unreachable!("version belongs to the parsed image"));
+    let lock_time = tx
+        .span_bytes(tx.lock_time_span())
+        .unwrap_or_else(|| unreachable!("lock time belongs to the parsed image"));
+
+    let mut engine = Sha256::new();
+    engine.update(version);
+    engine.update(body);
+    engine.update(lock_time);
+    let digest: [u8; 32] = Sha256::digest(engine.finalize()).into();
+    let base_size = len_u64(version.len()) + len_u64(body.len()) + len_u64(lock_time.len());
+    (Txid(Hash256::from_le_bytes(&digest)), base_size)
 }
 
 fn wtxid_from_span(tx: &ParsedTransaction<'_>) -> Wtxid {
@@ -308,50 +349,6 @@ fn wtxid_from_span(tx: &ParsedTransaction<'_>) -> Wtxid {
     Wtxid(double_sha256(bytes))
 }
 
-fn base_size_from_spans(tx: &ParsedTransaction<'_>) -> u64 {
-    let mut size = 4 + u64::from(tx.input_count_span().len()) + 4;
-    for input in tx.inputs() {
-        size += 36
-            + u64::from(compact_size_len(span_len(input.script_sig())))
-            + u64::from(input.script_sig().len())
-            + 4;
-    }
-    size += u64::from(tx.output_count_span().len());
-    for output in tx.outputs() {
-        size += 8
-            + u64::from(compact_size_len(span_len(output.script_pubkey())))
-            + u64::from(output.script_pubkey().len());
-    }
-    size
-}
-
-fn extend_span(scratch: &mut Vec<u8>, tx: &ParsedTransaction<'_>, span: ByteSpan) {
-    scratch.extend_from_slice(
-        tx.span_bytes(span)
-            .unwrap_or_else(|| unreachable!("span belongs to the parsed image")),
-    );
-}
-
-fn push_compact(scratch: &mut Vec<u8>, value: u64) {
-    match value {
-        0..=0xfc => scratch.push(
-            u8::try_from(value).unwrap_or_else(|_| unreachable!("value fits u8 by the match arm")),
-        ),
-        0xfd..=0xffff => {
-            scratch.push(0xfd);
-            scratch.extend_from_slice(&value.to_le_bytes()[..2]);
-        }
-        0x1_0000..=0xffff_ffff => {
-            scratch.push(0xfe);
-            scratch.extend_from_slice(&value.to_le_bytes()[..4]);
-        }
-        _ => {
-            scratch.push(0xff);
-            scratch.extend_from_slice(&value.to_le_bytes());
-        }
-    }
-}
-
 const fn compact_size_len(value: u64) -> u32 {
     match value {
         0..=0xfc => 1,
@@ -359,10 +356,6 @@ const fn compact_size_len(value: u64) -> u32 {
         0x1_0000..=0xffff_ffff => 5,
         _ => 9,
     }
-}
-
-fn span_len(span: ByteSpan) -> u64 {
-    u64::from(span.len())
 }
 
 fn len_u64(len: usize) -> u64 {

--- a/crates/consensus/src/block_view.rs
+++ b/crates/consensus/src/block_view.rs
@@ -5,7 +5,7 @@
 
 use bitcoin_rs_primitives::{
     Hash256, Tx, TxOut, Txid, Wtxid,
-    encode::double_sha256,
+    encode::{double_sha256, finalize_double_sha256},
     layout::{ByteSpan, ParsedBlock, ParsedTransaction},
 };
 
@@ -336,9 +336,8 @@ fn txid_and_base_size(tx: &ParsedTransaction<'_>) -> (Txid, u64) {
     engine.update(version);
     engine.update(body);
     engine.update(lock_time);
-    let digest: [u8; 32] = Sha256::digest(engine.finalize()).into();
     let base_size = len_u64(version.len()) + len_u64(body.len()) + len_u64(lock_time.len());
-    (Txid(Hash256::from_le_bytes(&digest)), base_size)
+    (Txid(finalize_double_sha256(engine)), base_size)
 }
 
 fn wtxid_from_span(tx: &ParsedTransaction<'_>) -> Wtxid {

--- a/crates/consensus/tests/block_facts_borrowed.rs
+++ b/crates/consensus/tests/block_facts_borrowed.rs
@@ -1,0 +1,173 @@
+//! BIP141 base serialization parity over borrowed transaction ranges.
+//! References: BIP141 Transaction ID / Block size; rust-bitcoin is the
+//! independent decoder and hash/weight oracle, not the candidate serializer.
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+#[path = "support/block_facts_fixture.rs"]
+mod fixtures;
+
+use bitcoin_rs_consensus::{BlockView, block_view::BlockFacts};
+use bitcoin_rs_primitives::layout::ParsedBlock;
+use bitcoin_rs_primitives::{Block, Tx, consensus_bytes};
+
+fn facts(block: &Block) -> BlockFacts {
+    let bytes = consensus_bytes(block);
+    let parsed = ParsedBlock::parse_exact(&bytes).expect("fixture layout");
+    let facts = BlockFacts::from_parsed(&parsed);
+    fixtures::assert_oracle(&bytes, &facts);
+    facts
+}
+
+#[test]
+fn sha256_and_compact_size_script_boundaries_match_oracle() {
+    // Include SHA256 padding/block boundaries and both representable
+    // script-length CompactSize transitions without allocating huge scripts.
+    for len in [0, 1, 55, 56, 63, 64, 65, 252, 253, 254, 65_535, 65_536] {
+        for witness_modulus in [0, 1, 2] {
+            let block = fixtures::fixture(3, 1, 1, len, witness_modulus);
+            assert!(!facts(&block).merkle_mutated());
+        }
+    }
+}
+
+#[test]
+fn count_prefixes_and_nonzero_transaction_origins_match_oracle() {
+    for count in [1, 252, 253, 254] {
+        for witness_modulus in [0, 1, 2] {
+            // Vary input, output and block transaction counts independently.
+            facts(&fixtures::fixture(3, count, 1, 0, witness_modulus));
+            facts(&fixtures::fixture(3, 1, count, 0, witness_modulus));
+            facts(&fixtures::fixture(count, 1, 1, 0, witness_modulus));
+        }
+    }
+}
+
+#[test]
+fn zero_outputs_and_empty_last_script_preserve_base_body_end() {
+    for witness_modulus in [0, 1, 2] {
+        for outputs in [0, 1, 2] {
+            let mut block = fixtures::fixture(3, 2, outputs, 17, witness_modulus);
+            for tx in &mut block.txs {
+                if let Some(output) = tx.outputs.last_mut() {
+                    output.script_pubkey.clear();
+                }
+            }
+            facts(&block);
+        }
+    }
+}
+
+#[test]
+fn witness_only_mutations_leave_txids_and_merkle_root_unchanged() {
+    let mut block = fixtures::fixture(3, 2, 2, 7, 2);
+    let original = facts(&block);
+    block.txs[1].inputs[0].witness = vec![Vec::new(), vec![0xab; 253]];
+    let mutated = facts(&block);
+    assert_eq!(original.txids(), mutated.txids());
+    assert_eq!(original.merkle_root(), mutated.merkle_root());
+    assert_ne!(original.wtxids(), mutated.wtxids());
+    assert_ne!(original.weight(), mutated.weight());
+}
+
+#[test]
+fn a_single_empty_witness_item_is_not_a_legacy_transaction() {
+    let mut block = fixtures::fixture(3, 2, 0, 0, 0);
+    block.txs[1].inputs[1].witness = vec![Vec::new()];
+    let result = facts(&block);
+    assert!(result.has_witness());
+    let ids = result.wtxids().expect("one empty item still has witness data");
+    assert_ne!(ids[1].0, result.txids()[1].0);
+    assert_eq!(ids[0].0, result.txids()[0].0);
+    assert_eq!(ids[2].0, result.txids()[2].0);
+}
+
+#[test]
+fn parsing_a_prefix_never_hashes_the_following_message() {
+    let block = fixtures::fixture(3, 2, 2, 253, 2);
+    let original = consensus_bytes(&block);
+    let mut bytes = original.clone();
+    bytes.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+    let mut reader = bytes.as_slice();
+    let parsed = ParsedBlock::parse(&mut reader).expect("prefix parse");
+    assert_eq!(reader, &[0xde, 0xad, 0xbe, 0xef]);
+    let actual = BlockFacts::from_parsed(&parsed);
+    fixtures::assert_oracle(&original, &actual);
+    assert_eq!(actual, facts(&block));
+    assert!(ParsedBlock::parse_exact(&bytes).is_err());
+}
+
+#[test]
+fn legacy_and_mixed_lazy_witness_ids_match_oracle_and_reuse_cache() {
+    for witness_modulus in [0, 1, 2, 3] {
+        let block = fixtures::fixture(9, 3, 2, 253, witness_modulus);
+        let bytes = consensus_bytes(&block);
+        let oracle: bitcoin::Block = bitcoin::consensus::deserialize(&bytes).expect("oracle");
+        let txids = block.txs.iter().map(Tx::txid).collect();
+        let mut view = BlockView::new(&block.txs, txids);
+        assert!(view.computed_witness_ids().is_none());
+        let ids = view.witness_ids();
+        assert_eq!(ids.len(), oracle.txdata.len());
+        for (actual, expected) in ids.iter().zip(&oracle.txdata) {
+            assert_eq!(actual.to_string(), expected.compute_wtxid().to_string());
+        }
+        let cached = ids.as_ptr();
+        assert_eq!(cached, view.witness_ids().as_ptr());
+    }
+}
+
+#[test]
+fn empty_blocks_preserve_lazy_and_parsed_fact_shapes() {
+    let block = fixtures::fixture(0, 1, 1, 0, 0);
+    let actual = facts(&block);
+    assert_eq!(actual.tx_count(), 0);
+    assert_eq!(actual.weight(), 324);
+    assert!(!actual.has_witness());
+    assert!(actual.merkle_root().is_none());
+    assert!(!actual.merkle_mutated());
+    let mut view = BlockView::new(&block.txs, Vec::new());
+    assert!(view.witness_ids().is_empty());
+}
+
+#[test]
+fn mutation_flag_distinguishes_real_duplicate_tail_from_odd_padding() {
+    // Core's [1..6] / [1..6,5,6] ambiguity: same root, only the latter
+    // contains equal real siblings. Apply it to actual wire transactions.
+    for witness_modulus in [0, 1, 2] {
+        let mut block = fixtures::fixture(6, 1, 1, 0, witness_modulus);
+        let original = facts(&block);
+        let tail = block.txs[4..].to_vec();
+        block.txs.extend(tail);
+        let duplicated = facts(&block);
+        assert_eq!(original.merkle_root(), duplicated.merkle_root());
+        assert!(!original.merkle_mutated());
+        assert!(duplicated.merkle_mutated());
+    }
+}
+
+#[test]
+fn noncanonical_script_lengths_still_fail_at_the_layout_boundary() {
+    for witness_modulus in [0, 1] {
+        let block = fixtures::fixture(1, 1, 1, 1, witness_modulus);
+        let mut bytes = consensus_bytes(&block);
+        let parsed = ParsedBlock::parse_exact(&bytes).expect("canonical layout");
+        let script = parsed.transactions()[0].inputs()[0].script_sig();
+        let prefix = usize::try_from(script.start()).expect("fixture offset") - 1;
+        drop(parsed);
+        drop(bytes.splice(prefix..prefix + 1, [0xfd, 1, 0]));
+        assert!(ParsedBlock::parse_exact(&bytes).is_err());
+        assert!(bitcoin::consensus::deserialize::<bitcoin::Block>(&bytes).is_err());
+    }
+}
+
+#[test]
+fn version_and_lock_time_bytes_remain_in_the_transaction_id() {
+    let mut block = fixtures::fixture(3, 1, 1, 0, 2);
+    let original = facts(&block);
+    block.txs[1].version = -1;
+    block.txs[1].lock_time = u32::MAX;
+    let changed = facts(&block);
+    assert_ne!(original.txids()[1], changed.txids()[1]);
+    assert_eq!(original.txids()[0], changed.txids()[0]);
+    assert_eq!(original.txids()[2], changed.txids()[2]);
+    assert_eq!(original.weight(), changed.weight());
+}

--- a/crates/consensus/tests/support/block_facts_fixture.rs
+++ b/crates/consensus/tests/support/block_facts_fixture.rs
@@ -1,0 +1,106 @@
+//! Deterministic wire fixtures shared by borrowed-fact tests and benchmarks.
+//! These are parse/identity workloads, not signed consensus-valid blocks.
+
+use bitcoin_rs_consensus::block_view::BlockFacts;
+use bitcoin_rs_primitives::{Block, BlockHash, Hash256, Header, OutPoint, Tx, TxIn, TxOut, Txid};
+
+/// A zero witness modulus selects legacy transactions; otherwise the last
+/// transaction in each modulus-sized group carries one witness stack.
+pub(crate) fn fixture(
+    tx_count: usize,
+    input_count: usize,
+    output_count: usize,
+    script_len: usize,
+    witness_modulus: usize,
+) -> Block {
+    let txs = (0..tx_count)
+        .map(|index| {
+            let identity = u32::try_from(index)
+                .unwrap_or_else(|error| panic!("fixture transaction count: {error}"));
+            let mut previous = [0_u8; 32];
+            previous[..4].copy_from_slice(&identity.to_le_bytes());
+            previous[4] = 1;
+            let witnessed = witness_modulus != 0 && (index + 1).is_multiple_of(witness_modulus);
+            let inputs = (0..input_count)
+                .map(|input_index| TxIn {
+                    previous_output: OutPoint::new(
+                        Txid(Hash256::from_le_bytes(&previous)),
+                        u32::try_from(input_index)
+                            .unwrap_or_else(|error| panic!("fixture input count: {error}")),
+                    ),
+                    script_sig: vec![0x51; script_len],
+                    sequence: 0xffff_fffe,
+                    witness: if witnessed && input_index == 0 {
+                        vec![vec![0x30; 72], vec![0x02; 33]]
+                    } else {
+                        Vec::new()
+                    },
+                })
+                .collect();
+            Tx {
+                version: 2,
+                inputs,
+                outputs: vec![
+                    TxOut {
+                        value: 1,
+                        script_pubkey: vec![0x51; script_len],
+                    };
+                    output_count
+                ],
+                lock_time: identity,
+            }
+        })
+        .collect();
+    Block {
+        header: Header {
+            version: 1,
+            prev_blockhash: BlockHash::default(),
+            merkle_root: Hash256::default(),
+            time: 0,
+            bits: 0,
+            nonce: 0,
+        },
+        txs,
+    }
+}
+
+/// Independent rust-bitcoin decoding, hashing, weight and Merkle reduction.
+/// All assertions run outside benchmark timing loops.
+pub(crate) fn assert_oracle(bytes: &[u8], facts: &BlockFacts) {
+    let oracle: bitcoin::Block = bitcoin::consensus::deserialize(bytes)
+        .unwrap_or_else(|error| panic!("oracle block decode: {error}"));
+    assert_eq!(facts.tx_count(), oracle.txdata.len());
+    assert_eq!(facts.weight(), oracle.weight().to_wu());
+    for (actual, expected) in facts.txids().iter().zip(&oracle.txdata) {
+        assert_eq!(actual.to_string(), expected.compute_txid().to_string());
+    }
+    let has_witness = oracle
+        .txdata
+        .iter()
+        .any(|tx| tx.input.iter().any(|input| !input.witness.is_empty()));
+    assert_eq!(facts.has_witness(), has_witness);
+    match facts.wtxids() {
+        Some(ids) => {
+            assert_eq!(ids.len(), oracle.txdata.len());
+            for (actual, expected) in ids.iter().zip(&oracle.txdata) {
+                assert_eq!(actual.to_string(), expected.compute_wtxid().to_string());
+            }
+        }
+        None => assert!(!has_witness, "witness-bearing facts must carry witness IDs"),
+    }
+    let root = bitcoin::merkle_tree::calculate_root(
+        oracle.txdata.iter().map(bitcoin::Transaction::compute_txid),
+    );
+    assert_eq!(
+        facts.merkle_root().map(|root| root.to_string()),
+        root.map(|root| root.to_string()),
+    );
+    assert_eq!(facts.transaction_spans().len(), oracle.txdata.len());
+    for (span, tx) in facts.transaction_spans().iter().zip(&oracle.txdata) {
+        let start = usize::try_from(span.start())
+            .unwrap_or_else(|error| panic!("fixture span start: {error}"));
+        let end = usize::try_from(span.end())
+            .unwrap_or_else(|error| panic!("fixture span end: {error}"));
+        assert_eq!(&bytes[start..end], bitcoin::consensus::serialize(tx));
+    }
+}

--- a/crates/primitives/src/encode.rs
+++ b/crates/primitives/src/encode.rs
@@ -51,7 +51,11 @@ pub fn double_sha256(bytes: &[u8]) -> Hash256 {
 }
 
 /// Finishes a streamed double-SHA256 over everything written to the engine.
-pub(crate) fn finalize_double_sha256(engine: Sha256) -> Hash256 {
+///
+/// This is the canonical finalization path for callers that build a hash from
+/// borrowed or otherwise incrementally available byte ranges.
+#[must_use]
+pub fn finalize_double_sha256(engine: Sha256) -> Hash256 {
     let first = engine.finalize();
     let second = Sha256::digest(first);
     let bytes: [u8; 32] = second.into();


### PR DESCRIPTION
## Status

Draft optimization candidate. Rust compilation, Clippy and matched performance evidence are still required. **No measured speedup, full-kernel equivalence, or readiness-for-merge claim.** Follow-up to the now-merged #798; its witness-validation fixes and review changes are preserved.

## Work removed

`BlockFacts::from_parsed` currently reconstructs every transaction's stripped serialization into one growable scratch buffer, re-encodes script CompactSize lengths, and then walks the input/output metadata again to compute stripped size.

- Hash legacy transactions directly from their borrowed transaction span.
- For SegWit, stream exactly three borrowed ranges into SHA256: version, canonical input/output bytes, and lock time. Marker/flag and witness bytes are excluded without field reconstruction.
- Compute stripped size from the same ranges in constant metadata work per transaction. Hashing itself remains linear in bytes; no cryptographic work is skipped.
- Delete `txid_from_spans`, `base_size_from_spans`, `extend_span`, `push_compact`, and `span_len`, together with the per-derivation transaction-sized scratch Vec.
- On first lazy witness-ID fill, reuse cached txids for witness-free transactions instead of serializing and double-hashing them again. Iterate over the full transaction slice, not a truncating zip; missing caller-supplied identity rows retain the old hashing fallback.

This does **not** make all BlockFacts construction allocation-free: identity vectors, layout spans, and the existing Merkle implementation remain unchanged. No parser behavior, consensus rule, public API, unsafe code, dependency, lockfile, feature default, cryptographic backend, storage format, or durability change.

## Comparator structure

Two commits deliberately separate the controls from the implementation:

1. `c8b084f8b530e2f98aa6116dcc4a282857fad76f` adds tests and benchmarks while retaining the original production blob `f97d1fb6a578a65b42d1296bc7d5d1aa1afd0dd2`. This is a source control, **not a measured baseline**.
2. `d79b9abf3f5a8f269d159176ec791a292ccd727b` changes only `crates/consensus/src/block_view.rs`; the harness is byte-identical to the parent.

The new Criterion target has 19 cases: eight fixture shapes measured as derivation-only and parse-plus-derivation, plus three first-fill lazy-witness-ID cases. Shapes include small legacy, 1,024-transaction legacy/SegWit/mixed blocks, 65,536-byte scripts, and 253-input/output boundaries. Fixtures are wire/identity workloads, not signed consensus-valid blocks. Construction, independent oracle assertions and lazy-cache reset are outside the relevant timed loops.

Run the identical command in separate worktrees/target directories for those two revisions:

```sh
cargo bench --locked -p bitcoin-rs-consensus --no-default-features --bench block_facts
```

Retain raw results for at least three alternating matched runs and apply CL-19/CL-20, including stability, host-noise and whole-apply/replay non-regression requirements. The microbenchmark is not a substitute for product workloads or RSS/high-water measurements.

## Correctness coverage added

Eleven Rust regression functions use independent rust-bitcoin decoding, txid/wtxid hashing, weight and Merkle reduction. They cover SHA256 and CompactSize boundaries; nonzero transaction origins; empty outputs/final scripts; witness-only mutation; a single empty witness item; trailing-message exclusion; lazy-cache identities and reuse; empty blocks; real duplicate-tail mutation versus padding; noncanonical-length rejection; and version/lock-time inclusion.

References:
- BIP141 transaction IDs and block weight: https://bips.dev/141/
- Existing parser owner: `crates/primitives/src/layout.rs`, blob `5065f10271480d0cafb0411e5da956f5f456e9ea`.
- SHA2 streaming API: https://docs.rs/crate/digest/0.11.0

## Executed checks and limits

- Reconstructed input files match their immutable Git blob SHAs; all five uploaded candidate blobs match the locally checked bytes.
- Local `git diff --check` passes. GitHub compare confirms exactly two commits and five intended paths (three added, two modified).
- A supplementary independent Python wire/range model checked 3,084 cases with zero mismatches and five OpenSSL SHA256d cross-checks. **This did not execute the Rust candidate and is not compiler-backed or differential-kernel evidence.**
- Cargo/rustc probes, formatting, native Clippy, native/kernel-feature regressions, native library tests, benchmark compilation and applicable CL-06, CL-08/13/21, CL-14/19, CL-20/23 commands returned **127: executable absent**. Rust tests and benchmarks have therefore not run locally. Terminal cloning also failed DNS resolution; the local verification tree contains only the reconstructed change set, not a complete buildable workspace.

Base: `5070f377ecee293b9c7739d4a59d2bba47e10543`. No force-push or main-branch mutation. Keep draft until compiler-backed gates and the required matched performance evidence exist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes redundant block-fact reserialization and witness double-hashing when deriving transaction metadata from parsed blocks.

- Hashes legacy transactions directly from their borrowed byte span.
- For SegWit, streams version, canonical input/output range, and lock time into SHA256 without field reconstruction.
- Computes stripped sizes from the same borrowed ranges instead of walking input/output metadata.
- Reuses cached txids for witness-free transactions on lazy witness-ID fill.
- Deletes the transaction-sized scratch buffer and helper functions for CompactSize re-encoding.
- Adds regression tests using rust-bitcoin as an independent oracle.
- Adds a 19-case Criterion microbenchmark; no measured speedup is claimed, and rustc/Clippy verification is still required.
- Makes `finalize_double_sha256` public in `crates/primitives` to reuse the shared streaming finalization.

<sup>Written for commit b1f472f62fd2cd36e1267d812eae9d95f5c0e641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

