### PR TITLE
fix(index): restore reconciliation fmt and strict Clippy

### DIFF
--- a/crates/index/src/reconcile.rs
+++ b/crates/index/src/reconcile.rs
@@ -3,7 +3,7 @@
 //! The index owner decides how durable derived state reaches consistency with a
 //! supplied active chain. The caller owns the authoritative chain representation
 //! and implements [`ActiveChainView`]; agreement between index watermarks alone
-//! never proves query readiness.
+//! never prove query readiness.
 
 use bitcoin_rs_primitives::Hash256;
 
@@ -166,11 +166,19 @@ pub fn plan_from_identity(
     target: ChainTip,
     chain: &impl ActiveChainView,
 ) -> ReconcilePlan {
-    let identity_matches_cursor = cursor.epoch == identity.epoch
-        && cursor.sequence == identity.sequence
-        && cursor.hash == identity.tip_hash
-        && cursor.height == identity.tip_height;
-    let identity_matches_target = identity.tip_hash == target.hash && identity.tip_height == target.height;
+    let identity_matches_cursor = (
+        cursor.epoch,
+        cursor.sequence,
+        cursor.hash,
+        cursor.height,
+    ) == (
+        identity.epoch,
+        identity.sequence,
+        identity.tip_hash,
+        identity.tip_height,
+    );
+    let identity_matches_target =
+        identity.tip_hash == target.hash && identity.tip_height == target.height;
     if identity_matches_cursor && identity_matches_target {
         return ReconcilePlan::CaughtUp;
     }

--- a/crates/index/src/reconcile.rs
+++ b/crates/index/src/reconcile.rs
@@ -166,17 +166,13 @@ pub fn plan_from_identity(
     target: ChainTip,
     chain: &impl ActiveChainView,
 ) -> ReconcilePlan {
-    let identity_matches_cursor = (
-        cursor.epoch,
-        cursor.sequence,
-        cursor.hash,
-        cursor.height,
-    ) == (
-        identity.epoch,
-        identity.sequence,
-        identity.tip_hash,
-        identity.tip_height,
-    );
+    let identity_matches_cursor = (cursor.epoch, cursor.sequence, cursor.hash, cursor.height)
+        == (
+            identity.epoch,
+            identity.sequence,
+            identity.tip_hash,
+            identity.tip_height,
+        );
     let identity_matches_target =
         identity.tip_hash == target.hash && identity.tip_height == target.height;
     if identity_matches_cursor && identity_matches_target {

--- a/crates/index/src/reconcile/tests.rs
+++ b/crates/index/src/reconcile/tests.rs
@@ -6,8 +6,7 @@
 
 use super::{
     ActiveChainView, CURSOR_BYTE_LEN, ChainIdentity, ChainTip, ConsumerCursor, ReconcileLeg,
-    ReconcilePhase, ReconcilePlan, SelectedWatermark, plan, plan_from_identity,
-    selected_watermark,
+    ReconcilePhase, ReconcilePlan, SelectedWatermark, plan, plan_from_identity, selected_watermark,
 };
 use crate::{IndexCapabilities, IndexWatermark, IndexWatermarks};
 use bitcoin_rs_primitives::Hash256;

--- a/crates/node/src/reconcile.rs
+++ b/crates/node/src/reconcile.rs
@@ -95,7 +95,9 @@ impl index_reconcile::ActiveChainView for BlockTreeActiveChain<'_> {
 
     fn common_ancestor_height(&self, position: Hash256) -> Option<u32> {
         let position_id = self.tree.lookup(position)?;
-        let ancestor = self.tree.find_common_ancestor(position_id, self.active_tip)?;
+        let ancestor = self
+            .tree
+            .find_common_ancestor(position_id, self.active_tip)?;
         self.tree.node(ancestor).ok().map(|node| node.height)
     }
 }


### PR DESCRIPTION
## Scope

Fix the two current-main CI failures exposed when #427 was refreshed onto `0e10cd7e1cfc3d37654c1d622be19cebc2dda196`. This is deliberately separate from the BlockStager ownership cut.

## Changes

- Apply Rust 1.98.1 formatting to `crates/index/src/reconcile.rs`, `crates/index/src/reconcile/tests.rs`, and `crates/node/src/reconcile.rs` exactly where `ci-pr.sh fmt` reported drift.
- Express `ConsumerCursor` ↔ `ChainIdentity` equality as one tuple comparison. This preserves the same four-field equality while avoiding `clippy::suspicious_operation_groupings` under `-D warnings`.

No ownership, storage format, API, compatibility, or runtime-policy change is intended.

## Evidence

The refreshed #427 CI run `34586758565` failed before tests only because:
- `fmt` reported these three reconciliation files.
- workspace/node Clippy reported `suspicious_operation_groupings` at `crates/index/src/reconcile.rs:171`.
- `deny` passed; fixture/fuzz-tool workflows passed.

Keep draft until this PR's own CI confirms formatting and strict Clippy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the two CI failures on main by applying Rust 1.98.1 formatting to the reconcile files and rewriting the `ConsumerCursor` ↔ `ChainIdentity` equality as one tuple comparison to satisfy `clippy::suspicious_operation_groupings` under `-D warnings`.

No ownership, storage format, API, compatibility, or runtime-policy change is intended; the equality still checks the same four fields.

<sup>Written for commit 27cde8c7d12c095a91c457853cde8466b8beed8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

