### PR TITLE
Repair dependency-range minimal lane for the rocksdb bindgen probe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,6 +227,11 @@ jobs:
       # `cargo check --workspace --all-targets` compiles the C++ kernel
       # engine; install its prerequisites.
       - run: sudo apt-get update && sudo apt-get install -y libboost-dev cmake
+      # The minimal lane checks `--all-features`, which enables the `rocksdb`
+      # backend; its bindgen build scripts probe libclang. The maximum lane
+      # uses default features and never builds bindgen, so this stays gated.
+      - run: sudo apt-get install -y libclang-dev
+        if: matrix.range == 'minimal'
       - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
       - uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly
         if: matrix.range == 'minimal'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,12 @@ workflow, coding standards, and verification commands used across the project.
   binary excludes `libbitcoinkernel`, but this does not make every dependency
   Rust-only.
 - Kernel-enabled checks additionally require CMake and Boost headers
-  (`cmake` and `libboost-dev` on Debian/Ubuntu). The consensus and node library
-  crates enable `kernel` by default; the binary does not. The exact defaults
-  are owned by the [validation-default contract](docs/contracts/validation-default.md).
+  (`cmake` and `libboost-dev` on Debian/Ubuntu). Checks that build the
+  `rocksdb` backend (notably the dependency-range minimal lane, which
+  checks `--all-features`) additionally require libclang (`libclang-dev`
+  on Debian/Ubuntu). The consensus and node library crates enable `kernel`
+  by default; the binary does not. The exact defaults are owned by the
+  [validation-default contract](docs/contracts/validation-default.md).
 - The PR comparator tests use Python 3.13. Fuzzing and dependency/feature
   matrix checks also need the tools described in the main workflow below.
 

--- a/crates/index/benches/history_resolve.rs
+++ b/crates/index/benches/history_resolve.rs
@@ -125,24 +125,24 @@ fn filler_tx(seed: u64) -> Tx {
     fill_bytes(seed, &mut txid_bytes);
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: 0.into(),
         inputs: vec![TxIn {
             previous_output: OutPoint {
                 txid: Txid(Hash256::from_le_bytes(&txid_bytes)),
                 vout: u32::try_from(seed & 0x3).unwrap_or(0),
             },
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Vec::new().into(),
+            sequence: u32::MAX.into(),
+            witness: Vec::new().into(),
         }],
         outputs: vec![
             TxOut {
-                value: 5_000,
-                script_pubkey: witness_script(seed ^ 0xa5a5_a5a5),
+                value: 5_000.into(),
+                script_pubkey: witness_script(seed ^ 0xa5a5_a5a5).into(),
             },
             TxOut {
-                value: 7_000,
-                script_pubkey: witness_script(seed ^ 0x5a5a_5a5a),
+                value: 7_000.into(),
+                script_pubkey: witness_script(seed ^ 0x5a5a_5a5a).into(),
             },
         ],
     }
@@ -158,19 +158,19 @@ fn target_tx(height: u32, target_script: &[u8]) -> Tx {
     );
     Tx {
         version: 2,
-        lock_time: 0,
+        lock_time: 0.into(),
         inputs: vec![TxIn {
             previous_output: OutPoint {
                 txid: Txid(Hash256::from_le_bytes(&txid_bytes)),
                 vout: 0,
             },
-            script_sig: Vec::new(),
-            sequence: u32::MAX,
-            witness: Vec::new(),
+            script_sig: Vec::new().into(),
+            sequence: u32::MAX.into(),
+            witness: Vec::new().into(),
         }],
         outputs: vec![TxOut {
-            value: 11_000,
-            script_pubkey: target_script.to_vec(),
+            value: 11_000.into(),
+            script_pubkey: target_script.to_vec().into(),
         }],
     }
 }
@@ -218,7 +218,7 @@ fn build_fixture(heights: u32, txs_per_block: usize) -> Fixture {
                 prev_blockhash,
                 merkle_root: Hash256::default(),
                 time: 0,
-                bits: 0,
+                bits: 0.into(),
                 nonce: 0,
             },
             txs: txdata,

--- a/crates/index/src/index/tests.rs
+++ b/crates/index/src/index/tests.rs
@@ -2,7 +2,8 @@ use super::block::is_op_return_script;
 use std::sync::Arc;
 
 use bitcoin_rs_primitives::{
-    Block, BlockHash, Hash256, Header, Network, OutPoint, Tx, TxIn, TxOut, Txid, consensus_bytes,
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, Network, OutPoint, Script,
+    Sequence, Tx, TxIn, TxOut, Txid, Witness, consensus_bytes,
 };
 use bitcoin_rs_storage::{ColumnFamily, KvStore, RocksDbStore, WriteBatch};
 
@@ -510,6 +511,10 @@ impl bitcoin_rs_storage::KvStore for FailingWriteStore {
 
     fn flush(&self) -> Result<(), bitcoin_rs_storage::StorageError> {
         self.0.flush()
+    }
+
+    fn arm_persist_fault(&self, fault: bitcoin_rs_storage::PersistFault) {
+        self.0.arm_persist_fault(fault);
     }
 
     fn snapshot(

--- a/crates/script/tests/segwit_raw_sighash.rs
+++ b/crates/script/tests/segwit_raw_sighash.rs
@@ -145,7 +145,7 @@ fn kernel_witness_parity(tx: &Tx, prevout: &TxOut, witness: &[Vec<u8>]) {
     use bitcoin_rs_consensus::{ConsensusError, kernel::verify_tx_scripts};
 
     let mut signed = tx.clone();
-    signed.inputs[INPUT].witness = witness.to_vec();
+    signed.inputs[INPUT].witness = witness.to_vec().into();
     // The other input has a synthetic OP_TRUE prevout. This is script-verdict
     // parity, not contextual block validation or a claim about historical UTXOs.
     let mut spent: Vec<_> = signed
@@ -157,8 +157,8 @@ fn kernel_witness_parity(tx: &Tx, prevout: &TxOut, witness: &[Vec<u8>]) {
                 prevout.clone()
             } else {
                 TxOut {
-                    value: VALUE,
-                    script_pubkey: vec![0x51],
+                    value: VALUE.into(),
+                    script_pubkey: vec![0x51].into(),
                 }
             };
             (input.previous_output, output)
@@ -168,7 +168,7 @@ fn kernel_witness_parity(tx: &Tx, prevout: &TxOut, witness: &[Vec<u8>]) {
         .expect("kernel accepts independently signed BIP143 input");
     // Every BIP143 mode commits to this amount. Ensure the oracle is not
     // vacuously accepting, and require a script rejection, not an engine error.
-    spent[INPUT].1.value += 1;
+    spent[INPUT].1.value = Amount::from_sat(spent[INPUT].1.value.to_sat() + 1);
     assert!(matches!(
         verify_tx_scripts(&signed, &spent, VerifyFlags::MANDATORY),
         Err(ConsensusError::Script {

--- a/docs/contracts/dependency-range.md
+++ b/docs/contracts/dependency-range.md
@@ -13,11 +13,13 @@ contract.
   `Cargo.toml` `[workspace.dependencies]` table.
 - `minimal` resolves each direct dependency at its oldest allowed version
   (`cargo +nightly update -Zdirect-minimal-versions`) and checks the
-  default workspace graph.
+  workspace graph with all features enabled (`--all-features`).
 - `maximum` resolves every crate to the newest version still inside its
   declared range (`cargo update`) and checks the default workspace graph.
-- Both lanes then run G20 against the mutated lockfile. Optional native
-  storage engines and the named feature matrix are owned by `FEAT-01`.
+- Both lanes then run G20 against the mutated lockfile. The `minimal`
+  lane enables every feature, so it compiles the optional native storage
+  engines at the oldest resolve. The named combinations themselves are
+  owned by `FEAT-01`.
 - Both lanes mutate `Cargo.lock`. They run on `main` only, never on a
   pull-request checkout.
 

--- a/scripts/check-dep-range.sh
+++ b/scripts/check-dep-range.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Resolve the workspace against the declared dependency range, not the
-# Resolve the workspace against the declared dependency range, not the
 # committed lockfile, and prove it still compiles.
 #
 #   scripts/check-dep-range.sh minimal
@@ -20,6 +19,9 @@
 # are also checked with every optional feature enabled. The maximum endpoint
 # uses the default feature set; the named feature matrix is owned by
 # FEAT-01 / scripts/check-feature-matrix.sh.
+# The minimal endpoint uses --all-features, so the rocksdb backend builds
+# bindgen; bindgen's clang-sys dependency needs a visible libclang at build
+# time. See CONTRIBUTING.md, Prerequisites.
 #
 # Owner: docs/contracts/dependency-range.md (DEP-01, DEP-02).
 


### PR DESCRIPTION
The minimal lane checks --all-features, which enables the rocksdb backend. At the minimal resolve, zstd-sys moves to 2.1.0, which drops bindgen from its default features; the unified bindgen then loses the runtime feature, so clang-sys takes its dynamic-link path and its build-time probe runs (verified in clang-sys 1.9.1 build.rs: with runtime on, main() is a no-op). The committed lockfile's zstd-sys 2.0.16 keeps runtime on, so the probe never runs there -- but libclang is still needed whenever the backend builds, since bindgen dlopens it when rust-librocksdb-sys's build script runs (my local all-features check at the committed lockfile loaded libclang 21/22 to do exactly that). In short: the build-time probe runs only at the minimal resolve; the library need is permanent. The job installed only libboost-dev and cmake (job 103454199104 log: no llvm-config, no libclang.so).

- Install libclang-dev on the minimal leg only, mirroring the existing nightly-toolchain gate. The maximum lane uses default features and never builds bindgen.
- Record the all-features minimal graph in DEP-01, whose prose still claimed the default workspace graph.
- Compile the kernel-gated script test helper (4 type errors: missing Into conversions, AddAssign on Amount). Fixed test-side; clippy clean.
- Compile the rocksdb-gated index bench fixtures (15 missing Into conversions) and index unit tests (missing imports, missing arm_persist_fault delegation). Fixed; clippy clean.
- Operator docs: libclang prerequisite in CONTRIBUTING prerequisites and a mechanism-plus-pointer note in the dep-range script header (single owner: CONTRIBUTING holds the install instruction).

This PR has two separable parts. Only the first is disputed:

- Lane policy (DISPUTED, maintainer picks): keep --all-features plus libclang-dev on the minimal leg (this PR: apt line + DEP-01 prose + two doc notes), or check the default graph (branch ci-fix/dep-range-minimal-default-graph: one commit, no sys dep, prose-faithful). The coverage case for keep: the minimal lane is the ONLY check in the repo that compiles the rocksdb-gated bench, the kernel-gated script test, and the rocksdb-gated index tests -- the sole required-features target workspace-wide, with no PR/fast lane building them. Rollback deletes that check; the 26 real type errors found across those three files return to invisibility while the declared range keeps claiming the backend.
- Code fixes (NOT disputed -- land either way): 26 real type errors across three targets that never compiled anywhere (kernel-gated script helper: 4; rocksdb-gated bench fixtures: 15; rocksdb-gated index tests: 7). Fixed test-side/bench-side; clippy clean. If rollback wins, these three commits move to a separate branch; only the apt line, the DEP-01 prose, and the doc notes stay in dispute.

Proof, labeled by family (they gate different things), BOTH GREEN:
- Deep lane (ci-main dispatch, proves the lane works): run 34667747258 -- dependency-range (minimal) and (maximum) both completed/success, zero failed steps.
- PR gate (ci.yml pull_request, the required checks): run 34668546484 on tip d25dfe63 -- completed/success (fmt, deny, rust all green).

No branch deleted; closing the rollback experiment is its author's call.

Separately banked, not this PR's scope: run 34657918203's full-node binary tests failed independently (63 min, exit 101, test failure) -- verdict-table row of its own.