### PR TITLE
Remove CONTRIBUTING.md link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,6 @@ verification commands, CI workflows, and crate architecture conventions.
 - [docs/contracts/](docs/contracts/) — Normative architecture and protocol contracts
 - [CONCEPTS.md](CONCEPTS.md) — Domain terminology and concepts
 
-- [CONTRIBUTING.md](CONTRIBUTING.md) — Development workflow and CI guidelines
-
 ## License
 
 Dual-licensed under [MIT](LICENSE-MIT) OR [Apache-2.0](LICENSE-APACHE). See


### PR DESCRIPTION
Removed link to CONTRIBUTING.md from the README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the CONTRIBUTING.md link from the README so the file list no longer references a contributing guide that doesn't exist.

<sup>Written for commit ec6462061e3c75c289f17b069e4ef2e0be2ab047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

