### PR TITLE
test(node): lock configuration layering and public API contracts

### DIFF
--- a/crates/node/tests/config_contracts.rs
+++ b/crates/node/tests/config_contracts.rs
@@ -1,0 +1,205 @@
+//! Public configuration contracts preserved across internal module boundaries.
+
+#[cfg(feature = "fjall")]
+use std::path::PathBuf;
+
+use bitcoin_rs_node::config::{
+    ChainstateJournalOverrides, NetworkSelection, P2pOverrides, RpcOverrides, ScriptIndexMode,
+    StorageOverrides, UserConfig,
+};
+#[cfg(feature = "fjall")]
+use bitcoin_rs_node::config::{Auth, resolve};
+
+#[test]
+// CONTRACT: docs/contracts/architecture.md#ARCH-05
+fn empty_layer_preserves_explicit_values() {
+    let mut layer = UserConfig {
+        storage: StorageOverrides {
+            dbcache_mb: Some(0),
+            ..StorageOverrides::default()
+        },
+        p2p: P2pOverrides {
+            dns_seeds: Some(false),
+            connect: Some(Vec::new()),
+            ..P2pOverrides::default()
+        },
+        rpc: RpcOverrides {
+            password: Some(String::new()),
+            ..RpcOverrides::default()
+        },
+        chainstate_journal: Some(ChainstateJournalOverrides {
+            enabled: Some(false),
+            blocks: Some(1),
+            ..ChainstateJournalOverrides::default()
+        }),
+        ..UserConfig::default()
+    };
+
+    layer.overlay(&UserConfig::default());
+
+    assert_eq!(layer.storage.dbcache_mb, Some(0));
+    assert_eq!(layer.p2p.dns_seeds, Some(false));
+    assert_eq!(layer.p2p.connect, Some(Vec::new()));
+    assert_eq!(layer.rpc.password.as_deref(), Some(""));
+    assert_eq!(
+        layer.chainstate_journal,
+        Some(ChainstateJournalOverrides {
+            enabled: Some(false),
+            blocks: Some(1),
+            ..ChainstateJournalOverrides::default()
+        })
+    );
+}
+
+#[test]
+// CONTRACT: docs/contracts/architecture.md#ARCH-05
+fn explicit_false_zero_and_empty_values_override_lower_layers() {
+    let mut lower = UserConfig {
+        storage: StorageOverrides {
+            prune_target_mb: Some(550),
+            ..StorageOverrides::default()
+        },
+        p2p: P2pOverrides {
+            dns_seeds: Some(true),
+            connect: Some(vec!["127.0.0.1:8333".to_owned()]),
+            ..P2pOverrides::default()
+        },
+        rpc: RpcOverrides {
+            password: Some("lower-password".to_owned()),
+            ..RpcOverrides::default()
+        },
+        ..UserConfig::default()
+    };
+    let higher = UserConfig {
+        storage: StorageOverrides {
+            prune_target_mb: Some(0),
+            ..StorageOverrides::default()
+        },
+        p2p: P2pOverrides {
+            dns_seeds: Some(false),
+            connect: Some(Vec::new()),
+            ..P2pOverrides::default()
+        },
+        rpc: RpcOverrides {
+            password: Some(String::new()),
+            ..RpcOverrides::default()
+        },
+        ..UserConfig::default()
+    };
+
+    lower.overlay(&higher);
+
+    assert_eq!(lower.storage.prune_target_mb, Some(0));
+    assert_eq!(lower.p2p.dns_seeds, Some(false));
+    assert_eq!(lower.p2p.connect, Some(Vec::new()));
+    assert_eq!(lower.rpc.password.as_deref(), Some(""));
+}
+
+#[test]
+fn network_aliases_preserve_the_selected_profile() {
+    for (value, expected) in [
+        (" BITCOIN ", NetworkSelection::Mainnet),
+        ("main", NetworkSelection::Mainnet),
+        ("test", NetworkSelection::Testnet3),
+        ("testnet", NetworkSelection::Testnet3),
+        ("testnet3", NetworkSelection::Testnet3),
+        ("testnet4", NetworkSelection::Testnet4),
+        ("SIGNET", NetworkSelection::Signet),
+        ("regtest", NetworkSelection::Regtest),
+        ("drynet4", NetworkSelection::Drynet4),
+    ] {
+        assert_eq!(NetworkSelection::parse(value), Some(expected));
+    }
+    assert_eq!(NetworkSelection::parse("unknown"), None);
+    assert_eq!(
+        NetworkSelection::Drynet4.consensus_network(),
+        NetworkSelection::Mainnet.consensus_network()
+    );
+}
+
+#[test]
+fn script_index_boolean_aliases_preserve_history_selection() {
+    for value in ["full", "TRUE", "1", " yes "] {
+        assert_eq!(ScriptIndexMode::parse(value), Some(ScriptIndexMode::Full));
+    }
+    for value in ["FALSE", "0", " no "] {
+        assert_eq!(ScriptIndexMode::parse(value), Some(ScriptIndexMode::Disabled));
+    }
+    assert_eq!(ScriptIndexMode::parse("utxo"), Some(ScriptIndexMode::Utxo));
+    assert!(ScriptIndexMode::Utxo.is_enabled());
+    assert!(!ScriptIndexMode::Utxo.keeps_history());
+    assert!(ScriptIndexMode::Full.keeps_history());
+    assert!(!ScriptIndexMode::Disabled.is_enabled());
+    assert_eq!(ScriptIndexMode::parse("unknown"), None);
+}
+
+#[cfg(feature = "fjall")]
+#[test]
+// CONTRACT: docs/contracts/architecture.md#ARCH-05
+fn resolve_keeps_cookie_and_partial_basic_auth_precedence() -> anyhow::Result<()> {
+    let lower = UserConfig {
+        rpc: RpcOverrides {
+            user: Some("lower-user".to_owned()),
+            password: Some("lower-password".to_owned()),
+            cookie: Some(PathBuf::from("not-opened.cookie")),
+            ..RpcOverrides::default()
+        },
+        ..UserConfig::default()
+    };
+    assert_eq!(
+        resolve(&[&lower])?.rpc.auth,
+        Auth::Cookie {
+            path: PathBuf::from("not-opened.cookie")
+        }
+    );
+
+    let higher = UserConfig {
+        rpc: RpcOverrides {
+            user: Some("higher-user".to_owned()),
+            ..RpcOverrides::default()
+        },
+        ..UserConfig::default()
+    };
+    assert_eq!(
+        resolve(&[&lower, &higher])?.rpc.auth,
+        Auth::basic("higher-user", "bitcoin-rs")
+    );
+    Ok(())
+}
+
+#[cfg(feature = "fjall")]
+#[test]
+// CONTRACT: docs/contracts/architecture.md#ARCH-05
+fn network_selection_resets_defaults_before_same_layer_overrides() -> anyhow::Result<()> {
+    use std::net::SocketAddr;
+
+    let lower = UserConfig {
+        rpc: RpcOverrides {
+            bind: Some(SocketAddr::from(([127, 0, 0, 1], 1234))),
+            ..RpcOverrides::default()
+        },
+        p2p: P2pOverrides {
+            dns_seeds: Some(false),
+            connect: Some(vec!["127.0.0.1:8333".to_owned()]),
+            ..P2pOverrides::default()
+        },
+        ..UserConfig::default()
+    };
+    let higher = UserConfig {
+        network: Some(NetworkSelection::Regtest),
+        p2p: P2pOverrides {
+            listen: Some(Vec::new()),
+            ..P2pOverrides::default()
+        },
+        ..UserConfig::default()
+    };
+
+    let config = resolve(&[&lower, &higher])?;
+
+    assert_eq!(config.network, NetworkSelection::Regtest.consensus_network());
+    assert_eq!(config.rpc.bind, SocketAddr::from(([127, 0, 0, 1], 18443)));
+    assert!(config.p2p.dns_seeds_enabled);
+    assert!(config.p2p.connect.is_empty());
+    assert!(config.p2p.listen.is_empty());
+    Ok(())
+}


### PR DESCRIPTION
## Scope
First atomic PR in the node configuration cleanup series. One commit, one new integration-test file; no production changes. Based on `f599c9d5906f999e35fed86ab6cd1f247d051a3a`.

The structural modularization PR will be stacked on this branch so these same public-API tests remain unchanged across the refactor. Merge this PR first, then retarget its dependent PR to `main`.

## Coverage
Adds six regressions in `crates/node/tests/config_contracts.rs`, importing only the existing public `bitcoin_rs_node::config` API:
- Empty overlays preserve explicit values; explicit false, zero, and empty values override lower layers.
- Network spelling aliases and script-index boolean aliases retain their existing meanings.
- Cookie authentication wins within a layer; a later partial Basic-auth layer replaces cookie auth with the existing fallback credential semantics.
- A later network selection resets network defaults before applying overrides from that same layer.

The two tests that resolve the Fjall-backed default configuration, and their imports, are gated on the `fjall` feature. Tests do not open cookie files, contact peers, or mutate operator data. Existing unit and integration tests are untouched.

## Verification performed
- Reconstructed the original configuration from the supplied patch and verified its exact Git blob identity: `12037c84cbad89cd7e789d795c829366c10c398e`. The current base still has this exact blob.
- Local changed-source-tree `git diff --check` passed.
- The new test file has six test functions and uses public API paths. It is byte-identical in the dependent refactor candidate.

## Pending acceptance — draft, not merge-ready
Local `cargo` and `rustc` are absent, and terminal cloning failed DNS resolution. This session has a verified changed-source subset, not a complete buildable checkout. Cargo formatting, Clippy, tests, and ownership-gate command probes returned 127 (`cargo: command not found`). No Rust tests or compiler-backed checks passed in this environment.

Run before merging:
```sh
cargo fmt --all -- --check
cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings
cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --test config_contracts
cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --no-fail-fast
```

No dependency, lockfile, feature-default, persistence, schema, workflow, or runtime changes. This series publishes the prepared configuration work only; it does not claim completion of the broader `apply.rs`, `sync.rs`, or `state.rs` cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six integration regression tests in `crates/node/tests/config_contracts.rs` that lock down the public `bitcoin_rs_node::config` API behavior before the upcoming refactor, so internal module changes can't silently alter configuration semantics. No production code changes.

- Tests cover empty-layer preservation, explicit false/zero/empty overrides, network and script-index aliases, cookie/basic-auth precedence, and network selection resetting defaults.
- The two tests that resolve the Fjall-backed default configuration are gated on the `fjall` feature.

<sup>Written for commit d63b7bd9fefaf35df4b55dfa370e32a411076a89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

