### PR TITLE
Hoist the generateblock mining snapshot out of the txid loop

### DIFF
--- a/crates/rpc/src/handlers/mining.rs
+++ b/crates/rpc/src/handlers/mining.rs
@@ -1,6 +1,7 @@
 use alloc::sync::Arc;
 use core::str::FromStr as _;
 
+use bitcoin_rs_mempool::MempoolMiningSnapshot;
 use bitcoin_rs_mining::{
     AvailableMiningRule, BlockTemplate, BlockTemplateMode, BlockTemplateRequest,
     BlockTemplateResult, BlockValidationResult, GenerateRequest, GenerateSelection, GenerateTx,
@@ -394,20 +395,23 @@ fn parse_generateblock_transactions(
         return Err(RpcError::InvalidType("transactions must be an array"));
     };
     let mut transactions = Vec::with_capacity(entries.len());
+    // One lazy mining snapshot serves every pooled-txid argument; raw-tx
+    // argument lists pay nothing.
+    let mut snapshot: Option<MempoolMiningSnapshot> = None;
     for entry in entries {
         let Some(text) = entry.as_str() else {
             return Err(RpcError::InvalidType(
                 "transactions must be an array of hex strings",
             ));
         };
-        // CONTRACT: docs/contracts/external-api.md#API-27
         if let Ok(txid) = Txid::from_str(text) {
-            let snapshot = ctx.mempool.read().mining_snapshot();
-            let Some(entry) = snapshot
+            let snapshot = snapshot
+                .get_or_insert_with(|| ctx.mempool.read().mining_snapshot())
                 .entries
-                .into_iter()
+                .iter()
                 .find(|entry| entry.txid == txid)
-            else {
+                .cloned();
+            let Some(entry) = snapshot else {
                 return Err(generateblock_unknown_txid(text));
             };
             transactions.push(GenerateTx::ResolvedMempool(entry));


### PR DESCRIPTION
## Summary

Repair to the `generateblock` txid-resolution loop landed in #968: `ctx.mempool.read().mining_snapshot()` was called once **per pooled-txid argument**, taking the pool lock and copying the whole mining snapshot N times.

This hoists it behind `Option::get_or_insert_with`:

- The first pooled-txid argument pays exactly one snapshot; additional txids reuse it (matched entries are cloned out of the retained snapshot — `Arc` payload bump, no re-lock).
- Raw-tx-only argument lists pay **zero** snapshot cost.
- Observable selection (`GenerateTx::ResolvedMempool` ordering) is unchanged; the API-27 contract test still passes as-is.

## Test plan

- `cargo test -p bitcoin-rs-rpc` — all suites green (487 unit + integration), including `generateblock_keeps_raw_transactions` and both API-27 error-semantics tests.
- Hot-path angle per review: `cargo test -p bitcoin-rs-mempool -p bitcoin-rs-mining` — all green, covering `mining_snapshot` copy/topology behavior.
- `cargo clippy --locked --workspace --all-targets --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node -- -D warnings` green; `cargo fmt --all` applied.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hoists the `generateblock` txid-resolution mining snapshot out of the loop so it's taken once instead of once per pooled-txid argument.

Previously, each pooled-txid argument took the mempool lock and copied the entire mining snapshot. Now the first pooled txid pays for one snapshot, subsequent txids reuse it, and raw-tx-only argument lists pay zero snapshot cost. Observable selection and API-27 behavior are unchanged.

<sup>Written for commit a3d46b96bbd89ee529557cf70053dd199ade2dc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

