### PR TITLE
Move g20 solver run to manual lane, keep K=128

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,10 @@ jobs:
       - name: Kernel consensus Clippy
         if: ${{ !cancelled() && steps.native_deps.outcome == 'success' && steps.toolchain.outcome == 'success' }}
         run: cargo clippy --locked -p bitcoin-rs-consensus --all-targets -- -D warnings
-      # Run every binary test, including the pinned process and formal gates.
+      # Run every binary test except the formal model gate: g20 needs ~30h+
+      # at K=128 (measured) and lives in the operator-invoked model-checker
+      # lane, so a main push does not spend days in the model checker. The
+      # two cheap g20 pin tests still run here; only the solver run is skipped.
       - name: Full-node binary tests
         if: ${{ !cancelled() && steps.native_deps.outcome == 'success' && steps.toolchain.outcome == 'success' && steps.fixtures.outcome == 'success' }}
         run: |
@@ -85,7 +88,8 @@ jobs:
             "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" \
             > target/apalache/run-context.txt
           cargo test --locked -p bitcoin-rs --no-fail-fast \
-            --no-default-features --features "${FULL_NODE_FEATURES}"
+            --no-default-features --features "${FULL_NODE_FEATURES}" \
+            -- --skip all_model_specs_check_with_apalache
       - name: Preserve public process compatibility evidence
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,12 +81,6 @@ jobs:
       - name: Full-node binary tests
         if: ${{ !cancelled() && steps.native_deps.outcome == 'success' && steps.toolchain.outcome == 'success' && steps.fixtures.outcome == 'success' }}
         run: |
-          # Never attribute cached or earlier-profile diagnostics to this run.
-          rm -rf -- target/apalache
-          mkdir -p target/apalache
-          printf 'commit=%s\nrun_id=%s\nattempt=%s\nprofile=full-node\n' \
-            "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" \
-            > target/apalache/run-context.txt
           cargo test --locked -p bitcoin-rs --no-fail-fast \
             --no-default-features --features "${FULL_NODE_FEATURES}" \
             -- --skip all_model_specs_check_with_apalache
@@ -96,17 +90,6 @@ jobs:
         with:
           name: process-compatibility-full-node-${{ github.run_attempt }}
           path: target/process-harness/**
-          if-no-files-found: warn
-          retention-days: 7
-      - name: Preserve full-node formal evidence
-        if: ${{ always() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: apalache-full-node-${{ github.run_attempt }}
-          path: |
-            target/apalache/**/run-*.txt
-            target/apalache/**/detailed*.log
-            target/apalache/**/counterexample*
           if-no-files-found: warn
           retention-days: 7
 

--- a/.github/workflows/model-check-manual.yml
+++ b/.github/workflows/model-check-manual.yml
@@ -1,0 +1,57 @@
+name: model-check-manual
+
+# Operator-invoked owner of gate g20 (issue: K=128 ChainAdmission Safety needs
+# ~30h+ at the pinned 4g heap, measured 2026-09-12; no hosted PR/main lane can
+# hold it). Runs the solver UNCHANGED at K=128. MANUAL ONLY, no schedule: a
+# cron on hosted runners (360-min cap) would fail every run and train everyone
+# to ignore the lane. Add a schedule back when a self-hosted/unbounded runner
+# exists. Informational: failures never block merges; they update the
+# CONSTRAINTS.md proof inventory only when green.
+on:
+  workflow_dispatch:
+concurrency:
+  group: model-check-manual
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: never
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  model-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - name: Provision pinned Core and Apalache fixtures
+        run: bash scripts/provision-ci-reference-fixtures.sh
+      - name: Formal model gate at K=128
+        run: |
+          set -o pipefail
+          rm -rf -- target/apalache
+          mkdir -p target/apalache
+          printf 'commit=%s\nrun_id=%s\nattempt=%s\nprofile=model-check-manual\n' \
+            "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" \
+            > target/apalache/run-context.txt
+          # --exact plus the count check: a filter matching zero tests exits 0
+          # and must never read as a green gate (CL-23: no invented zeroes).
+          cargo test --locked -p bitcoin-rs --no-fail-fast \
+            --no-default-features --features "rocksdb,fjall,redb" \
+            --test g20_formal_models -- --exact all_model_specs_check_with_apalache \
+            2>&1 | tee target/apalache/g20-summary.txt
+          grep -q '^test result: ok\. 1 passed' target/apalache/g20-summary.txt
+      - name: Preserve manual formal evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: apalache-manual-${{ github.run_attempt }}
+          path: |
+            target/apalache/g20-summary.txt
+            target/apalache/**/run-*.txt
+            target/apalache/**/detailed*.log
+            target/apalache/**/counterexample*
+          if-no-files-found: warn
+          retention-days: 7

--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -63,6 +63,17 @@ apalache-mc check --config=docs/models/<M>.cfg --inv=TypeOK,Safety,TransitionSaf
 apalache-mc check --config=docs/models/<M>.cfg --temporal=ConditionalProgress --length=128 --out-dir=target/apalache/<M> docs/models/<M>.tla
 ```
 
+Lane: the solver run is owned by the operator-invoked `model-check-manual`
+lane at K=128 unchanged (workflow_dispatch only; no schedule until a runner
+exists that can finish K=128). PR (`ci-pr.sh`) and main-push (`main.yml`
+full-node) lanes skip `all_model_specs_check_with_apalache` and run only the
+two cheap pin tests. Inventory rows above stay BLOCKED until a manual run
+returns rc 0. Measured 2026-09-12: ChainAdmission Safety needs ~30h+ at the
+pinned 4g heap, so no `ubuntu-latest` job (360-min cap) can return rc 0; the
+manual lane exercises the harness and preserves evidence but is not expected
+to go green on hosted runners. Revisit on a self-hosted/unbounded runner or
+a replacement validator (see research/formal-validator-replacement.md).
+
 Native to skill rc mapping, native rc preserved verbatim: `0 -> 0`; `150`
 parse and `120` typecheck `-> 12`; `12` counterexample `-> 13`; `75`
 spec-eval, `255` system error, timeout `-> 14`; hash divergence from this

--- a/scripts/ci-pr.sh
+++ b/scripts/ci-pr.sh
@@ -77,16 +77,15 @@ case "$1" in
     # Isolated so node's default zmq feature cannot unify this package on.
     profile "test: bitcoin-rs-rpc (no default features)" \
       cargo test --locked -p bitcoin-rs-rpc --no-default-features --no-fail-fast
-    # The workspace pass below owns the single formal solver run on `main`;
-    # this binary profile skips it (six invocations with unchanged inputs,
-    # properties, and bound, per CONSTRAINTS.md's Formal model tool identity).
+    # The formal solver run lives in the operator-invoked model-check-manual
+    # lane (K=128 needs ~30h+, measured); every CI lane skips it and runs
+    # only the cheap pin tests.
     profile "test: bitcoin-rs binary (rocksdb,fjall,redb)" \
       cargo test --locked -p bitcoin-rs --no-fail-fast \
         --no-default-features --features "rocksdb,fjall,redb" \
         -- --exact --skip all_model_specs_check_with_apalache
-    # The formal solver run (g20) is main-only: main.yml's unfiltered
-    # full-node tests own it, so a PR does not spend hours in the model
-    # checker for the same reason the binary profile skips it.
+    # Same skip for the workspace profile: no CI lane spends hours in the
+    # model checker for unchanged inputs, properties, and bound.
     profile "test: workspace (kernel-free)" \
       cargo test --locked --workspace --no-fail-fast \
         --exclude bitcoin-rs-consensus --exclude bitcoin-rs-node \


### PR DESCRIPTION
ChainAdmission Safety needs ~30h+ at the pinned 4g heap (measured 2026-09-12); no hosted lane can hold it.

- main-push full-node skips only the solver run; both pin tests still guard toolchain and inventory (proven green locally: 19 pass, 1 filtered).
- New dispatch-only model-check-manual workflow owns the K=128 run, with --exact plus count guard against invented zeroes.
- CONSTRAINTS.md lane note records hosted unsatisfiability and the revisit condition. Inventory stays BLOCKED. K=128 untouched.

Merge stays gated as always.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the g20 K=128 solver run to an operator-invoked manual workflow because it needs ~30h+ at the pinned 4g heap, which no hosted lane can hold.

- CI lanes (main-push and PR) skip `all_model_specs_check_with_apalache` but keep the two cheap g20 pin tests; the now-dead full-node evidence setup and upload are removed.
- The new `model-check-manual` workflow runs the solver unchanged with `--exact` and a count guard so a zero-match filter can't report a green gate.
- `CONSTRAINTS.md` records the hosted-lane unsatisfiability and the revisit condition; inventory rows stay BLOCKED.

<sup>Written for commit f8705aaa1a567dcb682d7b882b6ef8d6401992d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

