### PR TITLE
test(script): harden BIP143 and ECDSA policy with isolated kernel parity CI

### DIFF
--- a/.github/workflows/script-parity.yml
+++ b/.github/workflows/script-parity.yml
@@ -1,0 +1,99 @@
+name: script-parity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: script-parity-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  script-parity:
+    name: script-parity (${{ matrix.engine }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [native, kernel]
+    env:
+      CARGO_TERM_COLOR: never
+      CARGO_INCREMENTAL: 0
+      RUST_BACKTRACE: 1
+      ENGINE: ${{ matrix.engine }}
+      CARGO_TARGET_DIR: target/script-parity-${{ matrix.engine }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        id: toolchain
+        with:
+          toolchain: '1.95.0'
+          components: clippy
+      - name: Install kernel build prerequisites
+        if: matrix.engine == 'kernel'
+        run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
+      # Separate runners and target directories keep the native candidate and
+      # kernel-enabled oracle artifacts distinct. No shared build cache here.
+      - name: Record source, toolchain, lockfile, and feature graph
+        id: identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p evidence
+          features=()
+          if [[ "$ENGINE" == kernel ]]; then features=(--features bitcoin-rs-script/kernel); fi
+          {
+            printf 'engine=%s\npr_head=%s\ntarget_dir=%s\n' "$ENGINE" "$PR_HEAD_SHA" "$CARGO_TARGET_DIR"
+            git rev-parse HEAD
+            rustc --version --verbose
+            cargo --version
+            sha256sum Cargo.lock
+          } > evidence/identity.txt
+          cargo tree --locked -p bitcoin-rs-script --no-default-features \
+            "${features[@]}" > evidence/features.txt
+      - name: Lint primitives and script targets
+        if: ${{ !cancelled() && steps.identity.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          features=()
+          if [[ "$ENGINE" == kernel ]]; then features=(--features bitcoin-rs-script/kernel); fi
+          cargo clippy --locked -p bitcoin-rs-primitives -p bitcoin-rs-script \
+            --no-default-features "${features[@]}" --all-targets -- -D warnings \
+            2>&1 | tee evidence/clippy.log
+      # This focused acceptance lane is independent of Apalache provisioning
+      # and the full-workspace test job. Lint failure must not hide test output.
+      - name: Run primitives and script suites
+        if: ${{ !cancelled() && steps.identity.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          features=()
+          if [[ "$ENGINE" == kernel ]]; then features=(--features bitcoin-rs-script/kernel); fi
+          cargo test --locked -p bitcoin-rs-primitives -p bitcoin-rs-script \
+            --no-default-features "${features[@]}" --no-fail-fast -- --nocapture \
+            2>&1 | tee evidence/tests.log
+      - name: Record built artifact identities
+        if: ${{ always() && steps.identity.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -d "$CARGO_TARGET_DIR/debug/deps" ]]; then
+            find "$CARGO_TARGET_DIR/debug/deps" -maxdepth 1 -type f -executable -print0 \
+              | sort -z | xargs -0 -r sha256sum > evidence/executables.sha256
+          fi
+      - name: Preserve acceptance evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: script-parity-${{ matrix.engine }}-${{ github.run_attempt }}
+          path: evidence/
+          if-no-files-found: warn
+          retention-days: 7

--- a/crates/script/tests/ecdsa_encoding_order.rs
+++ b/crates/script/tests/ecdsa_encoding_order.rs
@@ -1,7 +1,14 @@
 //! ECDSA encoding-order regressions against Bitcoin Core.
 //!
-//! Empty signatures are a clean cryptographic failure, but they do not bypass
-//! public-key encoding checks that Core performs before signature verification.
+//! Originally anchored to Core v29.0; rechecked against v31.1 below.
+//! Empty ECDSA signatures are a clean verification failure, but Core still
+//! applies public-key encoding checks before reaching cryptographic verification.
+//!
+//! Reference: bitcoin/bitcoin v31.1, src/script/interpreter.cpp, Git blob
+//! 443714ceedaf6b0cc695316882080f79fb50316e: CheckSignatureEncoding,
+//! CheckPubKeyEncoding, EvalChecksigPreTapscript, and EvalScript's
+//! OP_CHECKMULTISIG loop. Assertions follow that reference's ordering and
+//! distinguish structural key policy from elliptic-curve point validity.
 
 #![expect(clippy::expect_used, reason = "fixed regression fixtures")]
 
@@ -179,4 +186,133 @@ fn encoding_error_precedence_matches_core() {
             code: ScriptErrCode::PubkeyType,
         }),
     );
+}
+
+#[test]
+fn empty_signature_key_policy_matrix_preserves_clean_false_and_error_order() {
+    let tx = fixture();
+    let prevouts = vec![p2wpkh_prevout(); tx.inputs.len()];
+    let public = PublicKey::from_secret_key(SECP256K1, &test_key());
+    let mut hybrid = public.serialize_uncompressed().to_vec();
+    hybrid[0] = 0x06 | (hybrid[64] & 1);
+    let mut invalid_point = vec![0xff; 33];
+    invalid_point[0] = 0x02; // structurally compressed; x is outside the curve field
+    // Columns are STRICTENC shape validity and compressed-key shape validity.
+    let keys = [
+        (Vec::new(), false, false),
+        (vec![0x02; 32], false, false),
+        (vec![0x05; 33], false, false),
+        (public.serialize().to_vec(), true, true),
+        (public.serialize_uncompressed().to_vec(), true, false),
+        (hybrid, false, false),
+        (invalid_point, true, true),
+    ];
+    let policy_bits = [
+        VerifyFlags::STRICTENC,
+        VerifyFlags::WITNESS_PUBKEYTYPE,
+        VerifyFlags::DERSIG,
+        VerifyFlags::LOW_S,
+        VerifyFlags::NULLFAIL,
+    ];
+    let mut checked = 0;
+    for version in [SigVersion::Base, SigVersion::WitnessV0] {
+        for mask in 0_u32..32 {
+            let mut flags = VerifyFlags::NONE;
+            for (bit, flag) in policy_bits.iter().enumerate() {
+                if mask & (1 << bit) != 0 {
+                    flags = flags.union(*flag);
+                }
+            }
+            for (key, strict_shape, compressed) in &keys {
+                let expected = if flags.contains(VerifyFlags::STRICTENC) && !*strict_shape {
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::PubkeyType,
+                    })
+                } else if version == SigVersion::WitnessV0
+                    && flags.contains(VerifyFlags::WITNESS_PUBKEYTYPE)
+                    && !*compressed
+                {
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::WitnessPubkeyType,
+                    })
+                } else {
+                    Ok(false)
+                };
+                let mut checker = TxSignatureChecker::new(&tx, INPUT, VALUE, &prevouts);
+                assert_eq!(
+                    checker.check_ecdsa_signature(&[], key, &[], version, flags),
+                    expected,
+                    "version={version:?}, flags={flags:?}, key={key:02x?}",
+                );
+                checked += 1;
+            }
+        }
+    }
+    assert_eq!(checked, 448);
+}
+
+#[test]
+fn undefined_hashtype_precedes_bad_pubkey_encoding() {
+    let tx = fixture();
+    let prevouts = vec![p2wpkh_prevout(); tx.inputs.len()];
+    // DER r=1, s=1 is structurally valid and low-S; 0x05 is undefined.
+    let signature = hex("300602010102010105");
+    let flags = VerifyFlags::STRICTENC
+        .union(VerifyFlags::WITNESS_PUBKEYTYPE)
+        .union(VerifyFlags::LOW_S);
+    for version in [SigVersion::Base, SigVersion::WitnessV0] {
+        let mut checker = TxSignatureChecker::new(&tx, INPUT, VALUE, &prevouts);
+        assert_eq!(
+            checker.check_ecdsa_signature(&signature, &[], &[], version, flags),
+            Err(ScriptError::Invalid {
+                code: ScriptErrCode::SigHashtype,
+            }),
+        );
+    }
+}
+
+#[test]
+fn unvisited_keys_and_unexecuted_sigops_do_not_trigger_encoding_checks() {
+    let tx = fixture();
+    let flags = VerifyFlags::MANDATORY
+        .union(VerifyFlags::STRICTENC)
+        .union(VerifyFlags::WITNESS_PUBKEYTYPE)
+        .union(VerifyFlags::NULLFAIL);
+    // Zero-of-one CHECKMULTISIG never visits the empty pubkey. An inactive
+    // CHECKSIG branch must not check either encoding or stack operands.
+    let cases = [
+        (vec![0x00, 0x00, 0x51, 0xae], vec![Vec::new()]),
+        (vec![0x00, 0x63, 0xac, 0x68, 0x51], Vec::new()),
+    ];
+    for (script, arguments) in cases {
+        let prevout = TxOut {
+            value: VALUE,
+            script_pubkey: script.clone(),
+        };
+        let script_sig = vec![0x00; arguments.len()];
+        assert_eq!(
+            Interpreter.execute(&script, &script_sig, &[], flags, &prevout, &tx, INPUT),
+            Ok(true),
+        );
+        let mut program = vec![0x00, 0x20];
+        program.extend_from_slice(&Sha256::digest(&script));
+        let witness_prevout = TxOut {
+            value: VALUE,
+            script_pubkey: program,
+        };
+        let mut witness = arguments;
+        witness.push(script);
+        assert_eq!(
+            Interpreter.execute(
+                &witness_prevout.script_pubkey,
+                &[],
+                &witness,
+                flags,
+                &witness_prevout,
+                &tx,
+                INPUT,
+            ),
+            Ok(true),
+        );
+    }
 }

--- a/crates/script/tests/segwit_v0_sighash_edges.rs
+++ b/crates/script/tests/segwit_v0_sighash_edges.rs
@@ -86,10 +86,10 @@ fn reference_bip143(
     if base != 2 && base != 3 {
         let bytes: Vec<u8> = tx.output.iter().flat_map(serialize).collect();
         outputs = double_sha256(&bytes);
-    } else if base == 3 {
-        if let Some(output) = tx.output.get(input) {
-            outputs = double_sha256(&serialize(output));
-        }
+    } else if base == 3
+        && let Some(output) = tx.output.get(input)
+    {
+        outputs = double_sha256(&serialize(output));
     }
     let selected = &tx.input[input];
     let mut preimage = serialize(&tx.version);
@@ -325,6 +325,187 @@ fn typed_segwit_api_preserves_named_modes_and_default_rejection() {
                 cache.segwit_v0_signature_hash(input, &script, VALUE, Sighash::Default),
                 Err(SighashError::DefaultOnlyTaproot),
             );
+        }
+    }
+}
+
+// This is a field-sensitivity check, not a second native digest implementation.
+// The expected commitment predicates below come from BIP143's field table.
+fn assert_field_commitment(
+    tx: &bitcoin::Transaction,
+    raw: u32,
+    committed: bool,
+    change: impl FnOnce(&mut bitcoin::Transaction),
+) {
+    let script = hex(SCRIPT_CODE);
+    let before = reference_bip143(tx, INPUT, &script, VALUE, raw);
+    let mut changed = tx.clone();
+    change(&mut changed);
+    let expected = reference_bip143(&changed, INPUT, &script, VALUE, raw);
+    let native: Tx = deserialize(&serialize(&changed)).expect("changed fixture decode");
+    let actual = SighashCache::new(&native)
+        .segwit_v0_signature_hash_raw(INPUT, &script, VALUE, raw)
+        .expect("changed transaction digest");
+    assert_eq!(actual.as_byte_array(), &expected, "raw={raw:#x}");
+    assert_eq!(before != expected, committed, "raw={raw:#x}");
+}
+
+#[test]
+fn every_raw_hashtype_commits_only_the_fields_required_by_bip143() {
+    let (_, tx) = fixture(2);
+    for byte in 0_u8..=u8::MAX {
+        let raw = u32::from(byte);
+        let anyone = raw & 0x80 != 0;
+        let all_outputs = !matches!(raw & 0x1f, 2 | 3);
+        assert_field_commitment(&tx, raw, true, |tx| tx.version.0 ^= 1);
+        assert_field_commitment(&tx, raw, true, |tx| {
+            tx.lock_time = bitcoin::absolute::LockTime::from_consensus(18);
+        });
+        assert_field_commitment(&tx, raw, true, |tx| {
+            tx.input[INPUT].previous_output.vout ^= 1;
+        });
+        assert_field_commitment(&tx, raw, true, |tx| {
+            tx.input[INPUT].sequence = bitcoin::Sequence(0xffff_fffe);
+        });
+        assert_field_commitment(&tx, raw, !anyone, |tx| {
+            tx.input[0].previous_output.vout ^= 1;
+        });
+        assert_field_commitment(&tx, raw, !anyone && all_outputs, |tx| {
+            tx.input[0].sequence = bitcoin::Sequence(0xffff_fffe);
+        });
+        assert_field_commitment(&tx, raw, raw & 0x1f != 2, |tx| {
+            tx.output[INPUT].value = bitcoin::Amount::from_sat(1);
+        });
+        assert_field_commitment(&tx, raw, all_outputs, |tx| {
+            tx.output[0].value = bitcoin::Amount::from_sat(1);
+        });
+        assert_field_commitment(&tx, raw, false, |tx| {
+            tx.input[INPUT].script_sig = bitcoin::ScriptBuf::from_bytes(vec![0x51]);
+            tx.input[INPUT].witness = bitcoin::Witness::from_slice(&[vec![0x01]]);
+        });
+    }
+}
+
+#[test]
+fn raw_segwit_cache_preserves_script_bytes_and_per_call_context() {
+    // Digest API coverage, not block-valid transactions: zero outputs and
+    // u64::MAX amounts deliberately probe serialization rather than money rules.
+    for output_count in [0, 1, 2] {
+        let (tx, oracle) = fixture(output_count);
+        let mut cache = SighashCache::new(&tx);
+        for length in [0, 1, 252, 253, 10_000] {
+            let script = vec![0xab; length]; // BIP143 must not strip CODESEPARATOR.
+            for value in [0, VALUE, u64::MAX] {
+                for input in [1, 0] {
+                    for raw in [0, 1, 2, 3, 0x21, 0x22, 0x23, 0x80, 0x83, u32::MAX] {
+                        assert_eq!(
+                            cache
+                                .segwit_v0_signature_hash_raw(input, &script, value, raw)
+                                .expect("mixed-context digest")
+                                .as_byte_array(),
+                            &reference_bip143(&oracle, input, &script, value, raw),
+                            "outputs={output_count}, input={input}, len={length}, raw={raw:#x}",
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn single_anyonecanpay_allows_only_paired_input_output_permutation() {
+    let (native, original) = fixture(2);
+    let mut permuted = original.clone();
+    permuted.input.swap(0, INPUT);
+    permuted.output.swap(0, INPUT);
+    let moved: Tx = deserialize(&serialize(&permuted)).expect("permuted fixture decode");
+    let script = hex(SCRIPT_CODE);
+    for raw in [3, 0x23, 0x43, 0x63, 0x83, 0xa3, 0xc3, 0xe3] {
+        let before = SighashCache::new(&native)
+            .segwit_v0_signature_hash_raw(INPUT, &script, VALUE, raw)
+            .expect("original SINGLE digest");
+        let after = SighashCache::new(&moved)
+            .segwit_v0_signature_hash_raw(0, &script, VALUE, raw)
+            .expect("permuted SINGLE digest");
+        assert_eq!(
+            before.as_byte_array(),
+            &reference_bip143(&original, INPUT, &script, VALUE, raw),
+        );
+        assert_eq!(
+            after.as_byte_array(),
+            &reference_bip143(&permuted, 0, &script, VALUE, raw),
+        );
+        assert_eq!(before == after, raw & 0x80 != 0, "raw={raw:#x}");
+        // Moving only the inputs or only the outputs is not the paired
+        // permutation allowed by SINGLE|ANYONECANPAY.
+        for inputs_only in [false, true] {
+            let mut unpaired = original.clone();
+            let index = if inputs_only {
+                unpaired.input.swap(0, INPUT);
+                0
+            } else {
+                unpaired.output.swap(0, INPUT);
+                INPUT
+            };
+            let native: Tx = deserialize(&serialize(&unpaired)).expect("unpaired fixture");
+            let hash = SighashCache::new(&native)
+                .segwit_v0_signature_hash_raw(index, &script, VALUE, raw)
+                .expect("unpaired digest");
+            assert_eq!(
+                hash.as_byte_array(),
+                &reference_bip143(&unpaired, index, &script, VALUE, raw),
+            );
+            assert_ne!(before, hash, "unpaired permutation: raw={raw:#x}");
+        }
+    }
+}
+
+#[test]
+fn p2wsh_signatures_preserve_unexecuted_codeseparators_for_every_hashtype() {
+    let (tx, oracle) = fixture(2);
+    let key = test_key();
+    let pubkey = PublicKey::from_secret_key(SECP256K1, &key).serialize();
+    let mut suffix = vec![0x21]; // push compressed pubkey
+    suffix.extend_from_slice(&pubkey);
+    suffix.extend_from_slice(&[0xac, 0x00, 0x63, 0xab, 0x68]); // CHECKSIG 0 IF CODESEP ENDIF
+    let mut script = vec![0xab]; // executed separator is excluded from scriptCode
+    script.extend_from_slice(&suffix);
+    let mut program = vec![0x00, 0x20];
+    program.extend_from_slice(&Sha256::digest(&script));
+    let prevout = TxOut {
+        value: VALUE,
+        script_pubkey: program,
+    };
+    // Remove the unexecuted opcode only, never matching bytes in pushed data.
+    let mut incorrectly_stripped = suffix.clone();
+    incorrectly_stripped.remove(suffix.len() - 2);
+    for byte in 0_u8..=u8::MAX {
+        let raw = u32::from(byte);
+        let expected = reference_bip143(&oracle, INPUT, &suffix, VALUE, raw);
+        let wrong = reference_bip143(&oracle, INPUT, &incorrectly_stripped, VALUE, raw);
+        assert_ne!(expected, wrong);
+        for (digest, valid) in [(expected, true), (wrong, false)] {
+            let mut signature = SECP256K1
+                .sign_ecdsa(&Message::from_digest(digest), &key)
+                .serialize_der()
+                .to_vec();
+            signature.push(byte);
+            let witness = vec![signature, script.clone()];
+            let result = verify_witness(&tx, &prevout, &witness, VerifyFlags::MANDATORY);
+            if valid {
+                assert_eq!(result, Ok(true), "raw={raw:#x}");
+                #[cfg(feature = "kernel")]
+                kernel_witness_parity(&tx, &prevout, &witness);
+            } else {
+                assert_eq!(
+                    result,
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::EvalFalse,
+                    }),
+                    "stripped scriptCode must not verify: raw={raw:#x}",
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Scope and integration
Follow-up to #808 and #810. During preparation, #808 merged externally, the encoding-order fix arrived on main through another change, and #810 was closed externally. This PR preserves the merged production tree and consolidates only the remaining regression and CI hardening. No reopening of #810, no force-push, and no main-branch write.

Base: `f599c9d5906f999e35fed86ab6cd1f247d051a3a`. Two commits; three files: two existing Rust regression targets and one shared workflow. No production code, dependency, lockfile, cryptographic backend, validation default, storage, or performance-promotion change.

## Regression coverage
**BIP143: eight tests, retaining the four original tests and published digest/signature anchor.**

- Preserve the 512 signed raw-byte cases and wrong-amount/STRICTENC checks.
- Add 2,304 selective-field mutation cases across all 256 hash-type bytes: version, locktime, selected/sibling outpoints and sequences, selected/sibling outputs, scriptSig and witness exclusion.
- Add 900 mixed-cache contexts spanning both indices, 0/1/2 outputs, CompactSize boundary script lengths, unchanged CODESEPARATOR bytes, and changing amounts. Zero-output and u64::MAX cases probe digest serialization, not block validity.
- Check paired versus unpaired SINGLE|ANYONECANPAY permutations, including nonstandard high-bit variants.
- Add 256 independently signed P2WSH CODESEPARATOR cases and wrong-script negative controls. Valid cases also enter the feature-gated real-kernel oracle with its wrong-amount rejection control.

**ECDSA encoding: six tests, preserving main's three existing tests and helper formatting.**

- Add a 448-case matrix: seven public-key shapes, 32 flag combinations, Base/WitnessV0 contexts. Covers malformed, compressed, uncompressed, hybrid, and structurally valid but invalid-point keys.
- Check undefined-hashtype error precedence ahead of bad-public-key encoding.
- Ensure zero-of-one multisig and inactive signature opcodes do not check unvisited keys.
- Replace vague reference attribution with verified Core v31.1 source functions and immutable interpreter Git blob `443714ceedaf6b0cc695316882080f79fb50316e`, retaining the earlier v29 provenance.

## Focused acceptance CI
One `script-parity` workflow runs native and kernel profiles independently on pinned Rust 1.95.0, with separate runners/target directories and no shared build cache. It executes all-target Clippy and complete primitives/script suites, selecting the feature-gated real-kernel comparisons in PR CI without depending on Apalache fixture provisioning.

Lint failure does not hide test output. Bash pipefail preserves failures through tee. Logs, actual checked-out commit and PR head, lockfile/toolchain identities, feature graphs, and executable hashes are retained as CI artifacts, including on failure. Existing CI is not weakened or replaced.

## Executed evidence and limits
- **10 supplementary Python/OpenSSL reference tests passed**, rerun after integration: 512 original valid signatures and 512 wrong-amount rejections; 256 additional CODESEPARATOR-valid signatures and 256 wrong-script rejections; 2,304 field-commitment reference cases; 900 context preimages; 24 paired/unpaired permutation checks.
- YAML parsing, every embedded Bash script's syntax, and four injected Cargo-failure propagation cases passed.
- Candidate Git blob identities match the published bytes. Reconstructed merged-main changed-file subset passes `git diff --check`.

**These checks did not execute the Rust candidate or libbitcoinkernel.** Cargo/rustc are absent locally; formatting, Clippy, regression and applicable constraint-command probes returned 127. The local tree is a verified source subset, not a full buildable checkout. The 448-case Rust policy matrix and all Rust acceptance results remain unexecuted locally. Workflow creation or queued jobs do not establish a passing verdict.

Final candidate blobs:
- BIP143 tests: `9781fdc620312c4b9c258d764346b7c644a98522`
- ECDSA tests: `6af8b4763542c56823cdc45b911d7baecdd9c348`
- Workflow: `86a80b0ba41eb0f50e742f6f85f956d4276b1d50`

## Outstanding gates
CL-06: `cargo test --locked -p bitcoin-rs-consensus --test overhaul_parse_parity -- --nocapture`

CL-20/CL-23: `cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test overhaul_evidence -- --nocapture`

Compiler-backed acceptance and matched performance evidence remain required. No numeric no-regression verdict, speedup, strict-Rust cryptographic closure, mainnet replay, or full-kernel equivalence is claimed. Timing an old incorrect early rejection against correct cryptographic verification is not a matched-result speedup comparison.

References: https://bips.dev/143/ and the immutable BIP143/Core source blobs recorded in the regression modules.