### PR TITLE
test(script): harden P2WSH, sighash-cache and zero-signature multisig parity

### DIFF
--- a/.github/workflows/script-parity.yml
+++ b/.github/workflows/script-parity.yml
@@ -1,0 +1,99 @@
+name: script-parity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: script-parity-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  script-parity:
+    name: script-parity (${{ matrix.engine }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [native, kernel]
+    env:
+      CARGO_TERM_COLOR: never
+      CARGO_INCREMENTAL: 0
+      RUST_BACKTRACE: 1
+      ENGINE: ${{ matrix.engine }}
+      CARGO_TARGET_DIR: target/script-parity-${{ matrix.engine }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        id: toolchain
+        with:
+          toolchain: '1.95.0'
+          components: clippy
+      - name: Install kernel build prerequisites
+        if: matrix.engine == 'kernel'
+        run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
+      # Separate runners and target directories keep the native candidate and
+      # kernel-enabled oracle artifacts distinct. No shared build cache here.
+      - name: Record source, toolchain, lockfile, and feature graph
+        id: identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p evidence
+          features=()
+          if [[ "$ENGINE" == kernel ]]; then features=(--features bitcoin-rs-script/kernel); fi
+          {
+            printf 'engine=%s\npr_head=%s\ntarget_dir=%s\n' "$ENGINE" "$PR_HEAD_SHA" "$CARGO_TARGET_DIR"
+            git rev-parse HEAD
+            rustc --version --verbose
+            cargo --version
+            sha256sum Cargo.lock
+          } > evidence/identity.txt
+          cargo tree --locked -p bitcoin-rs-script --no-default-features \
+            "${features[@]}" > evidence/features.txt
+      - name: Lint primitives and script targets
+        if: ${{ !cancelled() && steps.identity.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          features=()
+          if [[ "$ENGINE" == kernel ]]; then features=(--features bitcoin-rs-script/kernel); fi
+          cargo clippy --locked -p bitcoin-rs-primitives -p bitcoin-rs-script \
+            --no-default-features "${features[@]}" --all-targets -- -D warnings \
+            2>&1 | tee evidence/clippy.log
+      # This focused acceptance lane is independent of Apalache provisioning
+      # and the full-workspace test job. Lint failure must not hide test output.
+      - name: Run primitives and script suites
+        if: ${{ !cancelled() && steps.identity.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          features=()
+          if [[ "$ENGINE" == kernel ]]; then features=(--features bitcoin-rs-script/kernel); fi
+          cargo test --locked -p bitcoin-rs-primitives -p bitcoin-rs-script \
+            --no-default-features "${features[@]}" --no-fail-fast -- --nocapture \
+            2>&1 | tee evidence/tests.log
+      - name: Record built artifact identities
+        if: ${{ always() && steps.identity.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -d "$CARGO_TARGET_DIR/debug/deps" ]]; then
+            find "$CARGO_TARGET_DIR/debug/deps" -maxdepth 1 -type f -executable -print0 \
+              | sort -z | xargs -0 -r sha256sum > evidence/executables.sha256
+          fi
+      - name: Preserve acceptance evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: script-parity-${{ matrix.engine }}-${{ github.run_attempt }}
+          path: evidence/
+          if-no-files-found: warn
+          retention-days: 7

--- a/crates/script/tests/ecdsa_zero_signature_multisig.rs
+++ b/crates/script/tests/ecdsa_zero_signature_multisig.rs
@@ -1,0 +1,134 @@
+//! Zero-signature multisig boundaries, derived from Bitcoin Core v31.1
+//! `src/script/interpreter.cpp`, `OP_CHECKMULTISIG` / `OP_CHECKMULTISIGVERIFY`.
+//!
+//! Key count is bounded before matching; zero required signatures never visit
+//! a key, but still consume a dummy and enforce NULLDUMMY. This guards against
+//! applying the empty-signature encoding fix to keys Core does not examine.
+
+#![expect(clippy::expect_used, reason = "fixed regression fixtures")]
+
+use bitcoin_rs_primitives::{OutPoint, Tx, TxIn, TxOut, Txid};
+use bitcoin_rs_script::{Interpreter, ScriptErrCode, ScriptError, VerifyFlags};
+use secp256k1::{PublicKey, SECP256K1, SecretKey};
+use sha2::{Digest, Sha256};
+
+fn fixture() -> Tx {
+    Tx {
+        version: 2,
+        inputs: vec![TxIn {
+            previous_output: OutPoint::new(Txid::default(), 0),
+            script_sig: Vec::new(),
+            sequence: 0xffff_fffe,
+            witness: Vec::new(),
+        }],
+        outputs: vec![TxOut {
+            value: 49_000,
+            script_pubkey: vec![0x51],
+        }],
+        lock_time: 0,
+    }
+}
+
+fn zero_signature_script(pubkey: &[u8], count: u8, verify_only: bool) -> Vec<u8> {
+    assert!(pubkey.len() <= 75);
+    let mut script = vec![0x00]; // zero required signatures
+    for _ in 0..count {
+        script.push(u8::try_from(pubkey.len()).expect("short test key"));
+        script.extend_from_slice(pubkey);
+    }
+    match count {
+        0 => script.push(0x00),
+        1..=16 => script.push(0x50 + count),
+        _ => script.extend_from_slice(&[0x01, count]),
+    }
+    if verify_only {
+        script.extend_from_slice(&[0xaf, 0x51]); // CHECKMULTISIGVERIFY, TRUE
+    } else {
+        script.push(0xae); // CHECKMULTISIG
+    }
+    script
+}
+
+fn execute_case(
+    tx: &Tx,
+    script: &[u8],
+    dummy: &[u8],
+    witness_v0: bool,
+) -> Result<bool, ScriptError> {
+    let flags = VerifyFlags::MANDATORY
+        .union(VerifyFlags::STRICTENC)
+        .union(VerifyFlags::WITNESS_PUBKEYTYPE)
+        .union(VerifyFlags::NULLFAIL);
+    let (script_pubkey, script_sig, witness) = if witness_v0 {
+        let mut program = vec![0x00, 0x20];
+        program.extend_from_slice(&Sha256::digest(script));
+        (program, Vec::new(), vec![dummy.to_vec(), script.to_vec()])
+    } else {
+        assert!(dummy.len() <= 75);
+        let mut unlocking = vec![u8::try_from(dummy.len()).expect("short dummy")];
+        unlocking.extend_from_slice(dummy);
+        (script.to_vec(), unlocking, Vec::new())
+    };
+    let prevout = TxOut {
+        value: 50_000,
+        script_pubkey,
+    };
+    Interpreter.execute(
+        &prevout.script_pubkey,
+        &script_sig,
+        &witness,
+        flags,
+        &prevout,
+        tx,
+        0,
+    )
+}
+
+#[test]
+fn zero_signatures_skip_key_encoding_without_waiving_nulldummy() {
+    let tx = fixture();
+    let key = SecretKey::from_slice(&[1; 32]).expect("public test key");
+    let uncompressed = PublicKey::from_secret_key(SECP256K1, &key)
+        .serialize_uncompressed()
+        .to_vec();
+    let mut checked = 0;
+    for pubkey in [Vec::new(), vec![0x05; 33], uncompressed] {
+        for count in [0, 1, 2, 20] {
+            for verify_only in [false, true] {
+                let script = zero_signature_script(&pubkey, count, verify_only);
+                for witness_v0 in [false, true] {
+                    assert_eq!(
+                        execute_case(&tx, &script, &[], witness_v0),
+                        Ok(true),
+                        "unused keys: count={count}, verify={verify_only}, witness={witness_v0}",
+                    );
+                    assert_eq!(
+                        execute_case(&tx, &script, &[1], witness_v0),
+                        Err(ScriptError::Invalid {
+                            code: ScriptErrCode::SigNullDummy,
+                        }),
+                        "zero signatures must not waive NULLDUMMY",
+                    );
+                    checked += 2;
+                }
+            }
+        }
+    }
+    assert_eq!(checked, 96);
+}
+
+#[test]
+fn zero_signatures_do_not_waive_the_twenty_key_limit() {
+    let tx = fixture();
+    for verify_only in [false, true] {
+        let script = zero_signature_script(&[], 21, verify_only);
+        for witness_v0 in [false, true] {
+            assert_eq!(
+                execute_case(&tx, &script, &[], witness_v0),
+                Err(ScriptError::Invalid {
+                    code: ScriptErrCode::PubkeyCount,
+                }),
+            );
+        }
+    }
+}

--- a/crates/script/tests/segwit_v0_sighash_edges.rs
+++ b/crates/script/tests/segwit_v0_sighash_edges.rs
@@ -328,3 +328,147 @@ fn typed_segwit_api_preserves_named_modes_and_default_rejection() {
         }
     }
 }
+
+/// Keep an executed separator before an unexecuted separator. BIP143 drops
+/// the former prefix, but must retain the latter opcode in the signed suffix.
+fn separated_witness_script(key: &PublicKey, multisig: bool) -> Vec<u8> {
+    let mut script = vec![0xab, 0x00, 0x63, 0xab, 0x68];
+    if multisig {
+        script.push(0x51); // one signature
+    }
+    script.push(0x21);
+    script.extend_from_slice(&key.serialize());
+    if multisig {
+        // CHECKMULTISIG examines keys from the top of the stack. A valid but
+        // nonmatching last key must not trigger NULLFAIL before the first matches.
+        let other = SecretKey::from_slice(&[1; 32]).expect("public test key");
+        script.push(0x21);
+        script.extend_from_slice(&PublicKey::from_secret_key(SECP256K1, &other).serialize());
+        script.extend_from_slice(&[0x52, 0xae]);
+    } else {
+        script.push(0xac);
+    }
+    script
+}
+
+fn signed_script_witness(
+    digest: [u8; 32],
+    byte: u8,
+    script: &[u8],
+    multisig: bool,
+) -> Vec<Vec<u8>> {
+    let mut signature = SECP256K1
+        .sign_ecdsa(&Message::from_digest(digest), &test_key())
+        .serialize_der()
+        .to_vec();
+    signature.push(byte);
+    let mut witness = Vec::new();
+    if multisig {
+        witness.push(Vec::new()); // BIP147 dummy
+    }
+    witness.push(signature);
+    witness.push(script.to_vec());
+    witness
+}
+
+#[test]
+fn p2wsh_raw_hashtypes_preserve_executed_separator_suffix_and_multisig_matching() {
+    let pubkey = PublicKey::from_secret_key(SECP256K1, &test_key());
+    for multisig in [false, true] {
+        let script = separated_witness_script(&pubkey, multisig);
+        let suffix = &script[1..];
+        let mut removed_unexecuted = suffix.to_vec();
+        assert_eq!(removed_unexecuted.remove(2), 0xab);
+        let mut program = vec![0x00, 0x20];
+        program.extend_from_slice(&Sha256::digest(&script));
+        let prevout = TxOut {
+            value: VALUE,
+            script_pubkey: program,
+        };
+        for output_count in [1, 2] {
+            let (tx, oracle) = fixture(output_count);
+            for byte in 0_u8..=u8::MAX {
+                let raw = u32::from(byte);
+                let digest = reference_bip143(&oracle, INPUT, suffix, VALUE, raw);
+                let witness = signed_script_witness(digest, byte, &script, multisig);
+                assert_eq!(
+                    verify_witness(
+                        &tx,
+                        &prevout,
+                        &witness,
+                        VerifyFlags::MANDATORY.union(VerifyFlags::NULLFAIL),
+                    ),
+                    Ok(true),
+                    "P2WSH: multisig={multisig}, outputs={output_count}, raw={raw:#x}",
+                );
+                let mut wrong_amount = prevout.clone();
+                wrong_amount.value += 1;
+                assert_eq!(
+                    verify_witness(&tx, &wrong_amount, &witness, VerifyFlags::MANDATORY),
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::EvalFalse,
+                    }),
+                    "P2WSH must commit to the spent amount",
+                );
+                #[cfg(feature = "kernel")]
+                kernel_witness_parity(&tx, &prevout, &witness);
+                for wrong_code in [script.as_slice(), removed_unexecuted.as_slice()] {
+                    let wrong = reference_bip143(&oracle, INPUT, wrong_code, VALUE, raw);
+                    assert_ne!(digest, wrong, "script-code mutation must change the digest");
+                    let bad = signed_script_witness(wrong, byte, &script, multisig);
+                    assert_eq!(
+                        verify_witness(&tx, &prevout, &bad, VerifyFlags::MANDATORY),
+                        Err(ScriptError::Invalid {
+                            code: ScriptErrCode::EvalFalse,
+                        }),
+                        "wrong script code: multisig={multisig}, raw={raw:#x}",
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn cached_raw_sighash_matches_fresh_reference_across_inputs_and_compactsize_edges() {
+    // Populate and bypass the cached aggregates in both directions, including
+    // zero outputs, SINGLE with no matching output, and both CompactSize cutovers.
+    let raw_types = [
+        0x83, 0x82, 0x81, 0, 1, 2, 3, 0x41, 0x42, 0x43, 0x8000_0083, u32::MAX,
+    ];
+    for output_count in [0, 1, 2] {
+        let (tx, oracle) = fixture(output_count);
+        let mut cache = SighashCache::new(&tx);
+        for raw in raw_types {
+            for input in [1, 0, 1] {
+                for length in [0, 1, 252, 253, 254, 65_535, 65_536] {
+                    // This is a digest-engine test, not an executable script:
+                    // arbitrary supplied script-code bytes must be hashed verbatim.
+                    let script = vec![0xab; length];
+                    for value in [0, VALUE + 1] {
+                        let expected = reference_bip143(&oracle, input, &script, value, raw);
+                        let warm = cache
+                            .segwit_v0_signature_hash_raw(input, &script, value, raw)
+                            .expect("reused BIP143 cache");
+                        let fresh = SighashCache::new(&tx)
+                            .segwit_v0_signature_hash_raw(input, &script, value, raw)
+                            .expect("fresh BIP143 cache");
+                        assert_eq!(warm, fresh);
+                        assert_eq!(
+                            warm.as_byte_array(),
+                            &expected,
+                            "outputs={output_count}, input={input}, length={length}, raw={raw:#x}",
+                        );
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            cache.segwit_v0_signature_hash_raw(usize::MAX, &[], 0, u32::MAX),
+            Err(SighashError::InputOutOfRange {
+                index: usize::MAX,
+                total: tx.inputs.len(),
+            }),
+        );
+    }
+}


### PR DESCRIPTION
## Scope
Follow-up to the now-merged #808 and the encoding correction present on main. Four additional Rust regression functions; **no production-source, dependency, lockfile, cryptographic-backend, validation-default or operator-data changes**.

Based on `f599c9d5906f999e35fed86ab6cd1f247d051a3a`. Concurrent changes were re-read rather than overwritten. #810 was closed separately; this PR does not reopen it or replace its branch.

## Added coverage
- **1,024 P2WSH signing cases**: all 256 hash-type bytes × CHECKSIG/CHECKMULTISIG × one/two outputs. An executed CODESEPARATOR precedes an unexecuted one; only the executed prefix is removed. Each case also checks wrong amount and two wrong script-code signatures. The multisig fixture first encounters a valid but nonmatching key under NULLFAIL, guarding against premature failure.
- **1,512 digest/cache cases**: reuse a cache across input indices, amounts, raw types and output counts; compare to a fresh cache and the existing independently serialized BIP143 reference. Includes 252/253 and 65535/65536 script-length boundaries, zero outputs, missing SINGLE output and raw high bits. Overlarge script-code bytes are digest-engine inputs, not claims of consensus-valid executable scripts. Explicit out-of-range-input rejection remains covered.
- **100 zero-signature multisig verdict assertions**: legacy and P2WSH, CHECKMULTISIG and CHECKMULTISIGVERIFY, zero/one/two/twenty keys. Unvisited malformed/uncompressed keys must not trigger encoding errors; NULLDUMMY and the twenty-key bound still apply.

The existing BIP143 reference helper and published digest/signature anchor are reused, not replaced by the native implementation. Kernel-enabled builds invoke the existing real-kernel helper for valid P2WSH spends and wrong-amount rejection; policy-only flags are not claimed to be kernel-compared.

## Executed evidence versus pending gates
Supplementary **Python/OpenSSL reference execution**, not Rust execution:
- 1,024 independently signed P2WSH reference cases verified;
- 2,048 wrong-script signatures rejected;
- 1,024 wrong-amount cases rejected;
- 512 nonmatching multisig-key comparisons rejected;
- 1,512 reference serializations checked across the stated digest boundaries.

The source blobs uploaded here match the locally prepared bytes: sighash tests `550c2c8ba266568a7af6a01c8fc146d65db7faed`; zero-signature tests `1cf5f2208630cd76377dc291cb984d17fca22e3d`.

Local fmt, native/kernel all-target Clippy, targeted native/kernel Rust tests, CL-14 resource bounds and CL-20/23 evidence commands were attempted and returned **127: cargo absent**. Rust compilation and runtime correctness remain pending. No Rust/kernel/performance pass is inferred from the Python results or from queued CI.

## CI ownership
Carry forward **byte-for-byte** the `script-parity.yml` workflow authored concurrently on #810, blob `86a80b0ba41eb0f50e742f6f85f956d4276b1d50`. It was absent on this main baseline. This avoids a second competing verification workflow.

It pins Rust 1.95.0, runs primitives/script Clippy and suites in separate native and kernel jobs, keeps test diagnostics available after lint failure, and preserves source/lockfile/toolchain/feature and built-executable identities as artifacts. It has read-only contents permission and does not write commits or change defaults.

## References
- BIP143 scriptCode and hashOutputs rules: https://bips.dev/143/
- Bitcoin Core v31.1 `OP_CHECKMULTISIG` / `OP_CHECKMULTISIGVERIFY`: https://github.com/bitcoin/bitcoin/blob/v31.1/src/script/interpreter.cpp (blob `443714ceedaf6b0cc695316882080f79fb50316e`).

Keep draft pending compiler-backed checks. No full-kernel equivalence, strict-Rust crypto completion, matched performance result, merge or default promotion is claimed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests only — no production, dependency, or lockfile changes. Extends native-vs-BIP143 parity coverage for P2WSH sighash raw types and zero-signature multisig boundaries, and adds a CI workflow to run them with both native and kernel engines.

**New coverage**

- 1,024 P2WSH cases cover all 256 hash-type bytes for CHECKSIG and CHECKMULTISIG across one/two outputs, with executed CODESEPARATOR prefixes and wrong-script/wrong-amount rejection.
- 1,512 digest/cache cases compare reused and fresh `SighashCache` results against the existing BIP143 reference, including CompactSize cutovers and SINGLE with no matching output.
- 100 zero-signature multisig assertions confirm unvisited keys are never encoded, while NULLDUMMY and the 20-key bound still apply.
- Adds `script-parity.yml` to run Clippy and test suites for native and kernel features on separate runners and preserve evidence artifacts.

**Verification status**

- Independent Python/OpenSSL runs verified the signed, wrong-signature, wrong-amount, and nonmatching-key cases.
- Rust toolchain was unavailable locally, so no compiler, kernel parity, or performance pass is claimed yet — the workflow covers those checks on CI.

<sup>Written for commit c65d55fc0d524e6b3a13f3343859494dcf45a776. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

