### PR TITLE
docs: add a static developer evaluation landing page

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Explore bitcoin-rs: a Bitcoin full-node project for Rust-native integration. Inspect the evidence and contribute one reproducible result.">
+<meta name="color-scheme" content="dark">
+<title>bitcoin-rs — Build on Bitcoin. Inside Rust.</title>
+<style>
+:root{--bg:#0d1117;--panel:#151b23;--ink:#f2f5f8;--muted:#b0bac8;--line:#303b4a;--accent:#ffa84b;--max:1120px}
+*{box-sizing:border-box}body{overflow-wrap:anywhere}html{scroll-behavior:smooth}body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.6}a{color:inherit;text-underline-offset:.25em}a:focus-visible{outline:3px solid var(--accent);outline-offset:5px}code{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:.9em}.wrap{width:min(var(--max),calc(100% - 48px));margin-inline:auto}.skip{position:absolute;left:16px;top:-100px;padding:12px;background:var(--ink);color:var(--bg);z-index:5}.skip:focus{top:12px}.notice{background:#232016;color:#f2d49e;font-size:12px;letter-spacing:.025em;padding:10px 0;text-align:center}.nav{display:flex;align-items:center;justify-content:space-between;padding:24px 0;border-bottom:1px solid var(--line);gap:20px}.brand{font-weight:850;letter-spacing:-.04em;font-size:25px;text-decoration:none}.brand span{color:var(--accent)}nav{display:flex;gap:24px;font-size:14px;color:var(--muted)}.hero{padding:94px 0 66px;max-width:930px}.eyebrow{text-transform:uppercase;letter-spacing:.17em;font-size:12px;font-weight:800;color:var(--accent);margin:0 0 24px}h1{font-size:clamp(48px,7.7vw,90px);line-height:1.05;letter-spacing:-.065em;margin:0 0 28px;font-weight:850}h1 span{color:var(--accent)}.lead{font-size:clamp(18px,2.2vw,23px);line-height:1.55;color:var(--muted);max-width:780px;margin:0 0 32px}.actions{display:flex;flex-wrap:wrap;gap:12px;margin:28px 0 22px}.button{display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--line);border-radius:7px;padding:13px 21px;font-weight:750;text-decoration:none;font-size:15px;min-height:48px}.primary{background:var(--accent);color:#17120a;border-color:var(--accent)}.support{font-size:13px;color:var(--muted);max-width:730px}.pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:30px}.pill{font-family:ui-monospace,monospace;font-size:12px;padding:6px 11px;border:1px solid var(--line);border-radius:4px;color:var(--muted)}section{padding:54px 0;border-top:1px solid var(--line)}h2{font-size:clamp(28px,4vw,42px);letter-spacing:-.04em;line-height:1.2;margin:0 0 18px}h3{font-size:20px;letter-spacing:-.02em;margin:0 0 12px}.section-intro{color:var(--muted);max-width:760px;margin:0 0 28px}.grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:18px}.card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:26px}.card p{color:var(--muted);font-size:15px;margin:0}.index{font:700 12px ui-monospace,monospace;color:var(--accent);margin-bottom:22px}.wide{display:grid;grid-template-columns:1.2fr 1fr;gap:42px;align-items:start}.evidence{border-left:3px solid var(--accent);padding-left:22px}.evidence p{color:var(--muted);margin:0 0 18px;font-size:15px}.evidence strong{color:var(--ink)}.note{color:var(--muted);font-size:13px}.foot{padding:34px 0 44px;display:flex;justify-content:space-between;gap:28px;border-top:1px solid var(--line);color:var(--muted);font-size:12px}.foot p{margin:0;max-width:700px}.source-link{display:inline-block;margin-top:20px;font-size:13px;color:var(--accent)}@media(max-width:760px){.hero{padding-top:62px}.grid,.wide{grid-template-columns:1fr}.wide{gap:20px}nav{gap:14px;font-size:12px}.wrap{width:calc(100% - 36px)}.foot{display:block}.foot p+p{margin-top:20px}section{padding:42px 0}.notice{font-size:11px;padding-inline:14px}}@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="notice">DEVELOPER EVALUATION · Start locally. Verify claims against your build.</div>
+<header class="wrap nav">
+<a class="brand" href="https://github.com/gosuda/bitcoin-rs" aria-label="bitcoin-rs on GitHub">bitcoin<span>-rs</span></a>
+<nav aria-label="Primary"><a href="#why">Why evaluate</a><a href="#evidence">Evidence</a><a href="https://github.com/gosuda/bitcoin-rs">GitHub ↗</a></nav>
+</header>
+<main id="main" class="wrap" tabindex="-1">
+<div class="hero">
+<p class="eyebrow">Bitcoin full-node project / Rust-native integration</p>
+<h1>Build on Bitcoin.<br><span>Inside Rust.</span></h1>
+<p class="lead">Explore a Bitcoin full node through typed Rust integration, node-owned indexing, and familiar Bitcoin interfaces. Bring curiosity. Leave with one reproducible result.</p>
+<div class="actions"><a class="button primary" href="https://github.com/gosuda/bitcoin-rs">Explore the code ↗</a><a class="button" href="https://github.com/gosuda/bitcoin-rs/blob/main/docs/getting-started.md">Read the setup guide</a></div>
+<p class="support">Start with local developer evaluation, not production migration. Inspect the feature defaults, validation requirements, and release evidence before relying on a build.</p>
+<div class="pills"><span class="pill">Typed node API</span><span class="pill">Integrated indexing</span><span class="pill">Explicit evidence boundaries</span></div>
+</div>
+<section id="why" aria-labelledby="why-title">
+<p class="eyebrow">An architecture worth evaluating</p>
+<h2 id="why-title">More than a language port.</h2>
+<p class="section-intro">The interesting question is what your application can do with a node—and which boundaries make that integration clearer.</p>
+<div class="grid">
+<article class="card"><div class="index">01 / INTEGRATE</div><h3>A typed Rust surface.</h3><p>The project documents an in-process Node API. Explore the tradeoffs alongside the existing JSON-RPC path, rather than assuming every integration should cross a process boundary.</p><a class="source-link" href="https://github.com/gosuda/bitcoin-rs/blob/main/README.md">Inspect the documented API →</a></article>
+<article class="card"><div class="index">02 / QUERY</div><h3>Node-owned indexing.</h3><p>Evaluate ScriptIndex and Esplora-compatible surfaces. Check optional index configuration and readiness requirements before treating an API as available.</p><a class="source-link" href="https://github.com/gosuda/bitcoin-rs/blob/main/docs/getting-started.md">Read the capability setup →</a></article>
+<article class="card"><div class="index">03 / VERIFY</div><h3>Claims with boundaries.</h3><p>Build defaults, validation requirements, historical measurements, and remaining release evidence are separate things. Inspect their owners instead of trusting a headline.</p><a class="source-link" href="https://github.com/gosuda/bitcoin-rs/blob/main/docs/contracts/validation-default.md">Read the validation contract →</a></article>
+</div>
+</section>
+<section id="evidence" class="wide" aria-labelledby="evidence-title">
+<div><p class="eyebrow">Ambition is not a benchmark</p><h2 id="evidence-title">Know what the<br>evidence supports.</h2><p class="section-intro">This is an invitation to evaluate and contribute—not a certification of production readiness, universal compatibility, or current performance superiority.</p><a class="button" href="https://github.com/gosuda/bitcoin-rs/blob/main/CONSTRAINTS.md">Inspect the constraint register ↗</a></div>
+<div class="evidence">
+<p><strong>Kernel-free is a scoped statement.</strong><br>The documented default binary excludes libbitcoinkernel. Library and container defaults differ; other native dependencies still need review.</p>
+<p><strong>Historical does not mean current.</strong><br>The benchmark owner retains bounded results from superseded engines and marks end-state cells planned_not_executed. This page makes no current speed claim.</p>
+<p><strong>A first run is a first run.</strong><br>A startup or RPC response does not prove full consensus behavior, full-tip sync, recovery, or production safety.</p>
+<a class="source-link" href="https://github.com/gosuda/bitcoin-rs/blob/main/docs/benchmarks/end-to-end-sync.md">Read the benchmark limitations →</a>
+</div>
+</section>
+<section aria-labelledby="challenge-title">
+<p class="eyebrow">The developer challenge</p><h2 id="challenge-title">One Node. One Result.</h2>
+<p class="section-intro">Make your evaluation useful to the next developer. A reproducible non-security failure is valuable too.</p>
+<div class="grid">
+<article class="card"><div class="index">01</div><h3>Choose a local path.</h3><p>Use a separate regtest environment. Record the source revision, platform, build features, and exact commands. Do not use real funds or production data.</p></article>
+<article class="card"><div class="index">02</div><h3>Capture what happened.</h3><p>Record actual output—not a reconstructed success screenshot. Explain what the result tests, what failed, and what remains untested.</p></article>
+<article class="card"><div class="index">03</div><h3>Contribute one finding.</h3><p>Share a precise, redacted report or improvement through the contribution process. For potential vulnerabilities, confirm a private maintainer channel before sharing technical details; do not open a public report.</p></article>
+</div>
+<div class="actions"><a class="button primary" href="https://github.com/gosuda/bitcoin-rs/blob/main/CONTRIBUTING.md">Find your contribution path ↗</a></div>
+<p class="note">Record successes, failures, and untested behavior separately. First-run timings are not benchmark evidence.</p>
+</section>
+</main>
+<footer class="wrap foot"><p><strong>bitcoin-rs</strong> · A developer-evaluation overview.<br>Project documentation is not an independent runtime test or security audit. Recheck the linked evidence owners at the revision you evaluate.</p><p><a href="https://github.com/gosuda/bitcoin-rs/blob/main/CONTRIBUTING.md">Build prerequisites</a><br><a href="https://github.com/gosuda/bitcoin-rs">Project source ↗</a></p></footer>
+</body>
+</html>


### PR DESCRIPTION
## Scope

One file, one commit: `website/index.html`. Independently based on `f599c9d5906f999e35fed86ab6cd1f247d051a3a`. All project links target existing documentation; neither of the other launch PRs is required.

## Changes

Add the developer-facing **Build on Bitcoin. Inside Rust.** page and **One Node. One Result.** evaluation invitation. The page links the existing setup guide, validation contract, constraint register, benchmark owner, and contribution guide instead of duplicating command recipes or benchmark tables.

The launch-kit prototype is adapted for repository use: remove proposal/date banners and the unverified issue-number destination; retain explicit build-default, index-readiness, historical-evidence, and privacy boundaries. Add a focusable main landmark and long-word wrapping.

This is a self-contained HTML/CSS asset: no JavaScript, package manager, analytics, cookies, forms, third-party fonts, images, or external stylesheets. **It does not configure or deploy hosting, GitHub Pages, DNS, workflows, or any external campaign.**

## Local preview

From a checkout of this branch:

```sh
python3 -m http.server 8000 --bind 127.0.0.1 --directory website
```

Open `http://127.0.0.1:8000/` in a browser. Hosting this page publicly is a separate decision.

## Validation performed

- [x] Parsed HTML; one main landmark, one h1, unique IDs, and valid internal anchor targets.
- [x] Checked all 15 link targets: internal anchors or HTTPS project/documentation links; no launch-kit-local file references.
- [x] Chromium DOM rendering at 1440×1100, 768×1024, 390×844, and 320×800: no horizontal overflow. Desktop and mobile screenshots inspected.
- [x] First Tab reaches the skip link; Enter transfers focus to main.
- [x] Reduced-motion preference disables smooth scrolling.
- [x] 200% zoom at 1280px: no horizontal overflow.
- [x] No browser page errors or initial HTTP(S) requests during the render checks.
- [x] UTF-8, final newline, and trailing-whitespace checks passed.
- [ ] No deployed-site, cross-browser, or full accessibility audit was performed. Browser checks used local HTML content, not a deployed service.
- [ ] Clippy attempt was blocked by missing Cargo (exit 127); Rust build/tests and node execution were not run.

## Review boundary

Draft pending maintainer review of public wording, visual design, and applicable repository checks. The page is an evaluation invitation, not a security certification, production recommendation, or current performance-superiority claim. No runtime or deployment configuration changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a static developer evaluation landing page at `website/index.html` that introduces the `bitcoin-rs` project and invites one reproducible evaluation. The page links existing setup, validation, benchmark, and contribution docs instead of duplicating commands or tables, and makes no readiness or performance claims.

- Bundles the full page in a single HTML file with inline CSS; no JavaScript, images, analytics, cookies, forms, or third-party fonts.
- Does not configure or deploy hosting, GitHub Pages, DNS, or workflows; serving the page publicly is a separate decision.

<sup>Written for commit 4bac6823f66dea0eafbc23dd5a2d6707d28b60ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

