### PR TITLE
Fix the four red ci-main lanes

### DIFF
--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -37,7 +37,7 @@ criterion.workspace = true
 # `cfg(test)`, so the cross-crate admission park seam must arrive through the
 # `test-seam` feature, the same way `bitcoin-rs-node` and `bitcoin-rs-rpc`
 # opt in.
-bitcoin-rs-mempool = { path = ".", features = ["test-seam"] }
+bitcoin-rs-mempool = { workspace = true, features = ["test-seam"] }
 
 [[bench]]
 name = "pareto"

--- a/crates/node/src/storage_backend.rs
+++ b/crates/node/src/storage_backend.rs
@@ -60,6 +60,9 @@ fn open_generic<C>(
 where
     C: StoreConsumer,
 {
+    // The fallback arm below is the only reader; builds with every backend
+    // feature compiled in cfg it away, so consume the label here.
+    let _ = namespace;
     match backend {
         #[cfg(feature = "rocksdb")]
         StorageBackend::RocksDb => consumer.consume(Arc::new(match cache_bytes {

--- a/crates/script/tests/segwit_v0_sighash_edges.rs
+++ b/crates/script/tests/segwit_v0_sighash_edges.rs
@@ -145,7 +145,7 @@ fn kernel_witness_parity(tx: &Tx, prevout: &TxOut, witness: &[Vec<u8>]) {
     use bitcoin_rs_consensus::{ConsensusError, kernel::verify_tx_scripts};
 
     let mut signed = tx.clone();
-    signed.inputs[INPUT].witness = witness.to_vec();
+    signed.inputs[INPUT].witness = witness.to_vec().into();
     // The other input has a synthetic OP_TRUE prevout. This is script-verdict
     // parity, not contextual block validation or a claim about historical UTXOs.
     let mut spent: Vec<_> = signed
@@ -157,8 +157,8 @@ fn kernel_witness_parity(tx: &Tx, prevout: &TxOut, witness: &[Vec<u8>]) {
                 prevout.clone()
             } else {
                 TxOut {
-                    value: VALUE,
-                    script_pubkey: vec![0x51],
+                    value: VALUE.into(),
+                    script_pubkey: vec![0x51].into(),
                 }
             };
             (input.previous_output, output)
@@ -168,7 +168,7 @@ fn kernel_witness_parity(tx: &Tx, prevout: &TxOut, witness: &[Vec<u8>]) {
         .expect("kernel accepts independently signed BIP143 input");
     // Every BIP143 mode commits to this amount. Ensure the oracle is not
     // vacuously accepting, and require a script rejection, not an engine error.
-    spent[INPUT].1.value += 1;
+    spent[INPUT].1.value = spent[INPUT].1.value.saturating_add(1_u64.into());
     assert!(matches!(
         verify_tx_scripts(&signed, &spent, VerifyFlags::MANDATORY),
         Err(ConsensusError::Script {

--- a/deny.toml
+++ b/deny.toml
@@ -116,6 +116,9 @@ skip = [
     { crate = "hashbrown@0.16.1", reason = "metrics-util 0.20 and quick_cache 0.6" },
     # bitcoin 0.32 pins hex-conservative 0.2; bitcoin_slices uses 1.x.
     { crate = "hex-conservative@0.2.3", reason = "bitcoin 0.32 pin" },
+    # ahash 0.8 (sonic-rs JSON lane) pins zerocopy 0.7; the workspace uses 0.8.
+    { crate = "zerocopy@0.7.35", reason = "ahash 0.8.11 via sonic-rs" },
+    { crate = "zerocopy-derive@0.7.35", reason = "zerocopy 0.7 via ahash 0.8.11" },
     # cap-std 4 stack: fs-set-times 0.20 pins io-lifetimes 2, cap-std uses 3.
     { crate = "io-lifetimes@2.0.4", reason = "fs-set-times 0.20" },
     # system-deps 6 (zmq/rocksdb build chain) pins the toml 0.8 stack.

--- a/docs/contracts/wallet-facing.md
+++ b/docs/contracts/wallet-facing.md
@@ -109,10 +109,6 @@ mixed-tip page.
 - `crates/rpc/src/esplora.rs` tests `esplora_lives_only_under_the_api_prefix`, `api_is_the_public_electrs_directory`, and `esplora_is_the_mempool_backend_superset` (existing)
 - `bin/bitcoin-rs/tests/wallet_facing.rs::source_does_not_import_node_internals`
   (existing)
-- `crates/rpc/src/esplora.rs` tests
-  `esplora_lives_only_under_the_api_prefix`,
-  `api_is_the_public_electrs_directory`, and
-  `esplora_is_the_mempool_backend_superset` (existing)
 
 ## Vocabulary
 


### PR DESCRIPTION
Main has been red on `ci-main` since 7d5f8f24: every merge after it landed onto failing lanes that PR checks cannot see. This repairs all four deterministic failures plus one doc artifact of the same window.

**full-node Clippy** — `unused variable: namespace` in `crates/node/src/storage_backend.rs` (introduced by #892's state split). Only the unsupported-backend fallback arm reads the label, and the full-feature combo compiles that arm out. Fix: explicit consume (`let _ = namespace;`); behavior unchanged.

**bench-smoke / SegWit-v0 kernel parity** — `segwit_v0_sighash_edges.rs` assigned raw `u64`/`Vec` values to the unconditional `Amount`/`Script`/`Witness` newtype fields inside the kernel-cfg'd oracle, so the main-only kernel lane failed E0308/E0368. Fix: `Into` conversions at the four sites (`witness.to_vec().into()`, `VALUE.into()`, `vec![0x51].into()`, `saturating_add(1_u64.into())`).

**dependency-range (minimal + maximum)** — under lock regeneration: (a) mempool's self-dependency `{ path = ".", features = ["test-seam"] }` resolved as a wildcard ban; now `{ workspace = true, ... }` per the rpc/node pattern; (b) ahash 0.8.11 (via sonic-rs) pulls zerocopy 0.7 alongside the workspace 0.8 line; recorded as audited skips with the driver named, matching the established deny.toml pattern.

**docs** — the rpc-wave merge resolutions left the esplora.rs proof trio duplicated in wallet-facing.md; deduped.

Not addressed here: `overhaul_process_harness::signed_transaction_reaches_both_mempools…` (runner-side Core-provisioning flake family; fails identically on pristine main locally without fixtures) and the one-off apalache 3601s timeout on 8bec5b9d (g20 passed on the two adjacent runs).

Local verification: `ci-pr.sh fmt` clean, `clippy` 3/3 profiles ok, `test` all profiles green except the two fixture-dependent families (`g20`: apalache-mc missing locally, rc 11; process harness: ReferenceCore fixture missing — identical on main locally). Kernel parity lane reproduced failing pre-fix and passing post-fix; deny bans ok under both regenerated locks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the four red `ci-main` lanes plus a duplicated docs entry so main merges green again; no behavior changes outside type conversions and dependency metadata.

**Bug Fixes**
- Consume the unused `namespace` label in `open_generic` so the full-feature Clippy lane passes.
- Convert raw `u64`/`Vec` assignments to `Amount`/`Script`/`Witness` newtype fields in the SegWit-v0 kernel parity oracle so the kernel lane compiles.
- Deduplicate the esplora.rs proof trio in `docs/contracts/wallet-facing.md`.

**Dependencies**
- Point the mempool self-dependency at the workspace table so the dependency-range lanes resolve it as a versioned dependency instead of a wildcard ban.
- Record audited `zerocopy` 0.7 skips in `deny.toml`, pulled in by `ahash` 0.8.11 via `sonic-rs`.

<sup>Written for commit 68555e4bb0428c6541fc283be0aa65256c6825f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

