### PR TITLE
Move positional index reconciliation policy out of node

### DIFF
--- a/crates/index/src/reconcile.rs
+++ b/crates/index/src/reconcile.rs
@@ -1,10 +1,193 @@
-//! Derived-index reconciliation state and capability alignment.
+//! Derived-index reconciliation state and policy over supplied authoritative chain facts.
 //!
-//! These policies operate on supplied index state. The caller remains
-//! responsible for capturing and validating the authoritative chain view;
-//! agreement between watermarks alone does not prove query readiness.
+//! The index owner decides how durable derived state reaches consistency with a
+//! supplied active chain. The caller owns the authoritative chain representation
+//! and implements [`ActiveChainView`]; agreement between index watermarks alone
+//! never proves query readiness.
+
+use bitcoin_rs_primitives::Hash256;
 
 use crate::{IndexCapabilities, IndexWatermark, IndexWatermarks};
+
+/// Durable consumer-cursor length: epoch (8 LE) + sequence (8 LE) + height (4 LE) + hash.
+pub const CURSOR_BYTE_LEN: usize = 52;
+
+/// Applied-tip identity consumed by index reconciliation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChainTip {
+    /// Applied tip block hash.
+    pub hash: Hash256,
+    /// Applied tip height.
+    pub height: u32,
+}
+
+/// Coherent publisher identity supplied by the authoritative chain owner.
+///
+/// The index does not own or advance these fields. It compares them with its
+/// durable cursor so dropped wakeups and process restarts converge through the
+/// same positional reconciliation path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChainIdentity {
+    /// Process epoch of the supplied committed-chain snapshot.
+    pub epoch: u64,
+    /// Commit sequence in that epoch.
+    pub sequence: u64,
+    /// Applied tip block hash.
+    pub tip_hash: Hash256,
+    /// Applied tip height.
+    pub tip_height: u32,
+}
+
+/// Minimal authoritative-chain topology needed by derived-index reconciliation.
+///
+/// Index owns the decision. Node/chainstate owns the concrete tree and answers
+/// topology questions against one selected active tip. Process lifecycle,
+/// storage, and wake delivery are intentionally absent from this interface.
+pub trait ActiveChainView {
+    /// Whether `position` is represented by the authoritative chain topology.
+    fn contains(&self, position: Hash256) -> bool;
+
+    /// Whether `position` at `height` lies on the selected active chain.
+    fn position_on_active_chain(&self, position: Hash256, height: u32) -> bool;
+
+    /// Height of the newest block shared by `position` and the selected active
+    /// chain, or `None` when ancestry cannot be resolved.
+    fn common_ancestor_height(&self, position: Hash256) -> Option<u32>;
+}
+
+/// Durable position of an index consumer relative to committed chain events.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConsumerCursor {
+    /// Process epoch the consumed events belong to.
+    pub epoch: u64,
+    /// Commit-counter value of the last consumed event.
+    pub sequence: u64,
+    /// Height of the mirrored tip.
+    pub height: u32,
+    /// Hash of the mirrored tip.
+    pub hash: Hash256,
+}
+
+impl ConsumerCursor {
+    /// Builds the cursor for a fully consumed chain identity.
+    #[must_use]
+    pub const fn from_identity(identity: &ChainIdentity) -> Self {
+        Self {
+            epoch: identity.epoch,
+            sequence: identity.sequence,
+            height: identity.tip_height,
+            hash: identity.tip_hash,
+        }
+    }
+
+    /// Encodes the durable representation in [`CURSOR_BYTE_LEN`] bytes.
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; CURSOR_BYTE_LEN] {
+        let mut bytes = [0_u8; CURSOR_BYTE_LEN];
+        bytes[..8].copy_from_slice(&self.epoch.to_le_bytes());
+        bytes[8..16].copy_from_slice(&self.sequence.to_le_bytes());
+        bytes[16..20].copy_from_slice(&self.height.to_le_bytes());
+        bytes[20..].copy_from_slice(&self.hash.to_le_bytes());
+        bytes
+    }
+
+    /// Decodes the durable representation; `None` on any length mismatch.
+    ///
+    /// Cursor corruption is advisory-state corruption only. Row correctness is
+    /// anchored by capability watermarks, so consumers re-plan from row state.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != CURSOR_BYTE_LEN {
+            return None;
+        }
+        Some(Self {
+            epoch: u64::from_le_bytes(bytes[..8].try_into().ok()?),
+            sequence: u64::from_le_bytes(bytes[8..16].try_into().ok()?),
+            height: u32::from_le_bytes(bytes[16..20].try_into().ok()?),
+            hash: Hash256::from_le_bytes(&bytes[20..].try_into().ok()?),
+        })
+    }
+}
+
+/// What a derived-index consumer must do to move its rows onto the active chain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReconcilePlan {
+    /// The cursor names the live tip exactly; nothing to do.
+    CaughtUp,
+    /// The cursor position is on the active chain; connect forward.
+    Forward {
+        /// First height the consumer still has to index.
+        from_height: u32,
+    },
+    /// The cursor position is orphaned; disconnect to the common ancestor,
+    /// then connect forward.
+    RollbackAndForward {
+        /// Last height shared by the cursor branch and the active chain.
+        ancestor_height: u32,
+    },
+    /// The cursor block or its ancestry cannot be resolved; rebuild from the
+    /// consumer's earliest anchor.
+    Rebuild,
+}
+
+/// Plans one positional reconciliation pass for `cursor` against `target`.
+#[must_use]
+pub fn plan(
+    cursor: &ConsumerCursor,
+    target: ChainTip,
+    chain: &impl ActiveChainView,
+) -> ReconcilePlan {
+    if !chain.contains(cursor.hash) {
+        return ReconcilePlan::Rebuild;
+    }
+    if cursor.height == target.height && cursor.hash == target.hash {
+        return ReconcilePlan::CaughtUp;
+    }
+    if chain.position_on_active_chain(cursor.hash, cursor.height) {
+        return ReconcilePlan::Forward {
+            from_height: cursor.height.saturating_add(1),
+        };
+    }
+    match chain.common_ancestor_height(cursor.hash) {
+        Some(ancestor_height) => ReconcilePlan::RollbackAndForward { ancestor_height },
+        None => ReconcilePlan::Rebuild,
+    }
+}
+
+/// Plans from a coherent publisher identity plus the independently supplied
+/// authoritative tip.
+///
+/// Publisher identity is only a shortcut when it also names `target`; an old or
+/// torn identity must not manufacture `CaughtUp` against a different tip.
+#[must_use]
+pub fn plan_from_identity(
+    cursor: &ConsumerCursor,
+    identity: &ChainIdentity,
+    target: ChainTip,
+    chain: &impl ActiveChainView,
+) -> ReconcilePlan {
+    let identity_matches_cursor = cursor.epoch == identity.epoch
+        && cursor.sequence == identity.sequence
+        && cursor.hash == identity.tip_hash
+        && cursor.height == identity.tip_height;
+    let identity_matches_target = identity.tip_hash == target.hash && identity.tip_height == target.height;
+    if identity_matches_cursor && identity_matches_target {
+        return ReconcilePlan::CaughtUp;
+    }
+    plan(cursor, target, chain)
+}
+
+/// Canonical stale-branch depth used to choose rollback versus rebuild.
+#[must_use]
+pub fn rollback_depth(
+    chain: &impl ActiveChainView,
+    position: Hash256,
+    position_height: u32,
+) -> Option<u32> {
+    chain
+        .common_ancestor_height(position)
+        .map(|ancestor_height| position_height.saturating_sub(ancestor_height))
+}
 
 /// Reconciliation leg one capability's rows are executing against the
 /// applied tip. Forward is the resting leg: a watermark that names the
@@ -27,12 +210,6 @@ pub enum ReconcileLeg {
 }
 
 /// Reconciliation legs of every capability the worker owns.
-///
-/// Capabilities carry independent watermarks, so a selective reset can leave
-/// one capability rebuilding while its sibling still rewinds. The worker
-/// publishes each leg change so operators can tell a rewind or rebuild apart
-/// from ordinary forward catch-up, whose progress is the durable watermark
-/// itself.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ReconcilePhase {
     /// Transaction-lookup leg.
@@ -122,9 +299,6 @@ pub enum SelectedWatermark {
 }
 
 /// Selects an exact common watermark without consulting or owning chainstate.
-///
-/// Unselected capabilities do not affect the result. Equality includes both
-/// height and hash; mixed initialized/uninitialized selections are invalid.
 #[must_use]
 pub fn selected_watermark(
     watermarks: IndexWatermarks,

--- a/crates/index/src/reconcile/tests.rs
+++ b/crates/index/src/reconcile/tests.rs
@@ -1,11 +1,16 @@
 //! Contract coverage for reconciliation invariants in
 //! [`docs/contracts/indexing.md`](../../../docs/contracts/indexing.md).
 //! The tests below cover exact watermark alignment (`IDX-03`), selective
-//! capability reset (`IDX-04`), reorganization rollback (`IDX-06`), and
-//! isolated rebuild behavior (`IDX-07`).
+//! capability reset (`IDX-04`), reorganization rollback (`IDX-06`), isolated
+//! rebuild behavior (`IDX-07`), and positional cursor reconciliation.
 
-use super::{ReconcileLeg, ReconcilePhase, SelectedWatermark, selected_watermark};
+use super::{
+    ActiveChainView, CURSOR_BYTE_LEN, ChainIdentity, ChainTip, ConsumerCursor, ReconcileLeg,
+    ReconcilePhase, ReconcilePlan, SelectedWatermark, plan, plan_from_identity,
+    selected_watermark,
+};
 use crate::{IndexCapabilities, IndexWatermark, IndexWatermarks};
+use bitcoin_rs_primitives::Hash256;
 
 const A: IndexWatermark = IndexWatermark {
     height: 10,
@@ -20,11 +25,34 @@ const NEXT_HEIGHT: IndexWatermark = IndexWatermark {
     hash: [0x33; 32],
 };
 
+const ACTIVE: Hash256 = Hash256::from_le_bytes(&[0x41; 32]);
+const ORPHAN: Hash256 = Hash256::from_le_bytes(&[0x42; 32]);
+const MISSING: Hash256 = Hash256::from_le_bytes(&[0x43; 32]);
+const TARGET: Hash256 = Hash256::from_le_bytes(&[0x44; 32]);
+
 const fn capabilities(mask: u8) -> IndexCapabilities {
     IndexCapabilities {
         tx_lookup: mask & 1 != 0,
         script_history: mask & 2 != 0,
         script_live: mask & 4 != 0,
+    }
+}
+
+struct FixtureChain {
+    resolve_orphan_ancestor: bool,
+}
+
+impl ActiveChainView for FixtureChain {
+    fn contains(&self, position: Hash256) -> bool {
+        position == ACTIVE || position == ORPHAN
+    }
+
+    fn position_on_active_chain(&self, position: Hash256, height: u32) -> bool {
+        position == ACTIVE && height == 9
+    }
+
+    fn common_ancestor_height(&self, position: Hash256) -> Option<u32> {
+        (self.resolve_orphan_ancestor && position == ORPHAN).then_some(4)
     }
 }
 
@@ -42,8 +70,6 @@ fn selection_matches_exact_pairwise_equality_for_every_subset() {
                 };
                 for mask in 0..8 {
                     let selected = capabilities(mask);
-                    // Independent, pairwise statement of the contract. In particular,
-                    // None is a selected state, not an item to filter out.
                     let agree = (!selected.tx_lookup
                         || !selected.script_history
                         || tx_lookup == script_history)
@@ -99,7 +125,6 @@ fn same_height_different_hash_is_not_alignment() {
         selected_watermark(watermarks, capabilities(3)),
         SelectedWatermark::Invalid
     );
-    // A lagging or forked History capability cannot gate a Live-only selection.
     assert_eq!(
         selected_watermark(watermarks, capabilities(4)),
         SelectedWatermark::Valid(Some(A))
@@ -176,4 +201,94 @@ fn rollback_progress_covers_every_active_rollback() {
     assert_eq!(phase.rolling_back(), Some((120, 90)));
     assert_eq!(phase.rebuilding(), capabilities(4));
     assert_eq!(ReconcilePhase::default(), ReconcilePhase::FORWARD);
+}
+
+#[test]
+fn consumer_cursor_round_trips_exactly() {
+    let cursor = ConsumerCursor {
+        epoch: 7,
+        sequence: 11,
+        height: 123,
+        hash: Hash256::from_le_bytes(&[0x52; 32]),
+    };
+    let bytes = cursor.to_bytes();
+    assert_eq!(bytes.len(), CURSOR_BYTE_LEN);
+    assert_eq!(ConsumerCursor::from_bytes(&bytes), Some(cursor));
+    assert!(ConsumerCursor::from_bytes(&bytes[..CURSOR_BYTE_LEN - 1]).is_none());
+}
+
+#[test]
+fn positional_planner_distinguishes_forward_rollback_and_rebuild() {
+    let target = ChainTip {
+        hash: TARGET,
+        height: 12,
+    };
+    let cursor = |hash, height| ConsumerCursor {
+        epoch: 1,
+        sequence: 1,
+        height,
+        hash,
+    };
+    let resolved = FixtureChain {
+        resolve_orphan_ancestor: true,
+    };
+    assert_eq!(
+        plan(&cursor(ACTIVE, 9), target, &resolved),
+        ReconcilePlan::Forward { from_height: 10 }
+    );
+    assert_eq!(
+        plan(&cursor(ORPHAN, 9), target, &resolved),
+        ReconcilePlan::RollbackAndForward { ancestor_height: 4 }
+    );
+    assert_eq!(
+        plan(&cursor(MISSING, 9), target, &resolved),
+        ReconcilePlan::Rebuild
+    );
+
+    let unresolved = FixtureChain {
+        resolve_orphan_ancestor: false,
+    };
+    assert_eq!(
+        plan(&cursor(ORPHAN, 9), target, &unresolved),
+        ReconcilePlan::Rebuild,
+        "missing ancestry must not invent genesis as a common ancestor"
+    );
+}
+
+#[test]
+fn publisher_identity_cannot_claim_caught_up_against_a_different_target() {
+    let identity = ChainIdentity {
+        epoch: 3,
+        sequence: 5,
+        tip_hash: ACTIVE,
+        tip_height: 9,
+    };
+    let cursor = ConsumerCursor::from_identity(&identity);
+    let chain = FixtureChain {
+        resolve_orphan_ancestor: true,
+    };
+    assert_eq!(
+        plan_from_identity(
+            &cursor,
+            &identity,
+            ChainTip {
+                hash: TARGET,
+                height: 12,
+            },
+            &chain,
+        ),
+        ReconcilePlan::Forward { from_height: 10 }
+    );
+    assert_eq!(
+        plan_from_identity(
+            &cursor,
+            &identity,
+            ChainTip {
+                hash: ACTIVE,
+                height: 9,
+            },
+            &chain,
+        ),
+        ReconcilePlan::CaughtUp
+    );
 }

--- a/crates/node/src/reconcile.rs
+++ b/crates/node/src/reconcile.rs
@@ -1,27 +1,22 @@
-//! Reusable chain-event reconciliation seam for index consumers (#77).
+//! Node adapter for index-owned positional reconciliation.
 //!
-//! A reconciliation consumer persists a [`ConsumerCursor`] naming the exact
-//! chain state its rows already mirror. It wakes on a chain-event hint (or a
-//! poll tick), reads a fresh chain snapshot, and re-plans from its own
-//! persisted position over `BlockTree`. Hints are only wake-ups, never a
-//! replay log: a dropped hint, a missed sequence range, or a process restart
-//! all converge through the same position-based plan over the chain itself.
+//! `bitcoin-rs-index` owns cursor encoding and rollback/forward/rebuild policy.
+//! Node contributes only its coherent [`ChainSnapshot`] shape and an adapter
+//! over the authoritative [`BlockTree`].
 
 use bitcoin_rs_chain::{BlockTree, NodeId, TipSnapshot};
+use bitcoin_rs_index::reconcile as index_reconcile;
 use bitcoin_rs_primitives::Hash256;
 
 use crate::state::ChainSnapshot;
 
-/// Durable cursor length: epoch (8 LE) + sequence (8 LE) + height (4 LE) + hash.
-pub const CURSOR_BYTE_LEN: usize = 52;
+/// Durable cursor length, owned by the index subsystem.
+pub const CURSOR_BYTE_LEN: usize = index_reconcile::CURSOR_BYTE_LEN;
 
-/// Consumer view of the chain state its rows already mirror.
+/// Node-facing cursor shape for callers that consume [`ChainSnapshot`].
 ///
-/// `epoch` and `sequence` name the publisher event stream the consumer
-/// consumed; the row position itself is anchored by `height` and `hash`. A
-/// new process epoch never invalidates rows, but it does invalidate the
-/// advisory identity: a cursor from an older epoch must be re-planned from
-/// its row position before it may be trusted again.
+/// Durable representation and reconciliation semantics are owned by
+/// [`bitcoin_rs_index::reconcile::ConsumerCursor`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ConsumerCursor {
     /// Process epoch the consumed events belong to.
@@ -35,7 +30,7 @@ pub struct ConsumerCursor {
 }
 
 impl ConsumerCursor {
-    /// Builds the cursor for a fully consumed snapshot.
+    /// Builds a cursor from one coherent node snapshot.
     #[must_use]
     pub const fn from_snapshot(snapshot: &ChainSnapshot) -> Self {
         Self {
@@ -46,127 +41,123 @@ impl ConsumerCursor {
         }
     }
 
-    /// Encodes the durable representation in [`Self::CURSOR_BYTE_LEN`] bytes.
+    /// Encodes the index-owned durable representation.
     #[must_use]
     pub fn to_bytes(&self) -> [u8; CURSOR_BYTE_LEN] {
-        let mut bytes = [0_u8; CURSOR_BYTE_LEN];
-        bytes[..8].copy_from_slice(&self.epoch.to_le_bytes());
-        bytes[8..16].copy_from_slice(&self.sequence.to_le_bytes());
-        bytes[16..20].copy_from_slice(&self.height.to_le_bytes());
-        bytes[20..].copy_from_slice(&self.hash.to_le_bytes());
-        bytes
+        self.as_index_cursor().to_bytes()
     }
 
-    /// Decodes the durable representation; `None` on any length mismatch.
-    ///
-    /// A `None` result is advisory-cursor corruption only. Row correctness is
-    /// anchored by the watermark, so consumers treat it as "no cursor" and
-    /// re-plan from the row position.
+    /// Decodes the index-owned durable representation.
     #[must_use]
     pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() != CURSOR_BYTE_LEN {
-            return None;
+        index_reconcile::ConsumerCursor::from_bytes(bytes).map(Self::from_index_cursor)
+    }
+
+    const fn as_index_cursor(self) -> index_reconcile::ConsumerCursor {
+        index_reconcile::ConsumerCursor {
+            epoch: self.epoch,
+            sequence: self.sequence,
+            height: self.height,
+            hash: self.hash,
         }
-        Some(Self {
-            epoch: u64::from_le_bytes(bytes[..8].try_into().ok()?),
-            sequence: u64::from_le_bytes(bytes[8..16].try_into().ok()?),
-            height: u32::from_le_bytes(bytes[16..20].try_into().ok()?),
-            hash: Hash256::from_le_bytes(&bytes[20..].try_into().ok()?),
-        })
+    }
+
+    const fn from_index_cursor(cursor: index_reconcile::ConsumerCursor) -> Self {
+        Self {
+            epoch: cursor.epoch,
+            sequence: cursor.sequence,
+            height: cursor.height,
+            hash: cursor.hash,
+        }
     }
 }
 
-/// What a consumer must do to move its rows onto the active chain.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ReconcilePlan {
-    /// The cursor names the live tip exactly; nothing to do.
-    CaughtUp,
-    /// The cursor position is on the active chain; connect
-    /// `from_height..=target` in order.
-    Forward {
-        /// First height the consumer still has to index.
-        from_height: u32,
-    },
-    /// The cursor position is orphaned; disconnect back to `ancestor_height`
-    /// first, then connect forward. The ancestor lies on the active chain by
-    /// construction, so the forward leg always resumes from it.
-    RollbackAndForward {
-        /// Last height shared by the cursor branch and the active chain.
-        ancestor_height: u32,
-    },
-    /// The cursor block is absent from the tree (pruned or never seen);
-    /// rebuild from the consumer's earliest anchor.
-    Rebuild,
+pub use index_reconcile::ReconcilePlan;
+
+struct BlockTreeActiveChain<'a> {
+    tree: &'a BlockTree,
+    active_tip: NodeId,
 }
 
-/// Plans one reconciliation pass for `cursor` against the applied tip.
-///
-/// This is the canonical decision for a single-position consumer. The
-/// transaction index applies the same primitives through its per-capability
-/// selection, because its two watermarks can diverge and roll back
-/// independently; a consumer with one cursor calls this directly. The
-/// epoch/sequence fields never alter the plan — rows survive restarts, so the
-/// decision always derives from the cursor position on the current tree.
-#[must_use]
-pub fn plan(cursor: &ConsumerCursor, target: &TipSnapshot, tree: &BlockTree) -> ReconcilePlan {
-    let Some(cursor_id) = tree.lookup(cursor.hash) else {
-        return ReconcilePlan::Rebuild;
-    };
-    if cursor.height == target.height && cursor.hash == target.hash {
-        return ReconcilePlan::CaughtUp;
+impl index_reconcile::ActiveChainView for BlockTreeActiveChain<'_> {
+    fn contains(&self, position: Hash256) -> bool {
+        self.tree.lookup(position).is_some()
     }
-    if position_on_active_chain_by_id(tree, cursor_id, cursor.height, target.tip_id) {
-        return ReconcilePlan::Forward {
-            from_height: cursor.height.saturating_add(1),
+
+    fn position_on_active_chain(&self, position: Hash256, height: u32) -> bool {
+        let Some(position_id) = self.tree.lookup(position) else {
+            return false;
         };
+        self.tree
+            .node_at_height_from(self.active_tip, height)
+            .is_some_and(|active| active == position_id)
     }
-    ReconcilePlan::RollbackAndForward {
-        ancestor_height: common_ancestor_height(tree, cursor.hash, target.tip_id).unwrap_or(0),
+
+    fn common_ancestor_height(&self, position: Hash256) -> Option<u32> {
+        let position_id = self.tree.lookup(position)?;
+        let ancestor = self.tree.find_common_ancestor(position_id, self.active_tip)?;
+        self.tree.node(ancestor).ok().map(|node| node.height)
     }
 }
 
-/// Plans reconciliation from a publisher snapshot and a tree tip.
-///
-/// Sequence continuity is only a wake-up optimization: a gap, epoch change,
-/// or tip mismatch all use the same position-based rollback/forward plan.
-/// This keeps dropped hints and process restarts equivalent to delivered hints.
+const fn target(tip: &TipSnapshot) -> index_reconcile::ChainTip {
+    index_reconcile::ChainTip {
+        hash: tip.hash,
+        height: tip.height,
+    }
+}
+
+const fn identity(snapshot: &ChainSnapshot) -> index_reconcile::ChainIdentity {
+    index_reconcile::ChainIdentity {
+        epoch: snapshot.epoch,
+        sequence: snapshot.sequence,
+        tip_hash: snapshot.tip_hash,
+        tip_height: snapshot.tip_height,
+    }
+}
+
+/// Plans one reconciliation pass through index-owned policy.
 #[must_use]
-#[allow(clippy::suspicious_operation_groupings)]
+pub fn plan(cursor: &ConsumerCursor, target_tip: &TipSnapshot, tree: &BlockTree) -> ReconcilePlan {
+    let chain = BlockTreeActiveChain {
+        tree,
+        active_tip: target_tip.tip_id,
+    };
+    index_reconcile::plan(&cursor.as_index_cursor(), target(target_tip), &chain)
+}
+
+/// Plans from a coherent node snapshot through index-owned policy.
+#[must_use]
 pub fn plan_from_snapshot(
     cursor: &ConsumerCursor,
     snapshot: &ChainSnapshot,
-    target: &TipSnapshot,
+    target_tip: &TipSnapshot,
     tree: &BlockTree,
 ) -> ReconcilePlan {
-    let identity_matches = cursor.epoch == snapshot.epoch
-        && cursor.sequence == snapshot.sequence
-        && cursor.hash == snapshot.tip_hash
-        && cursor.height == snapshot.tip_height;
-    if identity_matches {
-        return ReconcilePlan::CaughtUp;
-    }
-    plan(cursor, target, tree)
+    let chain = BlockTreeActiveChain {
+        tree,
+        active_tip: target_tip.tip_id,
+    };
+    index_reconcile::plan_from_identity(
+        &cursor.as_index_cursor(),
+        &identity(snapshot),
+        target(target_tip),
+        &chain,
+    )
 }
 
-/// Height of the newest block shared by the cursor branch and the active
-/// chain ending at `active_tip`.
-///
-/// Both nodes live in the same tree, so the walk always reaches at least the
-/// genesis anchor; `None` means one of the nodes is no longer resolvable.
+/// Height of the newest block shared by `position` and `active_tip`.
 #[must_use]
 pub fn common_ancestor_height(
     tree: &BlockTree,
     position: Hash256,
     active_tip: NodeId,
 ) -> Option<u32> {
-    let position_id = tree.lookup(position)?;
-    common_ancestor_height_by_id(tree, position_id, active_tip)
+    let chain = BlockTreeActiveChain { tree, active_tip };
+    index_reconcile::ActiveChainView::common_ancestor_height(&chain, position)
 }
-/// Canonical stale-branch depth used to choose rollback versus rebuild.
-///
-/// The depth is measured from the persisted position back to its newest
-/// ancestor shared with the active chain. `None` means the position is no
-/// longer resolvable in the tree.
+
+/// Canonical stale-branch depth, with the decision owned by `index`.
 #[must_use]
 pub fn rollback_depth(
     tree: &BlockTree,
@@ -174,14 +165,11 @@ pub fn rollback_depth(
     position_height: u32,
     active_tip: NodeId,
 ) -> Option<u32> {
-    common_ancestor_height(tree, position, active_tip)
-        .map(|ancestor_height| position_height.saturating_sub(ancestor_height))
+    let chain = BlockTreeActiveChain { tree, active_tip };
+    index_reconcile::rollback_depth(&chain, position, position_height)
 }
-/// Returns whether the block `position` at `height` lies on the active chain
-/// ending at `active_tip`.
-///
-/// Absent blocks are simply off-chain; callers decide whether that means
-/// rollback or rebuild.
+
+/// Whether `position` at `height` lies on the selected active chain.
 #[must_use]
 pub fn position_on_active_chain(
     tree: &BlockTree,
@@ -189,28 +177,6 @@ pub fn position_on_active_chain(
     height: u32,
     active_tip: NodeId,
 ) -> bool {
-    let Some(id) = tree.lookup(position) else {
-        return false;
-    };
-    position_on_active_chain_by_id(tree, id, height, active_tip)
-}
-
-fn position_on_active_chain_by_id(
-    tree: &BlockTree,
-    position_id: NodeId,
-    height: u32,
-    active_tip: NodeId,
-) -> bool {
-    tree.node_at_height_from(active_tip, height)
-        .is_some_and(|active| active == position_id)
-}
-
-fn common_ancestor_height_by_id(
-    tree: &BlockTree,
-    position_id: NodeId,
-    active_tip: NodeId,
-) -> Option<u32> {
-    let ancestor = tree.find_common_ancestor(position_id, active_tip)?;
-    let node = tree.node(ancestor).ok()?;
-    Some(node.height)
+    let chain = BlockTreeActiveChain { tree, active_tip };
+    index_reconcile::ActiveChainView::position_on_active_chain(&chain, position, height)
 }


### PR DESCRIPTION
## Goal

Continue #217 / #645 and the boundary review from #742 without undoing newer mainline txindex modularization.

`bitcoin-rs-index` now owns the durable consumer cursor and the positional decision for how derived state relates to a supplied authoritative chain view. `node` keeps only the adapter from its `ChainSnapshot` / `BlockTree` authority into that policy.

## What changed

- add `ConsumerCursor`, `ChainIdentity`, `ChainTip`, `ActiveChainView`, and `ReconcilePlan` to `index::reconcile`
- move forward / rollback / rebuild planning into the index owner
- treat unresolved ancestry as `Rebuild` instead of manufacturing genesis as a common ancestor
- require an advisory publisher identity to also name the supplied authoritative target before it can short-circuit to `CaughtUp`
- keep capability phase and exact-watermark alignment policy in the same index-owned module
- reduce `node::reconcile` to a thin `BlockTree` / `ChainSnapshot` adapter while preserving its current public surface
- add index-side contract tests for cursor encoding, forward/rollback/rebuild planning, missing ancestry, and target/identity mismatch

## Boundary

`index` decides how a derived index reaches consistency with supplied chain facts. It does **not** own chainstate, block storage, UTXO authority, or process lifecycle. Node still supplies the authoritative tree/tip and supervises the worker.

This intentionally does not move the remaining worker execution/query/storage mechanics in `txindex_worker.rs`; those remain follow-up work under #645.

## Validation

The branch is based on current `main` and contains only the reconciliation ownership cut. Repository CI is the publication validation path for this push.

Related: #742, #645, #217.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves positional index reconciliation policy from `node` to `index`. Previously `node` planned reconciliation; now `index` owns cursor encoding and forward/rollback/rebuild planning, and `node` only adapts its chain view. This also changes two behaviors: unresolved ancestry now triggers a rebuild instead of assuming genesis as a common ancestor, and the advisory publisher identity can only short-circuit to `CaughtUp` when it names the supplied authoritative tip.

**Notes**
- Adds index-side contract tests for cursor encoding, planning, missing ancestry, and identity mismatch.
- Keeps `node`'s public `ConsumerCursor` and reconciliation functions as thin adapters without changing their surface.

<sup>Written for commit dfdaa911fe8800a776401f56f569928d22780953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

