### PR TITLE
Validate corpus seed content at publish time

### DIFF
--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -120,6 +120,12 @@ jobs:
           pattern: daily-fuzz-*
           path: campaign-output
           merge-multiple: true
+      - name: Check out policy owner
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          path: policy-owner
+          fetch-depth: 1
+          persist-credentials: false
       - name: Check out corpus repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -164,8 +170,16 @@ jobs:
               echo "corpus/${target} changed after campaign base ${corpus_base}" >&2
               exit 1
             fi
+            # Content validation: worker bytes are untrusted at publish time.
+            # Single owner scripts/validate-corpus-seeds.sh (same rule the
+            # campaign worker enforces); dotfiles and nested paths fail
+            # closed, since rsync would copy them unchecked otherwise. The
+            # budget flags guard the corpus repo against floods; the worker
+            # path omits them so they never cap lifetime corpus growth.
+            policy-owner/scripts/validate-corpus-seeds.sh \
+              -n 65536 -b 268435456 "${source}" "${target}"
             mkdir -p "corpus-repository/corpus/${target}"
-            rsync -a --delete "${source}/" "corpus-repository/corpus/${target}/"
+            rsync -a --no-links --delete "${source}/" "corpus-repository/corpus/${target}/"
             if [[ -n "$(git -C corpus-repository status --porcelain -- "corpus/${target}")" ]]; then
               changed_targets+=("${target}")
             fi

--- a/.github/workflows/fuzz-corpus-tools.yml
+++ b/.github/workflows/fuzz-corpus-tools.yml
@@ -24,5 +24,6 @@ jobs:
         run: |
           bash -n scripts/fuzz-policy.sh
           bash -n scripts/run-fuzz-campaign.sh
+          bash -n scripts/validate-corpus-seeds.sh
       - name: Run offline corpus-import regressions
-        run: python3 -m unittest discover -s scripts/tests -p 'test_import_qa_assets*.py' -v
+        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v

--- a/scripts/run-fuzz-campaign.sh
+++ b/scripts/run-fuzz-campaign.sh
@@ -162,16 +162,8 @@ fi
 coverage_report after
 
 if (( CMIN_STATUS == 0 )); then
-    find "${CORPUS_DIR}" -maxdepth 1 -type f -exec chmod 0644 {} +
-    while IFS= read -r -d '' input; do
-        expected="$(basename "${input}")"
-        actual="$(sha1sum "${input}")"
-        actual="${actual%% *}"
-        if [[ "${expected}" != "${actual}" ]]; then
-            echo "corpus input is not content-addressed: ${input}" >&2
-            exit 1
-        fi
-    done < <(find "${CORPUS_DIR}" -maxdepth 1 -type f -print0)
+    "$(dirname -- "${BASH_SOURCE[0]}")/validate-corpus-seeds.sh" \
+        "${CORPUS_DIR}" "${TARGET}"
     cp -a "${CORPUS_DIR}/." "${OUTPUT_DIR}/corpus/${TARGET}/"
 fi
 

--- a/scripts/tests/test_validate_corpus_seeds.py
+++ b/scripts/tests/test_validate_corpus_seeds.py
@@ -1,0 +1,125 @@
+"""Offline regressions for the corpus seed-content invariant.
+
+scripts/validate-corpus-seeds.sh owns the rule shared by the fuzz campaign
+worker and the corpus publication job: every entry (including dotfiles and
+nested paths, which shell globs miss but rsync copies) must be a
+non-symlink regular file named by its own SHA-1, within FUZZ_MAX_SEED_BYTES,
+with a positive count inside the sanity budget. Modes normalize to 0644.
+"""
+
+import hashlib
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "validate-corpus-seeds.sh"
+POLICY = SCRIPT.with_name("fuzz-policy.sh")
+_budget = re.search(
+    r"^readonly FUZZ_MAX_SEED_BYTES=([0-9]+)\s*(?:#.*)?$",
+    POLICY.read_text(),
+    re.M,
+)
+if _budget is None or int(_budget.group(1)) < 1:
+    raise RuntimeError("Cannot read the positive FUZZ_MAX_SEED_BYTES policy")
+BUDGET = int(_budget.group(1))
+
+
+def run_validator(*args):
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+class ValidateCorpusSeedsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.corpus = Path(self.tmp.name) / "corpus"
+        self.corpus.mkdir()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def add_seed(self, content: bytes, name: str | None = None):
+        digest = hashlib.sha1(content).hexdigest()
+        path = self.corpus / (name if name is not None else digest)
+        path.write_bytes(content)
+        return path
+
+    def test_valid_corpus_passes(self):
+        # The publish job invokes the validator by path, so the exec bit is
+        # part of the contract (subprocess "bash script" calls would not
+        # catch a missing one).
+        self.assertTrue(os.access(SCRIPT, os.X_OK))
+        self.add_seed(b"good-seed")
+        self.add_seed(b"another-seed")
+        proc = run_validator(str(self.corpus), "t")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        for entry in self.corpus.iterdir():
+            self.assertEqual(oct(entry.stat().st_mode & 0o777), "0o644")
+
+    def test_misnamed_seed_fails(self):
+        self.add_seed(b"tampered", name="0" * 40)
+        proc = run_validator(str(self.corpus), "t")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("not named by its sha1", proc.stderr)
+
+    def test_dotfile_payload_fails(self):
+        self.add_seed(b"good-seed")
+        self.add_seed(b"hidden", name=".payload")
+        proc = run_validator(str(self.corpus), "t")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn(".payload", proc.stderr)
+
+    def test_nested_path_fails(self):
+        self.add_seed(b"good-seed")
+        nested = self.corpus / "sub"
+        nested.mkdir()
+        content = b"nested"
+        (nested / hashlib.sha1(content).hexdigest()).write_bytes(content)
+        proc = run_validator(str(self.corpus), "t")
+        self.assertNotEqual(proc.returncode, 0)
+
+    def test_symlink_fails(self):
+        target = self.add_seed(b"good-seed")
+        digest = hashlib.sha1(b"link-target").hexdigest()
+        os.symlink(target, self.corpus / digest)
+        proc = run_validator(str(self.corpus), "t")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("non-regular", proc.stderr)
+
+    def test_oversized_seed_fails(self):
+        self.add_seed(b"x" * (BUDGET + 1))
+        proc = run_validator(str(self.corpus), "t")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("oversized", proc.stderr)
+
+    def test_empty_corpus_fails(self):
+        proc = run_validator(str(self.corpus), "t")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("refusing empty corpus", proc.stderr)
+
+    def test_budget_flags_reject_flood(self):
+        self.add_seed(b"one")
+        self.add_seed(b"two")
+        proc = run_validator(
+            "-n", "1", "-b", "268435456",
+            str(self.corpus), "t",
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("over budget", proc.stderr)
+
+    def test_budget_flags_accept_within_cap(self):
+        self.add_seed(b"one")
+        proc = run_validator(
+            "-n", "65536", "-b", "268435456",
+            str(self.corpus), "t",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-corpus-seeds.sh
+++ b/scripts/validate-corpus-seeds.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Single owner of the corpus seed-content invariant, shared by the fuzz
+# campaign worker (scripts/run-fuzz-campaign.sh) and the corpus publication
+# job (.github/workflows/daily-fuzz.yml).
+#
+# Usage: validate-corpus-seeds.sh [-n max-seeds] [-b max-bytes] <corpus-dir> [label]
+#
+# Every entry under <corpus-dir> (including dotfiles and nested paths, which
+# shell globs miss but rsync would copy) must be a non-symlink regular file
+# named by its own SHA-1 digest, no larger than FUZZ_MAX_SEED_BYTES, with a
+# positive count. The -n/-b sanity budget applies only when passed (the
+# publish job, guarding the corpus repo against floods); the worker path
+# omits it so the budget can never cap the corpus's lifetime growth. Modes
+# are normalized to 0644, the corpus repo's required mode. Exits non-zero
+# on the first refusal.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=fuzz-policy.sh
+source "${SCRIPT_DIR}/fuzz-policy.sh"
+
+max_seeds=0
+max_bytes=0
+while getopts ':n:b:' option; do
+    case "${option}" in
+        n) max_seeds="${OPTARG}" ;;
+        b) max_bytes="${OPTARG}" ;;
+        *) printf 'usage: %s [-n max-seeds] [-b max-bytes] <corpus-dir> [label]\n' "$0" >&2; exit 2 ;;
+    esac
+done
+shift $(( OPTIND - 1 ))
+CORPUS_DIR="${1:?usage: validate-corpus-seeds.sh [-n max-seeds] [-b max-bytes] <corpus-dir> [label]}"
+LABEL="${2:-${CORPUS_DIR}}"
+
+seed_count=0
+seed_bytes=0
+while IFS= read -r -d '' seed; do
+    rel="${seed#"${CORPUS_DIR}"/}"
+    [[ -f "${seed}" && ! -L "${seed}" ]] || {
+        printf 'refusing non-regular seed: %s\n' "${LABEL}/${rel}" >&2
+        exit 1
+    }
+    size="$(stat -c%s "${seed}")"
+    (( size <= FUZZ_MAX_SEED_BYTES )) || {
+        printf 'refusing oversized seed (%s bytes): %s\n' "${size}" "${LABEL}/${rel}" >&2
+        exit 1
+    }
+    hash="$(sha1sum "${seed}")"
+    hash="${hash%% *}"
+    [[ "${rel}" == "${hash}" ]] || {
+        printf 'refusing seed not named by its sha1: %s\n' "${LABEL}/${rel}" >&2
+        exit 1
+    }
+    seed_count=$(( seed_count + 1 ))
+    seed_bytes=$(( seed_bytes + size ))
+done < <(find "${CORPUS_DIR}" -mindepth 1 -print0)
+
+(( seed_count > 0 )) || { printf 'refusing empty corpus: %s\n' "${LABEL}" >&2; exit 1; }
+if (( max_seeds > 0 && seed_count > max_seeds )) ||
+   (( max_bytes > 0 && seed_bytes > max_bytes )); then
+    printf 'refusing corpus over budget: %s (%s seeds, %s bytes)\n' \
+        "${LABEL}" "${seed_count}" "${seed_bytes}" >&2
+    exit 1
+fi
+
+find "${CORPUS_DIR}" -mindepth 1 -type f -exec chmod 0644 {} +
+printf 'validated %s seeds (%s bytes) for %s\n' "${seed_count}" "${seed_bytes}" "${LABEL}" >&2


### PR DESCRIPTION
Follow-up to #980/#982 (post-merge review finding): the publish job validated branch bookkeeping but never seed bytes, so a tampered-but-successful worker leg could publish arbitrary inputs to the corpus repo consumed by the next campaign and local users.

- Per-seed publish-side checks before rsync: regular non-symlink file, basename == sha1 of content, size within FUZZ_MAX_SEED_BYTES (single owner: scripts/fuzz-policy.sh).
- Per-target sanity budget (count/bytes) against floods.
- Proven locally: YAML parses, fixture run accepts a valid seed and rejects an oversized sha1-valid seed.

Out of scope (noted for author/maintainer): fuzz-job timeout-minutes 90 vs coverage+fuzz+cmin duration; PAT grant scoping doc for FUZZ_CORPUS_TOKEN.

Merge stays gated as always.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates corpus seed content at publish time; previously only branch bookkeeping was checked, so a tampered-but-successful fuzz leg could publish arbitrary seeds to the corpus repo.

- Adds `scripts/validate-corpus-seeds.sh` as the single owner of the seed-content rule, shared by the campaign worker and the publish job.
- Rejects symlinks, non-regular files, misnamed (non-SHA-1) seeds, oversized seeds, and dotfiles or nested paths; `rsync` runs with `--no-links` and seeds normalize to 0644.
- A count/byte budget only the publish job passes guards the corpus repo against floods, and the new regressions run in CI.

<sup>Written for commit b16028bf985d3cdb1ed5a9dacfadfd9857bcf09a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

