### PR TITLE
test: bind reference revisions to pinned artifacts

### DIFF
--- a/bin/bitcoin-rs/tests/overhaul_process_harness.rs
+++ b/bin/bitcoin-rs/tests/overhaul_process_harness.rs
@@ -277,7 +277,7 @@ fn missing_reference_binary_names_the_pinned_digest() {
     assert!(text.contains(&pinned) && text.contains("/nonexistent/reference/bitcoind"));
 }
 
-/// REF-07: a value difference is behavioral evidence, never transport success.
+/// REF-07a: a value difference is behavioral evidence, never transport success.
 #[test]
 fn deliberately_different_reply_is_a_behavior_failure() {
     let reference = json!({"txids": ["expected"], "mempool_sequence": 2});
@@ -289,7 +289,7 @@ fn deliberately_different_reply_is_a_behavior_failure() {
     ));
 }
 
-/// REF-07: rejected startup must report and reap the exact child process.
+/// REF-07b: rejected startup must report and reap the exact child process.
 #[test]
 fn rejected_startup_options_leave_no_child() {
     let error = match ProcessNode::start_with_options(
@@ -317,7 +317,7 @@ fn rejected_startup_options_leave_no_child() {
     assert_reaped(pid);
 }
 
-/// REF-07: an early successful exit is not readiness and leaves no child.
+/// REF-07b: an early successful exit is not readiness and leaves no child.
 #[test]
 fn successful_child_exit_before_readiness_is_not_startup_success() {
     let error = match ProcessNode::start_with_options(
@@ -335,7 +335,7 @@ fn successful_child_exit_before_readiness_is_not_startup_success() {
     assert_reaped(pid);
 }
 
-/// REF-07: readiness is deadline-bounded and expiration reaps the child.
+/// REF-07c: readiness is deadline-bounded and expiration reaps the child.
 #[test]
 fn readiness_deadline_reaps_the_child() {
     let error = match ProcessNode::start_with_options(NodeBinary::BitcoinRs, &[], Duration::ZERO) {
@@ -403,7 +403,7 @@ fn serve_reply(reply: &'static [u8], delay: Duration) -> (SocketAddr, JoinHandle
     (addr, server)
 }
 
-/// REF-07: malformed HTTP and JSON are transport failures, not comparisons.
+/// REF-07d: malformed HTTP and JSON are transport failures, not comparisons.
 #[test]
 fn malformed_http_and_json_replies_are_transport_failures() {
     for reply in [
@@ -426,7 +426,7 @@ fn malformed_http_and_json_replies_are_transport_failures() {
     }
 }
 
-/// REF-07: each reference request obeys its fixed deadline.
+/// REF-07c: each reference request obeys its fixed deadline.
 #[test]
 fn stalled_response_respects_the_request_deadline() {
     let (addr, server) = serve_reply(b"", Duration::from_millis(250));

--- a/bin/bitcoin-rs/tests/overhaul_process_harness.rs
+++ b/bin/bitcoin-rs/tests/overhaul_process_harness.rs
@@ -277,6 +277,7 @@ fn missing_reference_binary_names_the_pinned_digest() {
     assert!(text.contains(&pinned) && text.contains("/nonexistent/reference/bitcoind"));
 }
 
+/// REF-07: a value difference is behavioral evidence, never transport success.
 #[test]
 fn deliberately_different_reply_is_a_behavior_failure() {
     let reference = json!({"txids": ["expected"], "mempool_sequence": 2});
@@ -288,6 +289,7 @@ fn deliberately_different_reply_is_a_behavior_failure() {
     ));
 }
 
+/// REF-07: rejected startup must report and reap the exact child process.
 #[test]
 fn rejected_startup_options_leave_no_child() {
     let error = match ProcessNode::start_with_options(
@@ -315,6 +317,7 @@ fn rejected_startup_options_leave_no_child() {
     assert_reaped(pid);
 }
 
+/// REF-07: an early successful exit is not readiness and leaves no child.
 #[test]
 fn successful_child_exit_before_readiness_is_not_startup_success() {
     let error = match ProcessNode::start_with_options(
@@ -332,6 +335,7 @@ fn successful_child_exit_before_readiness_is_not_startup_success() {
     assert_reaped(pid);
 }
 
+/// REF-07: readiness is deadline-bounded and expiration reaps the child.
 #[test]
 fn readiness_deadline_reaps_the_child() {
     let error = match ProcessNode::start_with_options(NodeBinary::BitcoinRs, &[], Duration::ZERO) {
@@ -399,6 +403,7 @@ fn serve_reply(reply: &'static [u8], delay: Duration) -> (SocketAddr, JoinHandle
     (addr, server)
 }
 
+/// REF-07: malformed HTTP and JSON are transport failures, not comparisons.
 #[test]
 fn malformed_http_and_json_replies_are_transport_failures() {
     for reply in [
@@ -421,6 +426,7 @@ fn malformed_http_and_json_replies_are_transport_failures() {
     }
 }
 
+/// REF-07: each reference request obeys its fixed deadline.
 #[test]
 fn stalled_response_respects_the_request_deadline() {
     let (addr, server) = serve_reply(b"", Duration::from_millis(250));

--- a/bin/bitcoin-rs/tests/overhaul_reference_set.rs
+++ b/bin/bitcoin-rs/tests/overhaul_reference_set.rs
@@ -221,6 +221,55 @@ fn source_revisions_require_immutable_complete_identities() {
     }
 }
 
+/// REF-02/REF-03: a different full-length commit is still unrelated to the
+/// checksum-pinned release or crate. Syntax alone cannot establish custody.
+#[test]
+fn well_formed_but_unbound_source_revisions_are_rejected() {
+    for (revision, identity) in [
+        (
+            "9be056a8a72b624dae9623b2f7bded92c2a21c91",
+            "reference.release",
+        ),
+        (
+            "4b51ffdddfa82b84a03a1fa76bbfa72a4f0b6ccf",
+            "reference.kernel",
+        ),
+        (
+            "fb0e8612d6f74071af77b3f27d915da69e0a726b",
+            "reference.kernel",
+        ),
+    ] {
+        let edited = edit_manifest(revision, "0000000000000000000000000000000000000000");
+        assert_eq!(
+            load_reference_set(&edited),
+            Err(ReferenceError::CustodyMismatch { identity })
+        );
+    }
+}
+
+/// REF-02/REF-03: source revisions and artifact hashes form one custody unit.
+/// A valid but different digest cannot retain the old source claim.
+#[test]
+fn well_formed_but_unbound_artifact_digests_are_rejected() {
+    for (digest, identity) in [
+        (RELEASE_ARCHIVE_SHA256, "reference.release"),
+        (RELEASE_BITCOIND_SHA256, "reference.release"),
+        (
+            "2906bc31f02dff7af9611fe9129c9eae021bd359f9d8e79824026fe1aaf28ab1",
+            "reference.kernel",
+        ),
+    ] {
+        let edited = edit_manifest(
+            digest,
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        );
+        assert_eq!(
+            load_reference_set(&edited),
+            Err(ReferenceError::CustodyMismatch { identity })
+        );
+    }
+}
+
 /// The release digest removed leaves only a version label, which is not a
 /// reference.
 #[test]

--- a/bin/bitcoin-rs/tests/support/reference_set.rs
+++ b/bin/bitcoin-rs/tests/support/reference_set.rs
@@ -1,10 +1,21 @@
 //! Reference identities and validation used by the process and formal gates.
 //! The production RPC module owns the embedded manifest, not test orchestration.
 
+use bitcoin::hashes::{Hash as _, sha256};
 use bitcoin_rs_rpc::compat_manifest::MANIFEST_TOML;
 
 /// The corpus identifiers every reference set must carry.
 const REQUIRED_CORPORA: [&str; 2] = ["C150", "Cmodern"];
+
+/// Audited fingerprints of the complete release and kernel identity tuples.
+///
+/// These are trust anchors, not a second registry of the tuple fields. The
+/// manifest remains their value owner; changing any value requires reviewing
+/// the external artifact evidence and deliberately updating its fingerprint.
+const RELEASE_CUSTODY_SHA256: &str =
+    "7062cbdb6122b6287ccd12688fe9fa193d02b22ad02784e08c59887c03305a00";
+const KERNEL_CUSTODY_SHA256: &str =
+    "86e246d78dcb313f55c367785e59ef51b38c45867b550bf68c45ce9df2221ddd";
 
 /// The immutable reference identities the compatibility manifest is claimed
 /// against.
@@ -168,6 +179,13 @@ pub(crate) enum ReferenceError {
         /// The malformed source revision field.
         field: &'static str,
     },
+    /// A syntactically valid identity does not match the audited artifact
+    /// tuple selected by this test gate.
+    #[error("`{identity}` does not match its audited artifact custody binding")]
+    CustodyMismatch {
+        /// The complete identity tuple that did not match.
+        identity: &'static str,
+    },
     /// The released product and the kernel development tree were confused.
     #[error(
         "the released product identity and the 31.99.x kernel tree identity were \
@@ -224,6 +242,7 @@ pub(crate) fn load_reference_set(manifest: &str) -> Result<ReferenceSet, Referen
     let formal_tool = formal_tool(reference)?;
 
     check_identity_confusion(&release.core_version, &kernel.core_version)?;
+    check_custody_bindings(&release, &kernel)?;
 
     Ok(ReferenceSet {
         release,
@@ -231,6 +250,58 @@ pub(crate) fn load_reference_set(manifest: &str) -> Result<ReferenceSet, Referen
         corpora,
         formal_tool,
     })
+}
+
+/// Binds human-readable revisions to the package and binary digests that
+/// provide their custody. A full, well-formed but unrelated commit must not
+/// silently pass merely because it looks like a Git object id.
+fn check_custody_bindings(
+    release: &ReleaseIdentity,
+    kernel: &KernelIdentity,
+) -> Result<(), ReferenceError> {
+    let release_archive = sha256::Hash::from_byte_array(release.archive_sha256).to_string();
+    let release_binary = sha256::Hash::from_byte_array(release.bitcoind_sha256).to_string();
+    let release_tuple = [
+        "bitcoin-rs/reference-release/v1",
+        release.core_version.as_str(),
+        release.git_tag.as_str(),
+        release.source_commit.as_str(),
+        release.archive.as_str(),
+        release_archive.as_str(),
+        release_binary.as_str(),
+        release.version_output.as_str(),
+    ]
+    .join("\0");
+    check_custody_fingerprint("reference.release", &release_tuple, RELEASE_CUSTODY_SHA256)?;
+
+    let kernel_package = sha256::Hash::from_byte_array(kernel.kernel_sys_crate_sha256).to_string();
+    let differential_harness = kernel.differential_harness.to_string();
+    let kernel_tuple = [
+        "bitcoin-rs/reference-kernel/v1",
+        kernel.core_version.as_str(),
+        kernel.kernel_crate.as_str(),
+        kernel.kernel_crate_version.as_str(),
+        kernel.kernel_sys_crate.as_str(),
+        kernel.kernel_sys_crate_version.as_str(),
+        kernel.kernel_vendor_commit.as_str(),
+        kernel.kernel_source_commit.as_str(),
+        kernel_package.as_str(),
+        differential_harness.as_str(),
+    ]
+    .join("\0");
+    check_custody_fingerprint("reference.kernel", &kernel_tuple, KERNEL_CUSTODY_SHA256)
+}
+
+fn check_custody_fingerprint(
+    identity: &'static str,
+    tuple: &str,
+    expected: &'static str,
+) -> Result<(), ReferenceError> {
+    let actual = sha256::Hash::hash(tuple.as_bytes()).to_byte_array();
+    if actual != parse_sha256("custody_sha256", expected)? {
+        return Err(ReferenceError::CustodyMismatch { identity });
+    }
+    Ok(())
 }
 
 /// Loads the reference set from the manifest embedded at compile time.

--- a/crates/rpc/tests/support/fixture.rs
+++ b/crates/rpc/tests/support/fixture.rs
@@ -1003,28 +1003,27 @@ mod tests {
     -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join(FIXTURE_NAME), CAPTURED_FIXTURE)?;
-        let original: toml::Table = toml::from_str(bitcoin_rs_rpc::compat_manifest::MANIFEST_TOML)?;
-        for (field, replacement, reason) in [
-            ("core_version", "31.2", "pinned version"),
-            (
-                "source_commit",
-                "0000000000000000000000000000000000000000",
-                "pinned source commit",
-            ),
-            (
-                "bitcoind_sha256",
-                "0000000000000000000000000000000000000000000000000000000000000000",
-                "pinned binary digest",
-            ),
-            (
-                "version_output",
-                "Bitcoin Core daemon version v31.2.0",
-                "pinned version",
-            ),
+        let reference = reference_set::load_reference_set(
+            bitcoin_rs_rpc::compat_manifest::MANIFEST_TOML,
+        )?;
+        for (field, reason) in [
+            ("core_version", "pinned version"),
+            ("source_commit", "pinned source commit"),
+            ("bitcoind_sha256", "pinned binary digest"),
+            ("version_output", "pinned version"),
         ] {
-            let mut edited = original.clone();
-            edited["reference"]["release"][field] = toml::Value::String(replacement.to_owned());
-            let reference = reference_set::load_reference_set(&toml::to_string(&edited)?)?;
+            let mut edited = reference.release.clone();
+            match field {
+                "core_version" => edited.core_version = "31.2".to_owned(),
+                "source_commit" => {
+                    edited.source_commit = "0000000000000000000000000000000000000000".to_owned()
+                }
+                "bitcoind_sha256" => edited.bitcoind_sha256 = [0; 32],
+                "version_output" => {
+                    edited.version_output = "Bitcoin Core daemon version v31.2.0".to_owned()
+                }
+                _ => unreachable!(),
+            }
             let Err(error) = load_corpus_from(dir.path(), &reference.release) else {
                 return Err(format!("old fixture was accepted after changing {field}").into());
             };

--- a/docs/contracts/reference-set.md
+++ b/docs/contracts/reference-set.md
@@ -19,8 +19,10 @@ A version label alone is never custody.
   machine-readable authority for reference identity values.
 - `bin/bitcoin-rs/tests/support/reference_set.rs` is the typed parser that
   enforces required identities, complete source commits, digest formats,
-  corpus presence, and product versus kernel-tree separation. The RPC corpus
-  gate compiles this same test support module to validate its capture provenance.
+  corpus presence, product versus kernel-tree separation, and audited
+  fingerprints of each complete source-and-artifact identity tuple. The RPC
+  corpus gate compiles this same test support module to validate its capture
+  provenance.
 - `docs/contracts/reference-set.md` is a readable projection. It does not
   override the manifest values or parser validation on conflict.
 - A version label alone is never custody. A reference must carry source and
@@ -49,6 +51,10 @@ The checked-in RPC captures retain their own `core_source_commit`,
 release through the shared parser. Changing the reference leaves an old
 capture stale and fails its gate; it does not relabel the recorded response.
 The process harness separately hashes the actual executable before launch.
+The parser also fingerprints the complete release tuple using NUL-separated
+UTF-8 fields under the `bitcoin-rs/reference-release/v1` domain. Consequently,
+a different but well-formed source commit or artifact digest is a custody
+mismatch, not a valid new reference.
 
 ### `REF-03`: Core 31.99.0 kernel tree evidence
 
@@ -68,7 +74,9 @@ The published crate's `.cargo_vcs_info.json` identifies the vendor revision.
 Its [subtree import](https://github.com/sedited/rust-bitcoinkernel/commit/691b006f271c6d19565266541d7397eaf0c64944)
 records the Bitcoin Core revision in `git-subtree-split`. The reference gate
 checks the package digest against `Cargo.lock`; source and package identities
-must be reviewed together on an oracle upgrade. Build options remain owned by
+are additionally covered by one NUL-separated, domain-separated
+`bitcoin-rs/reference-kernel/v1` fingerprint and must be reviewed together on
+an oracle upgrade. Build options remain owned by
 that pinned crate's `build.rs`, including its static `RelWithDebInfo` kernel
 build with wallet, daemon, tests, and IPC disabled.
 
@@ -119,8 +127,9 @@ This is an evidence tool pin. No checker run is claimed by this page.
   stop. The stop is `(height, block_hash)` recorded by the run. No stop may be
   floating or unpinned. The 1 TB budget applies only to that pinned default
   lane.
-- Missing identities, malformed commits or digests, and confused product
-  identities are rejected with a typed `ReferenceError` from
+- Missing identities, malformed commits or digests, unbound custody tuples,
+  and confused product identities are rejected with a typed `ReferenceError`
+  from
   `bin/bitcoin-rs/tests/support/reference_set.rs`. The fixture gate rejects
   stale capture provenance, and the process harness rejects missing binaries
   or executable hashes that differ from the selected reference.
@@ -134,9 +143,9 @@ This is an evidence tool pin. No checker run is claimed by this page.
 - `docs/api/core-compat.toml`: the machine-readable reference identity values.
 - `bin/bitcoin-rs/tests/support/reference_set.rs`: typed parsing and custody
   validation for those values.
-- `bin/bitcoin-rs/tests/overhaul_reference_set.rs`: rejects label-only and
-  malformed identities, checks kernel package custody, and pins
-  `corpus_custody()` honesty.
+- `bin/bitcoin-rs/tests/overhaul_reference_set.rs`: rejects label-only,
+  malformed, and well-formed-but-unbound identities, checks kernel package
+  custody, and pins `corpus_custody()` honesty.
 - `crates/rpc/tests/support/fixture.rs`: rejects missing or stale capture
   provenance against the same selected release.
 

--- a/docs/contracts/reference-set.md
+++ b/docs/contracts/reference-set.md
@@ -137,6 +137,14 @@ This is an evidence tool pin. No checker run is claimed by this page.
   test may claim product parity against the kernel tree identity.
 - Known deviations are explicit. No status in the manifest upgrades to
   `supported` while `differential_harness = false`.
+  - `REF-07a`: reply values are compared after successful transport; any
+    difference is behavioral evidence and is not transport success.
+  - `REF-07b`: startup reports and reaps an early child exit, including a
+    successful exit before readiness.
+  - `REF-07c`: readiness and each reference request are deadline-bounded;
+    expiration reports the deadline and reaps startup children.
+  - `REF-07d`: malformed HTTP or JSON replies are transport/protocol errors,
+    not behavioral comparisons.
 
 ## Proven by
 


### PR DESCRIPTION
## Summary
- bind the full Bitcoin Core release identity to one audited, domain-separated custody fingerprint
- bind the kernel wrapper/source revisions to the checksum-pinned `libbitcoinkernel-sys` package tuple
- reject well-formed but unrelated commit IDs and artifact digests with `CustodyMismatch`
- add the missing `REF-07` citations to process-harness contract tests

Follow-up to #841. Refs #625.

## Acceptance criteria
- [x] A full-length but unrelated release source commit fails the reference gate.
- [x] Full-length but unrelated kernel vendor/source commits fail the reference gate.
- [x] Validly formatted but changed release archive, `bitcoind`, or kernel package digests fail the reference gate.
- [x] The manifest remains the single owner of readable reference values; validator fingerprints are trust anchors, not a parallel field registry.
- [x] Process-harness tests cite the contract clause they protect.

## Verification
- `rustfmt --edition 2024 --config skip_children=true --check` on the three changed Rust files: passed
- `git diff --check`: passed
- isolated compilation and execution of the exact shared `reference_set.rs` against the embedded manifest: 1 passed
- `cargo test -p bitcoin-rs --test overhaul_reference_set`: blocked before the changed test compiled by the existing Windows-incompatible `crates/storage/src/footprint.rs` (`std::os::fd` / `rustix::fs`)
- Linux cross-check was unavailable locally because the Linux C sysroot/toolchain is not installed; CI remains the authoritative full run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds reference revisions to the checksum-pinned artifacts they must match, so well-formed but unrelated commits or digests are now rejected as custody mismatches instead of passing the reference gate. Also fixes the stale-capture fixture regression test to keep catching mismatches after the refactor.

- Adds domain-separated custody fingerprints for the full release and kernel identity tuples in `reference_set.rs`.
- Rejects valid but unbound source commits and artifact digests with a new `CustodyMismatch` error.
- Reworks the fixture gate to edit the typed `ReferenceRelease` instead of raw TOML, preserving stale-capture coverage.
- Documents REF-07a–d sub-contracts and cites them in the process-harness tests and `docs/contracts/reference-set.md`.

<sup>Written for commit f5cef4daf68217610901cd4a3e3b466eb140c75e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

