### PR TITLE
Fix(ci): teach ownership scan multiline receivers

### DIFF
--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -378,18 +378,17 @@ fn is_authorized_gateway_call(
             if trimmed.is_empty() {
                 continue;
             }
-            match trimmed.strip_prefix('.') {
-                Some(link) => parts.push(link.trim()),
-                None => {
-                    parts.push(
-                        trimmed
-                            .split_whitespace()
-                            .next_back()
-                            .unwrap_or(trimmed)
-                            .trim_end_matches(';'),
-                    );
-                    break;
-                }
+            if let Some(link) = trimmed.strip_prefix('.') {
+                parts.push(link.trim());
+            } else {
+                parts.push(
+                    trimmed
+                        .split_whitespace()
+                        .next_back()
+                        .unwrap_or(trimmed)
+                        .trim_end_matches(';'),
+                );
+                break;
             }
         }
         parts.reverse();

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -27,7 +27,10 @@ const AUTHORIZED_GATEWAY_CALLS: &[(&str, &str)] = &[
         "handles.mempool_gateway",
     ),
     // Reorg transaction reconsideration uses the same typed gateway owner.
-    ("crates/node/src/reorg/execution.rs", "handles.mempool_gateway"),
+    (
+        "crates/node/src/reorg/execution.rs",
+        "handles.mempool_gateway",
+    ),
 ];
 
 /// Mutating methods on `Mempool` that only the mempool owner may call from
@@ -356,19 +359,44 @@ fn is_authorized_gateway_call(
     }
 
     let before = &line[..method_pos];
-    let receiver = match before.rfind('.') {
+    // Resolve the receiver chain. A call split across lines leaves only a
+    // leading dot on the method line, so accumulate continuation lines above
+    // that start with '.' and anchor on the chain root's trailing expression.
+    // Single-line receivers keep their last whitespace-delimited token, which
+    // drops statement prefixes such as `let _ =`.
+    let fragment = match before.rfind('.') {
         Some(dot_pos) => before[..dot_pos].trim(),
         None => before.trim(),
     };
-    let receiver = if receiver.is_empty() {
-        lines[..line_index]
-            .iter()
-            .rev()
-            .map(|previous| previous.trim())
-            .find(|previous| !previous.is_empty())
-            .unwrap_or("")
+    let chained: String;
+    let receiver: &str = if fragment.contains(char::is_whitespace) {
+        fragment.split_whitespace().next_back().unwrap_or(fragment)
+    } else if fragment.is_empty() {
+        let mut parts: Vec<&str> = Vec::new();
+        for previous in lines[..line_index].iter().rev() {
+            let trimmed = previous.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match trimmed.strip_prefix('.') {
+                Some(link) => parts.push(link.trim()),
+                None => {
+                    parts.push(
+                        trimmed
+                            .split_whitespace()
+                            .next_back()
+                            .unwrap_or(trimmed)
+                            .trim_end_matches(';'),
+                    );
+                    break;
+                }
+            }
+        }
+        parts.reverse();
+        chained = parts.join(".");
+        &chained
     } else {
-        receiver
+        fragment
     };
 
     let normalized_path = path.replace('\\', "/");
@@ -472,6 +500,37 @@ mod tests {
             (
                 owner,
                 "handles.mempool_gateway.write().remove_for_block(origin, txs, txids, height);",
+                1,
+            ),
+        ] {
+            let mut result = empty_result();
+            scan_source(path, call, &mut result);
+            assert_eq!(
+                result.violations.len(),
+                expected_violations,
+                "{path}: {call}"
+            );
+            assert_eq!(result.mutating_calls_found, 1);
+        }
+    }
+
+    #[test]
+    fn multiline_receiver_chain_resolves_to_its_root() {
+        let owner = "/workspace/crates/node/src/reorg/execution.rs";
+        for (path, call, expected_violations) in [
+            (
+                owner,
+                "let _ = handles\n.mempool_gateway\n.reconsider_disconnected(origin, entries);",
+                0,
+            ),
+            (
+                owner,
+                "let _ = other\n.mempool_gateway\n.reconsider_disconnected(origin, entries);",
+                1,
+            ),
+            (
+                NON_OWNER,
+                "let _ = handles\n.mempool_gateway\n.reconsider_disconnected(origin, entries);",
                 1,
             ),
         ] {


### PR DESCRIPTION
Main overhaul_ownership is red: mempool_writer_source_scan_passes flags the blessed reorg reconsider_disconnected call because the scan resolves a split chain to '.mempool_gateway'. Accumulate continuation links; anchor on the chain root. Pinned by multiline_receiver_chain_resolves_to_its_root. Verified: 19/19 ownership tests, fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ownership scan so multiline receiver chains resolve to their chain root, stopping rustfmt-split calls from being flagged as unauthorized.

**Bug Fixes**
- The scan now accumulates continuation lines starting with `.` and anchors on the chain root instead of resolving to a leading-dot fragment.
- Single-line receivers keep their last whitespace-delimited token, which drops statement prefixes such as `let _ =`.

<sup>Written for commit 9edd23a8f1cd2cb0a8bb5777eed8a5979d1dcf1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

