### PR TITLE
docs(primitives): cite derive-wtxids.py for wtxid golden provenance

### DIFF
--- a/crates/primitives/tests/differential.rs
+++ b/crates/primitives/tests/differential.rs
@@ -86,7 +86,7 @@ fn assert_tx_roundtrip(serialized: &[u8], expected_wtxid: &str, context: &str) {
     // Golden wtxid derived independently of this codec (BIP141: double
     // SHA-256 of the full serialization; equal to the txid without witness
     // data). See tests/testdata/<height>.wtxids.txt provenance in
-    // scripts/fetch-golden.sh.
+    // scripts/derive-wtxids.py (the fetcher keeps its two-file cache contract).
     let expected = Wtxid::from_str(expected_wtxid)
         .unwrap_or_else(|error| panic!("{context}: golden wtxid hex: {error}"));
     assert_eq!(native.wtxid(), expected, "{context}: golden wtxid");


### PR DESCRIPTION
#483 moved the wtxid walker out of `fetch-golden.sh` into `scripts/derive-wtxids.py` (keeping the fetcher's recorded two-file cache contract), but `differential.rs`'s provenance comment still named the fetcher — a file that no longer derives anything. One-line repoint to the tool that reproduces every checked-in `.wtxids.txt` golden (validated byte-identical across all 15 fixtures during #483's review).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the provenance comment in `differential.rs` to reference `scripts/derive-wtxids.py` instead of `scripts/fetch-golden.sh`, matching the move of wtxid derivation logic. The fetcher no longer derives wtxids; it only maintains its two-file cache contract.

<sup>Written for commit c43c5a2abbd64de639c8934533423fd54baecee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

