### PR TITLE
fix(ci): restore green main — clippy lint name, locked feature matrix, bench format string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,7 +238,7 @@ jobs:
       # which builds libbitcoinkernel from C++ -- install its prerequisites
       # so the matrix runs unexcluded (deep lanes own the C++ toolchain).
       - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
-      - run: cargo hack check --locked --each-feature --no-dev-deps -p bitcoin-rs-node -p bitcoin-rs-consensus -p bitcoin-rs-storage
+      - run: cargo hack check --locked --each-feature -p bitcoin-rs-node -p bitcoin-rs-consensus -p bitcoin-rs-storage
 
   # Compile-only MSRV gate: the policy promise is that workspace crates build
   # on the declared MSRV. A second compile graph, so it runs on `main` only;

--- a/crates/mempool/examples/entry_construction_bench.rs
+++ b/crates/mempool/examples/entry_construction_bench.rs
@@ -118,10 +118,7 @@ fn main() {
                     }
                     let elapsed_ns = started.elapsed().as_nanos();
                     println!(
-                        concat!(
-                            "entry_sample,inputs={inputs},witness={},optimized={optimized},",
-                            "sample={sample},iterations={iterations},elapsed_ns={elapsed_ns}",
-                        ),
+                        "entry_sample,inputs={inputs},witness={},optimized={optimized},sample={sample},iterations={iterations},elapsed_ns={elapsed_ns}",
                         witness.is_some(),
                         inputs = inputs,
                         optimized = optimized,

--- a/crates/node/src/embed.rs
+++ b/crates/node/src/embed.rs
@@ -85,7 +85,7 @@ impl Node {
     ///
     /// The method drives synchronous node workers on the caller's task. It
     /// neither installs process signal handlers nor creates an executor.
-    #[allow(clippy::unused_async)]
+    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn start(
         config: crate::NodeConfig,
         runtime: crate::RuntimeInputs,
@@ -106,7 +106,7 @@ impl Node {
     }
 
     /// Returns a decoded block, distinguishing unknown from unavailable data.
-    #[allow(clippy::unused_async)]
+    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>, NodeError> {
         let hash = Hash256::from(hash);
         let Some(record) = self.context.block_by_hash(hash) else {
@@ -133,7 +133,7 @@ impl Node {
     /// A disabled or unhealthy confirmed index is unavailable, not an answer
     /// that the transaction does not exist. A complete negative lookup is
     /// `NodeError::NotFound`.
-    #[allow(clippy::unused_async)]
+    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn tx_by_id(&self, txid: Txid) -> Result<Tx, NodeError> {
         let pooled = self.state.mempool().read().transaction_by_txid(&txid);
         if let Some(tx) = pooled {
@@ -174,7 +174,7 @@ impl Node {
     ///
     /// Policy checks and ordered publication belong to the shared gateway;
     /// embedding does not insert directly into the pool or own another gateway.
-    #[allow(clippy::unused_async)]
+    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn broadcast(&self, tx: Tx) -> Result<MutationResult, NodeError> {
         let max_feerate = Some(bitcoin_rs_rpc::context::DEFAULT_MAX_RAW_TX_FEE_RATE_SAT_PER_KVB);
         self.context
@@ -183,7 +183,7 @@ impl Node {
     }
 
     /// Stops owned services, then publishes the clean-shutdown checkpoint.
-    #[allow(clippy::unused_async)]
+    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn shutdown(self) -> Result<(), NodeError> {
         self.shutdown_blocking()
     }

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -645,7 +645,6 @@ impl BlockBodySource for StoredBlockBodySource {
             .block_body_metadata(height, hash.0)
             .ok()
             .flatten()
-
     }
 }
 

--- a/crates/storage/src/block_body.rs
+++ b/crates/storage/src/block_body.rs
@@ -138,9 +138,9 @@ pub trait BlockBodyStore: Send + Sync {
             return Ok(None);
         };
         Ok(Some(BlockBodyMetadata {
-              body_size: body.len(),
-              tx_count,
-          }))
+            body_size: body.len(),
+            tx_count,
+        }))
     }
 
     /// Bytes this store's block files occupy on disk, when it keeps files.
@@ -404,9 +404,9 @@ impl<S: KvStore> BlockBodyStore for IndexedBlockBodyStore<S> {
         let body_size = usize::try_from(position.len)
             .map_err(|_| StorageError::InvalidOperation("block body length does not fit usize"))?;
         Ok(Some(BlockBodyMetadata {
-              body_size,
-              tx_count,
-          }))
+            body_size,
+            tx_count,
+        }))
     }
 
     fn sync(&self) -> Result<(), StorageError> {


### PR DESCRIPTION
Main is red on `ci` (fmt, rust/clippy) and `ci-main` (feature-combinations, minimal-versions). Four bounded fixes:

- **clippy**: the five async-for-API-uniformity methods on `Node` allowed `clippy::unused_async`, but rustc 1.98 fires `unused_async_trait_impl` — the allows named the wrong lint. Corrected the allow names.
- **feature-combinations**: `cargo hack --no-dev-deps --locked` is self-contradictory — `--no-dev-deps` strips dev-deps from manifests mid-run, making the committed lock look stale under `--locked`. Proven with a pristine-control workspace. Dropped `--no-dev-deps`; `--locked --each-feature` passes with the lock untouched.
- **minimal-versions**: named format-args capture does not apply inside a `concat!`-expanded literal; the bench example failed on every toolchain. Direct string literal with explicit named args.
- **fmt**: rustfmt on `state.rs` and `block_body.rs`.

Verified locally: `scripts/ci-pr.sh clippy` ok, `scripts/ci-pr.sh fmt` ok, full feature lane `cargo hack check --locked --each-feature -p bitcoin-rs-node -p bitcoin-rs-consensus -p bitcoin-rs-storage` passes, example compiles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the failing `ci` and `ci-main` lanes so main can pass Clippy, formatting, feature-combination, and minimal-version checks. These are build and formatting fixes only; runtime behavior and package interfaces remain unchanged.

**Bug Fixes**

- Allows both `clippy::unused_async` and `clippy::unused_async_trait_impl` on five intentionally synchronous-through-async `Node` methods.
- Removes `--no-dev-deps` from the locked `cargo hack --each-feature` matrix so it does not make the committed lockfile appear stale.
- Replaces the `concat!`-wrapped benchmark format string with a direct literal and explicit named arguments.
- Applies rustfmt corrections in `crates/node/src/state.rs` and `crates/storage/src/block_body.rs`.

<sup>Written for commit a015a5c0011051ad735cb7abb912846af53498f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

