### PR TITLE
ci: run fuzz corpus campaign daily

### DIFF
--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -1,9 +1,9 @@
-name: weekly-fuzz
+name: daily-fuzz
 
 on:
   schedule:
-    # Sunday 03:17 UTC / Sunday 12:17 KST.
-    - cron: "17 3 * * 0"
+    # Every day at 03:17 UTC / 12:17 KST.
+    - cron: "17 3 * * *"
   workflow_dispatch:
     inputs:
       duration_minutes:
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: weekly-fuzz-corpus
+  group: daily-fuzz-corpus
   cancel-in-progress: false
 
 env:
@@ -80,7 +80,7 @@ jobs:
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
         with:
           workspaces: fuzz -> target
-          shared-key: weekly-fuzz-${{ matrix.target }}
+          shared-key: daily-fuzz-${{ matrix.target }}
       - uses: taiki-e/install-action@9534c84618278caac52cb373bb164ed464dbd8af # cargo-fuzz
         with:
           tool: cargo-fuzz@0.13.2
@@ -98,7 +98,7 @@ jobs:
         if: ${{ always() && !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: weekly-fuzz-${{ matrix.target }}
+          name: daily-fuzz-${{ matrix.target }}
           retention-days: 14
           if-no-files-found: error
           path: |
@@ -117,7 +117,7 @@ jobs:
       - name: Download campaign outputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          pattern: weekly-fuzz-*
+          pattern: daily-fuzz-*
           path: campaign-output
           merge-multiple: true
       - name: Check out corpus repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ The companion corpus repository is
 [gosuda/bitcoin-rs-fuzz-corpus](https://github.com/gosuda/bitcoin-rs-fuzz-corpus).
 For local campaigns, see [shared corpus and local campaigns](fuzz/README.md#shared-corpus-and-local-campaigns)
 for a separate writable corpus and contribution guidance. The scheduled
-campaign is defined in [`.github/workflows/weekly-fuzz.yml`](.github/workflows/weekly-fuzz.yml).
+campaign is defined in [`.github/workflows/daily-fuzz.yml`](.github/workflows/daily-fuzz.yml).
 
 ### Dependency-range check
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -44,7 +44,7 @@ cargo +nightly fuzz run p2p_message -- -max_total_time=60
 The companion corpus repository is
 [gosuda/bitcoin-rs-fuzz-corpus](https://github.com/gosuda/bitcoin-rs-fuzz-corpus).
 It is the destination for the evolving exploration corpus; fuzz targets and
-local execution instructions live here in `bitcoin-rs`. A weekly campaign runs
+local execution instructions live here in `bitcoin-rs`. A daily campaign runs
 each target for one hour, minimizes its corpus, and commits through
 `github-actions[bot]` only when the minimized set changes. Reports and crash
 inputs are retained with the workflow run.


### PR DESCRIPTION
The evolving fuzz corpus now lives in its own repository, so weekly runs no longer protect bitcoin-rs history from meaningful churn. Run the campaign every day at 03:17 UTC (12:17 KST) while keeping each target's one-hour fuzzing budget unchanged.

This renames the workflow, concurrency group, cache keys, and artifacts from `weekly-fuzz` to `daily-fuzz`, and updates the contributor documentation. Manual 1/10/60-minute runs and the existing corpus publication safeguards are unchanged.

Validation:

- `actionlint v1.7.12 .github/workflows/daily-fuzz.yml .github/workflows/fuzz-corpus-tools.yml`
- `./scripts/ci-pr.sh fmt`
- `./scripts/ci-pr.sh clippy`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the scheduled fuzz corpus campaign every day instead of weekly so the evolving corpus keeps protecting `bitcoin-rs` from churn. Each target's one-hour fuzzing budget and the manual run and corpus publication safeguards are unchanged.

**Renames**
- Renames the workflow, concurrency group, cache keys, and artifacts from `weekly-fuzz` to `daily-fuzz`.
- Updates `CONTRIBUTING.md` and `fuzz/README.md` to reference the daily campaign.

<sup>Written for commit 99187bac7cadaf1abb5333437de8dd6718c0a43d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

