### PR TITLE
docs: add a reproducible local evaluation report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/local-evaluation.md
+++ b/.github/ISSUE_TEMPLATE/local-evaluation.md
@@ -1,0 +1,91 @@
+---
+name: Local evaluation report
+about: Share one reproducible setup problem, integration finding, or documentation improvement.
+title: '[Evaluation] '
+---
+
+## Before posting
+
+**This is a public, non-security report.** Do not include private keys, seed
+phrases, RPC credentials or cookies, production data, or identifying wallet
+queries. Redact logs and configuration before attaching them. Use a disposable
+local regtest environment, not real funds or a production datadir.
+
+For a potential vulnerability, stop here and confirm a private reporting channel
+with a maintainer before sharing technical details. This template is not a
+security-reporting channel.
+
+- [ ] I searched existing issues for the same finding.
+- [ ] This report contains no security-sensitive details or secrets.
+- [ ] I recorded actual commands and output; I did not reconstruct a successful result.
+
+## What did you evaluate?
+
+Describe one setup problem, integration behavior, or documentation improvement.
+Link the guide, API contract, or example you used. State whether the attempt
+completed, failed, or was blocked before the relevant behavior could be tested.
+
+## Revision and environment
+
+Record `unknown` for anything not captured; do not infer it. For optional
+features, distinguish `none` from `unknown`.
+
+| Field | Value |
+| --- | --- |
+| Source commit (`git rev-parse HEAD`) | |
+| Local modifications (clean, or describe relevant changes) | |
+| OS/version and CPU architecture | |
+| Rust toolchain (`rustc --version --verbose`) | |
+| Cargo version (`cargo --version`) | |
+| Exact build command and profile | |
+| Default features enabled? Additional features, or `none` | |
+| Storage backend | |
+| Validation engine and assume-valid setting | |
+| Network and enabled indexes | |
+| Fresh disposable datadir or reused test datadir? | |
+
+## Minimal reproduction
+
+Provide the smallest relevant commands in execution order, including redacted
+configuration and environment-variable overrides. Never paste a complete
+environment dump. State any prerequisites beyond the linked setup guide.
+
+```sh
+# Paste the commands you actually ran. Replace secrets with <REDACTED>.
+```
+
+## Expected behavior
+
+Describe the expectation and link its documented owner. An expectation is not
+an observed result.
+
+## Actual behavior and evidence
+
+Include relevant output, exit codes, and redacted logs. Report the first failed
+step separately from later steps you did not execute. State how many attempts
+produced the result, including failures rather than only the best attempt.
+
+```text
+Paste actual, redacted output here.
+```
+
+## Limits and next step
+
+What did this evaluation not test? A successful startup or RPC response does
+not establish consensus equivalence, recovery correctness, full-tip sync, or
+production readiness. Performance claims need the benchmark owner's evidence,
+not a first-run timing.
+
+Suggest one actionable documentation or code change, or one question for a
+maintainer. Do not attach sensitive datasets.
+
+## Discovery source (optional)
+
+Where did you find the project? Leave blank rather than including identifying
+tracking data.
+
+---
+
+[Getting started](https://github.com/gosuda/bitcoin-rs/blob/main/docs/getting-started.md)
+· [Contributing](https://github.com/gosuda/bitcoin-rs/blob/main/CONTRIBUTING.md)
+· [Benchmark evidence](https://github.com/gosuda/bitcoin-rs/blob/main/docs/benchmarks/end-to-end-sync.md)


### PR DESCRIPTION
## Scope

One file, one commit: `.github/ISSUE_TEMPLATE/local-evaluation.md`. Independently based on `f599c9d5906f999e35fed86ab6cd1f247d051a3a`; no dependency on the README or landing-page PR.

## Changes

Add a Markdown issue template for one actionable, reproducible developer-evaluation finding. It requests source revision, toolchain, build profile/features, storage/validation settings, minimal commands, expected versus actual behavior, exit codes, and untested boundaries. Unknown values remain `unknown`; absent optional features can be recorded as `none`.

The visible warning excludes vulnerabilities, credentials/cookies, private keys, identifying wallet queries, and production datasets. Potential vulnerabilities require a confirmed private maintainer channel before sharing technical details; no unverified reporting address is invented.

No labels, assignees, issue-closing automation, telemetry, or blank-issue restrictions are introduced. Discovery-source reporting is optional. Existing setup and benchmark owners remain the sources of technical instructions and evidence requirements.

## Validation

- [x] Parsed YAML front matter; verified valid `name`, `about`, and `title` fields with no automatic labels or assignees.
- [x] Parsed Markdown and checked UTF-8, final newline, and trailing whitespace.
- [x] Checked privacy and evidence-boundary prompts; no real credentials or synthetic result is included.
- [x] Checked the template shape against GitHub's official Markdown issue-template documentation.
- [ ] Repository UI activation is not tested: the template is only proposed on this branch and has not been merged to the default branch.
- [ ] Clippy attempt was blocked by missing Cargo (exit 127); Rust build/tests were not run.

## Review boundary

Draft pending maintainer review of the reporting workflow and applicable checks. This is a public non-security intake template, not a security policy or production-readiness claim. No node code or configuration defaults change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new issue template for submitting reproducible local evaluation reports, with prompts for environment details, minimal reproduction steps, expected versus actual behavior, and privacy guardrails for public non-security findings.

<sup>Written for commit 9c8f1abfaf0ea05c7558e09830a225f283987919. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

