### PR TITLE
fix(node): remove nonexistent embedding lint names

### DIFF
--- a/crates/node/src/embed.rs
+++ b/crates/node/src/embed.rs
@@ -85,7 +85,7 @@ impl Node {
     ///
     /// The method drives synchronous node workers on the caller's task. It
     /// neither installs process signal handlers nor creates an executor.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn start(
         config: crate::NodeConfig,
         runtime: crate::RuntimeInputs,
@@ -106,7 +106,7 @@ impl Node {
     }
 
     /// Returns a decoded block, distinguishing unknown from unavailable data.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>, NodeError> {
         let hash = Hash256::from(hash);
         let Some(record) = self.context.block_by_hash(hash) else {
@@ -133,7 +133,7 @@ impl Node {
     /// A disabled or unhealthy confirmed index is unavailable, not an answer
     /// that the transaction does not exist. A complete negative lookup is
     /// `NodeError::NotFound`.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn tx_by_id(&self, txid: Txid) -> Result<Tx, NodeError> {
         let pooled = self.state.mempool().read().transaction_by_txid(&txid);
         if let Some(tx) = pooled {
@@ -174,7 +174,7 @@ impl Node {
     ///
     /// Policy checks and ordered publication belong to the shared gateway;
     /// embedding does not insert directly into the pool or own another gateway.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn broadcast(&self, tx: Tx) -> Result<MutationResult, NodeError> {
         let max_feerate = Some(bitcoin_rs_rpc::context::DEFAULT_MAX_RAW_TX_FEE_RATE_SAT_PER_KVB);
         self.context
@@ -183,7 +183,7 @@ impl Node {
     }
 
     /// Stops owned services, then publishes the clean-shutdown checkpoint.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn shutdown(self) -> Result<(), NodeError> {
         self.shutdown_blocking()
     }


### PR DESCRIPTION
## Scope

Prerequisite for the remaining #742 node splits. Remove five references to the nonexistent `clippy::unused_async_trait_impl` lint from `crates/node/src/embed.rs`. Existing valid lint annotations remain. No runtime behavior, API, or storage changes.

One source-only commit: `4360ec7176000c4953ca87b3c7c6900b5694d9f5`, based on `a1178cc884e42b953a041d0c139bc47814b7ccae`.

## Executed validation

Rust 1.95.0 on the GitHub-hosted Linux runner:

```sh
cargo +1.95.0 clippy --locked -p bitcoin-rs-node --all-targets --no-default-features --features fjall,zmq -- -D warnings
git diff --check
```

Both passed before publication. No separate runtime test claim is made for this annotation-only change.

Evidence: https://github.com/gosuda/bitcoin-rs/actions/runs/34589797885 (the baseline section and publication step). That broader workbench run failed on other independent refactor candidates; those failures are not hidden by this PR. Only this validated source commit is included, not the workbench scripts or workflow.

Other node refactor PRs use this branch as their small, explicit prerequisite. No merge was performed by the workbench.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes five references to the nonexistent `clippy::unused_async_trait_impl` lint from `crates/node/src/embed.rs`. The old annotations could trigger warnings under newer Rust toolchains; the new code keeps only the valid `clippy::unused_async` annotations. No runtime behavior, API, or storage changes. This is a prerequisite for the remaining node split PRs.

<sup>Written for commit 4360ec7176000c4953ca87b3c7c6900b5694d9f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

