### PR TITLE
perf(script): reuse Taproot hash prefixes and eliminate tweak buffers

### DIFF
--- a/crates/script/src/taproot.rs
+++ b/crates/script/src/taproot.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use bitcoin_rs_primitives::Hash256;
 use secp256k1::{Message, Parity, Scalar, XOnlyPublicKey, schnorr::Signature};
 use sha2::{Digest, Sha256};
@@ -49,26 +51,27 @@ pub fn verify_taproot_scriptpath(
     verify_taproot_keypath(signature, message, public_key)
 }
 
-/// Tagged hash: `SHA256(SHA256(tag) || SHA256(tag) || msg)`.
-fn tagged_hash(tag: &[u8], msg: &[u8]) -> [u8; 32] {
+// BIP340 "Tagged Hashes": the doubled tag digest is exactly one SHA256
+// block. Keep only these two fixed public prefixes, never request data.
+static TAPBRANCH_ENGINE: LazyLock<Sha256> = LazyLock::new(|| tagged_hash_engine(b"TapBranch"));
+static TAPTWEAK_ENGINE: LazyLock<Sha256> = LazyLock::new(|| tagged_hash_engine(b"TapTweak"));
+
+/// Initializes SHA256 after `SHA256(tag) || SHA256(tag)`, before any message.
+fn tagged_hash_engine(tag: &[u8]) -> Sha256 {
     let tag_hash = Sha256::digest(tag);
     let mut engine = Sha256::new();
     Digest::update(&mut engine, tag_hash);
     Digest::update(&mut engine, tag_hash);
-    Digest::update(&mut engine, msg);
-    engine.finalize().into()
+    engine
 }
 
-/// Computes the `TapBranch` hash: `TaggedHash("TapBranch", min(a,b) || max(a,b))`.
-///
-/// Mirrors Core's `ComputeTapbranchHash`. The two 32-byte hashes are
-/// serialized in lexicographic order (comparing the raw byte arrays).
-fn compute_tapbranch_hash(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
+/// BIP341 `TapBranch`: raw-byte lexicographic ordering, not display order.
+fn compute_tapbranch_hash(prefix: &Sha256, a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
     let (first, second) = if a <= b { (a, b) } else { (b, a) };
-    let mut msg = [0u8; 64];
-    msg[..32].copy_from_slice(first);
-    msg[32..].copy_from_slice(second);
-    tagged_hash(b"TapBranch", &msg)
+    let mut engine = prefix.clone();
+    Digest::update(&mut engine, first);
+    Digest::update(&mut engine, second);
+    engine.finalize().into()
 }
 
 /// Walks the merkle path from `tapleaf_hash` through the control block's
@@ -80,10 +83,14 @@ fn compute_tapbranch_hash(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
 pub fn compute_taproot_merkle_root(control: &[u8], tapleaf_hash: &Hash256) -> Hash256 {
     let mut k = *tapleaf_hash.as_byte_array();
     let path = control.get(TAPROOT_CONTROL_BASE_SIZE..).unwrap_or(&[]);
-    for node in path.as_chunks::<TAPROOT_CONTROL_NODE_SIZE>().0 {
-        let mut sibling = [0_u8; TAPROOT_CONTROL_NODE_SIZE];
-        sibling.copy_from_slice(node);
-        k = compute_tapbranch_hash(&k, &sibling);
+    let nodes = path.as_chunks::<TAPROOT_CONTROL_NODE_SIZE>().0;
+    if nodes.is_empty() {
+        return *tapleaf_hash;
+    }
+    // Resolve lazy initialization once per path, not once per Merkle node.
+    let prefix = LazyLock::force(&TAPBRANCH_ENGINE);
+    for node in nodes {
+        k = compute_tapbranch_hash(prefix, &k, node);
     }
     Hash256::from_le_bytes(&k)
 }
@@ -112,9 +119,10 @@ pub fn verify_taproot_commitment(control: &[u8], program: &[u8], tapleaf_hash: &
     // The internal pubkey is serialized in big-endian (standard x-only form);
     // the merkle root is serialized in little-endian (matching Core's uint256
     // memory layout).
-    let mut tweak_msg = internal.serialize().to_vec();
-    tweak_msg.extend_from_slice(merkle_root.as_byte_array());
-    let tweak_bytes = tagged_hash(b"TapTweak", &tweak_msg);
+    let mut engine = LazyLock::force(&TAPTWEAK_ENGINE).clone();
+    Digest::update(&mut engine, internal.serialize());
+    Digest::update(&mut engine, merkle_root.as_byte_array());
+    let tweak_bytes = engine.finalize().into();
     let Ok(tweak) = Scalar::from_be_bytes(tweak_bytes) else {
         return false;
     };
@@ -313,5 +321,245 @@ mod tests {
         // The merkle root for a single leaf equals the tapleaf hash.
         let merkle = compute_taproot_merkle_root(&fixture.control, &fixture.tapleaf);
         assert_eq!(merkle.as_byte_array(), fixture.tapleaf.as_byte_array());
+    }
+
+    fn fixture_hex(text: &str) -> Result<Vec<u8>, std::num::ParseIntError> {
+        assert!(text.len().is_multiple_of(2));
+        (0..text.len())
+            .step_by(2)
+            .map(|offset| u8::from_str_radix(&text[offset..offset + 2], 16))
+            .collect()
+    }
+
+    struct CommitmentVector {
+        control: &'static str,
+        leaf: &'static str,
+        root: &'static str,
+        tweak: &'static str,
+        output: &'static str,
+    }
+
+    // BIP341 wallet-test-vectors.json, scriptPubKey cases 1, 3 and 5.
+    // Source Git blob: 11261b00ba24afb90b62109505d9ca5ddd773b3b.
+    // Expected roots/output keys are published bytes, not candidate outputs.
+    const BIP341_VECTORS: [CommitmentVector; 6] = [
+        CommitmentVector {
+            control: concat!(
+                "c1187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf",
+                "27",
+            ),
+            leaf: "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+            root: "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+            tweak: "cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001",
+            output: "147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+        },
+        CommitmentVector {
+            control: concat!(
+                "c0ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf37865",
+                "92f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a11",
+                "2a",
+            ),
+            leaf: "8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7",
+            root: "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+            tweak: "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+            output: "712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+        },
+        CommitmentVector {
+            control: concat!(
+                "faee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf37865",
+                "928ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47",
+                "a7",
+            ),
+            leaf: "f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a",
+            root: "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+            tweak: "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+            output: "712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+        },
+        CommitmentVector {
+            control: concat!(
+                "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e",
+                "6fffe578e9ea769027e4f5a3de40732f75a88a6353a09d767ddeb66accef85e5",
+                "53",
+            ),
+            leaf: "2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+            root: "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+            tweak: "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+            output: "91b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+        },
+        CommitmentVector {
+            control: concat!(
+                "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e",
+                "6f9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5cea",
+                "f62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b98",
+                "17",
+            ),
+            leaf: "ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c",
+            root: "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+            tweak: "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+            output: "91b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+        },
+        CommitmentVector {
+            control: concat!(
+                "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e",
+                "6fba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de",
+                "1c2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b98",
+                "17",
+            ),
+            leaf: "9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf6",
+            root: "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+            tweak: "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+            output: "91b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+        },
+    ];
+
+    #[test]
+    fn bip341_published_commitment_vectors() -> Result<(), Box<dyn std::error::Error>> {
+        for CommitmentVector {
+            control,
+            leaf,
+            root,
+            tweak,
+            output,
+        } in BIP341_VECTORS
+        {
+            let mut control = fixture_hex(control)?;
+            let leaf: [u8; 32] = fixture_hex(leaf)?.try_into().map_err(|_| "leaf width")?;
+            let leaf = Hash256::from_le_bytes(&leaf);
+            let expected_root = fixture_hex(root)?;
+            let actual = compute_taproot_merkle_root(&control, &leaf);
+            assert_eq!(actual.as_byte_array().as_slice(), expected_root);
+            let mut engine = std::sync::LazyLock::force(&super::TAPTWEAK_ENGINE).clone();
+            Digest::update(&mut engine, &control[1..33]);
+            Digest::update(&mut engine, actual.as_byte_array());
+            assert_eq!(engine.finalize().as_slice(), fixture_hex(tweak)?);
+            let output = fixture_hex(output)?;
+            assert!(verify_taproot_commitment(&control, &output, &leaf));
+            control[0] ^= 1;
+            assert!(!verify_taproot_commitment(&control, &output, &leaf));
+        }
+        Ok(())
+    }
+
+    // BIP340 Tagged Hashes and BIP341 Script validation rules: compare with
+    // the direct formula at every legal Merkle depth, including equal nodes.
+    #[test]
+    fn cached_branch_prefix_matches_direct_hash_at_every_control_depth() {
+        let leaf = Hash256::from_le_bytes(&[0x5a; 32]);
+        let mut control = vec![0; super::TAPROOT_CONTROL_BASE_SIZE];
+        let mut expected = *leaf.as_byte_array();
+        for depth in 0..=super::TAPROOT_CONTROL_MAX_NODE_COUNT {
+            assert_eq!(
+                compute_taproot_merkle_root(&control, &leaf).as_byte_array(),
+                &expected,
+                "depth={depth}"
+            );
+            if depth == super::TAPROOT_CONTROL_MAX_NODE_COUNT {
+                break;
+            }
+            let sibling: [u8; 32] = if depth.is_multiple_of(3) {
+                expected
+            } else {
+                Sha256::digest(depth.to_le_bytes()).into()
+            };
+            let (first, second) = if expected <= sibling {
+                (expected, sibling)
+            } else {
+                (sibling, expected)
+            };
+            expected = tagged_hash(b"TapBranch", &[first, second].concat());
+            control.extend_from_slice(&sibling);
+        }
+    }
+
+    // BIP340 domain separation: concurrent callers must not contaminate the
+    // two fixed prefixes or carry one message into the next message's state.
+    #[test]
+    fn cached_tag_prefixes_are_independent_across_threads() {
+        std::thread::scope(|scope| {
+            for seed in 0_u8..8 {
+                scope.spawn(move || {
+                    for byte in 0_u8..=u8::MAX {
+                        let message = [seed, byte].repeat(32);
+                        for (prefix, tag) in [
+                            (&super::TAPBRANCH_ENGINE, b"TapBranch".as_slice()),
+                            (&super::TAPTWEAK_ENGINE, b"TapTweak".as_slice()),
+                        ] {
+                            let mut engine = std::sync::LazyLock::force(prefix).clone();
+                            Digest::update(&mut engine, &message[..32]);
+                            Digest::update(&mut engine, &message[32..]);
+                            let actual: [u8; 32] = engine.finalize().into();
+                            assert_eq!(actual, tagged_hash(tag, &message));
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    // CONSTRAINTS.md CL-19/CL-20: this emits alternating raw samples with
+    // identical result hashes. It is not an E2E, allocation or cold-start
+    // gate and does not promote the candidate merely because timing ran.
+    #[test]
+    #[ignore = "manual paired release benchmark; retain raw samples for CL-19"]
+    fn benchmark_taproot_merkle_prefix_reuse() {
+        use std::hint::black_box;
+        use std::time::Instant;
+
+        fn baseline(control: &[u8], leaf: &Hash256) -> Hash256 {
+            let mut hash = *leaf.as_byte_array();
+            for node in control[super::TAPROOT_CONTROL_BASE_SIZE..]
+                .as_chunks::<32>()
+                .0
+            {
+                let (first, second) = if &hash <= node {
+                    (&hash, node)
+                } else {
+                    (node, &hash)
+                };
+                // The inspected baseline used this fixed stack buffer.
+                let mut message = [0_u8; 64];
+                message[..32].copy_from_slice(first);
+                message[32..].copy_from_slice(second);
+                hash = tagged_hash(b"TapBranch", &message);
+            }
+            Hash256::from_le_bytes(&hash)
+        }
+
+        let leaf = Hash256::from_le_bytes(&[0x5a; 32]);
+        for depth in [0_usize, 1, 8, 32, 128] {
+            let mut control = vec![0; super::TAPROOT_CONTROL_BASE_SIZE];
+            for index in 0..depth {
+                control.extend_from_slice(&Sha256::digest(index.to_le_bytes()));
+            }
+            let expected = baseline(&control, &leaf);
+            assert_eq!(compute_taproot_merkle_root(&control, &leaf), expected);
+            // Both implementations are warmed. Cold initialization requires
+            // a separate process and must be reported separately in CL-20.
+            for _ in 0..100 {
+                black_box(baseline(black_box(&control), black_box(&leaf)));
+                black_box(compute_taproot_merkle_root(
+                    black_box(&control),
+                    black_box(&leaf),
+                ));
+            }
+            for trial in 0..6 {
+                for cached in [trial % 2 == 0, trial % 2 != 0] {
+                    let start = Instant::now();
+                    let mut result = Hash256::default();
+                    for _ in 0..10_000 {
+                        result = black_box(if cached {
+                            compute_taproot_merkle_root(black_box(&control), black_box(&leaf))
+                        } else {
+                            baseline(black_box(&control), black_box(&leaf))
+                        });
+                    }
+                    let elapsed = start.elapsed().as_nanos();
+                    assert_eq!(result, expected);
+                    eprintln!(
+                        "taproot_merkle depth={depth} trial={trial} cached={cached} iterations=10000 elapsed_ns={elapsed} result={result}"
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Scope

One atomic commit, one file (`crates/script/src/taproot.rs`), based on `0e043b0aeba27955f08fe35523227b86bec3420a`. The source blob is unchanged from the inspected earlier main. Concurrent fixes on #809 and #811 were re-read and preserved; this PR does not modify those branches, their contracts, or their benchmarks.

## Remove repeated cryptographic setup and message buffers

- Derive exactly two fixed, private `LazyLock<Sha256>` prefixes for TapBranch and TapTweak from their literal tags. Clone the unfinalized state after `SHA256(tag) || SHA256(tag)`; no hard-coded midstate, custom SHA implementation, transaction cache, or request-derived retained state.
- Resolve the branch prefix once per nonempty Merkle path, rather than once per node. Zero-node paths return the leaf without initializing the prefix.
- Stream ordered sibling halves into the cloned engine. Remove the sibling copy and 64-byte concatenation buffer.
- Stream the serialized internal key and Merkle root into the tweak engine. Remove the temporary Vec and extension used for the 64-byte tweak message.

BIP340's Tagged Hashes section explicitly permits reuse of the SHA256 state after the doubled 32-byte tag digest. For a warm 64-byte tagged-hash message, source-level SHA256 compression work changes from **4 blocks to 2**: the baseline computes the tag digest (1) and hashes prefix/message/padding (3); the candidate hashes only message/padding (2). This excludes one-time prefix initialization and is **not a measured 2x throughput claim**. LazyLock checks, state clones, cold startup, hardware backends and elliptic-curve work still matter.

Raw-byte lexicographic branch ordering, message bytes, parsing/error order, output-key/parity verification and the caller-owned control-size check remain unchanged. No unsafe code, dependency, public API, default, schema or validation-policy change. The retained prefix count is fixed at two; byte-level memory and allocation results remain unmeasured.

## Regression coverage and benchmark

Keep the existing four native tests. Add three native test functions:

1. Six published BIP341 script paths from wallet-test-vectors.json cases 1, 3 and 5: exact Merkle roots, tweak digests, output commitments and flipped-parity rejection. Independent source Git blob: `11261b00ba24afb90b62109505d9ca5ddd773b3b`.
2. Every legal control depth 0 through 128, including equal siblings, against the direct tagged-hash formula.
3. Concurrent message/tag isolation: eight threads, 256 messages and both tags, compared with the direct formula. This is not claimed to isolate a first-initialization race.

Add an ignored paired **warm Merkle-only** release benchmark: depths 0/1/8/32/128, six alternating trials, 10,000 operations per sample, untimed setup/warmup, output equality and result hashes. The baseline retains the original direct formula and fixed stack buffer. It does not benchmark complete commitment verification, allocation/RSS, cold initialization, or E2E node throughput.

```
cargo +1.95.0 test --locked --release -p bitcoin-rs-script --lib benchmark_taproot_merkle_prefix_reuse -- --ignored --nocapture
```

## Executed evidence

- Original source blob: `bc9e907fcfff13a0e43236fe159fcd6d742bea9b`.
- Published candidate blob matches the reviewed local bytes: `8142890f1735e2c679ca895220d3c03a9dc30be6`.
- Independent Python hashlib direct-formula vs cloned-prefix models: **80,000 streamed-pair comparisons + 4,256 Merkle comparisons**, no mismatches, including the full depth range and preservation of existing partial-tail handling.
- Six published paths, three published tweak values, and six output-key/parity checks passed. Public-key checks used separate Python secp256k1 arithmetic against published outputs, not the candidate Rust verifier.
- Five deliberately faulty controls were detected: wrong tag, one tag digest, reversed branch order, a finalized digest substituted for a prefix state, and state carried between messages.
- The model rerun reproduced result digest `72e95bbb90254008cefe238ce05c4bcde08ca359ea6293f5ad722fe3bc227a65`.
- Patch application, exact resulting bytes, whitespace checks and reversal to the original source passed in a reconstructed single-file Git fixture. GitHub comparison confirms one commit / one file, +268/-20. This was not a full repository checkout/build.

**These are Python/reference and patch checks, not Rust execution, native SHA backend verification or measured performance results.**

## Pending native acceptance — keep draft

Cargo/rustc/rustup are absent from the preparation environment; git access fails DNS resolution. Explicit attempts to run pinned script tests, core vectors, the release benchmark, Clippy, rustfmt and applicable constraint commands fail before launch with `No such file or directory: 'cargo'`. No native check or benchmark is reported as passed. AGENTS.md's pre-publication Clippy requirement remains unsatisfied and is disclosed here, not waived.

Before acceptance: compile/test the exact head with Rust 1.95.0, run script/core-vector and independent-consensus checks, fix Clippy/rustfmt, and run the applicable CL-06, CL-14, CL-19 and CL-20/23 gates. CL-19 still requires at least three stable alternating runs, >=1.05x median gain above host noise and identical hashes, including affected E2E workloads. CL-20 cold-start, allocation/RSS, tail-latency and hardware-backend non-regression evidence is also pending. No repository-wide clean verdict, default promotion, merge or force-push.

References:
- https://bips.dev/340/#tagged-hashes
- https://bips.dev/341/
- https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json (blob pinned above)
- https://docs.rs/sha2/0.11.0/sha2/struct.Sha256.html
- https://doc.rust-lang.org/std/sync/struct.LazyLock.html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses the `TapBranch`/`TapTweak` tagged-hash prefixes and streams message bytes directly into a cloned SHA256 engine, removing the temporary Merkle and tweak buffers. For warm 64-byte tagged-hash messages, source-level SHA256 compression drops from 4 blocks to 2 (excluding one-time prefix setup); this is not a measured 2x throughput claim.

**Refactors**
- Fixes two `LazyLock<Sha256>` engines, cloned per message; the branch prefix is resolved once per nonempty Merkle path, and zero-node paths return the leaf without initializing it.
- Preserves message bytes, raw-byte lexicographic ordering, parsing/error order, and output-key/parity validation; no public API, dependency, unsafe code, default, or validation-policy changes.
- Adds published BIP341 script-path vectors (cases 1, 3, 5), control-depth coverage 0 through 128, and cross-thread tag-isolation tests, plus an ignored paired warm Merkle benchmark.

**Acceptance**
- The preparation environment lacked cargo/rustc and network access; compile and test with Rust 1.95.0, run the script/core vectors, and verify Clippy and rustfmt before merging.

<sup>Written for commit a7d6f1c06ad72feb117bb66db62c1665ba21737e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

