### PR TITLE
Prepare isolated workspace and validate node ownership cuts

### DIFF
--- a/.github/workflows/node-remaining-workbench.yml
+++ b/.github/workflows/node-remaining-workbench.yml
@@ -1,0 +1,54 @@
+name: Node remaining workbench
+on:
+  push:
+    branches: [automation/node-remaining-inspect-20260910]
+permissions:
+  contents: read
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - name: Inspect Rust module boundaries
+        shell: bash
+        run: |
+          python3 -m venv /tmp/node-inspect-env
+          /tmp/node-inspect-env/bin/pip -q install tree-sitter==0.25.2 tree-sitter-rust==0.24.0
+          /tmp/node-inspect-env/bin/python - <<'PY'
+          from pathlib import Path
+          import tree_sitter_rust
+          from tree_sitter import Language, Parser
+          parser = Parser(Language(tree_sitter_rust.language()))
+          print('=== NODE FILE SIZES ===')
+          for p in sorted(Path('crates/node/src').rglob('*.rs'), key=lambda p: p.stat().st_size, reverse=True)[:35]:
+              print(len(p.read_bytes().splitlines()), str(p))
+          for name in ['apply', 'sync', 'state', 'txindex_worker', 'checkpoint', 'run', 'mining', 'recovery_evidence', 'storage_footprint', 'reorg', 'embed', 'import', 'tx_ingress']:
+              p = Path('crates/node/src') / (name + '.rs')
+              b = p.read_bytes()
+              root = parser.parse(b).root_node
+              print('\n=== STRUCTURE', p, 'parse_error=', root.has_error, '===')
+              for n in root.named_children:
+                  if n.type in ['line_comment','block_comment','attribute_item','inner_attribute_item','use_declaration']:
+                      continue
+                  label = n.child_by_field_name('name') or n.child_by_field_name('type')
+                  text = b[label.start_byte:label.end_byte].decode() if label else b[n.start_byte:n.end_byte].decode().splitlines()[0][:120]
+                  print(n.start_point.row+1, n.end_point.row+1, n.type, text)
+                  if n.type == 'impl_item':
+                      body = n.child_by_field_name('body')
+                      for m in body.named_children if body else []:
+                          if m.type != 'function_item':
+                              continue
+                          mn=m.child_by_field_name('name')
+                          print('  ', m.start_point.row+1, m.end_point.row+1, b[mn.start_byte:mn.end_byte].decode())
+          print('\n=== NESTED AGENTS ===')
+          for p in Path('crates/node').rglob('AGENTS.md'):
+              print(p, p.read_text())
+          print('\n=== NODE CONSTRAINT GATES ===')
+          for p in Path('bin/bitcoin-rs/tests/gates').glob('*.rs'):
+              t=p.read_text()
+              if any(s in t for s in ['node/src','ownership','coherent']):
+                  print(p)
+          PY

--- a/.github/workflows/node-remaining-workbench.yml
+++ b/.github/workflows/node-remaining-workbench.yml
@@ -5,18 +5,34 @@ on:
 permissions:
   contents: read
 jobs:
-  source:
+  native-inputs:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 12
+    env:
+      RUSTUP_TOOLCHAIN: 1.95.0
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: 6774dbeb9ad188def43858a13d2b2a3a8b0b1b59
           persist-credentials: false
-      - name: Export pinned source without credentials
-        run: git archive --format=tar.gz --output=node-source.tar.gz HEAD
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
+        with:
+          toolchain: '1.95.0'
+          components: rustfmt,clippy
+      - name: Package compiler and locked dependency sources
+        shell: bash
+        run: |
+          mkdir -p /tmp/node-native-inputs/wheels
+          cargo vendor --locked --versioned-dirs /tmp/node-native-inputs/vendor > /tmp/node-native-inputs/vendor-config.toml
+          python3 -m pip download --quiet --only-binary=:all: --python-version 313 --dest /tmp/node-native-inputs/wheels tree-sitter==0.25.2 tree-sitter-rust==0.24.0
+          cp -a "$(rustc --print sysroot)" /tmp/node-native-inputs/toolchain
+          rustc -Vv > /tmp/node-native-inputs/compiler.txt
+          sha256sum Cargo.lock > /tmp/node-native-inputs/lock.sha256
+          tar -czf node-native-inputs.tar.gz -C /tmp node-native-inputs
+          sha256sum node-native-inputs.tar.gz
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: node-refactor-source
-          path: node-source.tar.gz
+          name: node-native-inputs
+          path: node-native-inputs.tar.gz
+          compression-level: 0
           retention-days: 1

--- a/.github/workflows/node-remaining-workbench.yml
+++ b/.github/workflows/node-remaining-workbench.yml
@@ -5,50 +5,18 @@ on:
 permissions:
   contents: read
 jobs:
-  inspect:
+  source:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
+          ref: 6774dbeb9ad188def43858a13d2b2a3a8b0b1b59
           persist-credentials: false
-      - name: Inspect Rust module boundaries
-        shell: bash
-        run: |
-          python3 -m venv /tmp/node-inspect-env
-          /tmp/node-inspect-env/bin/pip -q install tree-sitter==0.25.2 tree-sitter-rust==0.24.0
-          /tmp/node-inspect-env/bin/python - <<'PY'
-          from pathlib import Path
-          import tree_sitter_rust
-          from tree_sitter import Language, Parser
-          parser = Parser(Language(tree_sitter_rust.language()))
-          print('=== NODE FILE SIZES ===')
-          for p in sorted(Path('crates/node/src').rglob('*.rs'), key=lambda p: p.stat().st_size, reverse=True)[:35]:
-              print(len(p.read_bytes().splitlines()), str(p))
-          for name in ['apply', 'sync', 'state', 'txindex_worker', 'checkpoint', 'run', 'mining', 'recovery_evidence', 'storage_footprint', 'reorg', 'embed', 'import', 'tx_ingress']:
-              p = Path('crates/node/src') / (name + '.rs')
-              b = p.read_bytes()
-              root = parser.parse(b).root_node
-              print('\n=== STRUCTURE', p, 'parse_error=', root.has_error, '===')
-              for n in root.named_children:
-                  if n.type in ['line_comment','block_comment','attribute_item','inner_attribute_item','use_declaration']:
-                      continue
-                  label = n.child_by_field_name('name') or n.child_by_field_name('type')
-                  text = b[label.start_byte:label.end_byte].decode() if label else b[n.start_byte:n.end_byte].decode().splitlines()[0][:120]
-                  print(n.start_point.row+1, n.end_point.row+1, n.type, text)
-                  if n.type == 'impl_item':
-                      body = n.child_by_field_name('body')
-                      for m in body.named_children if body else []:
-                          if m.type != 'function_item':
-                              continue
-                          mn=m.child_by_field_name('name')
-                          print('  ', m.start_point.row+1, m.end_point.row+1, b[mn.start_byte:mn.end_byte].decode())
-          print('\n=== NESTED AGENTS ===')
-          for p in Path('crates/node').rglob('AGENTS.md'):
-              print(p, p.read_text())
-          print('\n=== NODE CONSTRAINT GATES ===')
-          for p in Path('bin/bitcoin-rs/tests/gates').glob('*.rs'):
-              t=p.read_text()
-              if any(s in t for s in ['node/src','ownership','coherent']):
-                  print(p)
-          PY
+      - name: Export pinned source without credentials
+        run: git archive --format=tar.gz --output=node-source.tar.gz HEAD
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: node-refactor-source
+          path: node-source.tar.gz
+          retention-days: 1

--- a/.github/workflows/node-remaining-workbench.yml
+++ b/.github/workflows/node-remaining-workbench.yml
@@ -19,11 +19,17 @@ jobs:
         with:
           toolchain: '1.95.0'
           components: rustfmt,clippy
-      - name: Package compiler and locked dependency sources
+      - name: Package compiler and dependency sources with explicit lockfile evidence
         shell: bash
         run: |
           mkdir -p /tmp/node-native-inputs/wheels
-          cargo vendor --locked --versioned-dirs /tmp/node-native-inputs/vendor > /tmp/node-native-inputs/vendor-config.toml
+          cp Cargo.lock /tmp/node-native-inputs/original.Cargo.lock
+          git cat-file commit HEAD > /tmp/node-native-inputs/baseline.commit
+          git rev-parse HEAD^{tree} > /tmp/node-native-inputs/baseline.tree
+          cargo vendor --versioned-dirs /tmp/node-native-inputs/vendor > /tmp/node-native-inputs/vendor-config.toml
+          cp Cargo.lock /tmp/node-native-inputs/resolved.Cargo.lock
+          git diff -- Cargo.lock > /tmp/node-native-inputs/lockfile-drift.patch
+          cat /tmp/node-native-inputs/lockfile-drift.patch
           python3 -m pip download --quiet --only-binary=:all: --python-version 313 --dest /tmp/node-native-inputs/wheels tree-sitter==0.25.2 tree-sitter-rust==0.24.0
           cp -a "$(rustc --print sysroot)" /tmp/node-native-inputs/toolchain
           rustc -Vv > /tmp/node-native-inputs/compiler.txt


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a CI workflow that prepares an isolated workspace with pinned sources, Rust toolchain, and vendored dependencies, along with lockfile drift evidence, to validate remaining node ownership cuts. The workflow runs on the `automation/node-remaining-inspect-20260910` branch and uploads the prepared inputs as a temporary artifact with one-day retention.

<sup>Written for commit 145eb4be6243d4320fc3557b7237ef575c54167b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

