### PR TITLE
Emit Core getblocktemplate coinbaseaux.flags empty hex

### DIFF
--- a/crates/node/tests/mining.rs
+++ b/crates/node/tests/mining.rs
@@ -598,6 +598,7 @@ fn proposal_rejects_excess_coinbase_without_side_effects() -> anyhow::Result<()>
     Ok(())
 }
 
+// CONTRACT: API-19
 #[test]
 fn proposal_without_coinbase_is_bad_cb_missing() -> anyhow::Result<()> {
     let state = open_regtest()?;
@@ -620,6 +621,7 @@ fn proposal_without_coinbase_is_bad_cb_missing() -> anyhow::Result<()> {
     Ok(())
 }
 
+// CONTRACT: API-19
 #[test]
 fn proposal_merkle_mismatch_is_bad_txnmrklroot() -> anyhow::Result<()> {
     let state = open_regtest()?;
@@ -638,6 +640,7 @@ fn proposal_merkle_mismatch_is_bad_txnmrklroot() -> anyhow::Result<()> {
     Ok(())
 }
 
+// CONTRACT: API-21
 #[test]
 fn proposal_commitment_without_witness_nonce_is_bad_witness_nonce_size() -> anyhow::Result<()> {
     let state = open_regtest()?;
@@ -671,6 +674,7 @@ fn proposal_commitment_without_witness_nonce_is_bad_witness_nonce_size() -> anyh
     Ok(())
 }
 
+// CONTRACT: API-21
 #[test]
 fn proposal_witness_without_commitment_is_unexpected_witness() -> anyhow::Result<()> {
     let state = open_regtest()?;
@@ -708,6 +712,7 @@ fn proposal_witness_without_commitment_is_unexpected_witness() -> anyhow::Result
     Ok(())
 }
 
+// CONTRACT: API-21
 #[test]
 fn proposal_wrong_witness_commitment_is_bad_witness_merkle_match() -> anyhow::Result<()> {
     let state = open_regtest()?;
@@ -1206,6 +1211,7 @@ fn propose_block(
     }
 }
 
+// CONTRACT: API-18
 #[test]
 fn proposal_of_an_applied_block_is_duplicate() -> anyhow::Result<()> {
     let state = open_regtest()?;
@@ -1220,6 +1226,7 @@ fn proposal_of_an_applied_block_is_duplicate() -> anyhow::Result<()> {
     Ok(())
 }
 
+// CONTRACT: API-18
 #[test]
 fn proposal_of_an_invalid_header_is_duplicate_invalid() -> anyhow::Result<()> {
     use bitcoin_rs_chain::NodeStatus;
@@ -1248,6 +1255,7 @@ fn proposal_of_an_invalid_header_is_duplicate_invalid() -> anyhow::Result<()> {
     Ok(())
 }
 
+// CONTRACT: API-18
 #[test]
 fn proposal_of_a_header_only_block_is_duplicate_inconclusive() -> anyhow::Result<()> {
     use bitcoin_rs_chain::NodeStatus;


### PR DESCRIPTION
Replacement for #586, retargeted to `main`.

#586's base (`cursor/mining-submit-witness-1522`) is a dead stacked link: its only PR (#535) merged on 2026-09-04 and its content is already on `main`, but the branch was never deleted, so #586 stayed pinned to it and GitHub's stack guard (open children #593/#591) blocked retargeting via both GraphQL and REST. The merge queue requires a `main` base, so this PR re-opens the same head against `main`. Will close #586 once this is enqueued.

Freshness-merged `origin/main` twice (through #474 and #475); tree diff vs `main` is exactly the 8 `// CONTRACT:` annotation lines in `crates/node/tests/mining.rs` (the code itself landed via the #499/#468/#594 lineage).

## Why

Core v31 `getblocktemplate` always emits `coinbaseaux: { "flags": HexStr(COINBASE_FLAGS) }`. The flags bytes are empty, so the hex string is `""`. We were projecting an empty object.

## Contract (`API-18`)

Owner: `render_block_template` in `crates/rpc/src/handlers/mining.rs`.

## Proof

- `getblocktemplate_renders_candidate_and_reuses_control_result` asserts `coinbaseaux.flags == ""`
- `mining_responses_deserialize_into_pinned_types` asserts the pinned v31 map
- 8 `// CONTRACT: API-18/API-19/API-21` annotations added to the proposal/submitblock tests in `crates/node/tests/mining.rs`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `// CONTRACT:` annotations to the mining proposal and submitblock tests, linking each test to the external API contract it covers (API-18, API-19, API-21). This is documentation only—no test or runtime behavior changes.

<sup>Written for commit c3398667c827804cb44a210e8b37cca787cb0bf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

