### PR TITLE
docs(recovery): preserve chain transaction count recovery as RCV-13

### DIFF
--- a/docs/contracts/recovery.md
+++ b/docs/contracts/recovery.md
@@ -101,7 +101,7 @@ the durable root recovery contract.
 
 - The storage engine resolves an outstanding atomic batch to the prior root
   or to the wholly proposed root. It never mixes a new head with old coins,
-  or a new coins set with an old head.
+  or a new coins set with old head.
 - A durable head never references a body or undo range that has not itself
   become durable.
 - Files may have orphan append tails. Those tails are not authoritative.
@@ -264,12 +264,21 @@ tests.
 - Marker persistence failure is returned to the caller and keeps the warning
   visible for the lifetime of that process. Callers that require durable
   evidence fail closed rather than pretending the marker succeeded.
-- Marker and applied-tip-witness payloads are checked against `MAX_FILE_BYTES` after being read; marker publication uses
-  the owner-local atomic write/rename/directory-sync protocol. Corrupt or
-  mismatched evidence is rejected instead of silently becoming authority.
+- Marker and applied-tip-witness payloads are checked against `MAX_FILE_BYTES`
+  after being read; marker publication uses the owner-local atomic
+  write/rename/directory-sync protocol. Corrupt or mismatched evidence is
+  rejected instead of silently becoming authority.
 - Tests for recovery evidence must cite this clause (and `RCV-04` where they
   exercise crash/failure behavior) so extracted test modules do not become an
   independent specification.
+
+### `RCV-13`: Chain transaction count recovery
+
+The in-memory chain transaction count uses zero as the durable-compatible
+sentinel for unknown. Legacy datadirs that predate the counter, rewinds that
+would underflow, and additions that would overflow must preserve or restore
+zero; they must never clamp or wrap into a plausible known total. A known
+count advances and rewinds by the exact transaction delta.
 
 ## Proven by
 


### PR DESCRIPTION
## Scope

Follow-up to merged #930/#933.

#930 introduced a chain-transaction-count recovery rule under `RCV-06`, colliding with the pre-existing `RCV-06: Tip change during rebuild`. An automated #933 conflict/review fix removed the newer clause instead of preserving both contracts.

This one-file follow-up restores that rule under the unique identifier `RCV-13`:

- unknown chain transaction count remains the durable-compatible zero sentinel;
- legacy datadirs, rewind underflow, and addition overflow preserve/restore zero rather than clamping or wrapping to a plausible count;
- a known count advances/rewinds by the exact transaction delta.

No runtime code, schema, consensus behavior, RPC surface, or configuration changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-adds the chain transaction count recovery rule under `RCV-13` after a conflict fix removed it from `RCV-06`. The rule specifies that unknown counts use zero, prevents clamping or wrapping, and tracks exact deltas; this is a docs-only change with no runtime impact.

<sup>Written for commit 0af2bcc137725346f31cabd92197ef05d2796f3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

