### PR TITLE
fix(node): bound txindex open cancellation and retain namespace exclusion

### DIFF
--- a/crates/node/src/txindex_worker.rs
+++ b/crates/node/src/txindex_worker.rs
@@ -141,17 +141,9 @@ const PREPARE_CHUNK_BYTES: usize = 32 << 20;
 const REVISION_QUIET_PERIOD: Duration = Duration::from_millis(100);
 const FORWARD_BATCH_DELAY: Duration = Duration::from_millis(100);
 
-/// Maximum time the txindex worker waits for the storage engine to open and
-/// recover the index store. A store open that exceeds this deadline is
-/// treated as a wedge — the worker publishes `Failed` so the node stays
-/// operable without the index rather than spinning one thread at 100% CPU
-/// indefinitely. The deadline is a backstop, not a tight bound: the issue's
-/// own data shows fjall/lsm-tree manifest recovery of a 139 GiB store logs
-/// progress within seconds and then, when wedged, freezes block I/O for
-/// hours. Thirty minutes is far below the observed wedge and far above any
-/// legitimate recovery, so it cannot falsely kill a slow-but-progressing
-/// open while still surfacing a stuck one. The 30-second heartbeat already
-/// makes a slow open observable to an operator watching logs.
+/// Upper bound on waiting for backend recovery. Timeout isolates the index
+/// failure from the node; it does not prove recovery stopped making progress.
+/// The backend helper cannot be cancelled, so abandonment poisons its namespace.
 const TXINDEX_OPEN_TIMEOUT: Duration = Duration::from_mins(30);
 
 /// Shared wake/revision/health state owned by `NodeState` and referenced by
@@ -558,6 +550,8 @@ enum ReconcileAction {
 enum TxIndexWorkerError {
     #[error("txindex worker stopped")]
     Stopped,
+    #[error("txindex store open abandoned on shutdown")]
+    OpenStopped,
     #[error("txindex durable watermark changed while a forward batch was pending")]
     PendingDurableChanged,
     #[error("txindex storage error: {0}")]
@@ -585,6 +579,11 @@ enum TxIndexWorkerError {
 }
 
 impl TxIndexWorkerError {
+    /// The backend helper may still hold or acquire the store after this error.
+    fn abandoned_open(&self) -> bool {
+        matches!(self, Self::OpenStopped | Self::OpenTimeout { .. })
+    }
+
     fn requires_capability_rebuild(&self) -> bool {
         matches!(
             self,

--- a/crates/node/src/txindex_worker/startup.rs
+++ b/crates/node/src/txindex_worker/startup.rs
@@ -34,7 +34,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
-use std::time::Instant;
 
 /// Worker-owned open: opens the store, constructs writer/reader/engine,
 /// publishes lifecycle, and runs reconciliation — all behind one
@@ -108,16 +107,35 @@ pub(super) fn run_worker_with_open(
 
     heartbeat.stop_and_join();
 
-    match worker_result {
-        Ok(()) => {
-            registry.release(&namespace_key, generation.id());
+    finish_worker(
+        runtime,
+        lifecycle,
+        generation,
+        &namespace_key,
+        worker_result,
+    );
+}
+
+/// Report the terminal outcome before releasing its namespace claim.
+/// An abandoned backend may still touch the store, so its claim must stay
+/// poisoned for the process lifetime (`IDX-07`).
+fn finish_worker(
+    runtime: &TxIndexRuntime,
+    lifecycle: &Arc<ArcSwap<TxIndexLifecycle>>,
+    generation: &Generation,
+    namespace_key: &Path,
+    result: Result<(), TxIndexWorkerError>,
+) {
+    let registry = &*NAMESPACE_REGISTRY;
+    if let Err(error) = result {
+        if error.abandoned_open() {
+            registry.poison(namespace_key, generation.id());
         }
-        Err(error) => {
-            tracing::error!(%error, "txindex worker open or run failed");
-            fail_worker(runtime, lifecycle, generation, &error.to_string());
-            registry.release(&namespace_key, generation.id());
-        }
+        tracing::error!(%error, "txindex worker open or run failed");
+        fail_worker(runtime, lifecycle, generation, &error.to_string());
     }
+    // Release is generation-checked and never removes a poisoned claim.
+    registry.release(namespace_key, generation.id());
 }
 
 /// Fails the worker as one unit: the runtime stops the loop and gates the
@@ -190,7 +208,7 @@ pub(super) fn open_and_run(
         spec.epoch,
         Duration::ZERO,
         TXINDEX_OPEN_TIMEOUT,
-        shutdown,
+        || shutdown.load(Ordering::Acquire) || generation.is_revoked() || runtime.should_stop(),
     )?;
 
     // Check shutdown and generation immediately after backend open returns.
@@ -263,8 +281,12 @@ pub(super) fn open_tx_index_with_timeout(
     epoch: u64,
     open_delay: Duration,
     open_timeout: Duration,
-    shutdown: &Arc<AtomicBool>,
+    should_stop: impl Fn() -> bool,
 ) -> Result<OpenTxIndex, TxIndexWorkerError> {
+    // No helper exists yet: cancellation here can release the namespace.
+    if should_stop() {
+        return Err(TxIndexWorkerError::Stopped);
+    }
     let (tx, rx) = std::sync::mpsc::channel();
     let backend = storage_backend;
     let dir = txindex_dir.to_path_buf();
@@ -276,39 +298,16 @@ pub(super) fn open_tx_index_with_timeout(
         })
         .map_err(|e| TxIndexWorkerError::Storage(bitcoin_rs_storage::StorageError::Io(e)))?;
 
-    // Poll in short slices so a shutdown during the open deadline
-    // exits promptly instead of waiting the full timeout.
-    let timeout = open_timeout;
-    let deadline = Instant::now() + timeout;
-    loop {
-        if shutdown.load(Ordering::Acquire) {
-            return Err(TxIndexWorkerError::Stopped);
-        }
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            tracing::error!(
-                timeout_secs = timeout.as_secs(),
-                backend = %storage_backend,
-                dir = %txindex_dir.display(),
-                "txindex store open timed out — the storage engine recovery \
-                 appears stuck; detaching the open thread and publishing Failed"
-            );
-            return Err(TxIndexWorkerError::OpenTimeout {
-                secs: timeout.as_secs(),
-            });
-        }
-        match rx.recv_timeout(remaining) {
-            Ok(result) => return result,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                return Err(TxIndexWorkerError::Storage(
-                    bitcoin_rs_storage::StorageError::Backend(
-                        "txindex open helper thread exited without result".to_owned(),
-                    ),
-                ));
-            }
-        }
+    let result = open_wait::wait_for_open_result(&rx, open_timeout, should_stop);
+    if matches!(&result, Err(TxIndexWorkerError::OpenTimeout { .. })) {
+        tracing::error!(
+            timeout_secs = open_timeout.as_secs(),
+            backend = %storage_backend,
+            dir = %txindex_dir.display(),
+            "txindex store open timed out; detaching the open helper and poisoning its namespace"
+        );
     }
+    result
 }
 
 /// Opens the txindex store on the worker thread through the namespace's single
@@ -353,3 +352,8 @@ where
         batch_limits,
     })
 }
+
+mod open_wait;
+
+#[cfg(test)]
+mod tests;

--- a/crates/node/src/txindex_worker/startup/open_wait.rs
+++ b/crates/node/src/txindex_worker/startup/open_wait.rs
@@ -1,0 +1,42 @@
+//! Bounded observation of a non-cancellable backend open.
+
+use super::{OpenTxIndex, TxIndexWorkerError};
+use std::time::{Duration, Instant};
+
+/// Maximum gap between cancellation checks while backend recovery is pending.
+const OPEN_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// The caller must retain namespace exclusion for abandoned-open errors.
+pub(super) fn wait_for_open_result(
+    receiver: &std::sync::mpsc::Receiver<Result<OpenTxIndex, TxIndexWorkerError>>,
+    timeout: Duration,
+    should_stop: impl Fn() -> bool,
+) -> Result<OpenTxIndex, TxIndexWorkerError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        // Shutdown wins even when its observation coincides with the deadline.
+        if should_stop() {
+            return Err(TxIndexWorkerError::OpenStopped);
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(TxIndexWorkerError::OpenTimeout {
+                secs: timeout.as_secs(),
+            });
+        }
+        match receiver.recv_timeout(remaining.min(OPEN_POLL_INTERVAL)) {
+            Ok(result) => return result,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(TxIndexWorkerError::Storage(
+                    bitcoin_rs_storage::StorageError::Backend(
+                        "txindex open helper thread exited without result".to_owned(),
+                    ),
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/node/src/txindex_worker/startup/open_wait/tests.rs
+++ b/crates/node/src/txindex_worker/startup/open_wait/tests.rs
@@ -1,0 +1,91 @@
+//! IDX-07 / IDX-08: cancellation is bounded without pretending to cancel a backend.
+
+use super::super::open_tx_index_with_timeout;
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+
+#[test]
+fn pending_open_rechecks_shutdown_before_the_open_deadline() {
+    let (open_tx, open_rx) = mpsc::channel();
+    let (done_tx, done_rx) = mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        let checks = AtomicUsize::new(0);
+        let result = wait_for_open_result(&open_rx, Duration::from_secs(30), || {
+            // Stop on the second check, after one pending receive. No scheduler
+            // race or storage-engine sleep is needed to put the wait in flight.
+            checks.fetch_add(1, Ordering::Relaxed) > 0
+        });
+        let _ = done_tx.send(result);
+    });
+    let result = done_rx.recv_timeout(Duration::from_secs(2));
+    // Unblock even the old, uncapped receive before asserting, so a regression
+    // fails promptly rather than leaking a 30-second test thread.
+    drop(open_tx);
+    assert!(worker.join().is_ok());
+    assert!(matches!(result, Ok(Err(TxIndexWorkerError::OpenStopped))));
+}
+
+#[test]
+fn shutdown_wins_over_an_expired_open_deadline() {
+    let (_tx, rx) = mpsc::channel();
+    assert!(matches!(
+        wait_for_open_result(&rx, Duration::ZERO, || true),
+        Err(TxIndexWorkerError::OpenStopped)
+    ));
+}
+
+#[test]
+fn expired_open_deadline_is_typed() {
+    let (_tx, rx) = mpsc::channel();
+    assert!(matches!(
+        wait_for_open_result(&rx, Duration::ZERO, || false),
+        Err(TxIndexWorkerError::OpenTimeout { secs: 0 })
+    ));
+}
+
+#[test]
+fn disconnected_open_helper_is_a_storage_failure() {
+    let (tx, rx) = mpsc::channel();
+    drop(tx);
+    assert!(matches!(
+        wait_for_open_result(&rx, Duration::from_secs(1), || false),
+        Err(TxIndexWorkerError::Storage(bitcoin_rs_storage::StorageError::Backend(reason)))
+            if reason == "txindex open helper thread exited without result"
+    ));
+}
+
+#[test]
+fn backend_error_is_preserved_without_becoming_abandonment() {
+    let (tx, rx) = mpsc::channel();
+    assert!(
+        tx.send(Err(TxIndexWorkerError::Storage(
+            bitcoin_rs_storage::StorageError::InvalidOperation("backend sentinel")
+        )))
+        .is_ok()
+    );
+    assert!(matches!(
+        wait_for_open_result(&rx, Duration::from_secs(1), || false),
+        Err(TxIndexWorkerError::Storage(
+            bitcoin_rs_storage::StorageError::InvalidOperation("backend sentinel")
+        ))
+    ));
+}
+
+#[test]
+fn shutdown_before_helper_creation_never_touches_the_store() -> std::io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("must-not-be-created");
+    let result = open_tx_index_with_timeout(
+        bitcoin_rs_storage::StorageBackend::Fjall,
+        &path,
+        8 << 20,
+        1,
+        Duration::ZERO,
+        Duration::from_secs(30),
+        || true,
+    );
+    assert!(matches!(result, Err(TxIndexWorkerError::Stopped)));
+    assert!(!path.exists());
+    Ok(())
+}

--- a/crates/node/src/txindex_worker/startup/tests.rs
+++ b/crates/node/src/txindex_worker/startup/tests.rs
@@ -1,0 +1,47 @@
+//! IDX-07: supervision owns namespace release after terminal worker outcomes.
+
+use super::*;
+
+/// IDX-07: a detached backend may still access the namespace after its worker exits.
+#[test]
+fn abandoned_open_outcomes_poison_the_namespace_before_release() -> std::io::Result<()> {
+    for error in [
+        TxIndexWorkerError::OpenStopped,
+        TxIndexWorkerError::OpenTimeout { secs: 1 },
+    ] {
+        let dir = tempfile::tempdir()?;
+        let key = dir.path().join("txindex");
+        let generation = Generation::new(1);
+        let runtime = TxIndexRuntime::new(crossbeam_channel::bounded(1).0);
+        let lifecycle = Arc::new(ArcSwap::from_pointee(TxIndexLifecycle::Opening));
+        assert!(NAMESPACE_REGISTRY.claim(key.clone(), generation.id()));
+        finish_worker(&runtime, &lifecycle, &generation, &key, Err(error));
+        assert!(runtime.should_stop());
+        assert!(matches!(**lifecycle.load(), TxIndexLifecycle::Failed(_)));
+        assert!(NAMESPACE_REGISTRY.is_poisoned(&key));
+        assert!(!NAMESPACE_REGISTRY.claim(key, 2));
+    }
+    Ok(())
+}
+
+/// IDX-07: completed workers and failures with no detached helper can release.
+#[test]
+fn completed_worker_outcomes_release_without_poisoning() -> std::io::Result<()> {
+    for result in [
+        Ok(()),
+        Err(TxIndexWorkerError::Stopped),
+        Err(TxIndexWorkerError::NoBodyStore),
+    ] {
+        let dir = tempfile::tempdir()?;
+        let key = dir.path().join("txindex");
+        let generation = Generation::new(1);
+        let runtime = TxIndexRuntime::new(crossbeam_channel::bounded(1).0);
+        let lifecycle = Arc::new(ArcSwap::from_pointee(TxIndexLifecycle::Opening));
+        assert!(NAMESPACE_REGISTRY.claim(key.clone(), generation.id()));
+        finish_worker(&runtime, &lifecycle, &generation, &key, result);
+        assert!(!NAMESPACE_REGISTRY.is_poisoned(&key));
+        assert!(NAMESPACE_REGISTRY.claim(key.clone(), 2));
+        NAMESPACE_REGISTRY.release(&key, 2);
+    }
+    Ok(())
+}

--- a/crates/node/src/txindex_worker_integration_tests.rs
+++ b/crates/node/src/txindex_worker_integration_tests.rs
@@ -603,7 +603,7 @@ fn open_timeout_publishes_error_not_infinite_spin() {
         1,
         Duration::from_secs(10),
         Duration::from_secs(1),
-        &shutdown,
+        || shutdown.load(Ordering::Acquire),
     );
 
     let Err(TxIndexWorkerError::OpenTimeout { secs }) = result else {

--- a/docs/contracts/indexing.md
+++ b/docs/contracts/indexing.md
@@ -253,3 +253,17 @@ remove another script's output.
 historical/live byte budget, independent row/scan/body-read admission limits,
 rejection of truncated scans, and non-consuming rejection of over-budget work
 (`IDX-03`, `CL-14`). No query limit or persisted representation changes.
+
+### Store-open cancellation evidence
+
+The store-open wait polls node shutdown, runtime stop, and generation revocation
+at bounded intervals. Once the helper has started, cancellation and timeout are
+typed abandoned-open outcomes: startup poisons the namespace before releasing
+the worker's claim. Cancellation before helper creation may release normally.
+These paths do not cancel the underlying storage-engine call.
+
+Evidence for `IDX-07` abandonment and `IDX-08` shutdown:
+`crates/node/src/txindex_worker/startup/open_wait/tests.rs` covers bounded
+cancellation, deadline precedence, disconnection, and backend error propagation;
+`crates/node/src/txindex_worker/startup/tests.rs` covers namespace poisoning and
+clean release. The query-budget limits and on-disk formats are unchanged.


### PR DESCRIPTION
## Stack and scope

Stacked on #946 so the behavior change is reviewable separately from the query cleanup. Merge #946 first, then retarget this PR to `main`; do not merge this follow-up into the refactor branch merely to land both changes together.

Exact source commit: `4c3450d55d1aca6c9539c9f7ee6a454d5806275e`.
Parent: `84da525ca6fa44bb0c53b895fe0340ce1c92c725`.

## Problem

The existing store-open loop said it polled shutdown in short slices but called `recv_timeout(remaining)`, which could block for the entire remaining 30-minute open deadline. Returning from that wait does not cancel the backend helper. Releasing the namespace after abandonment could therefore admit another opener while the detached helper still holds or acquires the same store.

## Changes

- Extract the bounded receive loop into the private `startup/open_wait.rs` owner. Each blocking wait is capped at 100 ms and rechecks node shutdown, runtime stop, and generation revocation.
- Distinguish cancellation before helper creation (`Stopped`, safe to release) from cancellation after helper creation (`OpenStopped`, abandoned backend). Keep timeout typed as `OpenTimeout`, and preserve backend/disconnection failures.
- Centralize terminal namespace handling in `finish_worker`. Poison an abandoned-open namespace before releasing the worker claim; the existing generation-checked registry keeps poisoned claims excluded for the process lifetime.
- Remove the unsupported claim that a recovery timeout proves a storage engine is wedged. Document that the helper cannot be cancelled.
- Add eight focused regression tests and update the indexing contract's evidence map.

No persisted format, schema, dependency, query-budget, batch-limit, or 30-minute recovery-deadline changes. This deliberately retains the existing process-lifetime namespace exclusion policy rather than pretending that dropping the receiver cancels backend recovery.

## Validation

Completed before pushing this source branch in the isolated [validation run](https://github.com/gosuda/bitcoin-rs/actions/runs/34603714053):

```sh
cargo fmt --all -- --check
cargo clippy --locked -p bitcoin-rs-node --no-default-features \
  --features fjall,redb,zmq --all-targets -- -D warnings
cargo test --locked -p bitcoin-rs-node --no-default-features \
  --features fjall,redb,zmq --lib txindex_worker -- --nocapture
```

All passed; **79 txindex tests passed**, including all existing worker regressions and the eight new shutdown/namespace tests. `git diff --check` also passed.

### Regression sensitivity

The same run temporarily restored the original uncapped receive. `pending_open_rechecks_shutdown_before_the_open_deadline` then failed as expected. The correct source was restored and verified before commit. This negative-control result is preserved in `open-negative-control.log` and is not a failure of the published candidate.

### Scope and known baseline failure

The parent refactor additionally passed the index crate suite (**96 tests**). Its `overhaul_ownership` audit reported **16 passed / 1 failed**, with the identical `mempool_writer_source_scan_passes` diagnostic reproduced against pristine main `7f5a460de67965ff36955bab1434c75f080ad384`: the existing `mempool_gateway.remove_for_block(` call at `crates/node/src/apply/connect.rs:538`. That audit is not represented as a green gate, and this PR does not change the audit or mempool code.

The `txindex-final-evidence` artifact contains both source patches, exact commits, compiler version, source archive, and validation logs. No temporary workbench scripts or workflow changes are included in either PR. RocksDB-specific execution and full-workspace behavioral tests are not claimed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes txindex store-open waits that could block for the entire 30‑minute deadline and ensures abandoned opens keep their namespace excluded so a second opener cannot race a detached backend helper.

- **Bug Fixes**
  - The open wait now polls shutdown, runtime stop, and generation revocation every 100 ms instead of using a single uncapped `recv_timeout`.
  - Cancellation before helper creation returns `Stopped` (safe to release); cancellation after helper creation returns `OpenStopped` (abandoned backend).
  - Abandoned opens poison the namespace before releasing the worker claim, keeping it excluded for the process lifetime.
  - Removed the claim that a recovery timeout proves the storage engine is wedged; the backend helper cannot be cancelled.
  - Added 8 regression tests and updated the indexing contract with the new cancellation evidence.

No persisted format, schema, dependency, or deadline changes.

<sup>Written for commit 4c3450d55d1aca6c9539c9f7ee6a454d5806275e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

