### PR TITLE
refactor(node): centralize storage runtime composition

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -50,6 +50,7 @@ pub mod shutdown;
 pub mod signal;
 /// Shared node state.
 pub mod state;
+mod storage_backend;
 /// Custody-grade data-directory storage-footprint evidence.
 pub mod storage_footprint;
 /// Block download orchestrator.

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -12,12 +12,6 @@ use bitcoin_rs_primitives::{Block, Tx, Txid, deserialize};
 use bitcoin_rs_rpc::context::{
     BlockLog, NetworkState, PruneResult, PruneService, PruneServiceError, PruneStatus,
 };
-#[cfg(any(
-    not(feature = "rocksdb"),
-    not(feature = "fjall"),
-    not(feature = "redb")
-))]
-use core::fmt;
 use core::mem::size_of;
 use crossbeam_channel::{Receiver, Sender};
 use hashbrown::HashMap;
@@ -482,79 +476,75 @@ pub enum DisconnectError {
     },
 }
 
-enum NodeStorage {
-    #[cfg(feature = "rocksdb")]
-    RocksDb(Arc<bitcoin_rs_storage::RocksDbStore>),
-    #[cfg(feature = "fjall")]
-    Fjall(Arc<bitcoin_rs_storage::FjallStore>),
-    #[cfg(feature = "redb")]
-    Redb(Arc<bitcoin_rs_storage::RedbStore>),
+struct NodeStorage {
+    backend: StorageBackend,
+    undo_store: Arc<dyn crate::apply::UndoStore>,
+    block_body_store: Arc<dyn crate::apply::PruneBodyStore>,
+    deferred: Arc<dyn DeferredChainstateServices>,
+    #[cfg(test)]
+    test_store: Arc<dyn TestStoreAccess>,
+}
+
+struct ChainstateComposer {
+    backend: StorageBackend,
+    block_files: Arc<FlatFileBlockStore>,
+}
+
+impl crate::storage_backend::StoreConsumer for ChainstateComposer {
+    type Output = NodeStorage;
+    type Error = bitcoin_rs_storage::StorageError;
+
+    fn consume<S>(
+        self,
+        store: Arc<S>,
+    ) -> core::result::Result<Self::Output, bitcoin_rs_storage::StorageError>
+    where
+        S: KvStore,
+    {
+        let deferred: Arc<dyn DeferredChainstateServices> = Arc::new(ChainstateStoreServices {
+            store: Arc::clone(&store),
+        });
+        Ok(NodeStorage {
+            backend: self.backend,
+            undo_store: Arc::new(crate::apply::KvUndoStore::new(Arc::clone(&store))),
+            block_body_store: Arc::new(crate::apply::FlatFilePruneBodyStore::open(
+                Arc::clone(&store),
+                self.block_files,
+            )),
+            deferred,
+            #[cfg(test)]
+            test_store: Arc::new(TestStore { store }),
+        })
+    }
 }
 
 impl NodeStorage {
     /// Opens the configured backend for the chainstate namespace with its
     /// cache share from the process budget.
-    fn open(config: &NodeConfig, chainstate_cache_bytes: u64) -> Result<Self> {
+    fn open(
+        config: &NodeConfig,
+        chainstate_cache_bytes: u64,
+        block_files: Arc<FlatFileBlockStore>,
+    ) -> Result<Self> {
         let chainstate_dir = config.data_dir.join("chainstate");
         std::fs::create_dir_all(&chainstate_dir)
             .with_context(|| format!("create chainstate_dir {}", chainstate_dir.display()))?;
 
-        match config.storage.backend {
-            #[cfg(feature = "rocksdb")]
-            StorageBackend::RocksDb => Ok(Self::RocksDb(Arc::new(
-                bitcoin_rs_storage::RocksDbStore::open_with_cache(
-                    &chainstate_dir,
-                    chainstate_cache_bytes,
-                )
-                .map_err(anyhow::Error::new)?,
-            ))),
-            #[cfg(feature = "fjall")]
-            StorageBackend::Fjall => Ok(Self::Fjall(Arc::new(
-                bitcoin_rs_storage::FjallStore::open_with_cache(
-                    &chainstate_dir,
-                    chainstate_cache_bytes,
-                )
-                .map_err(anyhow::Error::new)?,
-            ))),
-            #[cfg(feature = "redb")]
-            StorageBackend::Redb => Ok(Self::Redb(Arc::new(
-                bitcoin_rs_storage::RedbStore::open_with_cache(
-                    &chainstate_dir,
-                    chainstate_cache_bytes,
-                )
-                .map_err(anyhow::Error::new)?,
-            ))),
-            #[cfg(any(
-                not(feature = "rocksdb"),
-                not(feature = "fjall"),
-                not(feature = "redb")
-            ))]
-            other => bail!(
-                "unsupported storage backend: {other} (compiled features = {CompiledStorageFeatures})"
-            ),
-        }
+        let backend = config.storage.backend;
+        crate::storage_backend::open_chainstate(
+            backend,
+            &chainstate_dir,
+            Some(chainstate_cache_bytes),
+            ChainstateComposer {
+                backend,
+                block_files,
+            },
+        )
+        .map_err(anyhow::Error::new)
     }
 
     const fn kind(&self) -> &'static str {
-        match self {
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb(store) => {
-                let _ = store;
-                "rocksdb"
-            }
-            #[cfg(feature = "fjall")]
-            Self::Fjall(store) => {
-                let _ = store;
-                "fjall"
-            }
-            #[cfg(feature = "redb")]
-            Self::Redb(store) => {
-                let _ = store;
-                "redb"
-            }
-            #[cfg(not(any(feature = "rocksdb", feature = "fjall", feature = "redb")))]
-            _ => match *self {},
-        }
+        self.backend.as_str()
     }
 
     fn prune_service(
@@ -566,65 +556,18 @@ impl NodeStorage {
         authority: crate::apply::PruneAuthority,
         durable_tip_height: &Arc<AtomicU32>,
     ) -> Result<Arc<dyn PruneService>> {
-        match self {
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb(store) => Ok(Arc::new(NodePruneService::new(
-                Arc::clone(store),
-                Arc::clone(block_files),
-                Arc::clone(block_body_store),
-                blocks,
-                transactions,
-                authority,
-                Arc::clone(durable_tip_height),
-            )?)),
-            #[cfg(feature = "fjall")]
-            Self::Fjall(store) => Ok(Arc::new(NodePruneService::new(
-                Arc::clone(store),
-                Arc::clone(block_files),
-                Arc::clone(block_body_store),
-                blocks,
-                transactions,
-                authority,
-                Arc::clone(durable_tip_height),
-            )?)),
-            #[cfg(feature = "redb")]
-            Self::Redb(store) => Ok(Arc::new(NodePruneService::new(
-                Arc::clone(store),
-                Arc::clone(block_files),
-                Arc::clone(block_body_store),
-                blocks,
-                transactions,
-                authority,
-                Arc::clone(durable_tip_height),
-            )?)),
-            #[cfg(not(any(feature = "rocksdb", feature = "fjall", feature = "redb")))]
-            _ => match *self {},
-        }
+        self.deferred.prune_service(
+            Arc::clone(block_files),
+            Arc::clone(block_body_store),
+            blocks,
+            transactions,
+            authority,
+            Arc::clone(durable_tip_height),
+        )
     }
 
-    fn block_body_store(
-        &self,
-        files: Arc<FlatFileBlockStore>,
-    ) -> Arc<dyn crate::apply::PruneBodyStore> {
-        match self {
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb(store) => Arc::new(crate::apply::FlatFilePruneBodyStore::open(
-                Arc::clone(store),
-                files,
-            )),
-            #[cfg(feature = "fjall")]
-            Self::Fjall(store) => Arc::new(crate::apply::FlatFilePruneBodyStore::open(
-                Arc::clone(store),
-                files,
-            )),
-            #[cfg(feature = "redb")]
-            Self::Redb(store) => Arc::new(crate::apply::FlatFilePruneBodyStore::open(
-                Arc::clone(store),
-                files,
-            )),
-            #[cfg(not(any(feature = "rocksdb", feature = "fjall", feature = "redb")))]
-            _ => match *self {},
-        }
+    fn block_body_store(&self) -> Arc<dyn crate::apply::PruneBodyStore> {
+        Arc::clone(&self.block_body_store)
     }
 
     /// Builds the undo store for the configured backend.
@@ -633,16 +576,7 @@ impl NodeStorage {
     /// disconnect a block, so it could advance its tip into a chain it is
     /// unable to leave.
     fn undo_store(&self) -> Arc<dyn crate::apply::UndoStore> {
-        match self {
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb(store) => Arc::new(crate::apply::KvUndoStore::new(Arc::clone(store))),
-            #[cfg(feature = "fjall")]
-            Self::Fjall(store) => Arc::new(crate::apply::KvUndoStore::new(Arc::clone(store))),
-            #[cfg(feature = "redb")]
-            Self::Redb(store) => Arc::new(crate::apply::KvUndoStore::new(Arc::clone(store))),
-            #[cfg(not(any(feature = "rocksdb", feature = "fjall", feature = "redb")))]
-            _ => match *self {},
-        }
+        Arc::clone(&self.undo_store)
     }
 
     fn journal_writer(
@@ -650,16 +584,7 @@ impl NodeStorage {
         dir: cap_std::fs::Dir,
         bootstrap: JournalBootstrap,
     ) -> Result<crate::chainstate_journal::SharedJournalWriter> {
-        match self {
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb(store) => build_journal_writer(dir, Arc::clone(store), bootstrap),
-            #[cfg(feature = "fjall")]
-            Self::Fjall(store) => build_journal_writer(dir, Arc::clone(store), bootstrap),
-            #[cfg(feature = "redb")]
-            Self::Redb(store) => build_journal_writer(dir, Arc::clone(store), bootstrap),
-            #[cfg(not(any(feature = "rocksdb", feature = "fjall", feature = "redb")))]
-            _ => match *self {},
-        }
+        self.deferred.journal_writer(dir, bootstrap)
     }
 
     #[cfg(test)]
@@ -669,18 +594,9 @@ impl NodeStorage {
         hash: bitcoin_rs_primitives::Hash256,
     ) -> Result<Option<Vec<u8>>> {
         let key = bitcoin_rs_storage::pruning::block_body_key(height, hash);
-        match self {
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb(store) => {
-                Ok(store.get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?)
-            }
-            #[cfg(feature = "fjall")]
-            Self::Fjall(store) => Ok(store.get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?),
-            #[cfg(feature = "redb")]
-            Self::Redb(store) => Ok(store.get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?),
-            #[cfg(not(any(feature = "rocksdb", feature = "fjall", feature = "redb")))]
-            _ => match *self {},
-        }
+        Ok(self
+            .test_store
+            .get(bitcoin_rs_storage::pruning::BLOCK_DATA_CF, &key)?)
     }
 
     #[cfg(test)]
@@ -690,16 +606,17 @@ impl NodeStorage {
         hash: bitcoin_rs_primitives::Hash256,
     ) -> Result<Option<Vec<u8>>> {
         let key = bitcoin_rs_storage::pruning::block_undo_key(height, hash);
-        match self {
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb(store) => Ok(store.get(ColumnFamily::UndoData, &key)?),
-            #[cfg(feature = "fjall")]
-            Self::Fjall(store) => Ok(store.get(ColumnFamily::UndoData, &key)?),
-            #[cfg(feature = "redb")]
-            Self::Redb(store) => Ok(store.get(ColumnFamily::UndoData, &key)?),
-            #[cfg(not(any(feature = "rocksdb", feature = "fjall", feature = "redb")))]
-            _ => match *self {},
-        }
+        Ok(self.test_store.get(ColumnFamily::UndoData, &key)?)
+    }
+
+    #[cfg(test)]
+    fn write_test_rows(&self, rows: &[(ColumnFamily, Vec<u8>, Vec<u8>)]) -> Result<()> {
+        self.test_store.write_rows(rows).map_err(anyhow::Error::new)
+    }
+
+    #[cfg(test)]
+    fn read_test_row(&self, cf: ColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.test_store.get(cf, key).map_err(anyhow::Error::new)
     }
 }
 
@@ -712,6 +629,102 @@ struct JournalBootstrap {
     prev_hash: [u8; 32],
     chain_tx_count: u64,
     config: crate::config::ChainstateJournalConfig,
+}
+
+/// Capabilities whose inputs become available after the chainstate store is
+/// opened. This is a composition seam, not a storage API: concrete reads,
+/// batches, and durability remain generic over `KvStore` below it.
+trait DeferredChainstateServices: Send + Sync {
+    fn prune_service(
+        &self,
+        block_files: Arc<FlatFileBlockStore>,
+        block_body_store: Arc<dyn crate::apply::PruneBodyStore>,
+        blocks: Arc<RwLock<BlockLog>>,
+        transactions: Arc<RwLock<HashMap<Txid, Tx>>>,
+        authority: crate::apply::PruneAuthority,
+        durable_tip_height: Arc<AtomicU32>,
+    ) -> Result<Arc<dyn PruneService>>;
+
+    fn journal_writer(
+        &self,
+        dir: cap_std::fs::Dir,
+        bootstrap: JournalBootstrap,
+    ) -> Result<crate::chainstate_journal::SharedJournalWriter>;
+}
+
+struct ChainstateStoreServices<S> {
+    store: Arc<S>,
+}
+
+impl<S: KvStore> DeferredChainstateServices for ChainstateStoreServices<S> {
+    fn prune_service(
+        &self,
+        block_files: Arc<FlatFileBlockStore>,
+        block_body_store: Arc<dyn crate::apply::PruneBodyStore>,
+        blocks: Arc<RwLock<BlockLog>>,
+        transactions: Arc<RwLock<HashMap<Txid, Tx>>>,
+        authority: crate::apply::PruneAuthority,
+        durable_tip_height: Arc<AtomicU32>,
+    ) -> Result<Arc<dyn PruneService>> {
+        Ok(Arc::new(NodePruneService::new(
+            Arc::clone(&self.store),
+            block_files,
+            block_body_store,
+            blocks,
+            transactions,
+            authority,
+            durable_tip_height,
+        )?))
+    }
+
+    fn journal_writer(
+        &self,
+        dir: cap_std::fs::Dir,
+        bootstrap: JournalBootstrap,
+    ) -> Result<crate::chainstate_journal::SharedJournalWriter> {
+        build_journal_writer(dir, Arc::clone(&self.store), bootstrap)
+    }
+}
+
+#[cfg(test)]
+trait TestStoreAccess: Send + Sync {
+    fn get(
+        &self,
+        cf: ColumnFamily,
+        key: &[u8],
+    ) -> core::result::Result<Option<Vec<u8>>, bitcoin_rs_storage::StorageError>;
+
+    fn write_rows(
+        &self,
+        rows: &[(ColumnFamily, Vec<u8>, Vec<u8>)],
+    ) -> core::result::Result<(), bitcoin_rs_storage::StorageError>;
+}
+
+#[cfg(test)]
+struct TestStore<S> {
+    store: Arc<S>,
+}
+
+#[cfg(test)]
+impl<S: KvStore> TestStoreAccess for TestStore<S> {
+    fn get(
+        &self,
+        cf: ColumnFamily,
+        key: &[u8],
+    ) -> core::result::Result<Option<Vec<u8>>, bitcoin_rs_storage::StorageError> {
+        self.store.get(cf, key)
+    }
+
+    fn write_rows(
+        &self,
+        rows: &[(ColumnFamily, Vec<u8>, Vec<u8>)],
+    ) -> core::result::Result<(), bitcoin_rs_storage::StorageError> {
+        let mut batch = self.store.new_batch();
+        for (cf, key, value) in rows {
+            batch.put(*cf, key, value);
+        }
+        self.store.write(batch)
+    }
 }
 
 fn build_journal_writer<S: KvStore + 'static>(
@@ -1241,47 +1254,6 @@ impl<S: KvStore> PruneService for NodePruneService<S> {
     }
 }
 
-#[cfg(any(
-    not(feature = "rocksdb"),
-    not(feature = "fjall"),
-    not(feature = "redb")
-))]
-const COMPILED_STORAGE_FEATURES: &[&str] = &[
-    #[cfg(feature = "rocksdb")]
-    "rocksdb",
-    #[cfg(feature = "fjall")]
-    "fjall",
-    #[cfg(feature = "redb")]
-    "redb",
-];
-
-#[cfg(any(
-    not(feature = "rocksdb"),
-    not(feature = "fjall"),
-    not(feature = "redb")
-))]
-struct CompiledStorageFeatures;
-
-#[cfg(any(
-    not(feature = "rocksdb"),
-    not(feature = "fjall"),
-    not(feature = "redb")
-))]
-impl fmt::Display for CompiledStorageFeatures {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Some((first, rest)) = COMPILED_STORAGE_FEATURES.split_first() else {
-            return f.write_str("none");
-        };
-
-        f.write_str(first)?;
-        for feature in rest {
-            f.write_str(",")?;
-            f.write_str(feature)?;
-        }
-        Ok(())
-    }
-}
-
 fn tx_index_capabilities(config: &NodeConfig) -> bitcoin_rs_index::IndexCapabilities {
     bitcoin_rs_index::IndexCapabilities {
         // Full ScriptIndex-backed Esplora responses need exact historical
@@ -1307,20 +1279,6 @@ fn build_tx_index_open_spec(
     if config.storage.prune_target_mb > 0 {
         bail!("transaction and script indexing are not compatible with -prune");
     }
-    let batch_limits = match config.storage.backend {
-        #[cfg(feature = "rocksdb")]
-        StorageBackend::RocksDb => crate::txindex_worker::ROCKSDB_BATCH_LIMITS,
-        #[cfg(feature = "fjall")]
-        StorageBackend::Fjall => crate::txindex_worker::DEFAULT_BATCH_LIMITS,
-        #[cfg(feature = "redb")]
-        StorageBackend::Redb => crate::txindex_worker::REDB_BATCH_LIMITS,
-        #[cfg(any(
-            not(feature = "rocksdb"),
-            not(feature = "fjall"),
-            not(feature = "redb")
-        ))]
-        other => bail!("unsupported storage backend for txindex: {other}"),
-    };
     let canonical_data_root = config
         .data_dir
         .canonicalize()
@@ -1330,7 +1288,6 @@ fn build_tx_index_open_spec(
         namespace: "txindex",
         storage_backend: config.storage.backend,
         cache_bytes: txindex_cache_bytes,
-        batch_limits,
         epoch,
         enabled,
         rollback_rebuild_cutover: crate::txindex_worker::DEFAULT_ROLLBACK_REBUILD_CUTOVER,
@@ -1455,7 +1412,9 @@ impl NodeState {
         );
         let chainstate_cache_bytes = cache_shares[0].bytes;
         let txindex_cache_bytes = cache_shares[1].bytes;
-        let storage = NodeStorage::open(&config, chainstate_cache_bytes)?;
+        let block_files =
+            Arc::new(FlatFileBlockStore::open(&config.data_dir).map_err(anyhow::Error::new)?);
+        let storage = NodeStorage::open(&config, chainstate_cache_bytes, Arc::clone(&block_files))?;
         let undo_store = storage.undo_store();
         // Before anything reads the chainstate, let alone serves or syncs it.
         // A node that starts on a torn chainstate builds on it, and every block
@@ -1497,9 +1456,7 @@ impl NodeState {
                 );
             }
         }
-        let block_files =
-            Arc::new(FlatFileBlockStore::open(&config.data_dir).map_err(anyhow::Error::new)?);
-        let block_body_store = storage.block_body_store(Arc::clone(&block_files));
+        let block_body_store = storage.block_body_store();
 
         let zmq_endpoints = config.zmq_endpoints();
         #[cfg(feature = "zmq")]
@@ -3397,40 +3354,6 @@ mod tests {
 
     #[test]
     fn prune_reclaims_whole_files_and_keeps_current_file() -> anyhow::Result<()> {
-        fn seed<S: KvStore>(
-            store: &S,
-            height: u32,
-            hash: bitcoin_rs_primitives::Hash256,
-        ) -> anyhow::Result<()> {
-            let position = bitcoin_rs_storage::BlockFilePosition {
-                file_no: 0,
-                offset: 0,
-                len: 0,
-            };
-            let mut batch = store.new_batch();
-            batch.put(
-                bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
-                &bitcoin_rs_storage::pruning::block_body_key(height, hash),
-                &position.encode(),
-            );
-            batch.put(
-                bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
-                &bitcoin_rs_storage::block_file_max_height_key(0),
-                &bitcoin_rs_storage::encode_block_file_max_height(height),
-            );
-            store.write(batch)?;
-            Ok(())
-        }
-
-        fn metadata_exists<S: KvStore>(store: &S) -> anyhow::Result<bool> {
-            Ok(store
-                .get(
-                    bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
-                    &bitcoin_rs_storage::block_file_max_height_key(0),
-                )?
-                .is_some())
-        }
-
         let dir = tempfile::tempdir()?;
         let mut config = crate::NodeConfig::default_for_network(crate::Network::Regtest);
         config.data_dir = dir.path().join("node");
@@ -3451,15 +3374,23 @@ mod tests {
             .durable_tip_height
             .store(11 + CORE_REORG_SAFETY_MARGIN, Ordering::Release);
         let hash = bitcoin_rs_primitives::Hash256::from_le_bytes(&[10_u8; 32]);
-
-        match &state.storage {
-            #[cfg(feature = "rocksdb")]
-            NodeStorage::RocksDb(store) => seed(&**store, 10, hash)?,
-            #[cfg(feature = "fjall")]
-            NodeStorage::Fjall(store) => seed(&**store, 10, hash)?,
-            #[cfg(feature = "redb")]
-            NodeStorage::Redb(store) => seed(&**store, 10, hash)?,
-        }
+        let position = bitcoin_rs_storage::BlockFilePosition {
+            file_no: 0,
+            offset: 0,
+            len: 0,
+        };
+        state.storage.write_test_rows(&[
+            (
+                bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
+                bitcoin_rs_storage::pruning::block_body_key(10, hash).to_vec(),
+                position.encode().to_vec(),
+            ),
+            (
+                bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
+                bitcoin_rs_storage::block_file_max_height_key(0).to_vec(),
+                bitcoin_rs_storage::encode_block_file_max_height(10).to_vec(),
+            ),
+        ])?;
         let Some(service) = state.prune_service() else {
             anyhow::bail!("prune service should exist when prune_target_mb > 0");
         };
@@ -3470,14 +3401,13 @@ mod tests {
         assert!(!prunable_file.exists());
         assert!(current_file.exists());
         assert!(state.storage.stored_prune_body(10, hash)?.is_none());
-        let has_metadata = match &state.storage {
-            #[cfg(feature = "rocksdb")]
-            NodeStorage::RocksDb(store) => metadata_exists(&**store)?,
-            #[cfg(feature = "fjall")]
-            NodeStorage::Fjall(store) => metadata_exists(&**store)?,
-            #[cfg(feature = "redb")]
-            NodeStorage::Redb(store) => metadata_exists(&**store)?,
-        };
+        let has_metadata = state
+            .storage
+            .read_test_row(
+                bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
+                &bitcoin_rs_storage::block_file_max_height_key(0),
+            )?
+            .is_some();
         assert!(!has_metadata);
         Ok(())
     }
@@ -3495,17 +3425,6 @@ mod tests {
     /// what makes the first worth having.
     #[test]
     fn pruning_a_block_file_reduces_the_reported_disk_size() -> anyhow::Result<()> {
-        fn seed_file_height<S: KvStore>(store: &S, height: u32) -> anyhow::Result<()> {
-            let mut batch = store.new_batch();
-            batch.put(
-                bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
-                &bitcoin_rs_storage::block_file_max_height_key(0),
-                &bitcoin_rs_storage::encode_block_file_max_height(height),
-            );
-            store.write(batch)?;
-            Ok(())
-        }
-
         let dir = tempfile::tempdir()?;
         let mut config = crate::NodeConfig::default_for_network(crate::Network::Regtest);
         config.data_dir = dir.path().join("node");
@@ -3548,14 +3467,11 @@ mod tests {
 
         // Tell the pruner that file 0 tops out at height 10, so pruning to 11
         // makes it prunable.
-        match &state.storage {
-            #[cfg(feature = "rocksdb")]
-            NodeStorage::RocksDb(store) => seed_file_height(&**store, 10)?,
-            #[cfg(feature = "fjall")]
-            NodeStorage::Fjall(store) => seed_file_height(&**store, 10)?,
-            #[cfg(feature = "redb")]
-            NodeStorage::Redb(store) => seed_file_height(&**store, 10)?,
-        }
+        state.storage.write_test_rows(&[(
+            bitcoin_rs_storage::pruning::BLOCK_DATA_CF,
+            bitcoin_rs_storage::block_file_max_height_key(0).to_vec(),
+            bitcoin_rs_storage::encode_block_file_max_height(10).to_vec(),
+        )])?;
 
         let Some(service) = state.prune_service() else {
             anyhow::bail!("prune service should exist when prune_target_mb > 0");

--- a/crates/node/src/storage_backend.rs
+++ b/crates/node/src/storage_backend.rs
@@ -144,6 +144,10 @@ mod tests {
         "open_redb_tx_index_store",
     ];
 
+    // ARCH-03 in docs/contracts/architecture.md makes storage_backend.rs the
+    // sole owner of concrete backend construction. The consumers, test-module
+    // boundaries, and forbidden constructor tokens scanned here are the
+    // executable form of that architecture contract.
     #[test]
     fn runtime_backend_construction_has_one_owner() {
         for (name, source, test_module) in RUNTIME_CONSUMERS {

--- a/crates/node/src/storage_backend.rs
+++ b/crates/node/src/storage_backend.rs
@@ -1,0 +1,162 @@
+//! Runtime storage-backend composition.
+//!
+//! This module is the only node owner of concrete backend constructors. Each
+//! namespace is opened here and handed immediately to a generic consumer that
+//! constructs the narrow capability its caller needs. The visitor is not a
+//! second storage facade: all reads, writes, batches, and durability remain
+//! owned by [`bitcoin_rs_storage::KvStore`].
+
+use std::path::Path;
+use std::sync::Arc;
+
+use bitcoin_rs_storage::{KvStore, StorageBackend, StorageError};
+
+/// Consumes one freshly opened concrete store without exposing its type to the
+/// runtime caller.
+pub(crate) trait StoreConsumer {
+    type Output;
+    type Error: From<StorageError>;
+
+    fn consume<S>(self, store: Arc<S>) -> Result<Self::Output, Self::Error>
+    where
+        S: KvStore;
+}
+
+/// Opens the selected chainstate backend exactly once and transfers its whole
+/// ownership unit to `consumer`.
+pub(crate) fn open_chainstate<C>(
+    backend: StorageBackend,
+    path: &Path,
+    cache_bytes: Option<u64>,
+    consumer: C,
+) -> Result<C::Output, C::Error>
+where
+    C: StoreConsumer,
+{
+    open_generic("chainstate", backend, path, cache_bytes, consumer)
+}
+
+/// Opens a generic store view for custody-grade logical inspection. The redb
+/// txindex keeps using its specialized runtime representation; this view is
+/// read for the backend-neutral column-family ledger only.
+pub(crate) fn open_store_inspection<C>(
+    backend: StorageBackend,
+    path: &Path,
+    consumer: C,
+) -> Result<C::Output, C::Error>
+where
+    C: StoreConsumer,
+{
+    open_generic("inspection", backend, path, None, consumer)
+}
+
+fn open_generic<C>(
+    namespace: &str,
+    backend: StorageBackend,
+    path: &Path,
+    cache_bytes: Option<u64>,
+    consumer: C,
+) -> Result<C::Output, C::Error>
+where
+    C: StoreConsumer,
+{
+    match backend {
+        #[cfg(feature = "rocksdb")]
+        StorageBackend::RocksDb => consumer.consume(Arc::new(match cache_bytes {
+            Some(bytes) => bitcoin_rs_storage::RocksDbStore::open_with_cache(path, bytes)?,
+            None => bitcoin_rs_storage::RocksDbStore::open(path)?,
+        })),
+        #[cfg(feature = "fjall")]
+        StorageBackend::Fjall => consumer.consume(Arc::new(match cache_bytes {
+            Some(bytes) => bitcoin_rs_storage::FjallStore::open_with_cache(path, bytes)?,
+            None => bitcoin_rs_storage::FjallStore::open(path)?,
+        })),
+        #[cfg(feature = "redb")]
+        StorageBackend::Redb => consumer.consume(Arc::new(match cache_bytes {
+            Some(bytes) => bitcoin_rs_storage::RedbStore::open_with_cache(path, bytes)?,
+            None => bitcoin_rs_storage::RedbStore::open(path)?,
+        })),
+        #[cfg(any(
+            not(feature = "rocksdb"),
+            not(feature = "fjall"),
+            not(feature = "redb")
+        ))]
+        other => Err(unsupported(namespace, other).into()),
+    }
+}
+
+/// Opens the selected transaction-index backend exactly once. The redb lane
+/// deliberately retains its fixed-width specialized store.
+pub(crate) fn open_txindex<C>(
+    backend: StorageBackend,
+    path: &Path,
+    cache_bytes: Option<u64>,
+    consumer: C,
+) -> Result<C::Output, C::Error>
+where
+    C: StoreConsumer,
+{
+    match backend {
+        #[cfg(feature = "redb")]
+        StorageBackend::Redb => match cache_bytes {
+            Some(bytes) => consumer.consume(Arc::new(
+                bitcoin_rs_storage::open_redb_tx_index_store_with_cache(path, bytes)?,
+            )),
+            None => consumer.consume(Arc::new(bitcoin_rs_storage::open_redb_tx_index_store(
+                path,
+            )?)),
+        },
+        other => open_generic("txindex", other, path, cache_bytes, consumer),
+    }
+}
+
+#[cfg(any(
+    not(feature = "rocksdb"),
+    not(feature = "fjall"),
+    not(feature = "redb")
+))]
+fn unsupported(namespace: &str, backend: StorageBackend) -> StorageError {
+    StorageError::Backend(format!(
+        "unsupported storage backend for {namespace}: {backend}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    const RUNTIME_CONSUMERS: &[(&str, &str, &str)] = &[
+        ("state.rs", include_str!("state.rs"), "mod tests {"),
+        (
+            "storage_footprint.rs",
+            include_str!("storage_footprint.rs"),
+            "mod tests {",
+        ),
+        (
+            "txindex_worker.rs",
+            include_str!("txindex_worker.rs"),
+            "mod body_reader_tests {",
+        ),
+    ];
+
+    const CONCRETE_OPEN_TOKENS: &[&str] = &[
+        "RocksDbStore::open",
+        "FjallStore::open",
+        "RedbStore::open",
+        "open_redb_tx_index_store",
+    ];
+
+    #[test]
+    fn runtime_backend_construction_has_one_owner() {
+        for (name, source, test_module) in RUNTIME_CONSUMERS {
+            let test_start = source
+                .find(test_module)
+                .unwrap_or_else(|| panic!("{name} lost its expected test-module boundary"));
+            let production = &source[..test_start];
+            for token in CONCRETE_OPEN_TOKENS {
+                assert!(
+                    !production.contains(token),
+                    "{name} constructs a concrete backend with {token}; move it to storage_backend.rs"
+                );
+            }
+        }
+    }
+}

--- a/crates/node/src/storage_footprint.rs
+++ b/crates/node/src/storage_footprint.rs
@@ -517,28 +517,22 @@ fn io_from_footprint(error: &FootprintError) -> anyhow::Error {
 }
 
 fn scan_store(backend: StorageBackend, path: &Path, namespace: &str) -> Result<Vec<LogicalOwner>> {
-    match backend {
-        #[cfg(feature = "fjall")]
-        StorageBackend::Fjall => {
-            let store = bitcoin_rs_storage::FjallStore::open(path).map_err(anyhow::Error::new)?;
-            Ok(logical_store_owners(&store, namespace)?)
-        }
-        #[cfg(feature = "redb")]
-        StorageBackend::Redb => {
-            let store = bitcoin_rs_storage::RedbStore::open(path).map_err(anyhow::Error::new)?;
-            Ok(logical_store_owners(&store, namespace)?)
-        }
-        #[cfg(feature = "rocksdb")]
-        StorageBackend::RocksDb => {
-            let store = bitcoin_rs_storage::RocksDbStore::open(path).map_err(anyhow::Error::new)?;
-            Ok(logical_store_owners(&store, namespace)?)
-        }
-        #[cfg(any(
-            not(feature = "rocksdb"),
-            not(feature = "fjall"),
-            not(feature = "redb")
-        ))]
-        other => bail!("unsupported storage backend for footprint scan: {other}"),
+    crate::storage_backend::open_store_inspection(backend, path, LogicalScan { namespace })
+}
+
+struct LogicalScan<'a> {
+    namespace: &'a str,
+}
+
+impl crate::storage_backend::StoreConsumer for LogicalScan<'_> {
+    type Output = Vec<LogicalOwner>;
+    type Error = anyhow::Error;
+
+    fn consume<S>(self, store: Arc<S>) -> Result<Self::Output>
+    where
+        S: bitcoin_rs_storage::KvStore,
+    {
+        Ok(logical_store_owners(&*store, self.namespace)?)
     }
 }
 
@@ -546,46 +540,25 @@ fn scan_store_with_watermarks(
     backend: StorageBackend,
     path: &Path,
 ) -> Result<(Vec<LogicalOwner>, Option<IndexWatermarkEvidence>)> {
-    match backend {
-        #[cfg(feature = "fjall")]
-        StorageBackend::Fjall => {
-            let store =
-                Arc::new(bitcoin_rs_storage::FjallStore::open(path).map_err(anyhow::Error::new)?);
-            let owners = logical_store_owners(&*store, "txindex")?;
-            let watermarks = Indexer::new(store)
-                .watermarks()
-                .ok()
-                .map(watermark_evidence);
-            Ok((owners, watermarks))
-        }
-        #[cfg(feature = "redb")]
-        StorageBackend::Redb => {
-            let store =
-                Arc::new(bitcoin_rs_storage::RedbStore::open(path).map_err(anyhow::Error::new)?);
-            let owners = logical_store_owners(&*store, "txindex")?;
-            let watermarks = Indexer::new(store)
-                .watermarks()
-                .ok()
-                .map(watermark_evidence);
-            Ok((owners, watermarks))
-        }
-        #[cfg(feature = "rocksdb")]
-        StorageBackend::RocksDb => {
-            let store =
-                Arc::new(bitcoin_rs_storage::RocksDbStore::open(path).map_err(anyhow::Error::new)?);
-            let owners = logical_store_owners(&*store, "txindex")?;
-            let watermarks = Indexer::new(store)
-                .watermarks()
-                .ok()
-                .map(watermark_evidence);
-            Ok((owners, watermarks))
-        }
-        #[cfg(any(
-            not(feature = "rocksdb"),
-            not(feature = "fjall"),
-            not(feature = "redb")
-        ))]
-        other => bail!("unsupported storage backend for footprint scan: {other}"),
+    crate::storage_backend::open_store_inspection(backend, path, TxIndexScan)
+}
+
+struct TxIndexScan;
+
+impl crate::storage_backend::StoreConsumer for TxIndexScan {
+    type Output = (Vec<LogicalOwner>, Option<IndexWatermarkEvidence>);
+    type Error = anyhow::Error;
+
+    fn consume<S>(self, store: Arc<S>) -> Result<Self::Output>
+    where
+        S: bitcoin_rs_storage::KvStore,
+    {
+        let owners = logical_store_owners(&*store, "txindex")?;
+        let watermarks = Indexer::new(store)
+            .watermarks()
+            .ok()
+            .map(watermark_evidence);
+        Ok((owners, watermarks))
     }
 }
 

--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -76,19 +76,16 @@ const MAX_SERIALIZED_BLOCK_BYTES: usize = 4_000_000;
 /// commit bounded.
 const BATCH_BYTE_LIMIT: usize = 256 << 20;
 
-#[cfg(feature = "rocksdb")]
 pub(crate) const ROCKSDB_BATCH_LIMITS: PreparedBatchLimits = PreparedBatchLimits {
     max_rows: 1_000_000,
     max_bytes: BATCH_BYTE_LIMIT,
 };
 
-#[cfg(any(feature = "fjall", test))]
 pub(crate) const DEFAULT_BATCH_LIMITS: PreparedBatchLimits = PreparedBatchLimits {
     max_rows: 1_000_000,
     max_bytes: BATCH_BYTE_LIMIT,
 };
 
-#[cfg(feature = "redb")]
 pub(crate) const REDB_BATCH_LIMITS: PreparedBatchLimits = PreparedBatchLimits {
     max_rows: 16_000_000,
     max_bytes: BATCH_BYTE_LIMIT,
@@ -311,8 +308,6 @@ pub(crate) struct TxIndexOpenSpec {
     pub(crate) namespace: &'static str,
     pub(crate) storage_backend: bitcoin_rs_storage::StorageBackend,
     pub(crate) cache_bytes: u64,
-    #[allow(dead_code)]
-    pub(crate) batch_limits: PreparedBatchLimits,
     pub(crate) epoch: u64,
     pub(crate) enabled: IndexCapabilities,
     pub(crate) rollback_rebuild_cutover: u32,
@@ -713,7 +708,6 @@ fn open_and_run(
         spec.storage_backend,
         &txindex_dir,
         spec.cache_bytes,
-        spec.batch_limits,
         spec.epoch,
         Duration::ZERO,
         TXINDEX_OPEN_TIMEOUT,
@@ -759,7 +753,7 @@ fn open_and_run(
         applied_tip: Arc::clone(applied_tip),
         block_tree: Arc::clone(block_tree),
         body_store: body_store.clone(),
-        batch_limits: spec.batch_limits,
+        batch_limits: open.batch_limits,
         enabled: spec.enabled,
         rollback_rebuild_cutover: spec.rollback_rebuild_cutover,
         wake_rx: wake_rx.clone(),
@@ -787,7 +781,6 @@ fn open_tx_index_with_timeout(
     storage_backend: bitcoin_rs_storage::StorageBackend,
     txindex_dir: &Path,
     cache_bytes: u64,
-    batch_limits: PreparedBatchLimits,
     epoch: u64,
     open_delay: Duration,
     open_timeout: Duration,
@@ -799,14 +792,7 @@ fn open_tx_index_with_timeout(
     let _join = thread::Builder::new()
         .name("bitcoin-rs-txindex-open".to_owned())
         .spawn(move || {
-            let result = open_tx_index_on_worker(
-                backend,
-                &dir,
-                cache_bytes,
-                batch_limits,
-                epoch,
-                open_delay,
-            );
+            let result = open_tx_index_on_worker(backend, &dir, cache_bytes, epoch, open_delay);
             let _ = tx.send(result);
         })
         .map_err(|e| TxIndexWorkerError::Storage(bitcoin_rs_storage::StorageError::Io(e)))?;
@@ -846,59 +832,48 @@ fn open_tx_index_with_timeout(
     }
 }
 
-/// Opens the txindex store on the worker thread, preserving all backend
-/// constructors, cache paths, and batch limits.
+/// Opens the txindex store on the worker thread through the namespace's single
+/// runtime composition owner.
 fn open_tx_index_on_worker(
     storage_backend: bitcoin_rs_storage::StorageBackend,
     txindex_dir: &Path,
     cache_bytes: u64,
-    batch_limits: PreparedBatchLimits,
     epoch: u64,
     open_delay: Duration,
 ) -> Result<OpenTxIndex, TxIndexWorkerError> {
     if !open_delay.is_zero() {
         std::thread::sleep(open_delay);
     }
-    match storage_backend {
-        #[cfg(feature = "rocksdb")]
-        bitcoin_rs_storage::StorageBackend::RocksDb => {
-            let store = Arc::new(
-                bitcoin_rs_storage::RocksDbStore::open_with_cache(txindex_dir, cache_bytes)
-                    .map_err(|e| {
-                        TxIndexWorkerError::Storage(bitcoin_rs_storage::StorageError::backend(e))
-                    })?,
-            );
-            open_tx_index_store_on_worker(store, batch_limits, epoch)
-        }
-        #[cfg(feature = "fjall")]
-        bitcoin_rs_storage::StorageBackend::Fjall => {
-            let store = Arc::new(
-                bitcoin_rs_storage::FjallStore::open_with_cache(txindex_dir, cache_bytes).map_err(
-                    |e| TxIndexWorkerError::Storage(bitcoin_rs_storage::StorageError::backend(e)),
-                )?,
-            );
-            open_tx_index_store_on_worker(store, batch_limits, epoch)
-        }
-        #[cfg(feature = "redb")]
-        bitcoin_rs_storage::StorageBackend::Redb => {
-            let store = Arc::new(
-                bitcoin_rs_storage::open_redb_tx_index_store_with_cache(txindex_dir, cache_bytes)
-                    .map_err(|e| {
-                    TxIndexWorkerError::Storage(bitcoin_rs_storage::StorageError::backend(e))
-                })?,
-            );
-            open_tx_index_store_on_worker(store, batch_limits, epoch)
-        }
-        #[cfg(any(
-            not(feature = "rocksdb"),
-            not(feature = "fjall"),
-            not(feature = "redb")
-        ))]
-        other => Err(TxIndexWorkerError::Storage(
-            bitcoin_rs_storage::StorageError::Backend(format!(
-                "unsupported storage backend for txindex: {other}"
-            )),
-        )),
+    crate::storage_backend::open_txindex(
+        storage_backend,
+        txindex_dir,
+        Some(cache_bytes),
+        TxIndexComposer {
+            backend: storage_backend,
+            epoch,
+        },
+    )
+}
+
+struct TxIndexComposer {
+    backend: bitcoin_rs_storage::StorageBackend,
+    epoch: u64,
+}
+
+impl crate::storage_backend::StoreConsumer for TxIndexComposer {
+    type Output = OpenTxIndex;
+    type Error = TxIndexWorkerError;
+
+    fn consume<S>(self, store: Arc<S>) -> Result<Self::Output, Self::Error>
+    where
+        S: bitcoin_rs_storage::KvStore,
+    {
+        let batch_limits = match self.backend {
+            bitcoin_rs_storage::StorageBackend::RocksDb => ROCKSDB_BATCH_LIMITS,
+            bitcoin_rs_storage::StorageBackend::Fjall => DEFAULT_BATCH_LIMITS,
+            bitcoin_rs_storage::StorageBackend::Redb => REDB_BATCH_LIMITS,
+        };
+        open_tx_index_store_on_worker(store, batch_limits, self.epoch)
     }
 }
 
@@ -2150,7 +2125,7 @@ enum TxIndexWorkerError {
     #[error("txindex durable watermark changed while a forward batch was pending")]
     PendingDurableChanged,
     #[error("txindex storage error: {0}")]
-    Storage(#[source] bitcoin_rs_storage::StorageError),
+    Storage(#[from] bitcoin_rs_storage::StorageError),
     #[error(
         "txindex store open timed out after {secs}s — the storage engine recovery may be stuck"
     )]

--- a/crates/node/src/txindex_worker_integration_tests.rs
+++ b/crates/node/src/txindex_worker_integration_tests.rs
@@ -26,7 +26,6 @@ fn test_open_spec(dir: &std::path::Path, epoch: u64) -> TxIndexOpenSpec {
         namespace: "txindex",
         storage_backend: bitcoin_rs_storage::StorageBackend::Fjall,
         cache_bytes: 8 * 1024 * 1024,
-        batch_limits: DEFAULT_BATCH_LIMITS,
         epoch,
         enabled: IndexCapabilities::default(),
         rollback_rebuild_cutover: 0,
@@ -396,7 +395,6 @@ fn async_index_open_preserves_backend() {
             bitcoin_rs_storage::StorageBackend::Fjall,
             &fjall_dir,
             8 * 1024 * 1024,
-            DEFAULT_BATCH_LIMITS,
             1,
             Duration::ZERO,
         );
@@ -415,7 +413,6 @@ fn async_index_open_preserves_backend() {
             bitcoin_rs_storage::StorageBackend::Redb,
             &redb_dir,
             8 * 1024 * 1024,
-            REDB_BATCH_LIMITS,
             1,
             Duration::ZERO,
         );
@@ -434,7 +431,6 @@ fn async_index_open_preserves_backend() {
             bitcoin_rs_storage::StorageBackend::RocksDb,
             &rocks_dir,
             8 * 1024 * 1024,
-            ROCKSDB_BATCH_LIMITS,
             1,
             Duration::ZERO,
         );
@@ -604,7 +600,6 @@ fn open_timeout_publishes_error_not_infinite_spin() {
         bitcoin_rs_storage::StorageBackend::Fjall,
         &dir.path().join("txindex"),
         8 * 1024 * 1024,
-        DEFAULT_BATCH_LIMITS,
         1,
         Duration::from_secs(10),
         Duration::from_secs(1),

--- a/docs/contracts/architecture.md
+++ b/docs/contracts/architecture.md
@@ -103,6 +103,13 @@ Owners:
   retained shipped alternatives and independent product-matrix comparisons.
   MDBX had only a diagnostic role and no current consumer; it is removed as a
   complete ownership unit. Existing MDBX datadirs are not migrated or opened.
+- `crates/node/src/storage_backend.rs` is the sole owner of concrete runtime
+  backend construction in the node. Chainstate and txindex each cross that
+  boundary once, then immediately compose backend-neutral capabilities for
+  undo, pruning, journal, indexing, and footprint inspection. The consumer
+  visitor is only a composition seam; `KvStore` remains the owner of reads,
+  writes, batches, and durability. The txindex redb lane retains its specialized
+  fixed-width store rather than being widened to the generic redb adapter.
 
 ### `ARCH-04`: RPC surface independence from storage
 


### PR DESCRIPTION
Closes #823.

## What changed

- Centralized concrete RocksDB/Fjall/redb runtime construction in `crates/node/src/storage_backend.rs`.
- Chainstate now composes undo, pruning/body, and journal capabilities once, instead of repeating backend matches at each consumer.
- Txindex opens through the same composition owner while retaining redb's specialized fixed-width txindex store and backend-specific batch profiles.
- Storage-footprint inspection now uses the shared composition boundary.
- Added a regression test that rejects concrete backend constructors in the three runtime consumers.
- Documented the ownership boundary in `ARCH-03`.

MDBX removal landed first on main as commit [`6774dbeb`](https://github.com/gosuda/bitcoin-rs/commit/6774dbeb9ad188def43858a13d2b2a3a8b0b1b59). That commit removed the backend, features, dependencies, CI lanes, and implementation as one ownership unit; no MDBX datadir migration is provided because it had no current runtime consumer.

## Before / after

Across `state.rs`, `storage_footprint.rs`, and `txindex_worker.rs`, concrete open calls fall from 15 to 3; the three remaining calls are test-only. The 8 production constructor/cache variants now live in the single composition owner.

## Verification

Passed locally (WSL, after temporary workarounds for three unrelated main-branch compile errors; those workarounds are not part of this PR):

- `cargo check -p bitcoin-rs-node --no-default-features --features fjall`
- `cargo check -p bitcoin-rs-node --no-default-features --features redb`
- `cargo test -p bitcoin-rs-node --no-default-features --features fjall storage_backend::tests::runtime_backend_construction_has_one_owner`
- `cargo test -p bitcoin-rs-node --no-default-features --features fjall prune_reclaims_whole_files_and_keeps_current_file`
- `cargo test -p bitcoin-rs-node --no-default-features --features fjall async_index_open_preserves_backend`

The full `rocksdb,fjall,redb` check reached the native RocksDB dependency but the local WSL environment lacks `libclang.so`; it stopped in `zstd-sys` bindgen after 40.95s (155% CPU, 1,226,428 KiB max RSS). CI should provide the authoritative full-feature result and timing artifact.

Unrelated baseline blockers observed: missing `coinbase` binding in consensus witness verification, `std::io::Sink` vs `bitcoin_io::Write` in P2P wire sizing, and an ambiguous `ok_or(...into())` in the chainstate journal writer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #823. Centralizes concrete RocksDB/Fjall/redb runtime construction in `crates/node/src/storage_backend.rs`, so chainstate, txindex, and footprint inspection each open a backend once and compose the capabilities they need.

**Details**
- Chainstate now composes undo, pruning/body, and journal services from a single open, replacing repeated backend matches.
- Txindex opens through the same composition owner while retaining redb's specialized fixed-width txindex store and backend-specific batch profiles.
- Storage-footprint inspection now uses the shared composition boundary.
- A regression test enforces the `ARCH-03` ownership contract by rejecting concrete backend constructors in runtime consumers.

<sup>Written for commit 7844c7751b192b42bc83f57062119b8ef32d9a2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

