### PR TITLE
perf(sync): avoid full reorg plans on the linear IBD frontier

### DIFF
--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -1438,6 +1438,32 @@ impl BlockSync {
         );
     }
 
+    /// Projects SYNC-FRONTIER-01 into the scheduler's first pending height.
+    /// Keep fallible ancestry navigation separate from request publication.
+    fn first_connect_height(
+        tree: &bitcoin_rs_chain::BlockTree,
+        applied_hash: Hash256,
+        target: bitcoin_rs_chain::NodeId,
+    ) -> Option<u32> {
+        let applied_id = tree.lookup(applied_hash)?;
+        let height = tree.node(applied_id).ok()?.height;
+        let successor = if tree.node_at_height_from(target, height) == Some(applied_id) {
+            height
+                .checked_add(1)
+                .and_then(|height| tree.node_at_height_from(target, height))
+        } else {
+            None
+        };
+        let first = successor.or_else(|| {
+            plan_reorg(tree, applied_id, target)
+                .ok()?
+                .connect
+                .first()
+                .copied()
+        })?;
+        Some(tree.node(first).ok()?.height)
+    }
+
     fn send_getdata_for_pending_blocks(
         &self,
         sync_peer_addr: SocketAddr,
@@ -1448,40 +1474,11 @@ impl BlockSync {
     ) -> GetdataRequestOutcome {
         let now = Instant::now();
         let tree = self.handles.block_tree.read();
-        let Some(applied_id) = tree.lookup(applied_tip.hash) else {
+        let Some(request_start_height) =
+            Self::first_connect_height(&tree, applied_tip.hash, chain_tip.tip_id)
+        else {
             return GetdataRequestOutcome::default();
         };
-        let Ok(applied_node) = tree.node(applied_id) else {
-            return GetdataRequestOutcome::default();
-        };
-        // Only the first connect height is needed by the bounded scheduler.
-        // On linear IBD, use the existing ancestry index rather than building
-        // and discarding a connect Vec proportional to the full header gap.
-        let successor = if tree.node_at_height_from(chain_tip.tip_id, applied_node.height)
-            == Some(applied_id)
-        {
-            applied_node
-                .height
-                .checked_add(1)
-                .and_then(|height| tree.node_at_height_from(chain_tip.tip_id, height))
-        } else {
-            None
-        };
-        let first_connect = if let Some(successor) = successor {
-            successor
-        } else {
-            let Ok(plan) = plan_reorg(&tree, applied_id, chain_tip.tip_id) else {
-                return GetdataRequestOutcome::default();
-            };
-            let Some(first_connect) = plan.connect.first().copied() else {
-                return GetdataRequestOutcome::default();
-            };
-            first_connect
-        };
-        let Ok(first_connect) = tree.node(first_connect) else {
-            return GetdataRequestOutcome::default();
-        };
-        let request_start_height = first_connect.height;
 
         let mut window = self.download_window.lock();
         let request = window.next_peer_request(
@@ -2049,6 +2046,28 @@ mod tests {
                 }
             }
         }
+        Ok(())
+    }
+
+    // SYNC-FRONTIER-01: an invalidated height index must preserve the
+    // unchanged parent-plan result even when public node_mut leaves a gap.
+    #[test]
+    fn request_frontier_retains_parent_plan_on_height_gaps()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut tree = BlockTree::new();
+        let root = tree.insert_node(None, genesis_header(), NodeStatus::HeaderValid)?;
+        let root_hash = tree.node(root)?.hash;
+        let header = test_header(BlockHash::from(root_hash), 1);
+        let child = tree.insert_node(Some(root), header, NodeStatus::HeaderValid)?;
+        tree.node_mut(child)?.height = 2;
+        let plan = bitcoin_rs_chain::plan_reorg(&tree, root, child)?;
+        let [first] = plan.connect.as_slice() else {
+            return Err("expected one connect node".into());
+        };
+        assert_eq!(
+            BlockSync::first_connect_height(&tree, root_hash, child),
+            Some(tree.node(*first)?.height),
+        );
         Ok(())
     }
 

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -911,6 +911,13 @@ impl BlockSync {
 
     /// Returns the header tip when the applied chain is not on its branch.
     ///
+    /// SYNC-FRONTIER-01: ancestry is identified by node identity, not height
+    /// alone. An applied ancestor needs no switch; request selection starts at
+    /// the first connect node of the parent-walk plan. The trusted active-height
+    /// index may answer linear-sync queries without constructing that plan.
+    /// Forks, disconnected roots, and invalidated indices retain parent-walk
+    /// semantics. This does not change admission, request budgets, or apply.
+    ///
     /// The applied tip is on the branch exactly when the header tip's ancestor
     /// at the applied height is the applied block itself.
     fn outweighed_branch_target(&self) -> Option<bitcoin_rs_chain::NodeId> {
@@ -921,6 +928,13 @@ impl BlockSync {
         }
         let tree = self.handles.block_tree.read();
         let applied_id = tree.lookup(applied.hash)?;
+        // Normal IBD extends the applied chain. Its trusted height index proves
+        // ancestry without allocating a plan for the entire remaining chain.
+        // Keep the parent-walk planner for actual forks and disconnected roots.
+        let applied_height = tree.node(applied_id).ok()?.height;
+        if tree.node_at_height_from(chain_tip.tip_id, applied_height) == Some(applied_id) {
+            return None;
+        }
         let plan = plan_reorg(&tree, applied_id, chain_tip.tip_id).ok()?;
         (!plan.disconnect.is_empty()).then_some(chain_tip.tip_id)
     }
@@ -1437,13 +1451,34 @@ impl BlockSync {
         let Some(applied_id) = tree.lookup(applied_tip.hash) else {
             return GetdataRequestOutcome::default();
         };
-        let Ok(plan) = plan_reorg(&tree, applied_id, chain_tip.tip_id) else {
+        let Ok(applied_node) = tree.node(applied_id) else {
             return GetdataRequestOutcome::default();
         };
-        let Some(first_connect) = plan.connect.first() else {
-            return GetdataRequestOutcome::default();
+        // Only the first connect height is needed by the bounded scheduler.
+        // On linear IBD, use the existing ancestry index rather than building
+        // and discarding a connect Vec proportional to the full header gap.
+        let successor = if tree.node_at_height_from(chain_tip.tip_id, applied_node.height)
+            == Some(applied_id)
+        {
+            applied_node
+                .height
+                .checked_add(1)
+                .and_then(|height| tree.node_at_height_from(chain_tip.tip_id, height))
+        } else {
+            None
         };
-        let Ok(first_connect) = tree.node(*first_connect) else {
+        let first_connect = if let Some(successor) = successor {
+            successor
+        } else {
+            let Ok(plan) = plan_reorg(&tree, applied_id, chain_tip.tip_id) else {
+                return GetdataRequestOutcome::default();
+            };
+            let Some(first_connect) = plan.connect.first().copied() else {
+                return GetdataRequestOutcome::default();
+            };
+            first_connect
+        };
+        let Ok(first_connect) = tree.node(first_connect) else {
             return GetdataRequestOutcome::default();
         };
         let request_start_height = first_connect.height;
@@ -1891,6 +1926,131 @@ mod tests {
     use super::Inventory;
     use super::Message;
     use crate::apply::Chainstate;
+
+    fn check_sync_frontier_pair(
+        sync: &BlockSync,
+        rx: &crossbeam_channel::Receiver<Message>,
+        addr: SocketAddr,
+        applied: &TipSnapshot,
+        target: &TipSnapshot,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let expected = bitcoin_rs_chain::plan_reorg(
+            &sync.handles.block_tree.read(),
+            applied.tip_id,
+            target.tip_id,
+        )
+        .ok();
+        sync.handles
+            .applied_tip
+            .store(Some(Arc::new(applied.clone())));
+        sync.handles.chain_tip.store(Some(Arc::new(target.clone())));
+        assert_eq!(
+            sync.outweighed_branch_target(),
+            expected
+                .as_ref()
+                .filter(|plan| !plan.disconnect.is_empty())
+                .map(|_| target.tip_id),
+            "branch gate differs: {applied:?} -> {target:?}; indexed or parent-walk fixture"
+        );
+        sync.install_budget(super::default_sync_budget());
+        let outcome = sync.send_getdata_for_pending_blocks(addr, true, 100, target, applied);
+        let expected_ids = expected
+            .as_ref()
+            .map(|plan| plan.connect.as_slice())
+            .unwrap_or_default();
+        if expected_ids.is_empty() {
+            assert!(!outcome.sent);
+            assert!(rx.try_recv().is_err());
+            return Ok(());
+        }
+        assert!(outcome.sent);
+        let Message::GetData(inventory) = rx.try_recv()? else {
+            return Err("expected witness getdata".into());
+        };
+        let requested = inventory
+            .into_iter()
+            .map(|item| match item {
+                Inventory::WitnessBlock(hash) => Ok(Hash256::from_le_bytes(hash.as_byte_array())),
+                _ => Err("expected witness block inventory"),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let tree = sync.handles.block_tree.read();
+        let expected_hashes = expected_ids
+            .iter()
+            .take(requested.len())
+            .map(|id| tree.node(*id).map(|node| node.hash))
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(requested, expected_hashes);
+        assert!(!requested.is_empty());
+        assert!(rx.try_recv().is_err());
+        Ok(())
+    }
+
+    // SYNC-FRONTIER-01: the documented contracts of outweighed_branch_target
+    // and send_getdata_for_pending_blocks require ancestry, not equal heights.
+    // Independent oracle: crates/chain/src/reorg.rs::plan_reorg, unchanged by
+    // this optimization. Compare actual emitted hashes, not only batch sizes.
+    #[test]
+    fn indexed_sync_frontiers_match_parent_plans() -> Result<(), Box<dyn std::error::Error>> {
+        let mut tree = BlockTree::new();
+        let root = tree.insert_node(None, genesis_header(), NodeStatus::HeaderValid)?;
+        let mut main = vec![root];
+        for tag in 1..=12 {
+            let parent = *main.last().ok_or("missing main parent")?;
+            let header = test_header(BlockHash::from(tree.node(parent)?.hash), tag);
+            main.push(tree.insert_node(Some(parent), header, NodeStatus::HeaderValid)?);
+        }
+        let mut fork = vec![main[2]];
+        for tag in 101..=106 {
+            let parent = *fork.last().ok_or("missing fork parent")?;
+            let header = test_header(BlockHash::from(tree.node(parent)?.hash), tag);
+            fork.push(tree.insert_node(Some(parent), header, NodeStatus::HeaderValid)?);
+        }
+        let foreign_header = test_header(BlockHash::from(Hash256::from_le_bytes(&[0; 32])), 200);
+        let foreign = tree.insert_node(None, foreign_header, NodeStatus::HeaderValid)?;
+        let endpoints = [root, main[2], main[6], main[12], fork[2], fork[6], foreign];
+        let snapshots = endpoints
+            .iter()
+            .map(|&tip_id| {
+                let node = tree.node(tip_id)?;
+                Ok(TipSnapshot {
+                    tip_id,
+                    height: node.height,
+                    chainwork: node.chainwork,
+                    hash: node.hash,
+                })
+            })
+            .collect::<Result<Vec<_>, bitcoin_rs_chain::ChainError>>()?;
+        let chain_tip = tree.tip_handle();
+        let applied_tip = Arc::new(ArcSwapOption::empty());
+        let block_tree = Arc::new(RwLock::new(tree));
+        let peers = Arc::new(PeerTable::new());
+        let (_, headers_rx) = unbounded::<InboundHeaders>();
+        let (_, blocks_rx) = unbounded::<bitcoin_rs_p2p::InboundBlock>();
+        let sync = BlockSync::for_test(
+            apply_handles(chain_tip, Arc::clone(&applied_tip), Arc::clone(&block_tree)),
+            Arc::clone(&peers),
+            Arc::new(Mutex::new(headers_rx)),
+            Arc::new(Mutex::new(blocks_rx)),
+        );
+        let addr = SocketAddr::from(([127, 0, 0, 1], 8_333));
+        let rx = connect_peer(&peers, synthetic_peer(addr, 100));
+
+        // Repeat the same matrix after public node_mut invalidates the index,
+        // without changing any node. Cached and parent-walk answers must agree.
+        for tainted in [false, true] {
+            if tainted {
+                let mut tree = block_tree.write();
+                let _ = tree.node_mut(main[12])?;
+            }
+            for applied in &snapshots {
+                for target in &snapshots {
+                    check_sync_frontier_pair(&sync, &rx, addr, applied, target)?;
+                }
+            }
+        }
+        Ok(())
+    }
 
     #[test]
     fn tick_sends_getdata_for_headers_above_applied_tip() -> Result<(), Box<dyn std::error::Error>>

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -710,14 +710,28 @@ impl BlockSync {
         false
     }
 
+    /// Returns whether `ancestor` is the node at `height` on `descendant`'s branch.
+    fn is_ancestor_at_height(
+        tree: &BlockTree,
+        ancestor: NodeId,
+        height: u32,
+        descendant: NodeId,
+    ) -> bool {
+        tree.node_at_height_from(descendant, height) == Some(ancestor)
+    }
+
     /// Uses the active-chain height index only while the applied tip is its prefix.
     ///
     /// During a header-first reorg the caller retains old-height blocks rather
     /// than walking the applied ancestry or dropping a body from the new branch.
     fn indexed_applied_ancestry_tip(tree: &BlockTree, applied_tip: &TipSnapshot) -> Option<NodeId> {
         let active_tip = tree.tip()?;
-        (tree.node_at_height_from(active_tip.tip_id, applied_tip.height)
-            == Some(applied_tip.tip_id))
+        Self::is_ancestor_at_height(
+            tree,
+            applied_tip.tip_id,
+            applied_tip.height,
+            active_tip.tip_id,
+        )
         .then_some(active_tip.tip_id)
     }
 
@@ -920,7 +934,7 @@ impl BlockSync {
     ///
     /// The applied tip is on the branch exactly when the header tip's ancestor
     /// at the applied height is the applied block itself.
-    fn outweighed_branch_target(&self) -> Option<bitcoin_rs_chain::NodeId> {
+    fn outweighed_branch_target(&self) -> Option<NodeId> {
         let chain_tip = self.handles.chain_tip.load_full()?;
         let applied = self.handles.applied_tip.load_full()?;
         if chain_tip.hash == applied.hash {
@@ -932,7 +946,7 @@ impl BlockSync {
         // ancestry without allocating a plan for the entire remaining chain.
         // Keep the parent-walk planner for actual forks and disconnected roots.
         let applied_height = tree.node(applied_id).ok()?.height;
-        if tree.node_at_height_from(chain_tip.tip_id, applied_height) == Some(applied_id) {
+        if Self::is_ancestor_at_height(&tree, applied_id, applied_height, chain_tip.tip_id) {
             return None;
         }
         let plan = plan_reorg(&tree, applied_id, chain_tip.tip_id).ok()?;
@@ -1441,26 +1455,23 @@ impl BlockSync {
     /// Projects SYNC-FRONTIER-01 into the scheduler's first pending height.
     /// Keep fallible ancestry navigation separate from request publication.
     fn first_connect_height(
-        tree: &bitcoin_rs_chain::BlockTree,
+        tree: &BlockTree,
         applied_hash: Hash256,
-        target: bitcoin_rs_chain::NodeId,
+        target: NodeId,
     ) -> Option<u32> {
         let applied_id = tree.lookup(applied_hash)?;
         let height = tree.node(applied_id).ok()?.height;
-        let successor = if tree.node_at_height_from(target, height) == Some(applied_id) {
-            height
-                .checked_add(1)
-                .and_then(|height| tree.node_at_height_from(target, height))
-        } else {
-            None
-        };
-        let first = successor.or_else(|| {
-            plan_reorg(tree, applied_id, target)
-                .ok()?
-                .connect
-                .first()
-                .copied()
-        })?;
+        if Self::is_ancestor_at_height(tree, applied_id, height, target)
+            && let Some(successor_height) = height.checked_add(1)
+            && tree.node_at_height_from(target, successor_height).is_some()
+        {
+            return Some(successor_height);
+        }
+        let first = plan_reorg(tree, applied_id, target)
+            .ok()?
+            .connect
+            .into_iter()
+            .next()?;
         Some(tree.node(first).ok()?.height)
     }
 
@@ -1964,18 +1975,12 @@ mod tests {
         let Message::GetData(inventory) = rx.try_recv()? else {
             return Err("expected witness getdata".into());
         };
-        let requested = inventory
-            .into_iter()
-            .map(|item| match item {
-                Inventory::WitnessBlock(hash) => Ok(Hash256::from_le_bytes(hash.as_byte_array())),
-                _ => Err("expected witness block inventory"),
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let requested = witness_block_inventory(inventory)?;
         let tree = sync.handles.block_tree.read();
         let expected_hashes = expected_ids
             .iter()
             .take(requested.len())
-            .map(|id| tree.node(*id).map(|node| node.hash))
+            .map(|id| tree.node(*id).map(|node| BlockHash(node.hash)))
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(requested, expected_hashes);
         assert!(!requested.is_empty());


### PR DESCRIPTION
## Change

Remove two full-header-gap reorg-plan constructions from ordinary linear initial block download:

- `outweighed_branch_target` only needs to establish whether the applied tip is an ancestor of the header tip.
- `send_getdata_for_pending_blocks` only needs the first connect height before consulting the bounded request scheduler; previously it built a complete connect vector per peer.

Both now use the existing `BlockTree::node_at_height_from` ancestry index. Trusted active-chain lookups avoid the full walk and allocation. Forks and disconnected roots retain the unchanged `plan_reorg` fallback. The fallible request-frontier projection is isolated in `first_connect_height`, keeping the request-publication method within strict Clippy's size limit. A missing successor-height lookup also falls back to the parent plan, preserving public height-gap behavior.

No new cache, dependency, unsafe code, public API, consensus rule, validation bypass, default feature, storage format, durability change, or request/window-budget increase.

## Published scope and identity

Current source head: `31ecae939d7893056cdb2bdcb7704a80f1915d2c`.
Current PR base: `a1178cc884e42b953a041d0c139bc47814b7ccae`.
Frozen measurement control: `e6c5eae02738260b5b7240738323098afd6d7c5b`.

Only **`crates/node/src/sync.rs`** differs from the PR base, including its private tests: +190/-11 at this head. The branch contains the original optimization, an intervening main merge, and the focused lint/fallback repair. Concurrent main changes were retained; no force push or main-branch write was performed.

Published sync blob: **`3de5be397112b587fed10ec76ec83209ddea6ec8`**. This is byte-identical to the final workbench-tested and measured sync source. Workbench workflows, scratch scripts, and temporary probes are not included in this PR.

## Correctness coverage

Contract: `SYNC-FRONTIER-01` beside `outweighed_branch_target`. Independent oracle: unchanged `crates/chain/src/reorg.rs::plan_reorg`.

- `indexed_sync_frontiers_match_parent_plans`: seven endpoints produce 49 applied/header pairs, repeated after public `node_mut` invalidates the index: **98 cases in one test**. It compares branch-switch decisions and actual emitted witness-block hashes for linear ancestors, equal tips, same-height forks, backwards targets, and disconnected roots. The same matrix passed on the original implementation; this is equivalence evidence, not an old-fails/new-passes bug reproduction.
- `request_frontier_retains_parent_plan_on_height_gaps`: confirms a missing successor height still produces the parent's first-connect height after public height mutation. No new fallback policy or lint suppression is introduced.

## Audited final workbench results

[Run 34581408620](https://github.com/gosuda/bitcoin-rs/actions/runs/34581408620), job `103205650328`, artifact **10192295915**, `sync-speed-recheck-34581408620`.

Downloaded ZIP SHA-256 independently verified: `2f29945facd70a3370e765a11b039832c0b43a9b1de6ecf0c6be654e4960c0f9`.

| Check | Raw-log result |
|---|---|
| Strict native-node Clippy, all targets, `-D warnings` | Passed |
| Native-node unit suite | **548 passed, 0 failed, 0 ignored** |
| `sync_smoke` | **2 passed** |
| Binary `overhaul_evidence` | **5 passed** |
| Changed-file rustfmt and `git diff --check` | Passed |
| Full-workspace, kernel, x86, all-backend validation | Not established by this workbench |

Commands used `--locked`, `-p bitcoin-rs-node --no-default-features --features fjall,zmq`; the binary evidence command used `-p bitcoin-rs --no-default-features --features fjall --test overhaul_evidence`. The workbench explicitly sets `shell: bash`, so failures in logged pipelines propagate.

Environment: Rust **1.98.1** (`48a229ceaefd4985c50990b14116b6d856af0985`), Cargo 1.98.1, LLVM 22.1.8, Ubuntu 24.04 AArch64, four-core ARM **Neoverse-N2**, measurements pinned to CPU 0. Cargo.lock SHA-256: `813f2e5806b84b8a66733e61d524b554d37e944cbd12baaca6f86cefa3ce5b74`.

Important identity boundary: that workbench tested local source commit `5bb2dbd628717d001eb558f7c5edfb8c6ff571b5`, tree `0e8bb03ae937441ce4befbd1af76b6d0244f41a0`. Its source-file blob matches the published repair, but the final PR tree also includes the intervening main merge. These are not whole-tree-identical builds. The workbench's publish guard refused to overwrite the changed branch; its overall conclusion was failure at publication, not at Clippy, tests, or measurement. The repaired source is now present on the PR at the head above. Normal integrated-head CI remains a separate gate.

## Latest component measurements — not total sync speed

Frozen **262,144-header** synthetic linear chain; **three control/candidate pairs in AB/BA/AB order** per mode. Each process measured 21 batches of 16 operations. Values below are medians of the three process medians, in ns per operation.

| Actual code path | Control | Candidate | Run-median stability within 5% |
|---|---:|---:|---|
| Branch gate | 1,080,750.06 ns | 74.00 ns | Control **failed**; candidate passed |
| Direct request-frontier call with saturated window | 1,096,007.44 ns | 136.44 ns | Control **failed**; candidate passed |
| Frozen saturated `BlockSync::tick` | 7,649.00 ns | 7,480.06 ns | Both passed |

The removed full-gap planning explains the large component difference; **these are not full-node speedup multipliers**. The tick ratio is only **1.0226x**, below CL-19's 1.05x threshold. Control noise in the two direct-path measurements independently prevents treating those runs as a stable promotion result. No favorable run was discarded.

All **18 runs** emitted 256 requested hashes and the same request/final-tip digest:
`622d3ca1170d8f755b91619c61588fa4dcb33998cd9101699d34670274addc47`.

The artifact retains all raw samples, binary identities, per-run p95/p99/max, command/probe sources, source patch, and test logs. Those tails describe **16-operation batch averages**, not individual-operation tail latency. These probes do not measure block download, script verification, block application, database durability, full IBD wall time, or non-target workloads.

## Historical corrections and remaining gates

The first run, `34575019303` / artifact `10189735438`, used Rust 1.95.0 and mistakenly hid Clippy failure behind `tee`. Its initial green-step-based Clippy claim was explicitly withdrawn. The raw log contained five then-unknown lint names in unchanged `embed.rs` and the source-created 117/100-line finding. The final source factors the method rather than suppressing the lint, and the final explicit-pipefail run above passes. The intermediate recheck `34580712545` was cancelled and is not completion evidence.

The original `overhaul_resource_bounds` attempt was **blocked**, exit 101, because that test target does not exist. It has not been converted into a pass.

For published head `31ecae939d7893056cdb2bdcb7704a80f1915d2c`, normal PR runs `34583282352` (`ci`), `34583282311` (`fixture-tools`), and `34583282264` (`fuzz-corpus-tools`) report **`action_required`**. The CI run has no jobs; no integrated-head CI pass is claimed.

**Keep draft. CL-19/CL-20 promotion remains unsatisfied:** matched full-IBD and non-target-cell latency/memory/throughput evidence is missing, and the direct-path control stability checks failed. The performance review finding remains open. No merge requested, no constraint waived, and no zero-findings or end-to-end speedup sign-off is claimed.