### PR TITLE
Fix(rpc): scope compat template proof off mainnet gates

### DIFF
--- a/crates/rpc/tests/core_compat.rs
+++ b/crates/rpc/tests/core_compat.rs
@@ -370,8 +370,12 @@ impl MiningControl for CompatMiningControl {
 
 #[test]
 fn mining_responses_deserialize_into_pinned_types() -> Result<(), Box<dyn std::error::Error>> {
+    // API-12 mainnet gates (peers + IBD) live in the handler unit tests.
+    // This rendering proof runs off-mainnet so it reaches the template.
+    let mut ctx = Context::new();
+    ctx.chain_network = Network::Regtest;
     let handler = Handler::new(Arc::new(
-        Context::new().with_mining_control(Arc::new(CompatMiningControl)),
+        ctx.with_mining_control(Arc::new(CompatMiningControl)),
     ));
 
     let template: corepc_types::v31::GetBlockTemplate =


### PR DESCRIPTION
Main is red: mining_responses_deserialize_into_pinned_types fails with ClientNotConnected since #479's API-12 mainnet gates landed (peerless mainnet ctx rejected). This rendering proof runs on regtest; gate behavior stays covered by the handler unit tests. Verified: core_compat 7/7 green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `mining_responses_deserialize_into_pinned_types` failing on main after the API-12 mainnet gates landed. The rendering proof now runs on regtest so it reaches the template; gate behavior stays covered by the handler unit tests.

<sup>Written for commit 693bf30aa6f7059cdc775180f9e0f93806edec6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

