### PR TITLE
Pin Cmodern corpus manifest digest

### DIFF
--- a/bin/bitcoin-rs/tests/overhaul_reference_set.rs
+++ b/bin/bitcoin-rs/tests/overhaul_reference_set.rs
@@ -39,15 +39,16 @@ const FORMAL_ARCHIVE_SHA256: &str =
 /// Pinned formal-tool jar digest; see [`RELEASE_ARCHIVE_SHA256`].
 const FORMAL_JAR_SHA256: &str = "079b6c2320252469dcf79afec6886b8255d3dd1b34a9484433c88986752efaa8";
 
-/// Stand-in digest used to prove a corpus can be pinned once exported.
-const SAMPLE_CORPUS_MANIFEST_SHA256: &str =
-    "1111111111111111111111111111111111111111111111111111111111111111";
 /// The canonical C150 manifest identity recorded at export on 2026-09-07: the
 /// `manifest_sha256` field embedded inside the manifest, not the SHA-256 of the
 /// manifest file itself. Used here to prove that removing it returns that
 /// corpus to blocked custody.
 const C150_MANIFEST_SHA256: &str =
     "5eff01d897b6f3b39039d1ff7b9b4b0872a7a15463fa516b4cc7bfe7c001b91d";
+/// The canonical Cmodern manifest identity, recorded at export on 2026-09-09;
+/// see [`C150_MANIFEST_SHA256`].
+const CMODERN_MANIFEST_SHA256: &str =
+    "b87bac6720d1b68acadaa9863b56073ee213f4613e8dfa4a93c4459dc5f017cd";
 
 /// Decodes a 64-hex-character literal into the digest bytes a loader must
 /// produce.
@@ -332,6 +333,12 @@ fn a_missing_corpus_is_named_by_id() {
             "stop_height = 709635\n",
             "stop_hash = ",
             "\"00000000000000000001f9ee4f69cbc75ce61db5178175c2ad021fe1df5bad8f\"\n",
+            "# Exported 2026-09-09 by the pinned bitcoind (digest 986e63b3); see the\n",
+            "# campaign-corpora contract and products.json for canonical corpus\n",
+            "# measurements and terminal-state evidence.\n",
+            "# Canonical manifest identity per CORP-02: the `manifest_sha256` field the\n",
+            "# exporter embeds inside the manifest, NOT the SHA-256 of the manifest file.\n",
+            "manifest_sha256 = \"b87bac6720d1b68acadaa9863b56073ee213f4613e8dfa4a93c4459dc5f017cd\"\n",
         ),
         "",
     );
@@ -343,10 +350,10 @@ fn a_missing_corpus_is_named_by_id() {
     );
 }
 
-/// Custody is honest about what is absent. C150 was exported on 2026-09-07 so
-/// it carries a real manifest digest, while Cmodern awaits its own export and
-/// stays blocked by name. Removing a recorded digest must put that corpus
-/// back to blocked rather than leaving a stale claim.
+/// Custody is honest about what is absent. C150 was exported on 2026-09-07 and
+/// Cmodern on 2026-09-09, so both carry real manifest digests. Removing a
+/// recorded digest must put that corpus — and only that corpus — back to
+/// blocked rather than leaving a stale claim.
 #[test]
 fn corpus_custody_distinguishes_pinned_from_blocked() {
     let blocked = CorpusCustody::Blocked {
@@ -357,34 +364,34 @@ fn corpus_custody_distinguishes_pinned_from_blocked() {
         set.corpus_custody(),
         vec![
             ("C150".to_owned(), CorpusCustody::Pinned),
-            ("Cmodern".to_owned(), blocked.clone()),
-        ]
-    );
-
-    let pinned_both = edit_manifest(
-        "id = \"Cmodern\"\n",
-        &format!("id = \"Cmodern\"\nmanifest_sha256 = \"{SAMPLE_CORPUS_MANIFEST_SHA256}\"\n"),
-    );
-    let set =
-        load_reference_set(&pinned_both).expect("a pinned corpus manifest digest still loads");
-    assert_eq!(
-        set.corpus_custody(),
-        vec![
-            ("C150".to_owned(), CorpusCustody::Pinned),
             ("Cmodern".to_owned(), CorpusCustody::Pinned),
         ]
     );
 
-    let unpinned = edit_manifest(
+    let unpinned_c150 = edit_manifest(
         &format!("manifest_sha256 = \"{C150_MANIFEST_SHA256}\"\n"),
         "",
     );
-    let set = load_reference_set(&unpinned)
+    let set = load_reference_set(&unpinned_c150)
         .expect("a corpus without its export digest still loads, blocked");
     assert_eq!(
         set.corpus_custody(),
         vec![
             ("C150".to_owned(), blocked.clone()),
+            ("Cmodern".to_owned(), CorpusCustody::Pinned),
+        ]
+    );
+
+    let unpinned_cmodern = edit_manifest(
+        &format!("manifest_sha256 = \"{CMODERN_MANIFEST_SHA256}\"\n"),
+        "",
+    );
+    let set = load_reference_set(&unpinned_cmodern)
+        .expect("a corpus without its export digest still loads, blocked");
+    assert_eq!(
+        set.corpus_custody(),
+        vec![
+            ("C150".to_owned(), CorpusCustody::Pinned),
             ("Cmodern".to_owned(), blocked),
         ]
     );

--- a/docs/api/core-compat.toml
+++ b/docs/api/core-compat.toml
@@ -76,9 +76,9 @@ bitcoind_sha256 = "986e63b3c8770f08d0059820ad3dd085d1ab9e1bea23946c243f858a06888
 version_output = "Bitcoin Core daemon version v31.1.0 bitcoind"
 
 # Replay corpora, pinned by stop identity. `manifest_sha256` is produced when
-# the corpus archive is exported and is deliberately ABSENT until then: a
-# placeholder digest here would be an invented one, so the loader reports the
-# corpus as custody-blocked instead.
+# the corpus archive is exported; until then it stays ABSENT (a placeholder
+# digest would be an invented one, so the loader reports the corpus as
+# custody-blocked instead). Both corpora below now carry exported digests.
 
 [[reference.corpora]]
 id = "C150"
@@ -95,6 +95,12 @@ manifest_sha256 = "5eff01d897b6f3b39039d1ff7b9b4b0872a7a15463fa516b4cc7bfe7c001b
 id = "Cmodern"
 stop_height = 709635
 stop_hash = "00000000000000000001f9ee4f69cbc75ce61db5178175c2ad021fe1df5bad8f"
+# Exported 2026-09-09 by the pinned bitcoind (digest 986e63b3); see the
+# campaign-corpora contract and products.json for canonical corpus
+# measurements and terminal-state evidence.
+# Canonical manifest identity per CORP-02: the `manifest_sha256` field the
+# exporter embeds inside the manifest, NOT the SHA-256 of the manifest file.
+manifest_sha256 = "b87bac6720d1b68acadaa9863b56073ee213f4613e8dfa4a93c4459dc5f017cd"
 
 # The formal model checker, pinned by archive and jar digest. Evidence tool
 # only; no checker run is claimed anywhere in this file.

--- a/docs/contracts/reference-set.md
+++ b/docs/contracts/reference-set.md
@@ -97,6 +97,8 @@ The product corpora are defined in
   response at height 150,000.
 - `Cmodern`: mainnet blocks `0 .. 709,635`; stop hash
   `00000000000000000001f9ee4f69cbc75ce61db5178175c2ad021fe1df5bad8f`.
+  `txouts` 75,903,651; `total_amount_sat` 1,887,251,879,232,217;
+  `muhash` `71f94b3136225ba9f77ae89b68fdace431470af64bd29dd055e173830f837e5a`.
   The Cmodern oracle is the first certified Core 31.1 `gettxoutsetinfo`
   response at height 709,635. A cell may not close on a guessed or recalled
   UTXO total.

--- a/docs/contracts/reference-set.md
+++ b/docs/contracts/reference-set.md
@@ -101,10 +101,11 @@ The product corpora are defined in
   response at height 709,635. A cell may not close on a guessed or recalled
   UTXO total.
 
-`manifest_sha256` is optional until the archive exists. C150 carries its
-exported digest; Cmodern has no exported digest yet. `corpus_custody()` in
-`bin/bitcoin-rs/tests/support/reference_set.rs` reports such a corpus as
-`Blocked { missing: "manifest_sha256" }` rather than inventing a digest.
+`manifest_sha256` is optional until the archive exists. C150 (exported
+2026-09-07) and Cmodern (exported 2026-09-09) carry their exported digests.
+`corpus_custody()` in `bin/bitcoin-rs/tests/support/reference_set.rs` reports
+a corpus without one as `Blocked { missing: "manifest_sha256" }` rather than
+inventing a digest.
 
 Each corpus archive uses the Core-framed format with a manifest digest
 produced at export time. A length-prefixed diagnostic file is not a product

--- a/tools/campaign-corpus/products.json
+++ b/tools/campaign-corpus/products.json
@@ -61,6 +61,9 @@
       "state": {
         "height": 709635,
         "bestblock": "00000000000000000001f9ee4f69cbc75ce61db5178175c2ad021fe1df5bad8f",
+        "txouts": 75903651,
+        "total_amount_sat": 1887251879232217,
+        "muhash": "71f94b3136225ba9f77ae89b68fdace431470af64bd29dd055e173830f837e5a",
         "oracle": "core_gettxoutsetinfo_muhash_at_stop"
       }
     }

--- a/tools/campaign-corpus/test_corpus.py
+++ b/tools/campaign-corpus/test_corpus.py
@@ -414,6 +414,9 @@ class FreezePins(unittest.TestCase):
         self.assertEqual(cmodern.stop_hash, CMODERN_HASH)
         self.assertEqual(cmodern.block_count, 709_636)
         self.assertEqual(cmodern.census["specials"], "all_positive")
+        self.assertEqual(cmodern.state["txouts"], 75_903_651)
+        self.assertEqual(cmodern.state["total_amount_sat"], 1_887_251_879_232_217)
+        self.assertEqual(cmodern.state["muhash"], "71f94b3136225ba9f77ae89b68fdace431470af64bd29dd055e173830f837e5a")
         self.assertEqual(cmodern.state["oracle"], "core_gettxoutsetinfo_muhash_at_stop")
 
     def test_validation_posture_and_oracle(self) -> None:


### PR DESCRIPTION
Closes the last open item of #625: pin manifest_sha256 b87bac67... for the Cmodern corpus in core-compat.toml (proven three ways: embedded manifest field, acquisition record, independent canonical-preimage recompute; byte-identity tied). Flips Cmodern custody Blocked->pinned in the reference-set gate (28 green) and updates the REF-04 projection sentence. No oracle numbers invented; parser untouched.

Merge stays gated as always.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Cmodern corpus manifest digest from its 2026-09-09 export, flipping custody from Blocked to Pinned so `corpus_custody()` reports both reference corpora as pinned. This closes the last open item of #625.

- Adds Cmodern's certified terminal-state measurements (`txouts`, `total_amount_sat`, `muhash`) to `products.json` and asserts them in `test_corpus.py` as canonical export evidence.
- The gate test now proves that removing either corpus's digest returns exactly that corpus to Blocked.
- `docs/contracts/reference-set.md` no longer describes Cmodern as awaiting export.

<sup>Written for commit df051e1caaa485a002020f2e36a48ab3e639ff6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

