### PR TITLE
Fix(node): restore server-owned template capabilities

### DIFF
--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -27,7 +27,10 @@ const AUTHORIZED_GATEWAY_CALLS: &[(&str, &str)] = &[
         "handles.mempool_gateway",
     ),
     // Reorg transaction reconsideration uses the same typed gateway owner.
-    ("crates/node/src/reorg/execution.rs", "handles.mempool_gateway"),
+    (
+        "crates/node/src/reorg/execution.rs",
+        "handles.mempool_gateway",
+    ),
 ];
 
 /// Mutating methods on `Mempool` that only the mempool owner may call from

--- a/crates/node/src/mining/candidate.rs
+++ b/crates/node/src/mining/candidate.rs
@@ -16,7 +16,6 @@ use bitcoin_rs_mempool::MempoolMiningSnapshot;
 use bitcoin_rs_mempool::SnapshotEntry;
 use bitcoin_rs_mining::AvailableMiningRule;
 use bitcoin_rs_mining::BlockTemplate;
-use bitcoin_rs_mining::BlockTemplateRequest;
 use bitcoin_rs_mining::BlockValidationResult;
 use bitcoin_rs_mining::Candidate;
 use bitcoin_rs_mining::CandidateContext;
@@ -333,7 +332,6 @@ impl MiningCoordinator {
     pub(super) fn template_from_candidate(
         network: Network,
         candidate: Arc<Candidate>,
-        request: &BlockTemplateRequest,
         submit_old: Option<bool>,
         version_bits_available: Vec<AvailableMiningRule>,
         version_bits_required: u32,
@@ -352,24 +350,15 @@ impl MiningCoordinator {
         if signet.is_some() {
             rules.push(MiningRule::new("signet"));
         }
-        let mut capabilities = vec![
-            MiningCapability::new("proposal"),
-            MiningCapability::new("longpoll"),
-        ];
-        for capability in &request.capabilities {
-            if !capabilities
-                .iter()
-                .any(|known| known.as_str() == capability.as_str())
-            {
-                capabilities.push(capability.clone());
-            }
-        }
         BlockTemplate {
-            candidate,
             rules,
+            candidate,
             version_bits_available,
             version_bits_required,
-            capabilities,
+            capabilities: vec![
+                MiningCapability::new("proposal"),
+                MiningCapability::new("longpoll"),
+            ],
             mutable: vec![
                 TemplateMutation::Time,
                 TemplateMutation::Transactions,

--- a/crates/node/src/mining/candidate_template_tests.rs
+++ b/crates/node/src/mining/candidate_template_tests.rs
@@ -105,15 +105,6 @@ fn sample_candidate(previous: Hash256, csv_active: bool, segwit_active: bool) ->
     }
 }
 
-fn empty_request() -> bitcoin_rs_mining::BlockTemplateRequest {
-    bitcoin_rs_mining::BlockTemplateRequest {
-        mode: bitcoin_rs_mining::BlockTemplateMode::Template,
-        capabilities: Vec::new(),
-        rules: Vec::new(),
-        long_poll_id: None,
-    }
-}
-
 fn template_for(
     candidate: Candidate,
     submit_old: Option<bool>,
@@ -121,7 +112,6 @@ fn template_for(
     super::MiningCoordinator::template_from_candidate(
         Network::Regtest,
         Arc::new(candidate),
-        &empty_request(),
         submit_old,
         Vec::new(),
         0,
@@ -179,7 +169,6 @@ fn signet_template_carries_challenge_and_mandatory_rule() {
             true,
             true,
         )),
-        &empty_request(),
         None,
         Vec::new(),
         0,

--- a/crates/node/src/mining/control.rs
+++ b/crates/node/src/mining/control.rs
@@ -129,7 +129,6 @@ impl MiningControl for MiningCoordinator {
                 let template = Self::template_from_candidate(
                     self.network,
                     candidate,
-                    &request,
                     submit_old,
                     version_bits_available,
                     version_bits_required,


### PR DESCRIPTION
Main node mining suite is red: template_does_not_echo_client_capabilities fails since #479's capabilities echo landed. Core advertises server capabilities; echoing client caps contradicts the pinned contract. Revert to the fixed server set. Also takes rustfmt's ownership_scan.rs layout (main fmt lane). Verified: node mining lib 22/22, contract test green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores server-owned GBT capabilities so the node template no longer echoes client capabilities. The mining contract requires the server to advertise only its fixed capabilities; echoing client caps broke `template_does_not_echo_client_capabilities` and made the node mining suite red.

**Notes**
- Applies rustfmt layout to `bin/bitcoin-rs/tests/support/ownership_scan.rs`.

<sup>Written for commit 762020187a48093b2b054d139c5619ca9f761333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

