### PR TITLE
test(script): harden native ECDSA parity and pre-merge verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,16 +172,70 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+  native-script:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      CARGO_TARGET_DIR: target/script-native
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        id: toolchain
+        with:
+          toolchain: "1.95.0"
+          components: clippy
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      # The same permanent script tests run without external reference setup.
+      # Record compiler identity and retain both successful and failed output.
+      - name: Native script tests
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/script-native-evidence
+          {
+            git rev-parse HEAD
+            rustc -Vv
+            cargo -V
+            sha256sum Cargo.lock
+          } | tee target/script-native-evidence/context.txt
+          cargo test --locked -p bitcoin-rs-script --no-default-features \
+            --no-fail-fast -- --nocapture 2>&1 | tee target/script-native-evidence/tests.log
+      - name: Native script Clippy
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/script-native-evidence
+          cargo clippy --locked -p bitcoin-rs-script --no-default-features \
+            --all-targets -- -D warnings 2>&1 | tee target/script-native-evidence/clippy.log
+      - name: Preserve native script evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: script-native-${{ github.run_attempt }}
+          path: target/script-native-evidence/
+          if-no-files-found: warn
+          retention-days: 7
+
   bench-smoke:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        id: toolchain
+        with:
+          toolchain: "1.95.0"
+          components: clippy
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
       # The kernel engine is built from C++ (cmake + libboost-dev); the default
       # feature set now includes it, so every production lane installs the
       # prerequisites up front.
-      - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
+      - name: Kernel prerequisites
+        id: kernel_deps
+        run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
       # Reuse this lane's C++ prerequisites for the focused kernel regression;
       # the ordinary test job exercises the same target with the native backend.
       - name: Witness activation kernel regression
@@ -199,6 +253,45 @@ jobs:
       - run: |
           cargo bench --locked -p bitcoin-rs-node --no-run \
             --no-default-features --features fjall --bench chainstate_journal
+
+      # Native script tests do not compile this feature-gated oracle. Exercise
+      # it before merge, with separate build output and retained diagnostics.
+      - name: SegWit-v0 kernel parity
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' && steps.kernel_deps.outcome == 'success' }}
+        shell: bash
+        env:
+          CARGO_TARGET_DIR: target/script-kernel-oracle
+        run: |
+          set -euo pipefail
+          mkdir -p target/script-kernel-evidence
+          {
+            git rev-parse HEAD
+            rustc -Vv
+            cargo -V
+            sha256sum Cargo.lock
+          } | tee target/script-kernel-evidence/context.txt
+          cargo test --locked -p bitcoin-rs-script --no-default-features \
+            --features kernel --test segwit_v0_sighash_edges -- --nocapture \
+            2>&1 | tee target/script-kernel-evidence/tests.log
+      - name: SegWit-v0 kernel Clippy
+        if: ${{ !cancelled() && steps.toolchain.outcome == 'success' && steps.kernel_deps.outcome == 'success' }}
+        shell: bash
+        env:
+          CARGO_TARGET_DIR: target/script-kernel-oracle
+        run: |
+          set -euo pipefail
+          mkdir -p target/script-kernel-evidence
+          cargo clippy --locked -p bitcoin-rs-script --no-default-features \
+            --features kernel --test segwit_v0_sighash_edges -- -D warnings \
+            2>&1 | tee target/script-kernel-evidence/clippy.log
+      - name: Preserve kernel script evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: script-kernel-${{ github.run_attempt }}
+          path: target/script-kernel-evidence/
+          if-no-files-found: warn
+          retention-days: 7
 
   deny:
     runs-on: ubuntu-latest

--- a/crates/script/tests/ecdsa_encoding_order.rs
+++ b/crates/script/tests/ecdsa_encoding_order.rs
@@ -1,7 +1,14 @@
-//! ECDSA encoding-order regressions against Bitcoin Core.
+//! ECDSA encoding-order regressions against Bitcoin Core v31.1.
 //!
-//! Empty signatures are a clean cryptographic failure, but they do not bypass
-//! public-key encoding checks that Core performs before signature verification.
+//! Empty ECDSA signatures are a clean verification failure, but Core still
+//! applies public-key encoding checks before reaching cryptographic verification.
+//!
+//! Contract: Bitcoin Core v31.1, commit
+//! `9be056a8a72b624dae9623b2f7bded92c2a21c91`, `src/script/interpreter.cpp`
+//! (blob `443714ceedaf6b0cc695316882080f79fb50316e`): `CheckSignatureEncoding`,
+//! `CheckPubKeyEncoding`, `EvalChecksigPreTapscript`, and `OP_CHECKMULTISIG`.
+//! The zero-signature multisig case also pins the latter's lazy key checks:
+//! keys are checked only while a signature is being matched, not up front.
 
 #![expect(clippy::expect_used, reason = "fixed regression fixtures")]
 
@@ -178,5 +185,103 @@ fn encoding_error_precedence_matches_core() {
         Err(ScriptError::Invalid {
             code: ScriptErrCode::PubkeyType,
         }),
+    );
+}
+
+#[test]
+fn empty_signature_policy_matrix_preserves_error_order_and_clean_false() {
+    let tx = fixture();
+    let prevouts = vec![p2wpkh_prevout(); tx.inputs.len()];
+    let mut checker = TxSignatureChecker::new(&tx, INPUT, VALUE, &prevouts);
+    let public = PublicKey::from_secret_key(SECP256K1, &test_key());
+    // The last entry is deliberately off-curve but correctly encoded. Empty
+    // signatures must not require cryptographic parsing of an unused key.
+    let mut off_curve = vec![0xff; 33];
+    off_curve[0] = 0x02;
+    let keys = [
+        (Vec::new(), false, false),
+        (vec![0x05; 33], false, false),
+        (vec![0x02; 32], false, false),
+        (vec![0x02; 65], false, false),
+        (public.serialize().to_vec(), true, true),
+        (public.serialize_uncompressed().to_vec(), true, false),
+        (off_curve, true, true),
+    ];
+    let policies = [
+        VerifyFlags::DERSIG,
+        VerifyFlags::LOW_S,
+        VerifyFlags::STRICTENC,
+        VerifyFlags::WITNESS_PUBKEYTYPE,
+        VerifyFlags::NULLFAIL,
+        VerifyFlags::NULLDUMMY,
+    ];
+    for mask in 0..(1_u32 << policies.len()) {
+        let mut flags = VerifyFlags::NONE;
+        for (index, policy) in policies.iter().enumerate() {
+            if mask & (1 << index) != 0 {
+                flags = flags.union(*policy);
+            }
+        }
+        for version in [SigVersion::Base, SigVersion::WitnessV0] {
+            for (key, strict_valid, compressed) in &keys {
+                let expected = if flags.contains(VerifyFlags::STRICTENC) && !strict_valid {
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::PubkeyType,
+                    })
+                } else if version == SigVersion::WitnessV0
+                    && flags.contains(VerifyFlags::WITNESS_PUBKEYTYPE)
+                    && !compressed
+                {
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::WitnessPubkeyType,
+                    })
+                } else {
+                    Ok(false)
+                };
+                assert_eq!(
+                    checker.check_ecdsa_signature(&[], key, &[], version, flags),
+                    expected,
+                    "mask={mask:#x}, version={version:?}, key={key:?}",
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn zero_signature_multisig_does_not_validate_unexamined_keys() {
+    let tx = fixture();
+    // 0-of-1 with an empty (invalidly encoded) key; only the dummy is consumed.
+    // Hoisting key checks into a pre-scan would incorrectly reject this script.
+    let script = vec![0x00, 0x00, 0x51, 0xae];
+    let flags = VerifyFlags::MANDATORY
+        .union(VerifyFlags::STRICTENC)
+        .union(VerifyFlags::WITNESS_PUBKEYTYPE)
+        .union(VerifyFlags::NULLFAIL);
+    let legacy_prevout = TxOut {
+        value: VALUE,
+        script_pubkey: script.clone(),
+    };
+    assert_eq!(
+        Interpreter.execute(&script, &[0x00], &[], flags, &legacy_prevout, &tx, INPUT),
+        Ok(true),
+    );
+    let mut program = vec![0x00, 0x20];
+    program.extend_from_slice(&Sha256::digest(&script));
+    let witness_prevout = TxOut {
+        value: VALUE,
+        script_pubkey: program,
+    };
+    assert_eq!(
+        Interpreter.execute(
+            &witness_prevout.script_pubkey,
+            &[],
+            &[Vec::new(), script],
+            flags,
+            &witness_prevout,
+            &tx,
+            INPUT,
+        ),
+        Ok(true),
     );
 }

--- a/crates/script/tests/segwit_v0_sighash_edges.rs
+++ b/crates/script/tests/segwit_v0_sighash_edges.rs
@@ -328,3 +328,115 @@ fn typed_segwit_api_preserves_named_modes_and_default_rejection() {
         }
     }
 }
+
+// Each script executes its first separator, retains separator-valued pushed
+// data, and leaves a later separator in an unexecuted branch. BIP143 commits
+// the suffix after the executed separator verbatim (bip-0143, Specification).
+fn separator_witness_script(pubkey: &[u8], multisig: bool, verify: bool) -> Vec<u8> {
+    let mut script = vec![0xab, 0x02, 0xab, 0xab, 0x75]; // CODESEPARATOR, push, DROP
+    if multisig {
+        script.push(0x51);
+    }
+    script.push(u8::try_from(pubkey.len()).expect("short public key"));
+    script.extend_from_slice(pubkey);
+    if multisig {
+        script.push(0x51);
+    }
+    script.push(match (multisig, verify) {
+        (false, false) => 0xac, // CHECKSIG
+        (false, true) => 0xad,  // CHECKSIGVERIFY
+        (true, false) => 0xae,  // CHECKMULTISIG
+        (true, true) => 0xaf,   // CHECKMULTISIGVERIFY
+    });
+    if verify {
+        script.push(0x51); // successful VERIFY still needs a true final stack
+    }
+    script.extend_from_slice(&[0x00, 0x63, 0xab, 0x68]); // false IF CODESEPARATOR ENDIF
+    script
+}
+
+#[test]
+fn every_hashtype_verifies_all_witness_ecdsa_opcodes_with_separators() {
+    let key = test_key();
+    let pubkey = PublicKey::from_secret_key(SECP256K1, &key).serialize();
+    for (multisig, verify) in [(false, false), (false, true), (true, false), (true, true)] {
+        let script = separator_witness_script(&pubkey, multisig, verify);
+        let mut program = vec![0x00, 0x20];
+        program.extend_from_slice(&Sha256::digest(&script));
+        let prevout = TxOut {
+            value: VALUE,
+            script_pubkey: program,
+        };
+        let failure = match (multisig, verify) {
+            (false, true) => ScriptErrCode::CheckSigVerify,
+            (true, true) => ScriptErrCode::CheckMultisigVerify,
+            (_, false) => ScriptErrCode::EvalFalse,
+        };
+        for output_count in [1, 2] {
+            let (tx, oracle) = fixture(output_count);
+            for byte in 0_u8..=u8::MAX {
+                let digest = reference_bip143(&oracle, INPUT, &script[1..], VALUE, u32::from(byte));
+                let mut signature = SECP256K1
+                    .sign_ecdsa(&Message::from_digest(digest), &key)
+                    .serialize_der()
+                    .to_vec();
+                signature.push(byte);
+                let mut witness = Vec::new();
+                if multisig {
+                    witness.push(Vec::new()); // CHECKMULTISIG dummy, not a signature
+                }
+                witness.extend([signature, script.clone()]);
+                assert_eq!(
+                    verify_witness(&tx, &prevout, &witness, VerifyFlags::MANDATORY),
+                    Ok(true),
+                    "multisig={multisig}, verify={verify}, outputs={output_count}, raw={byte:#x}",
+                );
+                let mut wrong_amount = prevout.clone();
+                wrong_amount.value += 1;
+                assert_eq!(
+                    verify_witness(&tx, &wrong_amount, &witness, VerifyFlags::MANDATORY),
+                    Err(ScriptError::Invalid { code: failure }),
+                    "wrong amount: multisig={multisig}, verify={verify}, raw={byte:#x}",
+                );
+                let strict = VerifyFlags::MANDATORY.union(VerifyFlags::STRICTENC);
+                let expected = if matches!(byte, 1 | 2 | 3 | 0x81 | 0x82 | 0x83) {
+                    Ok(true)
+                } else {
+                    Err(ScriptError::Invalid {
+                        code: ScriptErrCode::SigHashtype,
+                    })
+                };
+                assert_eq!(verify_witness(&tx, &prevout, &witness, strict), expected);
+                #[cfg(feature = "kernel")]
+                kernel_witness_parity(&tx, &prevout, &witness);
+            }
+        }
+    }
+}
+
+#[test]
+fn raw_segwit_script_code_is_verbatim_across_compactsize_boundaries() {
+    // These are digest-API inputs, not necessarily executable scripts. Mixing
+    // scripts, amounts, and modes on one cache must not reuse script-dependent
+    // or amount-dependent state. Both CompactSize encodings around 253 matter.
+    for output_count in [1, 2] {
+        let (tx, oracle) = fixture(output_count);
+        let mut cache = SighashCache::new(&tx);
+        for size in [0, 1, 252, 253, 520, 10_000] {
+            let script = vec![0xab; size];
+            for value in [VALUE, VALUE + 1] {
+                for raw in [0, 1, 3, 0x83, 0xc2, u32::MAX] {
+                    let expected = reference_bip143(&oracle, INPUT, &script, value, raw);
+                    assert_eq!(
+                        cache
+                            .segwit_v0_signature_hash_raw(INPUT, &script, value, raw)
+                            .expect("raw script-code digest")
+                            .as_byte_array(),
+                        &expected,
+                        "outputs={output_count}, script_len={size}, value={value}, raw={raw:#x}",
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Scope and concurrent changes

Follow-up to the native script fixes discussed in #808 and #810. During preparation, #808 was merged and #810 was closed outside this session. Both production corrections are now present on `main`; this PR starts from `f599c9d5906f999e35fed86ab6cd1f247d051a3a` instead of updating deleted/closed branches.

**One commit, three files. No production source, dependency, lockfile, feature default, operator data, or branch-protection change.** The merged encoding test's `verify_witness` helper and all original test bodies are preserved byte-for-byte. No merge or force-push was performed.

## Regression coverage added

- **2,048 signed P2WSH cases:** every one-byte ECDSA sighash value × `CHECKSIG`, `CHECKSIGVERIFY`, `CHECKMULTISIG`, `CHECKMULTISIGVERIFY` × missing/present matching `SIGHASH_SINGLE` output. The independent BIP143 preimage includes the suffix after an executed `OP_CODESEPARATOR`, separator-valued pushed data, and an unexecuted later separator. Each fixture checks its positive verdict, wrong-amount failure, `STRICTENC` policy, and feature-gated real-kernel acceptance/rejection.
- **144 digest cases:** script-code lengths 0/1/252/253/520/10,000, two amounts, six raw modes, and two output counts on a reused cache. These are digest-API fixtures, not claims that every script is executable.
- **896 empty-signature cases:** all combinations of six flags, Base/WitnessV0, and seven key shapes, including a correctly encoded off-curve key. Assert exact error precedence versus clean false.
- **Zero-signature multisig controls:** 0-of-1 with an unexamined invalid key must still succeed in legacy and P2WSH forms. This prevents accidentally replacing Core's lazy matching checks with an eager key scan.

Four new Rust regression functions extend the existing seven; none of the original tests is removed.

## Pre-merge CI coverage

Add an independent `native-script` job running all native script tests and all-target Clippy. It does not depend on Core/Apalache fixture provisioning or unrelated workspace tests. Add the kernel-enabled sighash test and Clippy steps to the existing C++ prerequisite job, preserving its existing checks.

Both paths use Rust **1.95.0**, `--locked`, separate native/oracle target directories, and `set -euo pipefail` around diagnostic capture. Test failures do not suppress the corresponding lint step; cancellation or failed prerequisite installation still stops execution. Retain compiler identity, commit, lockfile hash and successful/failed logs as seven-day CI artifacts. Every pre-existing CI gate remains.

## Independent references

Encoding assertions are pinned to Bitcoin Core **v31.1**, commit `9be056a8a72b624dae9623b2f7bded92c2a21c91`, `src/script/interpreter.cpp` blob `443714ceedaf6b0cc695316882080f79fb50316e`: `CheckSignatureEncoding`, `CheckPubKeyEncoding`, `EvalChecksigPreTapscript`, and the `OP_CHECKMULTISIG` branch.

BIP143 reference serialization remains anchored to its published P2WPKH digest/signature and independent rust-bitcoin wire encoding, not the native sighash implementation: https://bips.dev/143/ .

## Executed verification and limits

**Executed locally:** six original Python/OpenSSL reference tests and six extended reference/CI-shell tests passed. Across the reference runs, 512 existing plus 2,048 new signed fixtures verified; their 2,560 wrong-amount controls rejected. The extended checks also covered the 896 encoding combinations, 144 script-code boundary cases and zero-signature controls. The supplementary Python fixture VM implements only the opcodes needed by these fixtures; it is not the Rust candidate or a full kernel oracle.

Exact CI shell snippets were tested with compiler stand-ins returning success and exit 23 to verify failure propagation and retained logs. This verifies shell behavior, **not compilation**. Final three-file patch application/reversal, whitespace, original-test preservation, combined CI composition and Git blob identities passed on complete changed-file reconstructions, not a full buildable checkout.

**Not executed:** Rust compilation/tests, rustfmt, Clippy, binary kernel comparison, replay, fuzzing, sanitizers or performance measurements. Actual local Rust commands and the applicable CL-06/CL-20 commands returned **127: Cargo/rustc absent**. Compiler-backed CI and matched performance evidence remain outstanding; this stays a draft.

No speedup, full native-kernel equivalence, strict-Rust cryptography, constraint closure, or default-promotion claim.

## Published identities

- Commit: `336385a1ffd61c68fd457d1e285dd8993f56e791`
- SegWit regression blob: `11bfe781183dac71a2f53bd5d234cee7befffd68`
- Encoding regression blob: `04f2b67aaaef7b6054f64b8e5250c7655398718b`
- CI blob: `075d639aa307c80e890594c90f29dfc953c9ee4b`

All three uploaded blobs exactly match the locally checked candidate bytes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests and a dedicated CI job to harden native ECDSA script parity against Bitcoin Core v31.1. Test-only change; no production code, dependency, lockfile, or default-feature changes.

**Test coverage**
- 2,048 signed P2WSH fixtures cover every one-byte sighash value × all four ECDSA opcodes × missing/present `SIGHASH_SINGLE` outputs, with executed/unexecuted `CODESEPARATOR` and pushed separator data.
- Adds 896 empty-signature flag/key combinations, 144 script-code CompactSize boundary digest cases, and zero-signature multisig controls that pin Core's lazy key-checking behavior.

**CI**
- New independent `native-script` job runs script tests and all-target Clippy without external fixture provisioning.
- Existing C++ prerequisite job gains kernel-enabled sighash tests and Clippy steps; both paths pin Rust 1.95.0, use separate target directories, and retain compiler/lockfile identity and logs as 7-day artifacts.

<sup>Written for commit 336385a1ffd61c68fd457d1e285dd8993f56e791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

