### PR TITLE
Advertise only implemented mining template capabilities

### DIFF
--- a/crates/node/src/mining/candidate.rs
+++ b/crates/node/src/mining/candidate.rs
@@ -16,7 +16,6 @@ use bitcoin_rs_mempool::MempoolMiningSnapshot;
 use bitcoin_rs_mempool::SnapshotEntry;
 use bitcoin_rs_mining::AvailableMiningRule;
 use bitcoin_rs_mining::BlockTemplate;
-use bitcoin_rs_mining::BlockTemplateRequest;
 use bitcoin_rs_mining::BlockValidationResult;
 use bitcoin_rs_mining::Candidate;
 use bitcoin_rs_mining::CandidateContext;
@@ -333,7 +332,6 @@ impl MiningCoordinator {
     pub(super) fn template_from_candidate(
         network: Network,
         candidate: Arc<Candidate>,
-        request: &BlockTemplateRequest,
         submit_old: Option<bool>,
         version_bits_available: Vec<AvailableMiningRule>,
         version_bits_required: u32,
@@ -352,18 +350,11 @@ impl MiningCoordinator {
         if signet.is_some() {
             rules.push(MiningRule::new("signet"));
         }
-        let mut capabilities = vec![
+        // API-11 advertises producer capabilities, never client-requested names.
+        let capabilities = vec![
             MiningCapability::new("proposal"),
             MiningCapability::new("longpoll"),
         ];
-        for capability in &request.capabilities {
-            if !capabilities
-                .iter()
-                .any(|known| known.as_str() == capability.as_str())
-            {
-                capabilities.push(capability.clone());
-            }
-        }
         BlockTemplate {
             candidate,
             rules,

--- a/crates/node/src/mining/candidate_template_tests.rs
+++ b/crates/node/src/mining/candidate_template_tests.rs
@@ -105,15 +105,6 @@ fn sample_candidate(previous: Hash256, csv_active: bool, segwit_active: bool) ->
     }
 }
 
-fn empty_request() -> bitcoin_rs_mining::BlockTemplateRequest {
-    bitcoin_rs_mining::BlockTemplateRequest {
-        mode: bitcoin_rs_mining::BlockTemplateMode::Template,
-        capabilities: Vec::new(),
-        rules: Vec::new(),
-        long_poll_id: None,
-    }
-}
-
 fn template_for(
     candidate: Candidate,
     submit_old: Option<bool>,
@@ -121,7 +112,6 @@ fn template_for(
     super::MiningCoordinator::template_from_candidate(
         Network::Regtest,
         Arc::new(candidate),
-        &empty_request(),
         submit_old,
         Vec::new(),
         0,
@@ -179,7 +169,6 @@ fn signet_template_carries_challenge_and_mandatory_rule() {
             true,
             true,
         )),
-        &empty_request(),
         None,
         Vec::new(),
         0,

--- a/crates/node/src/mining/control.rs
+++ b/crates/node/src/mining/control.rs
@@ -129,7 +129,6 @@ impl MiningControl for MiningCoordinator {
                 let template = Self::template_from_candidate(
                     self.network,
                     candidate,
-                    &request,
                     submit_old,
                     version_bits_available,
                     version_bits_required,

--- a/crates/node/tests/mining.rs
+++ b/crates/node/tests/mining.rs
@@ -830,11 +830,15 @@ fn template_does_not_echo_client_capabilities() -> anyhow::Result<()> {
     mining.publish_generation();
     let template = expect_template(mining.get_block_template(BlockTemplateRequest {
         mode: BlockTemplateMode::Template,
-        capabilities: vec![MiningCapability::new("coinbasetxn")],
+        capabilities: vec![
+            MiningCapability::new("coinbasetxn"),
+            MiningCapability::new("unknown-client-only"),
+            MiningCapability::new("proposal"),
+        ],
         rules: Vec::new(),
         long_poll_id: None,
     })?);
-    // Bitcoin Core's getblocktemplate contract advertises server capabilities,
+    // API-11 advertises only implemented server capabilities,
     // and omits Signet metadata on networks that are not Signet.
     assert_eq!(
         template

--- a/docs/contracts/external-api.md
+++ b/docs/contracts/external-api.md
@@ -214,7 +214,7 @@ fixture replay gate. `API-11` is the BIP22/BIP23
 ### `API-11`: BIP22/BIP23 template extras
 
 - **Owner**: `MiningCoordinator::template_from_candidate` in
-  `crates/node/src/mining.rs`; JSON projection in
+  `crates/node/src/mining/candidate.rs`; JSON projection in
   `crates/rpc/src/handlers/mining.rs` `render_block_template`.
 - Capabilities are the producer’s implemented set (`proposal`, `longpoll`).
   Client-advertised names are not echoed.


### PR DESCRIPTION
## Scope and order

Fourth and final PR in the remaining node-cleanup series: #944 → #945 → #947 → this PR. This is a deliberate behavior correction, separated from the structural refactors.

The existing `template_does_not_echo_client_capabilities` integration test exposed an `API-11` regression: the producer copied arbitrary client-requested names into the returned `getblocktemplate` capability list. It returned `coinbasetxn` even though the producer contract only advertises `proposal` and `longpoll`.

- Remove the client-capability echo loop; advertise only the implemented producer capabilities.
- Remove the now-unused private `BlockTemplateRequest` parameter and its callers/imports.
- Delete the empty-request fixture helper that existed only for that parameter.
- Strengthen the regression request with `coinbasetxn`, an unknown client-only capability, and a duplicate supported capability. The exact expected producer list stays unchanged.
- Point `API-11` at `mining/candidate.rs`, its actual implementation owner.

Five changed files, +9 / -26 lines. No change to consensus validation, template selection, generation keys, persistence, mining defaults, or public request types.

## Verified final source

Published commit: `bb069d23c4714ef32fd0a37c5e5083b2639d6519`.
Exact full tree: `e04d9caa08b630b02e9cc15903348e815ce1f3dc`.

Passed before push with Rust 1.95.0:

```sh
cargo fmt -p bitcoin-rs-node -- --check
cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --all-targets -- -D warnings
cargo clippy --locked -p bitcoin-rs-node --no-default-features --features fjall,redb,zmq --all-targets -- -D warnings
cargo clippy --locked -p bitcoin-rs-node --no-default-features --features redb,zmq --all-targets -- -D warnings
cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --lib -- --test-threads=1
cargo test --locked -p bitcoin-rs-node --no-default-features --features fjall,zmq --test mining --test embed --test shutdown -- --test-threads=1
cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test overhaul_ownership --test overhaul_evidence -- --nocapture
cargo test --locked -p bitcoin-rs --no-default-features --features fjall --test g18_hot_path_ledger -- --nocapture
```

Results: 535 node unit tests; 38 mining integration tests; 3 embedding integration tests; 23 ownership/evidence tests; 21 hot-path-ledger tests. All passed. The standalone mining unit selection also passed 17 tests. The native shutdown target compiles but contains zero enabled tests; this is not runtime shutdown coverage.

Evidence: [per-stage native validation](https://github.com/gosuda/bitcoin-rs/actions/runs/34602393344) and [final exact-tree validation and successful publication](https://github.com/gosuda/bitcoin-rs/actions/runs/34603845234), artifact `node-publication-verified`. The final run re-executed all 535 unit tests, all 41 enabled integration tests, final Clippy, and ledger validation on every stage. Original logs and checksums are preserved in the artifact.

These results do not claim full-workspace, kernel, RocksDB, cross-platform, performance, or redb-only runtime-suite acceptance. The separate redb-only state-fixture limitation is recorded in #944. No tests were disabled to make this regression pass.

All four branches contain source-only, independently scoped commits. They were pushed in atomic batches within the repository's three-ref-per-push limit, without changing that policy. No workbench files, main writes, merges, or force-pushes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `getblocktemplate` response echoing client-requested capability names; it now advertises only the producer's implemented capabilities (`proposal`, `longpoll`) per API-11. No consensus, selection, or persistence behavior changes.

**Bug Fixes**

- Removes the client-capability echo loop and the now-unused `BlockTemplateRequest` parameter from `template_from_candidate`.
- Strengthens the regression test with an unknown client-only capability and a duplicate supported capability; expected producer list unchanged.
- Points API-11 ownership at `crates/node/src/mining/candidate.rs`.

<sup>Written for commit bb069d23c4714ef32fd0a37c5e5083b2639d6519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

