### PR TITLE
Refactor apply ownership and validation processes

### DIFF
--- a/.github/workflows/node-breaking-apply-workbench.yml
+++ b/.github/workflows/node-breaking-apply-workbench.yml
@@ -1,0 +1,58 @@
+name: node-breaking-apply-workbench
+
+on:
+  push:
+    branches: [automation/node-breaking-apply-workbench-20260910]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: node-breaking-apply-workbench
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: never
+  CARGO_INCREMENTAL: 0
+  BASE_SHA: 135d2e54d8d3630a609db6d5cc25045a59c966e1
+  TARGET_BRANCH: refactor/node-break-body-store
+
+jobs:
+  transform-validate-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
+      - name: Apply ownership cut
+        run: python3 scripts/node-breaking-apply.py
+      - name: Format
+        run: cargo fmt --all
+      - name: Clippy
+        run: cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings
+      - name: Node tests
+        run: cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --no-fail-fast
+      - name: Ownership gate
+        run: cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test overhaul_ownership -- --nocapture
+      - name: Publish clean validated commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f scripts/node-breaking-apply.py .github/workflows/node-breaking-apply-workbench.yml
+          git add -A
+          if git diff --cached --name-only | grep -Ev '^(crates/node/|docs/)' ; then
+            echo 'unexpected changed path' >&2
+            exit 1
+          fi
+          tree=$(git write-tree)
+          commit=$(printf '%s\n\n%s\n' \
+            'refactor(node): move block-body persistence behind its owner' \
+            'Break the crate-internal apply paths for prune/body storage. Body persistence, ordered snapshot reads, flat-file positions, ranged reads, metadata, and durability now live under apply::body_store; all node callers migrate to that owner and the old apply-level paths disappear.' \
+            | git commit-tree "$tree" -p "$BASE_SHA")
+          git push origin "$commit:refs/heads/$TARGET_BRANCH"
+          echo "published_commit=$commit" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/node-breaking-apply-workbench.yml
+++ b/.github/workflows/node-breaking-apply-workbench.yml
@@ -14,7 +14,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: never
   CARGO_INCREMENTAL: 0
-  BASE_SHA: 135d2e54d8d3630a609db6d5cc25045a59c966e1
+  BASE_SHA: 6774dbeb9ad188def43858a13d2b2a3a8b0b1b59
   TARGET_BRANCH: refactor/node-break-body-store
 
 jobs:
@@ -25,6 +25,15 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
+      - name: Reset source to current refactor base
+        shell: bash
+        run: |
+          cp scripts/node-breaking-apply.py "$RUNNER_TEMP/transform.py"
+          cp .github/workflows/node-breaking-apply-workbench.yml "$RUNNER_TEMP/workflow.yml"
+          git reset --hard "$BASE_SHA"
+          mkdir -p scripts .github/workflows
+          cp "$RUNNER_TEMP/transform.py" scripts/node-breaking-apply.py
+          cp "$RUNNER_TEMP/workflow.yml" .github/workflows/node-breaking-apply-workbench.yml
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
         with:
           components: rustfmt, clippy
@@ -45,7 +54,7 @@ jobs:
           set -euo pipefail
           rm -f scripts/node-breaking-apply.py .github/workflows/node-breaking-apply-workbench.yml
           git add -A
-          if git diff --cached --name-only | grep -Ev '^(crates/node/|docs/)' ; then
+          if git diff --cached --name-only "$BASE_SHA" | grep -Ev '^(crates/node/|docs/)' ; then
             echo 'unexpected changed path' >&2
             exit 1
           fi

--- a/.github/workflows/node-breaking-apply-workbench.yml
+++ b/.github/workflows/node-breaking-apply-workbench.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Format
         run: cargo fmt --all
       - name: Clippy
-        run: cargo clippy -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings
+        run: cargo clippy --no-deps -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings
       - name: Node tests
         run: cargo test -p bitcoin-rs-node --no-default-features --features fjall,zmq --no-fail-fast
       - name: Ownership gate

--- a/.github/workflows/node-breaking-apply-workbench.yml
+++ b/.github/workflows/node-breaking-apply-workbench.yml
@@ -38,6 +38,19 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
+      - name: Patch known current-main consensus compile break for validation only
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          path = Path('crates/consensus/src/verify_block_impl.rs')
+          text = path.read_text()
+          needle = "    // BIP141: coinbase witness must have exactly one 32-byte element (the reserved value).\n    let Some(input) = coinbase.inputs.first() else {\n"
+          replacement = "    // BIP141: coinbase witness must have exactly one 32-byte element (the reserved value).\n    let Some(coinbase) = block.txs.first() else {\n        return false;\n    };\n    let Some(input) = coinbase.inputs.first() else {\n"
+          if needle not in text:
+              raise SystemExit('known consensus compile-break anchor changed')
+          path.write_text(text.replace(needle, replacement, 1))
+          PY
       - name: Apply ownership cut
         run: python3 scripts/node-breaking-apply.py
       - name: Format
@@ -52,7 +65,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git checkout "$BASE_SHA" -- Cargo.lock
+          git checkout "$BASE_SHA" -- Cargo.lock crates/consensus/src/verify_block_impl.rs
           rm -f scripts/node-breaking-apply.py .github/workflows/node-breaking-apply-workbench.yml
           git add -A
           if git diff --cached --name-only "$BASE_SHA" | grep -Ev '^(crates/node/|docs/)' ; then

--- a/.github/workflows/node-breaking-apply-workbench.yml
+++ b/.github/workflows/node-breaking-apply-workbench.yml
@@ -43,15 +43,16 @@ jobs:
       - name: Format
         run: cargo fmt --all
       - name: Clippy
-        run: cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings
+        run: cargo clippy -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings
       - name: Node tests
-        run: cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --no-fail-fast
+        run: cargo test -p bitcoin-rs-node --no-default-features --features fjall,zmq --no-fail-fast
       - name: Ownership gate
-        run: cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test overhaul_ownership -- --nocapture
+        run: cargo test -p bitcoin-rs --no-default-features --features fjall --test overhaul_ownership -- --nocapture
       - name: Publish clean validated commit
         shell: bash
         run: |
           set -euo pipefail
+          git checkout "$BASE_SHA" -- Cargo.lock
           rm -f scripts/node-breaking-apply.py .github/workflows/node-breaking-apply-workbench.yml
           git add -A
           if git diff --cached --name-only "$BASE_SHA" | grep -Ev '^(crates/node/|docs/)' ; then

--- a/.github/workflows/node-breaking-apply-workbench.yml
+++ b/.github/workflows/node-breaking-apply-workbench.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   transform-validate-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262

--- a/.github/workflows/node-breaking-apply-workbench.yml
+++ b/.github/workflows/node-breaking-apply-workbench.yml
@@ -38,18 +38,27 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
-      - name: Patch known current-main consensus compile break for validation only
+      - name: Patch known current-main compile breaks for validation only
         shell: bash
         run: |
           python3 - <<'PY'
           from pathlib import Path
-          path = Path('crates/consensus/src/verify_block_impl.rs')
-          text = path.read_text()
+
+          consensus = Path('crates/consensus/src/verify_block_impl.rs')
+          text = consensus.read_text()
           needle = "    // BIP141: coinbase witness must have exactly one 32-byte element (the reserved value).\n    let Some(input) = coinbase.inputs.first() else {\n"
           replacement = "    // BIP141: coinbase witness must have exactly one 32-byte element (the reserved value).\n    let Some(coinbase) = block.txs.first() else {\n        return false;\n    };\n    let Some(input) = coinbase.inputs.first() else {\n"
           if needle not in text:
               raise SystemExit('known consensus compile-break anchor changed')
-          path.write_text(text.replace(needle, replacement, 1))
+          consensus.write_text(text.replace(needle, replacement, 1))
+
+          wire = Path('crates/p2p/src/wire.rs')
+          text = wire.read_text()
+          needle = "            bitcoin::consensus::Encodable::consensus_encode(&envelope, &mut std::io::sink())?\n"
+          replacement = "            bitcoin::consensus::serialize(&envelope).len()\n"
+          if needle not in text:
+              raise SystemExit('known p2p bitcoin-io compile-break anchor changed')
+          wire.write_text(text.replace(needle, replacement, 1))
           PY
       - name: Apply ownership cut
         run: python3 scripts/node-breaking-apply.py
@@ -65,7 +74,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git checkout "$BASE_SHA" -- Cargo.lock crates/consensus/src/verify_block_impl.rs
+          git checkout "$BASE_SHA" -- Cargo.lock crates/consensus/src/verify_block_impl.rs crates/p2p/src/wire.rs
           rm -f scripts/node-breaking-apply.py .github/workflows/node-breaking-apply-workbench.yml
           git add -A
           if git diff --cached --name-only "$BASE_SHA" | grep -Ev '^(crates/node/|docs/)' ; then

--- a/scripts/node-breaking-apply.py
+++ b/scripts/node-breaking-apply.py
@@ -25,7 +25,24 @@ body = src[start:end].rstrip() + "\n"
 src = src[:start] + src[end:]
 src = src.replace("mod scratch;\n", "pub(crate) mod body_store;\nmod scratch;\n", 1)
 
-header = '''//! Durable block-body storage and ordered snapshot readers.\n//!\n//! This is the sole node owner of block-body persistence, flat-file position\n//! decoding, ranged reads, metadata reads, prefetch ordering, and durability.\n\nuse std::sync::Arc;\n\nuse bitcoin_rs_primitives::{Hash256, varint};\nuse bitcoin_rs_storage::{\n    BlockFilePosition, FlatFileBlockReader, FlatFileBlockStore, KvSnapshot, KvStore, StorageError,\n    WriteBatch, block_file_max_height_key, decode_block_file_max_height,\n    encode_block_file_max_height,\n};\n\nconst SERIALIZED_BLOCK_HEADER_LEN: usize = 80;\nconst SERIALIZED_BLOCK_METADATA_PREFIX_LEN: usize = SERIALIZED_BLOCK_HEADER_LEN + 9;\n\n'''
+header = '''//! Durable block-body storage and ordered snapshot readers.
+//!
+//! This is the sole node owner of block-body persistence, flat-file position
+//! decoding, ranged reads, metadata reads, prefetch ordering, and durability.
+
+use std::sync::Arc;
+
+use bitcoin_rs_primitives::{Hash256, varint};
+use bitcoin_rs_storage::{
+    BlockFilePosition, FlatFileBlockReader, FlatFileBlockStore, KvSnapshot, KvStore, StorageError,
+    WriteBatch, block_file_max_height_key, decode_block_file_max_height,
+    encode_block_file_max_height,
+};
+
+const SERIALIZED_BLOCK_HEADER_LEN: usize = 80;
+const SERIALIZED_BLOCK_METADATA_PREFIX_LEN: usize = SERIALIZED_BLOCK_HEADER_LEN + 9;
+
+'''
 BODY.write_text(header + body)
 APPLY.write_text(src)
 
@@ -51,7 +68,17 @@ for path in (ROOT / "crates/node").rglob("*.rs"):
     if changed != text:
         path.write_text(changed)
 
-# The ownership cut is intentionally breaking: these names are no longer\n# exported from `crate::apply`; callers must name the body_store owner.\nfor legacy in ("crate::apply::PruneBodyStore", "crate::apply::PruneBodyReader", "crate::apply::FlatFilePruneBodyStore"):
-    for path in (ROOT / "crates/node").rglob("*.rs"):
-        if legacy in path.read_text():
-            raise SystemExit(f"legacy apply path remains in {path}: {legacy}")
+# Breaking contract: callers name the body-store owner directly; no apply-level
+# aliases survive this cut.
+legacy_paths = (
+    "crate::apply::PruneBodyStore",
+    "crate::apply::PruneBodyReader",
+    "crate::apply::FlatFilePruneBodyStore",
+)
+for path in (ROOT / "crates/node").rglob("*.rs"):
+    if path == BODY:
+        continue
+    text = path.read_text()
+    for old_path in legacy_paths:
+        if old_path in text:
+            raise SystemExit(f"legacy apply path remains in {path}: {old_path}")

--- a/scripts/node-breaking-apply.py
+++ b/scripts/node-breaking-apply.py
@@ -24,6 +24,28 @@ end = src.index(end_marker, start)
 body = src[start:end].rstrip() + "\n"
 src = src[:start] + src[end:]
 src = src.replace("mod scratch;\n", "pub(crate) mod body_store;\nmod scratch;\n", 1)
+src = src.replace(
+    "    Block, ConsensusEncode as _, Hash256, Network, OutPoint, Tx, TxOut, Txid, consensus_bytes,\n    varint,\n",
+    "    Block, ConsensusEncode as _, Hash256, Network, OutPoint, Tx, TxOut, Txid, consensus_bytes,\n",
+    1,
+)
+src = src.replace(
+    "use bitcoin_rs_storage::{\n    BlockFilePosition, FlatFileBlockReader, FlatFileBlockStore, InMemoryUndoStore, KvSnapshot,\n    KvStore, StorageError, WriteBatch, block_file_max_height_key, decode_block_file_max_height,\n    encode_block_file_max_height,\n};\n",
+    "use bitcoin_rs_storage::{InMemoryUndoStore, KvSnapshot, KvStore, WriteBatch};\n",
+    1,
+)
+src = src.replace(
+    "use scratch::{ApplyScratch, ApplyScratchCapacities, SameBlockSpentSet};\n",
+    "use body_store::PruneBodyStore;\nuse scratch::{ApplyScratch, ApplyScratchCapacities, SameBlockSpentSet};\n",
+    1,
+)
+# Tests stay with the apply transaction for now but must address the moved owner
+# directly; no apply-level forwarding constants/functions are introduced.
+src = src.replace("super::decode_block_tx_count", "super::body_store::decode_block_tx_count")
+src = src.replace(
+    "SERIALIZED_BLOCK_HEADER_LEN",
+    "super::body_store::SERIALIZED_BLOCK_HEADER_LEN",
+)
 
 header = '''//! Durable block-body storage and ordered snapshot readers.
 //!
@@ -39,10 +61,15 @@ use bitcoin_rs_storage::{
     encode_block_file_max_height,
 };
 
-const SERIALIZED_BLOCK_HEADER_LEN: usize = 80;
+pub(super) const SERIALIZED_BLOCK_HEADER_LEN: usize = 80;
 const SERIALIZED_BLOCK_METADATA_PREFIX_LEN: usize = SERIALIZED_BLOCK_HEADER_LEN + 9;
 
 '''
+body = body.replace(
+    "fn decode_block_tx_count(bytes: &[u8]) -> Option<usize> {",
+    "pub(super) fn decode_block_tx_count(bytes: &[u8]) -> Option<usize> {",
+    1,
+)
 BODY.write_text(header + body)
 APPLY.write_text(src)
 
@@ -68,8 +95,6 @@ for path in (ROOT / "crates/node").rglob("*.rs"):
     if changed != text:
         path.write_text(changed)
 
-# Breaking contract: callers name the body-store owner directly; no apply-level
-# aliases survive this cut.
 legacy_paths = (
     "crate::apply::PruneBodyStore",
     "crate::apply::PruneBodyReader",

--- a/scripts/node-breaking-apply.py
+++ b/scripts/node-breaking-apply.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APPLY = ROOT / "crates/node/src/apply.rs"
+BODY = ROOT / "crates/node/src/apply/body_store.rs"
+
+src = APPLY.read_text()
+if "pub(crate) mod body_store;" in src:
+    raise SystemExit("apply body-store split already present")
+
+for line in (
+    "const SERIALIZED_BLOCK_HEADER_LEN: usize = 80;\n",
+    "const SERIALIZED_BLOCK_METADATA_PREFIX_LEN: usize = SERIALIZED_BLOCK_HEADER_LEN + 9;\n",
+):
+    if line not in src:
+        raise SystemExit(f"missing expected constant: {line.strip()}")
+    src = src.replace(line, "", 1)
+
+start_marker = "fn decode_block_tx_count(bytes: &[u8]) -> Option<usize> {"
+end_marker = "/// Admission barrier shared by every cloned apply handle."
+start = src.index(start_marker)
+end = src.index(end_marker, start)
+body = src[start:end].rstrip() + "\n"
+src = src[:start] + src[end:]
+src = src.replace("mod scratch;\n", "pub(crate) mod body_store;\nmod scratch;\n", 1)
+
+header = '''//! Durable block-body storage and ordered snapshot readers.\n//!\n//! This is the sole node owner of block-body persistence, flat-file position\n//! decoding, ranged reads, metadata reads, prefetch ordering, and durability.\n\nuse std::sync::Arc;\n\nuse bitcoin_rs_primitives::{Hash256, varint};\nuse bitcoin_rs_storage::{\n    BlockFilePosition, FlatFileBlockReader, FlatFileBlockStore, KvSnapshot, KvStore, StorageError,\n    WriteBatch, block_file_max_height_key, decode_block_file_max_height,\n    encode_block_file_max_height,\n};\n\nconst SERIALIZED_BLOCK_HEADER_LEN: usize = 80;\nconst SERIALIZED_BLOCK_METADATA_PREFIX_LEN: usize = SERIALIZED_BLOCK_HEADER_LEN + 9;\n\n'''
+BODY.write_text(header + body)
+APPLY.write_text(src)
+
+replacements = {
+    "crate::apply::PruneBodyStore": "crate::apply::body_store::PruneBodyStore",
+    "crate::apply::PruneBodyReader": "crate::apply::body_store::PruneBodyReader",
+    "crate::apply::FlatFilePruneBodyStore": "crate::apply::body_store::FlatFilePruneBodyStore",
+    "use crate::apply::{PruneBodyReader, PruneBodyStore};":
+        "use crate::apply::body_store::{PruneBodyReader, PruneBodyStore};",
+    "use crate::apply::PruneBodyStore;":
+        "use crate::apply::body_store::PruneBodyStore;",
+    "use crate::apply::{ApplyAdmission, PruneBodyStore, UndoStore};":
+        "use crate::apply::body_store::PruneBodyStore;\nuse crate::apply::{ApplyAdmission, UndoStore};",
+}
+
+for path in (ROOT / "crates/node").rglob("*.rs"):
+    if path == BODY:
+        continue
+    text = path.read_text()
+    changed = text
+    for old, new in replacements.items():
+        changed = changed.replace(old, new)
+    if changed != text:
+        path.write_text(changed)
+
+# The ownership cut is intentionally breaking: these names are no longer\n# exported from `crate::apply`; callers must name the body_store owner.\nfor legacy in ("crate::apply::PruneBodyStore", "crate::apply::PruneBodyReader", "crate::apply::FlatFilePruneBodyStore"):
+    for path in (ROOT / "crates/node").rglob("*.rs"):
+        if legacy in path.read_text():
+            raise SystemExit(f"legacy apply path remains in {path}: {legacy}")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an automated workbench that moves block-body persistence out of `apply.rs` into a new `body_store` owner module, validates the result, and publishes a clean commit to `refactor/node-break-body-store`.

**New Features**
- Adds `node-breaking-apply-workbench.yml`, which resets to a base SHA, runs the apply script, formats, lints, runs node and ownership-gate tests, then pushes the validated commit.
- Patches known consensus and p2p compile breaks only during validation; the published commit keeps the original files.

**Refactors**
- `scripts/node-breaking-apply.py` moves body-persistence constants, `decode_block_tx_count`, and prune/body-store types into `crates/node/src/apply/body_store.rs`.
- Old `crate::apply::` paths for `PruneBodyStore`, `PruneBodyReader`, and `FlatFilePruneBodyStore` are removed; node callers now use `crate::apply::body_store::`.

<sup>Written for commit a0275ba2dd7c61115e371c39668a5ad8984579a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

