### PR TITLE
Restore node cleanup validation and ownership gates

### DIFF
--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -26,6 +26,8 @@ const AUTHORIZED_GATEWAY_CALLS: &[(&str, &str)] = &[
         "crates/node/src/apply/connect.rs",
         "handles.mempool_gateway",
     ),
+    // Reorg transaction reconsideration uses the same typed gateway owner.
+    ("crates/node/src/reorg/execution.rs", "handles.mempool_gateway"),
 ];
 
 /// Mutating methods on `Mempool` that only the mempool owner may call from
@@ -39,6 +41,7 @@ pub(crate) const MUTATING_METHODS: &[&str] = &[
     "insert_entry(",
     "replace_transaction(",
     "remove_for_block(",
+    "reconsider_disconnected(",
     "enforce_size_limit(",
     "evict_below_fee_rate(",
     "prioritise(",
@@ -445,6 +448,16 @@ mod tests {
                 owner,
                 "handles.mempool_gateway.remove_for_block(origin, txs, txids, height);",
                 0,
+            ),
+            (
+                "crates/node/src/reorg/execution.rs",
+                "handles.mempool_gateway.reconsider_disconnected(AdmissionOrigin::Reorg, candidates.into_entries());",
+                0,
+            ),
+            (
+                NON_OWNER,
+                "handles.mempool_gateway.reconsider_disconnected(AdmissionOrigin::Reorg, candidates.into_entries());",
+                1,
             ),
             (
                 NON_OWNER,

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -22,7 +22,10 @@ const AUTHORIZED_GATEWAY_CALLS: &[(&str, &str)] = &[
     ("crates/rpc/src/handlers/mining.rs", "ctx.mempool"),
     // Block apply evicts the block's transactions through the generation
     // guarded gateway; this is the node's only production mutation site.
-    ("crates/node/src/apply.rs", "handles.mempool_gateway"),
+    (
+        "crates/node/src/apply/connect.rs",
+        "handles.mempool_gateway",
+    ),
 ];
 
 /// Mutating methods on `Mempool` that only the mempool owner may call from
@@ -430,6 +433,43 @@ mod tests {
                 path,
                 "ctx.mempool\n    .prioritise(txid, fee_delta)"
             ));
+        }
+    }
+
+    /// ARCH-07 permits this gateway call, not a second mempool mutation owner.
+    #[test]
+    fn node_connection_authorizes_only_its_typed_gateway_receiver() {
+        let owner = "/workspace/crates/node/src/apply/connect.rs";
+        for (path, call, expected_violations) in [
+            (
+                owner,
+                "handles.mempool_gateway.remove_for_block(origin, txs, txids, height);",
+                0,
+            ),
+            (
+                NON_OWNER,
+                "handles.mempool_gateway.remove_for_block(origin, txs, txids, height);",
+                1,
+            ),
+            (
+                owner,
+                "handles.mempool.remove_for_block(origin, txs, txids, height);",
+                1,
+            ),
+            (
+                owner,
+                "handles.mempool_gateway.write().remove_for_block(origin, txs, txids, height);",
+                1,
+            ),
+        ] {
+            let mut result = empty_result();
+            scan_source(path, call, &mut result);
+            assert_eq!(
+                result.violations.len(),
+                expected_violations,
+                "{path}: {call}"
+            );
+            assert_eq!(result.mutating_calls_found, 1);
         }
     }
 

--- a/crates/node/benches/sync_pipeline.rs
+++ b/crates/node/benches/sync_pipeline.rs
@@ -1157,6 +1157,7 @@ fn populate_sync_header_chain(
     (blocks, received_scan_expected)
 }
 
+#[cfg(feature = "fjall")]
 fn populate_header_chain_from_blocks(tree: &mut BlockTree, blocks: &[Block]) {
     let genesis = Network::Regtest.genesis_block();
     let genesis_id = tree

--- a/crates/node/src/apply/window.rs
+++ b/crates/node/src/apply/window.rs
@@ -34,13 +34,11 @@ pub(super) fn apply_window_admitted(
         return Err(WindowApplyError {
             applied: 0,
             committed: Vec::new(),
-            source: ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Kernel(
-                format!(
-                    "window has {} blocks but {} serialized bodies",
-                    blocks.len(),
-                    serialized.len()
-                ),
-            )),
+            source: ApplyError::Consensus(bitcoin_rs_consensus::ConsensusError::Kernel(format!(
+                "window has {} blocks but {} serialized bodies",
+                blocks.len(),
+                serialized.len()
+            ))),
             disposition: WindowApplyDisposition::Operational,
             invalidated: Box::default(),
         });

--- a/crates/node/src/embed.rs
+++ b/crates/node/src/embed.rs
@@ -85,7 +85,7 @@ impl Node {
     ///
     /// The method drives synchronous node workers on the caller's task. It
     /// neither installs process signal handlers nor creates an executor.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn start(
         config: crate::NodeConfig,
         runtime: crate::RuntimeInputs,
@@ -106,7 +106,7 @@ impl Node {
     }
 
     /// Returns a decoded block, distinguishing unknown from unavailable data.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>, NodeError> {
         let hash = Hash256::from(hash);
         let Some(record) = self.context.block_by_hash(hash) else {
@@ -133,7 +133,7 @@ impl Node {
     /// A disabled or unhealthy confirmed index is unavailable, not an answer
     /// that the transaction does not exist. A complete negative lookup is
     /// `NodeError::NotFound`.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn tx_by_id(&self, txid: Txid) -> Result<Tx, NodeError> {
         let pooled = self.state.mempool().read().transaction_by_txid(&txid);
         if let Some(tx) = pooled {
@@ -174,7 +174,7 @@ impl Node {
     ///
     /// Policy checks and ordered publication belong to the shared gateway;
     /// embedding does not insert directly into the pool or own another gateway.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn broadcast(&self, tx: Tx) -> Result<MutationResult, NodeError> {
         let max_feerate = Some(bitcoin_rs_rpc::context::DEFAULT_MAX_RAW_TX_FEE_RATE_SAT_PER_KVB);
         self.context
@@ -183,7 +183,7 @@ impl Node {
     }
 
     /// Stops owned services, then publishes the clean-shutdown checkpoint.
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
+    #[allow(clippy::unused_async)]
     pub async fn shutdown(self) -> Result<(), NodeError> {
         self.shutdown_blocking()
     }

--- a/crates/node/src/mining/candidate.rs
+++ b/crates/node/src/mining/candidate.rs
@@ -165,16 +165,15 @@ impl MiningCoordinator {
             Err(error) => Err(error.clone()),
         };
         if let Some(flight) = state.in_flight.as_mut()
-            && flight.key == key && flight.id == flight_id
+            && flight.key == key
+            && flight.id == flight_id
         {
             flight.result = Some(returned.clone());
         }
         self.wake.notify_all();
-        if state
-            .in_flight
-            .as_ref()
-            .is_some_and(|flight| flight.key == key && flight.id == flight_id && flight.result.is_some())
-        {
+        if state.in_flight.as_ref().is_some_and(|flight| {
+            flight.key == key && flight.id == flight_id && flight.result.is_some()
+        }) {
             state.in_flight = None;
         }
         flight_guard.armed = false;

--- a/crates/node/src/reconcile.rs
+++ b/crates/node/src/reconcile.rs
@@ -95,12 +95,7 @@ pub fn plan_from_snapshot(
         tree,
         active_tip: target_tip.tip_id,
     };
-    index_reconcile::plan_from_identity(
-        cursor,
-        &identity(snapshot),
-        target(target_tip),
-        &chain,
-    )
+    index_reconcile::plan_from_identity(cursor, &identity(snapshot), target(target_tip), &chain)
 }
 
 /// Height of the newest block shared by `position` and `active_tip`.

--- a/crates/node/src/state/prune.rs
+++ b/crates/node/src/state/prune.rs
@@ -111,10 +111,10 @@ impl<S: KvStore> PruneService for NodePruneService<S> {
             .ok_or_else(|| PruneServiceError::failed("prune height overflow"))?;
 
         let durable_tip_height = self.durable_tip_height.load(Ordering::Acquire);
-          let effective_prune_below = pruner_tip
-              .min(durable_tip_height)
-              .saturating_sub(policy.retention_depth());
-          let prune_candidates: Vec<(u32, bitcoin_rs_primitives::BlockHash, usize)> = {
+        let effective_prune_below = pruner_tip
+            .min(durable_tip_height)
+            .saturating_sub(policy.retention_depth());
+        let prune_candidates: Vec<(u32, bitcoin_rs_primitives::BlockHash, usize)> = {
             let blocks = self.blocks.read();
             blocks
                 .iter()

--- a/crates/node/src/state/tests.rs
+++ b/crates/node/src/state/tests.rs
@@ -11,23 +11,16 @@ use bitcoin_rs_chain::TipSnapshot;
 
 use bitcoin_rs_primitives::{Block, Hash256, Tx, Txid, chain_constants::CORE_REORG_SAFETY_MARGIN};
 
-use bitcoin_rs_rpc::context::{BlockLog, PruneService, PruneServiceError};
-
-use bitcoin_rs_storage::FlatFileBlockStore;
+use bitcoin_rs_rpc::context::PruneServiceError;
 
 use core::mem::size_of;
 
 use hashbrown::HashMap;
 
-use parking_lot::RwLock;
-
-use super::{events::*, index::*, prune::load_pruneheight, restore::*};
+use super::{events::*, index::*, restore::*};
 
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, AtomicU32, Ordering},
-    },
+    sync::{Arc, atomic::Ordering},
     time::Duration,
 };
 

--- a/crates/node/src/state/tests/prune.rs
+++ b/crates/node/src/state/tests/prune.rs
@@ -417,7 +417,7 @@ fn manual_prune_removes_pruned_block_transactions_from_cache() -> anyhow::Result
         anyhow::bail!("prune service should exist when prune_target_mb > 0");
     };
     // Pruning cannot evict cached transactions while their block still lies
-    // above the durable checkpoint's reorg-retention floor (ARCH-07).
+    // above the durable checkpoint's reorg-retention floor (ARCH-08).
     service
         .prune_to_height(11)
         .map_err(|err| anyhow::anyhow!("prune failed: {err}"))?;

--- a/crates/node/src/state/tests/prune.rs
+++ b/crates/node/src/state/tests/prune.rs
@@ -416,6 +416,19 @@ fn manual_prune_removes_pruned_block_transactions_from_cache() -> anyhow::Result
     let Some(service) = state.prune_service() else {
         anyhow::bail!("prune service should exist when prune_target_mb > 0");
     };
+    // Pruning cannot evict cached transactions while their block still lies
+    // above the durable checkpoint's reorg-retention floor (ARCH-07).
+    service
+        .prune_to_height(11)
+        .map_err(|err| anyhow::anyhow!("prune failed: {err}"))?;
+    assert!(state.transactions.read().contains_key(&pruned_txid));
+    assert!(state.transactions.read().contains_key(&unrelated_txid));
+
+    // The synthetic applied-tip fixture must also publish durability before
+    // any block below the requested height becomes eligible for pruning.
+    state
+        .durable_tip_height
+        .store(11 + CORE_REORG_SAFETY_MARGIN, Ordering::Release);
     service
         .prune_to_height(11)
         .map_err(|err| anyhow::anyhow!("prune failed: {err}"))?;
@@ -558,8 +571,13 @@ fn prune_refuses_after_apply_admission_closes() -> anyhow::Result<()> {
 #[allow(clippy::too_many_lines)]
 #[test]
 fn prune_to_height_serializes_overlapping_calls() -> anyhow::Result<()> {
+    use super::super::prune::load_pruneheight;
+    use bitcoin_rs_rpc::context::{BlockLog, PruneService};
+    use bitcoin_rs_storage::FlatFileBlockStore;
+    use parking_lot::RwLock;
     use std::sync::Barrier;
     use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::{AtomicBool, AtomicU32};
     use std::time::Duration;
 
     struct BlockingPruneBodyStore {

--- a/crates/node/src/storage_backend.rs
+++ b/crates/node/src/storage_backend.rs
@@ -142,7 +142,22 @@ mod tests {
         (
             "storage_footprint.rs",
             include_str!("storage_footprint.rs"),
-            Some("mod tests {"),
+            None,
+        ),
+        (
+            "storage_footprint/budget.rs",
+            include_str!("storage_footprint/budget.rs"),
+            None,
+        ),
+        (
+            "storage_footprint/identity.rs",
+            include_str!("storage_footprint/identity.rs"),
+            None,
+        ),
+        (
+            "storage_footprint/scan.rs",
+            include_str!("storage_footprint/scan.rs"),
+            None,
         ),
         (
             "txindex_worker.rs",

--- a/crates/node/src/txindex_worker/capability.rs
+++ b/crates/node/src/txindex_worker/capability.rs
@@ -1,6 +1,10 @@
 //! Txindex lifecycle/progress projection for RPC capability reporting.
 
-use super::*;
+use super::{
+    Arc, ArcSwap, CapabilityState, CapabilityStatus, IndexCapabilities, IndexProgress,
+    TxIndexCapabilitySource, TxIndexLifecycle, TxIndexQueryEngine, TxIndexRuntime, TxQueryError,
+    txindex_status,
+};
 
 /// Progress reads that raced a tip or revision move before the status
 /// report gives up on a coherent answer for this snapshot.

--- a/crates/node/src/txindex_worker/query.rs
+++ b/crates/node/src/txindex_worker/query.rs
@@ -1,6 +1,15 @@
 //! Snapshot-gated txindex queries and the index-side block source.
 
-use super::*;
+use super::{
+    Arc, Block, BlockBodySource, BlockHash, BlockLog, BlockSource, BlockTree, Hash256,
+    IndexCapabilities, IndexCapability, IndexReader, IndexWatermark, MAX_SERIALIZED_BLOCK_BYTES,
+    Mutex, Ordering, OutPoint, PrefixScanLimit, QUERY_BODY_READ_LIMIT, QUERY_SCAN_BYTE_LIMIT,
+    QUERY_SCAN_COUNT_LIMIT, QUERY_SCAN_ROW_LIMIT, RwLock, ScriptHash, ScriptHistoryRecord,
+    ScriptIndexQuery, ScriptIndexRecord, ScriptIndexSnapshot, ScriptLiveScan, SpendingRecord,
+    TipSnapshot, Tx, TxIndexInfo, TxIndexQuery, TxIndexRuntime, TxIndexScan, TxIndexScanRow,
+    TxIndexSnapshot, TxPosition, TxPositionValue, TxQueryError, Txid, deserialize,
+    record_at_height,
+};
 
 /// Aggregate work budget shared by every operation in one public query.
 struct QueryBudget {

--- a/docs/contracts/architecture.md
+++ b/docs/contracts/architecture.md
@@ -221,6 +221,14 @@ Owners:
   owns the durable event journal; this is dependency direction, not a second
   event contract. Do not push cross-store ordering into `utxo` or `storage`.
 
+### `ARCH-08`: Durable pruning and reorg retention
+
+- Transaction-cache pruning must not remove transactions from a block above
+  the durable checkpoint's reorg-retention floor. A requested prune height
+  becomes eligible only after durability has been published through
+  `CORE_REORG_SAFETY_MARGIN`; this protects reconsideration of disconnected
+  transactions during reorg handling.
+
 ## Live gaps
 
 - **Node slimming and extraction (#217)**: Peer connection session and lease


### PR DESCRIPTION
## Scope

First commit in the remaining node-cleanup series, based on `729f0e8691ec25401b8150ea9934c890a37e988a`. This prerequisite makes the existing module cuts independently testable before the txindex and checkpoint follow-ups.

- Remove the nonexistent `clippy::unused_async_trait_impl` annotations; retain the valid lint controls. Replace the two wildcard imports introduced by #936 with explicit imports.
- Keep Fjall-only fixture imports local to their gated test, and gate the matching benchmark helper. Do not change the configured storage default.
- Point the ownership scanner at the actual `apply/connect.rs` mutation owner. Keep positive and negative assertions rejecting the retired root and other non-owner apply modules.
- Scan the real storage-footprint implementation files after their split, rather than assuming an inline test module still exists.
- Correct the pruning fixture: first prove cached transactions remain protected above the durable checkpoint's reorg-retention floor; only then explicitly publish fixture durability and assert eviction. Production pruning and durability rules are unchanged.

12 changed files; +114 / -42 lines. Formatting residue in affected node files is included. No storage schema, dependency, feature-default, consensus, or production retention change.

## Validation

Exact source commit: `11ac6140ce7a8c60d5e72d393829485b90a29a11`.
Exact tree: `c42b9dafde6d39db5c2cc5807c082996607471bd`.

Passed before push with Rust 1.95.0:

```sh
cargo fmt -p bitcoin-rs-node -- --check
cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings
cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib state::tests::prune -- --test-threads=1
cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test overhaul_ownership --test overhaul_evidence -- --nocapture
cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test g18_hot_path_ledger -- --nocapture
```

Results: 13 pruning tests, 23 ownership/evidence tests, and 21 hot-path-ledger tests passed. Separate local redb-only all-target Clippy also passed.

Evidence: [native stage validation](https://github.com/gosuda/bitcoin-rs/actions/runs/34602393344), [final source-reference validation and successful publication](https://github.com/gosuda/bitcoin-rs/actions/runs/34603845234). The latter's `node-publication-verified` artifact retains the original logs, their checksums, exact source bundle, and publication manifest.

The mining capability integration regression is deliberately fixed in the last PR of the series, not hidden in this prerequisite. A separate redb-only state-test experiment is not a passing runtime lane: existing fixtures still choose the configured Fjall default (8 passed / 54 failed). No backend default is changed to disguise that limitation. RocksDB/kernel and full-workspace verification are not claimed.

Publication used complete source-only commits in policy-compliant atomic batches of at most three refs. No workbench scripts or workflows are included in this PR; no main-branch write, merge, or force-push was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores node cleanup validation and ownership gates so the module splits are independently testable.

- Removes nonexistent `clippy::unused_async_trait_impl` annotations and replaces wildcard imports with explicit imports in txindex worker modules.
- Points the ownership scanner at the actual `apply/connect.rs` mutation owner, authorizes reorg-driven `reconsider_disconnected` calls, and keeps assertions that reject the retired root and other non-owner modules.
- Scans the real storage-footprint implementation files after their split instead of assuming an inline test module.
- Corrects the pruning fixture to prove cached transactions stay protected above the durable checkpoint's reorg-retention floor before asserting eviction.
- Documents the durable pruning retention rule as ARCH-08.
- Gates Fjall-only benchmark and fixture imports behind the `fjall` feature.

Production pruning, durability, storage schema, consensus, and default backend behavior are unchanged.

<sup>Written for commit f3284c1fcfbb7fa0bf9298bf0ccfcb97f19bcf49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

