### PR TITLE
Close ownership-gate gaps: index, peer owner, profiles, walk

### DIFF
--- a/bin/bitcoin-rs/tests/overhaul_ownership.rs
+++ b/bin/bitcoin-rs/tests/overhaul_ownership.rs
@@ -175,6 +175,10 @@ fn real_adapters_forward_their_backend_features() {
         .expect("real workspace feature tables must satisfy the forwarding rules");
 }
 
+/// The workspace members carry hundreds of production sources; a scan below
+/// this floor means the file walk collapsed and a green verdict is void.
+const MIN_SCANNED_FILES: usize = 100;
+
 #[test]
 fn mempool_writer_source_scan_passes() {
     let OwnershipScanResult {
@@ -184,6 +188,11 @@ fn mempool_writer_source_scan_passes() {
         mempool_mutations_found,
         ..
     } = scan_ownership_violations();
+    assert!(
+        files_scanned >= MIN_SCANNED_FILES,
+        "the ownership scan saw only {files_scanned} files; the workspace walk \
+         collapsed"
+    );
 
     let _ = writeln!(
         std::io::stderr(),
@@ -208,6 +217,11 @@ fn index_capability_scan_passes() {
         files_scanned,
         ..
     } = scan_ownership_violations();
+    assert!(
+        files_scanned >= MIN_SCANNED_FILES,
+        "the ownership scan saw only {files_scanned} files; the workspace walk \
+         collapsed"
+    );
 
     let _ = writeln!(
         std::io::stderr(),
@@ -236,6 +250,11 @@ fn p2p_peer_owner_scan_passes() {
         files_scanned,
         ..
     } = scan_ownership_violations();
+    assert!(
+        files_scanned >= MIN_SCANNED_FILES,
+        "the ownership scan saw only {files_scanned} files; the workspace walk \
+         collapsed"
+    );
 
     let _ = writeln!(
         std::io::stderr(),

--- a/bin/bitcoin-rs/tests/overhaul_ownership.rs
+++ b/bin/bitcoin-rs/tests/overhaul_ownership.rs
@@ -1,8 +1,9 @@
 //! ARCH-01/ARCH-02/ARCH-08 ownership boundary checks.
 //!
 //! The suite validates dependency direction, storage-engine confinement,
-//! single mempool mutation ownership, and the frozen P2P forwarding-wrapper
-//! inventory.
+//! single mempool mutation ownership, derived-index capability ownership,
+//! peer registration/cancellation ownership, and the frozen P2P
+//! forwarding-wrapper inventory.
 
 #![expect(
     clippy::expect_used,
@@ -212,6 +213,34 @@ fn index_capability_scan_passes() {
     assert!(
         index_capability_sites > 0,
         "the index capability scan matched no production capability selection"
+    );
+}
+
+#[test]
+fn p2p_peer_owner_scan_passes() {
+    let OwnershipScanResult {
+        peer_owner_violations,
+        peer_mutations_found,
+        files_scanned,
+        ..
+    } = scan_ownership_violations();
+
+    let _ = writeln!(
+        std::io::stderr(),
+        "p2p peer owner scan: files={files_scanned}, \
+         peer mutation sites={peer_mutations_found}, \
+         violations={}",
+        peer_owner_violations.len()
+    );
+    assert!(
+        peer_owner_violations.is_empty(),
+        "peer registration and cancellation must stay with the P2P owner \
+         (PeerTable/P2pService) apart from the audited sync teardown handles \
+         and the RPC disconnectnode operator path: {peer_owner_violations:?}"
+    );
+    assert!(
+        peer_mutations_found > 0,
+        "the p2p peer owner scan matched no production peer mutation"
     );
 }
 

--- a/bin/bitcoin-rs/tests/overhaul_ownership.rs
+++ b/bin/bitcoin-rs/tests/overhaul_ownership.rs
@@ -14,9 +14,21 @@ mod support;
 
 use std::io::Write as _;
 use std::path::Path;
-
-use support::dependency_graph::{BIN_CRATE, Validation, WorkspaceGraph};
+use support::dependency_graph::{BIN_CRATE, FeatureProfile, Validation, WorkspaceGraph};
 use support::ownership_scan::{OwnershipScanResult, scan_ownership_violations};
+
+/// Operator-facing binary feature profiles, mirroring the CI build lanes in
+/// `.github/workflows/main.yml`: the shipped default, the minimal native
+/// storage lane that executes this gate, the portable minimal-plus-zmq
+/// lane, the full-node matrix lane with every backend and the kernel
+/// oracle, and the defaults-plus-kernel optional lane.
+const FEATURE_PROFILES: &[FeatureProfile] = &[
+    FeatureProfile::new("default", &[], true),
+    FeatureProfile::new("minimal-native", &["fjall"], false),
+    FeatureProfile::new("minimal-zmq", &["fjall", "zmq"], false),
+    FeatureProfile::new("full-node", &["rocksdb", "fjall", "redb", "kernel"], false),
+    FeatureProfile::new("optional-kernel", &["kernel"], true),
+];
 
 #[test]
 fn real_metadata_validates() {
@@ -241,6 +253,74 @@ fn p2p_peer_owner_scan_passes() {
     assert!(
         peer_mutations_found > 0,
         "the p2p peer owner scan matched no production peer mutation"
+    );
+}
+
+#[test]
+fn feature_profiles_preserve_ownership_rules() {
+    let graph = WorkspaceGraph::from_cargo_metadata();
+    for profile in FEATURE_PROFILES {
+        let violations = graph.profile_ownership_violations(profile);
+        let _ = writeln!(
+            std::io::stderr(),
+            "feature profile `{}`: violations={}",
+            profile.name,
+            violations.len()
+        );
+        assert!(
+            violations.is_empty(),
+            "profile `{}` must preserve the ownership rules: {violations:?}",
+            profile.name
+        );
+    }
+}
+
+#[test]
+fn synthetic_backendless_minimal_profile_fails() {
+    let mut graph = WorkspaceGraph::from_cargo_metadata();
+    // Sever node's `fjall` forwarding: the minimal lane loses its backend.
+    graph.set_feature("bitcoin-rs-node", "fjall", &[]);
+
+    let violations = graph.profile_ownership_violations(&FeatureProfile::new(
+        "minimal-native",
+        &["fjall"],
+        false,
+    ));
+    assert!(
+        violations
+            .iter()
+            .any(|violation| violation.contains("activates no storage backend")),
+        "a backendless minimal profile must fail profile parity: {violations:?}"
+    );
+}
+
+#[test]
+fn synthetic_kernel_leak_into_minimal_profile_fails() {
+    let mut graph = WorkspaceGraph::from_cargo_metadata();
+    // A kernel engine smuggled onto the backend forwarding chain.
+    graph.set_feature(
+        "bitcoin-rs-node",
+        "fjall",
+        &[
+            "bitcoin-rs-chain/fjall",
+            "bitcoin-rs-index/fjall",
+            "bitcoin-rs-p2p/fjall",
+            "bitcoin-rs-storage/fjall",
+            "bitcoin-rs-utxo/fjall",
+            "bitcoin-rs-consensus/kernel",
+        ],
+    );
+
+    let violations = graph.profile_ownership_violations(&FeatureProfile::new(
+        "minimal-native",
+        &["fjall"],
+        false,
+    ));
+    assert!(
+        violations
+            .iter()
+            .any(|violation| violation.contains("kernel engine out of the production graph")),
+        "a kernel leak into the minimal profile must fail profile parity: {violations:?}"
     );
 }
 

--- a/bin/bitcoin-rs/tests/overhaul_ownership.rs
+++ b/bin/bitcoin-rs/tests/overhaul_ownership.rs
@@ -15,7 +15,7 @@ use std::io::Write as _;
 use std::path::Path;
 
 use support::dependency_graph::{BIN_CRATE, Validation, WorkspaceGraph};
-use support::ownership_scan::{WriterScanResult, scan_mempool_writer_violations};
+use support::ownership_scan::{OwnershipScanResult, scan_ownership_violations};
 
 #[test]
 fn real_metadata_validates() {
@@ -164,25 +164,54 @@ fn real_adapters_forward_their_backend_features() {
 
 #[test]
 fn mempool_writer_source_scan_passes() {
-    let WriterScanResult {
-        violations,
+    let OwnershipScanResult {
+        mempool_writer_violations,
         files_scanned,
         pool_writes_found,
-        mutating_calls_found,
-    } = scan_mempool_writer_violations();
+        mempool_mutations_found,
+        ..
+    } = scan_ownership_violations();
 
     let _ = writeln!(
         std::io::stderr(),
         "mempool writer scan: files={files_scanned}, \
          .pool().write()/.mempool().write()={pool_writes_found}, \
-         mutating_calls={mutating_calls_found}, \
+         mutating_calls={mempool_mutations_found}, \
          violations={}",
-        violations.len()
+        mempool_writer_violations.len()
     );
     assert!(
-        violations.is_empty(),
+        mempool_writer_violations.is_empty(),
         "non-owner production code must not call mutating mempool methods or \
-         .pool().write(): {violations:?}"
+         .pool().write(): {mempool_writer_violations:?}"
+    );
+}
+
+#[test]
+fn index_capability_scan_passes() {
+    let OwnershipScanResult {
+        index_capability_violations,
+        index_capability_sites,
+        files_scanned,
+        ..
+    } = scan_ownership_violations();
+
+    let _ = writeln!(
+        std::io::stderr(),
+        "index capability scan: files={files_scanned}, \
+         capability sites={index_capability_sites}, \
+         violations={}",
+        index_capability_violations.len()
+    );
+    assert!(
+        index_capability_violations.is_empty(),
+        "config-optional derived-index capability selection must stay with its \
+         owners (crates/index, the node txindex runtime, and the node state \
+         config projection): {index_capability_violations:?}"
+    );
+    assert!(
+        index_capability_sites > 0,
+        "the index capability scan matched no production capability selection"
     );
 }
 

--- a/bin/bitcoin-rs/tests/overhaul_ownership.rs
+++ b/bin/bitcoin-rs/tests/overhaul_ownership.rs
@@ -324,6 +324,24 @@ fn synthetic_kernel_leak_into_minimal_profile_fails() {
     );
 }
 
+/// Storage's rocksdb feature implies `dep:rust-rocksdb`, whose crate name
+/// is not one of the backend feature names: the backend rule must follow
+/// storage's own feature names, so a rocksdb-only lane composes too.
+#[test]
+fn synthetic_rocksdb_only_profile_reaches_its_backend() {
+    let graph = WorkspaceGraph::from_cargo_metadata();
+
+    let violations = graph.profile_ownership_violations(&FeatureProfile::new(
+        "rocksdb-only",
+        &["rocksdb"],
+        false,
+    ));
+    assert!(
+        violations.is_empty(),
+        "a rocksdb-only profile composes and must pass profile parity: {violations:?}"
+    );
+}
+
 const KNOWN_P2P_FORWARDING_WRAPPERS: &[&str] = &[
     "peer_table",
     "banned_subnets",

--- a/bin/bitcoin-rs/tests/support/dependency_graph.rs
+++ b/bin/bitcoin-rs/tests/support/dependency_graph.rs
@@ -514,15 +514,15 @@ impl WorkspaceGraph {
         let activated = self.resolve_profile(profile);
         let mut violations = Vec::new();
 
-        // The backend must reach the storage crate as an activated optional
-        // dependency through the node forwarding chain: a backend feature
-        // name alone does not compose storage.
+        // The backend must reach the storage crate as an activated feature
+        // through the node forwarding chain: a backend feature name at node
+        // alone does not compose storage. Storage declares every backend by
+        // its plain name (`fjall`, `redb`, `rocksdb`), so the plain test
+        // covers every engine uniformly.
         let backend_reached = activated.get(STORAGE_CRATE).is_some_and(|features| {
-            features.iter().any(|feature| {
-                feature
-                    .strip_prefix("dep:")
-                    .is_some_and(|dependency| BACKEND_FEATURES.contains(&dependency))
-            })
+            features
+                .iter()
+                .any(|feature| BACKEND_FEATURES.contains(&feature.as_str()))
         });
         if !backend_reached {
             violations.push(format!(

--- a/bin/bitcoin-rs/tests/support/dependency_graph.rs
+++ b/bin/bitcoin-rs/tests/support/dependency_graph.rs
@@ -6,7 +6,7 @@
 //! and backend feature-forwarding rules described in
 //! `docs/contracts/architecture.md`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
 
 /// Storage engine crates. Only `bitcoin-rs-storage` may depend on these.
@@ -89,6 +89,31 @@ pub(crate) struct Validation {
     pub classified: usize,
     /// Human-readable summary.
     pub summary: String,
+}
+
+/// One operator-facing binary feature profile, mirroring a CI build lane.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FeatureProfile {
+    /// Lane name used in violation messages.
+    pub(crate) name: &'static str,
+    /// CLI `--features` tokens applied to the binary crate.
+    pub(crate) features: &'static [&'static str],
+    /// Whether the binary's default features participate.
+    pub(crate) defaults: bool,
+}
+
+impl FeatureProfile {
+    pub(crate) const fn new(
+        name: &'static str,
+        features: &'static [&'static str],
+        defaults: bool,
+    ) -> Self {
+        Self {
+            name,
+            features,
+            defaults,
+        }
+    }
 }
 
 /// Locates the workspace root `Cargo.toml` from the integration test's
@@ -413,5 +438,156 @@ impl WorkspaceGraph {
             ),
         }
         checked
+    }
+
+    /// Resolves one binary feature profile to the activated workspace
+    /// crate/feature sets, walking the same `crate/feature` and `dep:` token
+    /// chains as `g19_validation_default`.
+    ///
+    /// Dependency-edge default features are deliberately not modeled: the
+    /// workspace pins `default-features = false` on the consensus and node
+    /// edges, and every engine surface (kernel, zmq, backends) reaches the
+    /// binary only through the explicit forwarding chains this walk follows.
+    pub(crate) fn resolve_profile(
+        &self,
+        profile: &FeatureProfile,
+    ) -> BTreeMap<String, BTreeSet<String>> {
+        let mut activated: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        let mut queue: Vec<(String, String)> = Vec::new();
+        if profile.defaults
+            && let Some(defaults) = self
+                .features
+                .get(BIN_CRATE)
+                .and_then(|features| features.get("default"))
+        {
+            for feature in defaults {
+                queue.push((BIN_CRATE.to_owned(), feature.clone()));
+            }
+        }
+        for feature in profile.features {
+            queue.push((BIN_CRATE.to_owned(), (*feature).to_owned()));
+        }
+        while let Some((package, feature)) = queue.pop() {
+            if !activated
+                .entry(package.clone())
+                .or_default()
+                .insert(feature.clone())
+            {
+                continue;
+            }
+            let Some(implies) = self
+                .features
+                .get(&package)
+                .and_then(|features| features.get(&feature))
+            else {
+                continue;
+            };
+            for token in implies {
+                if let Some((target, target_feature)) = token.split_once('/') {
+                    let target = target.trim_end_matches('?');
+                    queue.push((target.to_owned(), target_feature.to_owned()));
+                } else if token == "default" {
+                    if let Some(defaults) = self
+                        .features
+                        .get(&package)
+                        .and_then(|features| features.get("default"))
+                    {
+                        for default in defaults {
+                            queue.push((package.clone(), default.clone()));
+                        }
+                    }
+                } else {
+                    // Same-package features and `dep:` activation markers.
+                    queue.push((package.clone(), token.clone()));
+                }
+            }
+        }
+        activated
+    }
+
+    /// Returns the ownership violations of one binary feature profile: the
+    /// profile must reach a storage backend through the node forwarding
+    /// chain, backend features must stay on the forwarding allowlist, and
+    /// the kernel and ZMQ engines must follow their explicit selection
+    /// chains — present exactly when the profile selects them.
+    pub(crate) fn profile_ownership_violations(&self, profile: &FeatureProfile) -> Vec<String> {
+        let activated = self.resolve_profile(profile);
+        let mut violations = Vec::new();
+
+        // The backend must reach the storage crate as an activated optional
+        // dependency through the node forwarding chain: a backend feature
+        // name alone does not compose storage.
+        let backend_reached = activated.get(STORAGE_CRATE).is_some_and(|features| {
+            features.iter().any(|feature| {
+                feature
+                    .strip_prefix("dep:")
+                    .is_some_and(|dependency| BACKEND_FEATURES.contains(&dependency))
+            })
+        });
+        if !backend_reached {
+            violations.push(format!(
+                "profile `{}` activates no storage backend through the node \
+                 forwarding chain; a node without a backend cannot compose its \
+                 storage",
+                profile.name
+            ));
+        }
+
+        let node_features = activated.get(NODE_CRATE);
+        for (package, features) in &activated {
+            for feature in features {
+                if BACKEND_FEATURES.contains(&feature.as_str())
+                    && !BACKEND_FORWARDING_CRATES.contains(&package.as_str())
+                {
+                    violations.push(format!(
+                        "profile `{}` activates backend feature `{feature}` on \
+                         non-forwarding crate `{package}`",
+                        profile.name
+                    ));
+                }
+            }
+        }
+
+        let kernel_selected = node_features.is_some_and(|features| features.contains("kernel"));
+        let consensus_kernel = activated
+            .get("bitcoin-rs-consensus")
+            .is_some_and(|features| features.contains("dep:bitcoinkernel"));
+        if kernel_selected != consensus_kernel {
+            violations.push(if kernel_selected {
+                format!(
+                    "profile `{}` selects `kernel` without reaching `dep:bitcoinkernel` \
+                     on `bitcoin-rs-consensus`",
+                    profile.name
+                )
+            } else {
+                format!(
+                    "profile `{}` must keep the kernel engine out of the production graph",
+                    profile.name
+                )
+            });
+        }
+
+        let zmq_selected = activated
+            .get(BIN_CRATE)
+            .is_some_and(|features| features.contains("zmq"));
+        let zmq_owned = activated
+            .get(RPC_CRATE)
+            .is_some_and(|features| features.contains("dep:zmq"));
+        if zmq_selected != zmq_owned {
+            violations.push(if zmq_selected {
+                format!(
+                    "profile `{}` selects `zmq` without enabling the owned `dep:zmq` \
+                     dependency on `{RPC_CRATE}`",
+                    profile.name
+                )
+            } else {
+                format!(
+                    "profile `{}` must keep the ZMQ surface out of the production graph",
+                    profile.name
+                )
+            });
+        }
+
+        violations
     }
 }

--- a/bin/bitcoin-rs/tests/support/dependency_graph.rs
+++ b/bin/bitcoin-rs/tests/support/dependency_graph.rs
@@ -7,7 +7,9 @@
 //! `docs/contracts/architecture.md`.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
 use std::process::Command;
+use std::sync::LazyLock;
 
 /// Storage engine crates. Only `bitcoin-rs-storage` may depend on these.
 pub(crate) const ENGINE_CRATES: [&str; 3] = ["fjall", "redb", "rust-rocksdb"];
@@ -124,31 +126,62 @@ pub(crate) fn workspace_root_manifest() -> std::path::PathBuf {
         .join("Cargo.toml")
 }
 
+/// Runs `cargo metadata --locked --offline --no-deps --format-version 1`
+/// against the workspace root manifest.
+fn run_cargo_metadata() -> serde_json::Value {
+    let output = Command::new(env!("CARGO"))
+        .args([
+            "metadata",
+            "--locked",
+            "--offline",
+            "--no-deps",
+            "--format-version",
+            "1",
+            "--manifest-path",
+            workspace_root_manifest().to_str().expect("utf8 root path"),
+        ])
+        .output()
+        .expect("run cargo metadata");
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("parse cargo metadata JSON")
+}
+
+/// Directories of the cargo-metadata workspace members, resolved once.
+///
+/// The ownership scan walks exactly these directories: sibling checkouts
+/// under `.outline/worktree/`, vendored trees, and any other non-member
+/// production code under the checkout root must never influence a gate run.
+pub(crate) fn workspace_member_dirs() -> &'static [PathBuf] {
+    static DIRS: LazyLock<Vec<PathBuf>> = LazyLock::new(|| {
+        let metadata = run_cargo_metadata();
+        let mut dirs: Vec<PathBuf> = metadata["packages"]
+            .as_array()
+            .expect("packages array")
+            .iter()
+            .map(|package| {
+                let manifest = package["manifest_path"].as_str().expect("manifest path");
+                std::path::Path::new(manifest)
+                    .parent()
+                    .expect("manifest parent")
+                    .to_owned()
+            })
+            .collect();
+        dirs.sort();
+        dirs.dedup();
+        dirs
+    });
+    DIRS.as_slice()
+}
+
 impl WorkspaceGraph {
     /// Runs `cargo metadata --locked --offline --no-deps --format-version 1` and
     /// parses the result.
     pub(crate) fn from_cargo_metadata() -> Self {
-        let output = Command::new(env!("CARGO"))
-            .args([
-                "metadata",
-                "--locked",
-                "--offline",
-                "--no-deps",
-                "--format-version",
-                "1",
-                "--manifest-path",
-                workspace_root_manifest().to_str().expect("utf8 root path"),
-            ])
-            .output()
-            .expect("run cargo metadata");
-        assert!(
-            output.status.success(),
-            "cargo metadata failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let metadata: serde_json::Value =
-            serde_json::from_slice(&output.stdout).expect("parse cargo metadata JSON");
-        Self::from_json(&metadata)
+        Self::from_json(&run_cargo_metadata())
     }
 
     /// Parses the same `cargo metadata --format-version 1` shape from a

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -3,13 +3,17 @@
 //!
 //! The scan walks workspace Rust sources (excluding `tests/`, `benches/`, and
 //! `examples/`) and ignores code inside top-level `#[cfg(test)]` items and
-//! `#[test]` functions. A small Rust lexical mask keeps braces and mutator-like
-//! text inside comments, quoted strings, raw strings, and character literals
-//! from changing item boundaries or producing false matches. Production code
-//! outside `crates/mempool/src/` fails the scan if it directly calls a mutating
-//! `Mempool` method or acquires the pool write lock through a bypass pattern.
+//! `#[test]` functions. Whole files whose module is declared with a
+//! `#[cfg(test)] mod <name>;` attribute — test-support files whose helpers
+//! carry no `#[test]` marks of their own — are skipped as well. A small Rust
+//! lexical mask keeps braces and mutator-like text inside comments, quoted
+//! strings, raw strings, and character literals from changing item boundaries
+//! or producing false matches. Production code outside `crates/mempool/src/`
+//! fails the scan if it directly calls a mutating `Mempool` method or
+//! acquires the pool write lock through a bypass pattern.
 
-use std::path::Path;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
 /// Audited cross-crate gateway mutation expressions.
 ///
@@ -83,12 +87,21 @@ fn empty_result() -> WriterScanResult {
 /// Walks the workspace and returns any mempool-writer violations.
 pub(crate) fn scan_mempool_writer_violations() -> WriterScanResult {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let mut files = Vec::new();
+    collect_rust_files(&root, &mut files);
+    files.sort();
+    let test_modules = cfg_test_module_stems(&files);
     let mut result = empty_result();
-    scan_dir(&root, &mut result);
+    for path in &files {
+        if is_test_module_file(path, &test_modules) {
+            continue;
+        }
+        scan_file(path, &mut result);
+    }
     result
 }
 
-fn scan_dir(dir: &Path, result: &mut WriterScanResult) {
+fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) {
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
             let path = entry.path();
@@ -100,12 +113,99 @@ fn scan_dir(dir: &Path, result: &mut WriterScanResult) {
                 if matches!(name, "target" | "tests" | "benches" | "examples") {
                     continue;
                 }
-                scan_dir(&path, result);
+                collect_rust_files(&path, files);
             } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
-                scan_file(&path, result);
+                files.push(path);
             }
         }
     }
+}
+
+/// Collects the stems of modules declared `#[cfg(test)] mod <stem>;`.
+///
+/// Such a declaration compiles its module file only under `cfg(test)`, but a
+/// per-file lexical scan cannot see the parent's attribute. Recording the
+/// stems keeps test-support files such as `sync/tests.rs` — whose helpers
+/// carry no `#[test]` marks of their own — out of the production scan without
+/// guessing from file names alone. An inline `mod <stem> { .. }` block is not
+/// recorded: [`scan_source`] already skips its items line by line.
+fn cfg_test_module_stems(files: &[PathBuf]) -> BTreeSet<String> {
+    let contents = files
+        .iter()
+        .map(|path| std::fs::read_to_string(path).unwrap_or_default());
+    cfg_test_module_stems_from(contents)
+}
+
+fn cfg_test_module_stems_from<I>(contents: I) -> BTreeSet<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut stems = BTreeSet::new();
+    for content in contents {
+        let lines: Vec<&str> = content.lines().collect();
+        for (index, raw_line) in lines.iter().enumerate() {
+            let trimmed = raw_line.trim();
+            let Some(rest) = cfg_test_attribute(trimmed) else {
+                continue;
+            };
+            if let Some(stem) = mod_stem(rest) {
+                stems.insert(stem);
+                continue;
+            }
+            if !rest.trim().is_empty() {
+                continue;
+            }
+            // Attribute-only line: the `mod` declaration follows after any
+            // further attributes, comments, or blank lines.
+            for next in lines.iter().skip(index + 1) {
+                let next_trimmed = next.trim();
+                if next_trimmed.is_empty()
+                    || next_trimmed.starts_with("//")
+                    || next_trimmed.starts_with("#!")
+                    || cfg_test_attribute(next_trimmed).is_some()
+                    || next_trimmed.starts_with("#[")
+                {
+                    continue;
+                }
+                if let Some(stem) = mod_stem(next_trimmed) {
+                    stems.insert(stem);
+                }
+                break;
+            }
+        }
+    }
+    stems
+}
+
+/// Recognizes a `#[cfg(…test…)]` attribute and returns the line remainder
+/// after the closing bracket. `cfg(not(test))` is rejected: it flags
+/// production code, not test code.
+fn cfg_test_attribute(trimmed: &str) -> Option<&str> {
+    let rest = trimmed.strip_prefix("#[cfg(")?;
+    let end = rest.rfind(")]")?;
+    let payload = &rest[..end];
+    if !payload.contains("test") || payload.contains("not(test)") {
+        return None;
+    }
+    Some(&rest[end + ")]".len()..])
+}
+
+/// Extracts `<stem>` from a complete external `mod <stem>;` declaration.
+/// Returns `None` for inline `mod <stem> { .. }` blocks and non-mod items.
+fn mod_stem(rest: &str) -> Option<String> {
+    let tail = rest.trim().strip_prefix("mod ")?;
+    let name = tail.strip_suffix(';')?.trim();
+    (!name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_'))
+    .then(|| name.to_owned())
+}
+
+fn is_test_module_file(path: &Path, test_modules: &BTreeSet<String>) -> bool {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| test_modules.contains(stem))
 }
 
 fn scan_file(path: &Path, result: &mut WriterScanResult) {
@@ -392,7 +492,11 @@ fn is_authorized_gateway_call(
 
 #[cfg(test)]
 mod tests {
-    use super::{LexState, code_line, empty_result, is_authorized_gateway_call, scan_source};
+    use super::{
+        LexState, cfg_test_module_stems_from, code_line, empty_result, is_authorized_gateway_call,
+        is_test_module_file, scan_source,
+    };
+    use std::path::Path;
 
     const MINING_HANDLER: &str = "/workspace/crates/rpc/src/handlers/mining.rs";
     const NON_OWNER: &str = "/workspace/crates/node/src/fake.rs";
@@ -414,6 +518,48 @@ mod tests {
         let mut result = empty_result();
         scan_source(NON_OWNER, source, &mut result);
         result.violations
+    }
+
+    #[test]
+    fn cfg_test_stems_cover_external_module_declarations_only() {
+        let stems = cfg_test_module_stems_from([
+            "#[cfg(test)]\nmod tests;\n".to_owned(),
+            "#[cfg(all(test, feature = \"fjall\"))]\nmod body_reader_tests;\n".to_owned(),
+            "#[cfg(test)] mod tests;\n".to_owned(),
+            "#[cfg(test)]\n\n// leading comment\n#[expect(unused)]\nmod helpers;\n".to_owned(),
+        ]);
+        assert_eq!(
+            stems,
+            ["body_reader_tests", "helpers", "tests"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
+        );
+
+        let not_stems = cfg_test_module_stems_from([
+            "#[cfg(not(test))]\nmod production;\n".to_owned(),
+            "#[cfg(test)]\nmod inline {\n    fn helper() {}\n}\n".to_owned(),
+            "#[cfg(test)]\nfn a_test_helper() {}\n".to_owned(),
+            "mod plainly_gated;\n".to_owned(),
+        ]);
+        assert!(not_stems.is_empty(), "{not_stems:?}");
+    }
+
+    #[test]
+    fn a_test_module_file_is_skipped_by_its_stem() {
+        let stems = cfg_test_module_stems_from(["#[cfg(test)]\nmod tests;\n".to_owned()]);
+        assert!(is_test_module_file(
+            Path::new("/workspace/crates/node/src/sync/tests.rs"),
+            &stems
+        ));
+        assert!(!is_test_module_file(
+            Path::new("/workspace/crates/node/src/sync/peers.rs"),
+            &stems
+        ));
+        assert!(!is_test_module_file(
+            Path::new("/workspace/crates/node/src/lib.rs"),
+            &stems
+        ));
     }
 
     #[test]

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -106,7 +106,10 @@ pub(crate) const PEER_MUTATION_METHODS: &[&str] = &[
 /// Receiver-qualified patterns for the peer mutators whose bare name is
 /// shared with another owner's API: `ChainTransition::disconnect` also
 /// reads `disconnect(`, so only a `peer_table` receiver counts here.
-pub(crate) const PEER_TABLE_PATTERNS: &[&str] = &[".peer_table.disconnect("];
+pub(crate) const PEER_TABLE_PATTERNS: &[&str] = &[
+    ".peer_table.disconnect(",
+    "PeerTable::disconnect(",
+];
 
 /// Audited non-owner peer mutation receivers. The receiver must be the
 /// complete audited expression — the sync worker's shared state handle —
@@ -182,7 +185,13 @@ fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         panic!("scan cannot read workspace member dir {}", dir.display());
     };
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|error| {
+            panic!(
+                "scan cannot read an entry in workspace member dir {}: {error}",
+                dir.display()
+            )
+        });
         let path = entry.path();
         if path.is_dir() {
             let name = path

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -10,7 +10,10 @@
 //! strings, raw strings, and character literals from changing item boundaries
 //! or producing false matches. Production code outside `crates/mempool/src/`
 //! fails the scan if it directly calls a mutating `Mempool` method or
-//! acquires the pool write lock through a bypass pattern.
+//! acquires the pool write lock through a bypass pattern. Derived-index
+//! capability selection fails the scan outside its three owners: the
+//! `crates/index` crate, the `crates/node` txindex runtime, and the
+//! `crates/node/src/state` config projection.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -62,30 +65,54 @@ pub(crate) const MUTATING_METHODS: &[&str] = &[
 /// covers `MempoolGateway::pool()`.
 pub(crate) const POOL_WRITE_PATTERNS: &[&str] = &[".mempool().write(", ".pool().write("];
 
+/// Capability-forcing and config-projection expressions for the derived
+/// transaction/script index.
+///
+/// `txindex` and `scriptindex` are config-optional: a node composes and
+/// validates without them. They become a required dependency of a compose
+/// path exactly when code outside the owners constructs `IndexCapabilities`
+/// or calls the config projection, so every such expression must sit in an
+/// owner file. A bare type mention (a field, a parameter, an import) forces
+/// nothing and is not matched.
+pub(crate) const INDEX_CAPABILITY_PATTERNS: &[&str] = &[
+    "IndexCapabilities {",
+    "IndexCapabilities::",
+    "derived_index_capabilities(",
+    "build_derived_index_open_spec(",
+];
+
 /// Result of the source scan.
 #[derive(Debug)]
-pub(crate) struct WriterScanResult {
-    /// Human-readable violations, one per call site.
-    pub violations: Vec<String>,
+pub(crate) struct OwnershipScanResult {
+    /// Mempool mutations outside the mempool owner, one per call site.
+    pub mempool_writer_violations: Vec<String>,
+    /// Derived-index capability selection outside the index owners.
+    pub index_capability_violations: Vec<String>,
     /// Number of production source files examined.
     pub files_scanned: usize,
     /// Number of raw pool write sites found.
     pub pool_writes_found: usize,
-    /// Number of mutating method calls found (including gateway calls).
-    pub mutating_calls_found: usize,
+    /// Number of mutating mempool method calls found (including gateway
+    /// calls).
+    pub mempool_mutations_found: usize,
+    /// Number of derived-index capability expressions found (including
+    /// owner files).
+    pub index_capability_sites: usize,
 }
 
-fn empty_result() -> WriterScanResult {
-    WriterScanResult {
-        violations: Vec::new(),
+fn empty_result() -> OwnershipScanResult {
+    OwnershipScanResult {
+        mempool_writer_violations: Vec::new(),
+        index_capability_violations: Vec::new(),
         files_scanned: 0,
         pool_writes_found: 0,
-        mutating_calls_found: 0,
+        mempool_mutations_found: 0,
+        index_capability_sites: 0,
     }
 }
 
-/// Walks the workspace and returns any mempool-writer violations.
-pub(crate) fn scan_mempool_writer_violations() -> WriterScanResult {
+/// Walks the workspace and returns every single-owner boundary violation.
+pub(crate) fn scan_ownership_violations() -> OwnershipScanResult {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let mut files = Vec::new();
     collect_rust_files(&root, &mut files);
@@ -208,7 +235,7 @@ fn is_test_module_file(path: &Path, test_modules: &BTreeSet<String>) -> bool {
         .is_some_and(|stem| test_modules.contains(stem))
 }
 
-fn scan_file(path: &Path, result: &mut WriterScanResult) {
+fn scan_file(path: &Path, result: &mut OwnershipScanResult) {
     let path_str = path.to_string_lossy();
     let content = std::fs::read_to_string(path).unwrap_or_default();
     scan_source(&path_str, &content, result);
@@ -366,7 +393,7 @@ fn is_test_attribute(trimmed: &str) -> bool {
         || trimmed.starts_with("#[test(")
 }
 
-fn scan_source(path_str: &str, content: &str, result: &mut WriterScanResult) {
+fn scan_source(path_str: &str, content: &str, result: &mut OwnershipScanResult) {
     let is_mempool_owner = path_str.replace('\\', "/").contains("/crates/mempool/src/");
     let raw_lines: Vec<&str> = content.lines().collect();
     let mut lex = LexState::default();
@@ -417,7 +444,7 @@ fn scan_source(path_str: &str, content: &str, result: &mut WriterScanResult) {
             if line.contains(pattern) {
                 result.pool_writes_found += 1;
                 if !is_mempool_owner {
-                    result.violations.push(format!(
+                    result.mempool_writer_violations.push(format!(
                         "raw pool write `{pattern}` at {}:{}: {}",
                         path_str,
                         index + 1,
@@ -429,12 +456,26 @@ fn scan_source(path_str: &str, content: &str, result: &mut WriterScanResult) {
 
         for method in MUTATING_METHODS {
             if let Some(pos) = line.find(method) {
-                result.mutating_calls_found += 1;
+                result.mempool_mutations_found += 1;
                 if !is_mempool_owner
                     && !is_authorized_gateway_call(path_str, line, pos, &code_lines, index)
                 {
-                    result.violations.push(format!(
+                    result.mempool_writer_violations.push(format!(
                         "raw mempool mutation `{method}` at {}:{}: {}",
+                        path_str,
+                        index + 1,
+                        raw_lines[index].trim()
+                    ));
+                }
+            }
+        }
+
+        for pattern in INDEX_CAPABILITY_PATTERNS {
+            if line.contains(pattern) {
+                result.index_capability_sites += 1;
+                if !is_index_capability_owner(path_str) {
+                    result.index_capability_violations.push(format!(
+                        "derived-index capability `{pattern}` at {}:{}: {}",
                         path_str,
                         index + 1,
                         raw_lines[index].trim()
@@ -490,6 +531,19 @@ fn is_authorized_gateway_call(
         })
 }
 
+/// Returns true when `path` belongs to one of the three derived-index
+/// capability owners: the `crates/index` crate that owns the type and its
+/// durable writer, the node txindex runtime that drives the worker and query
+/// engine, and the node state module whose `index.rs` is the only config
+/// projection.
+fn is_index_capability_owner(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized.contains("/crates/index/src/")
+        || normalized.contains("/crates/node/src/state/")
+        || normalized.contains("/crates/node/src/txindex.rs")
+        || normalized.contains("/crates/node/src/txindex/")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -517,7 +571,7 @@ mod tests {
     fn violations(source: &str) -> Vec<String> {
         let mut result = empty_result();
         scan_source(NON_OWNER, source, &mut result);
-        result.violations
+        result.mempool_writer_violations
     }
 
     #[test]
@@ -560,6 +614,84 @@ mod tests {
             Path::new("/workspace/crates/node/src/lib.rs"),
             &stems
         ));
+    }
+
+    #[test]
+    fn only_derived_index_owners_select_capabilities() {
+        for (path, source) in [
+            (
+                "/workspace/crates/node/src/state/index.rs",
+                "bitcoin_rs_index::IndexCapabilities {\n    tx_lookup: config.indexes.txindex,\n}",
+            ),
+            (
+                "/workspace/crates/node/src/state/open.rs",
+                "let indexed = !derived_index_capabilities(&config).is_empty();",
+            ),
+            (
+                "/workspace/crates/node/src/txindex/query.rs",
+                "self.with_snapshot(IndexCapabilities::TX_LOOKUP, |snapshot, tip, budget| {})",
+            ),
+            (
+                "/workspace/crates/index/src/write.rs",
+                "writer.reset_capabilities(IndexCapabilities::SCRIPT_LIVE)?;",
+            ),
+        ] {
+            let mut result = empty_result();
+            scan_source(path, source, &mut result);
+            assert!(
+                result.index_capability_violations.is_empty(),
+                "{path}: {:?}",
+                result.index_capability_violations
+            );
+            assert_eq!(result.index_capability_sites, 1, "{path}");
+        }
+    }
+
+    /// Forcing capability selection in a compose or apply path is exactly
+    /// the config-optional index becoming required.
+    #[test]
+    fn capability_forcing_outside_the_owners_is_flagged() {
+        for (path, source) in [
+            (
+                "/workspace/crates/node/src/apply/connect.rs",
+                "let caps = IndexCapabilities::ALL;",
+            ),
+            (
+                "/workspace/crates/node/src/startup.rs",
+                "let spec = build_derived_index_open_spec(&config, 0, 1)?.unwrap();",
+            ),
+            (
+                "/workspace/crates/rpc/src/handlers/chain.rs",
+                "IndexCapabilities::TX_LOOKUP",
+            ),
+        ] {
+            let mut result = empty_result();
+            scan_source(path, source, &mut result);
+            assert_eq!(
+                result.index_capability_violations.len(),
+                1,
+                "{path}: {:?}",
+                result.index_capability_violations
+            );
+        }
+    }
+
+    #[test]
+    fn capability_type_mentions_and_text_do_not_force_anything() {
+        for source in [
+            "fn f(capabilities: IndexCapabilities) {}",
+            "use bitcoin_rs_index::IndexCapabilities;",
+            "const T: &str = \"IndexCapabilities::ALL\";",
+            "// IndexCapabilities::ALL in a comment",
+        ] {
+            let mut result = empty_result();
+            scan_source(NON_OWNER, source, &mut result);
+            assert!(
+                result.index_capability_violations.is_empty(),
+                "{source}"
+            );
+            assert_eq!(result.index_capability_sites, 0, "{source}");
+        }
     }
 
     #[test]
@@ -666,11 +798,11 @@ mod tests {
             let mut result = empty_result();
             scan_source(path, call, &mut result);
             assert_eq!(
-                result.violations.len(),
+                result.mempool_writer_violations.len(),
                 expected_violations,
                 "{path}: {call}"
             );
-            assert_eq!(result.mutating_calls_found, 1);
+            assert_eq!(result.mempool_mutations_found, 1);
         }
     }
 
@@ -705,7 +837,7 @@ mod tests {
                 &mut result,
             );
             assert_eq!(
-                result.violations.is_empty(),
+                result.mempool_writer_violations.is_empty(),
                 permitted,
                 "{path}: {receiver}"
             );
@@ -735,11 +867,11 @@ mod tests {
             let mut result = empty_result();
             scan_source(path, call, &mut result);
             assert_eq!(
-                result.violations.len(),
+                result.mempool_writer_violations.len(),
                 expected_violations,
                 "{path}: {call}"
             );
-            assert_eq!(result.mutating_calls_found, 1);
+            assert_eq!(result.mempool_mutations_found, 1);
         }
     }
 

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -13,7 +13,9 @@
 //! acquires the pool write lock through a bypass pattern. Derived-index
 //! capability selection fails the scan outside its three owners: the
 //! `crates/index` crate, the `crates/node` txindex runtime, and the
-//! `crates/node/src/state` config projection.
+//! `crates/node/src/state` config projection. Peer registration and
+//! cancellation fail the scan outside `crates/p2p/src/` apart from
+//! explicitly audited receiver expressions.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -81,6 +83,44 @@ pub(crate) const INDEX_CAPABILITY_PATTERNS: &[&str] = &[
     "build_derived_index_open_spec(",
 ];
 
+/// Peer registration and cancellation mutators on `PeerTable`,
+/// `P2pService`, and the connections they own. The names are distinctive
+/// enough to scan bare. Owner-owned free functions such as
+/// `apply_network_active` keep their mutation inside `crates/p2p` and are
+/// not second owners. `PeerLease::cancel` and `PeerConnection::cancel` have
+/// no production caller outside the owner; a new one belongs here only
+/// together with an audited receiver.
+pub(crate) const PEER_MUTATION_METHODS: &[&str] = &[
+    "register(",
+    "publish_info(",
+    "publish_ready(",
+    "remove_current(",
+    "disconnect_source(",
+    "disconnect_connection(",
+    "disconnect_matching(",
+    "cancel_all(",
+];
+
+/// Receiver-qualified patterns for the peer mutators whose bare name is
+/// shared with another owner's API: `ChainTransition::disconnect` also
+/// reads `disconnect(`, so only a `peer_table` receiver counts here.
+pub(crate) const PEER_TABLE_PATTERNS: &[&str] = &[".peer_table.disconnect("];
+
+/// Audited non-owner peer mutation receivers. The receiver must be the
+/// complete audited expression — the sync worker's shared state handle —
+/// never a lookalike local.
+pub(crate) const AUTHORIZED_PEER_TABLE_CALLS: &[(&str, &str)] = &[
+    // Header sync tears down the peer a fault was blamed on.
+    ("crates/node/src/sync/headers.rs", "self.peer_table"),
+    // Download-window selection drops a stale peer connection.
+    ("crates/node/src/sync/peers.rs", "self.peer_table"),
+];
+
+/// Paths allowed to call the receiver-qualified peer mutators from non-owner
+/// code: the RPC operator surface (`disconnectnode`) is the one permitted
+/// caller.
+pub(crate) const AUTHORIZED_PEER_TABLE_PATHS: &[&str] = &["crates/rpc/src/handlers/network.rs"];
+
 /// Result of the source scan.
 #[derive(Debug)]
 pub(crate) struct OwnershipScanResult {
@@ -88,6 +128,8 @@ pub(crate) struct OwnershipScanResult {
     pub mempool_writer_violations: Vec<String>,
     /// Derived-index capability selection outside the index owners.
     pub index_capability_violations: Vec<String>,
+    /// Peer registration/cancellation outside the P2P owner and its audits.
+    pub peer_owner_violations: Vec<String>,
     /// Number of production source files examined.
     pub files_scanned: usize,
     /// Number of raw pool write sites found.
@@ -98,16 +140,20 @@ pub(crate) struct OwnershipScanResult {
     /// Number of derived-index capability expressions found (including
     /// owner files).
     pub index_capability_sites: usize,
+    /// Number of peer mutation call sites found (including owner files).
+    pub peer_mutations_found: usize,
 }
 
 fn empty_result() -> OwnershipScanResult {
     OwnershipScanResult {
         mempool_writer_violations: Vec::new(),
         index_capability_violations: Vec::new(),
+        peer_owner_violations: Vec::new(),
         files_scanned: 0,
         pool_writes_found: 0,
         mempool_mutations_found: 0,
         index_capability_sites: 0,
+        peer_mutations_found: 0,
     }
 }
 
@@ -220,7 +266,17 @@ fn cfg_test_attribute(trimmed: &str) -> Option<&str> {
 /// Extracts `<stem>` from a complete external `mod <stem>;` declaration.
 /// Returns `None` for inline `mod <stem> { .. }` blocks and non-mod items.
 fn mod_stem(rest: &str) -> Option<String> {
-    let tail = rest.trim().strip_prefix("mod ")?;
+    let mut declared = rest.trim();
+    if let Some(tail) = declared.strip_prefix("pub") {
+        declared = tail.trim_start();
+    }
+    if let Some(tail) = declared
+        .strip_prefix("(crate)")
+        .or_else(|| declared.strip_prefix("(super)"))
+    {
+        declared = tail.trim_start();
+    }
+    let tail = declared.strip_prefix("mod ")?;
     let name = tail.strip_suffix(';')?.trim();
     (!name.is_empty()
         && name
@@ -393,6 +449,10 @@ fn is_test_attribute(trimmed: &str) -> bool {
         || trimmed.starts_with("#[test(")
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "each single-owner boundary runs as one visible loop inside the shared line walk"
+)]
 fn scan_source(path_str: &str, content: &str, result: &mut OwnershipScanResult) {
     let is_mempool_owner = path_str.replace('\\', "/").contains("/crates/mempool/src/");
     let raw_lines: Vec<&str> = content.lines().collect();
@@ -483,6 +543,39 @@ fn scan_source(path_str: &str, content: &str, result: &mut OwnershipScanResult) 
                 }
             }
         }
+
+        for method in PEER_MUTATION_METHODS {
+            if let Some(pos) = line.find(method) {
+                result.peer_mutations_found += 1;
+                if !is_p2p_owner(path_str)
+                    && !is_authorized_peer_table_call(path_str, line, pos, &code_lines, index)
+                {
+                    result.peer_owner_violations.push(format!(
+                        "peer mutation `{method}` at {}:{}: {}",
+                        path_str,
+                        index + 1,
+                        raw_lines[index].trim()
+                    ));
+                }
+            }
+        }
+
+        for pattern in PEER_TABLE_PATTERNS {
+            if line.contains(pattern) {
+                result.peer_mutations_found += 1;
+                let operator_audited = AUTHORIZED_PEER_TABLE_PATHS
+                    .iter()
+                    .any(|allowed| authorized_path(path_str, allowed));
+                if !is_p2p_owner(path_str) && !operator_audited {
+                    result.peer_owner_violations.push(format!(
+                        "peer table mutation `{pattern}` at {}:{}: {}",
+                        path_str,
+                        index + 1,
+                        raw_lines[index].trim()
+                    ));
+                }
+            }
+        }
     }
 }
 
@@ -495,39 +588,11 @@ fn is_authorized_gateway_call(
     lines: &[String],
     line_index: usize,
 ) -> bool {
-    let normalized_path = path.replace('\\', "/");
     AUTHORIZED_GATEWAY_CALLS
         .iter()
         .any(|(allowed_path, allowed_receiver)| {
-            let path_matches = normalized_path == *allowed_path
-                || normalized_path
-                    .strip_suffix(allowed_path)
-                    .is_some_and(|prefix| prefix.ends_with('/'));
-            if !path_matches {
-                return false;
-            }
-
-            // Rustfmt can split both field access and the method call across
-            // lines. Read the masked code backwards, skipping only whitespace,
-            // and require the entire audited receiver rather than a suffix.
-            let mut before = line[..method_pos]
-                .chars()
-                .rev()
-                .chain(
-                    lines[..line_index]
-                        .iter()
-                        .rev()
-                        .flat_map(|previous| previous.chars().rev()),
-                )
-                .filter(|ch| !ch.is_whitespace());
-            before.next() == Some('.')
-                && allowed_receiver
-                    .chars()
-                    .rev()
-                    .all(|expected| before.next() == Some(expected))
-                && before
-                    .next()
-                    .is_none_or(|ch| ch != '.' && ch != '_' && ch.is_ascii_punctuation())
+            authorized_path(path, allowed_path)
+                && receiver_expression_is(line, method_pos, lines, line_index, allowed_receiver)
         })
 }
 
@@ -544,12 +609,103 @@ fn is_index_capability_owner(path: &str) -> bool {
         || normalized.contains("/crates/node/src/txindex/")
 }
 
+/// Returns true when `path` is `allowed` or reaches it across a directory
+/// boundary, so a lookalike sibling directory cannot inherit an audit.
+fn authorized_path(path: &str, allowed: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized == allowed
+        || normalized
+            .strip_suffix(allowed)
+            .is_some_and(|prefix| prefix.ends_with('/'))
+}
+
+/// Reads the masked code backwards from the method position and requires
+/// the entire audited receiver rather than a suffix. Rustfmt can split both
+/// field access and the method call across lines, so the chain continues
+/// through the preceding lines. The boundary before the receiver passes
+/// when the run of code is separated there — whitespace, and therefore any
+/// control-flow keyword, or plain punctuation. A glued identifier
+/// (`my_self`), a `_`, or a longer chain (`other.`) reads as a different
+/// expression and fails.
+fn receiver_expression_is(
+    line: &str,
+    method_pos: usize,
+    lines: &[String],
+    line_index: usize,
+    receiver: &str,
+) -> bool {
+    let mut stream = line[..method_pos].chars().rev().chain(
+        lines[..line_index]
+            .iter()
+            .rev()
+            .flat_map(|previous| previous.chars().rev()),
+    );
+    // The method's own dot.
+    let Some((dot, _)) = next_code_char(&mut stream) else {
+        return false;
+    };
+    if dot != '.' {
+        return false;
+    }
+    for expected in receiver.chars().rev() {
+        let Some((got, _)) = next_code_char(&mut stream) else {
+            return false;
+        };
+        if got != expected {
+            return false;
+        }
+    }
+    match next_code_char(&mut stream) {
+        None => true,
+        Some((ch, separated)) => {
+            separated || (ch.is_ascii_punctuation() && !matches!(ch, '.' | '_'))
+        }
+    }
+}
+
+/// Returns the next non-whitespace character and whether whitespace was
+/// skipped before it.
+fn next_code_char(stream: &mut impl Iterator<Item = char>) -> Option<(char, bool)> {
+    let mut separated = false;
+    loop {
+        match stream.next() {
+            Some(ch) if ch.is_whitespace() => separated = true,
+            other => return other.map(|ch| (ch, separated)),
+        }
+    }
+}
+
+/// Returns true only when a peer mutation sits on a receiver expression
+/// explicitly audited in [`AUTHORIZED_PEER_TABLE_CALLS`].
+fn is_authorized_peer_table_call(
+    path: &str,
+    line: &str,
+    method_pos: usize,
+    lines: &[String],
+    line_index: usize,
+) -> bool {
+    AUTHORIZED_PEER_TABLE_CALLS
+        .iter()
+        .any(|(allowed_path, allowed_receiver)| {
+            authorized_path(path, allowed_path)
+                && receiver_expression_is(line, method_pos, lines, line_index, allowed_receiver)
+        })
+}
+
+/// Returns true when `path` is inside the P2P owner crate: `PeerTable`,
+/// `P2pService`, and the connections they spawn are the single peer
+/// registration and cancellation owner.
+fn is_p2p_owner(path: &str) -> bool {
+    path.replace('\\', "/").contains("/crates/p2p/src/")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         LexState, cfg_test_module_stems_from, code_line, empty_result, is_authorized_gateway_call,
         is_test_module_file, scan_source,
     };
+    use std::collections::BTreeSet;
     use std::path::Path;
 
     const MINING_HANDLER: &str = "/workspace/crates/rpc/src/handlers/mining.rs";
@@ -581,14 +737,20 @@ mod tests {
             "#[cfg(all(test, feature = \"fjall\"))]\nmod body_reader_tests;\n".to_owned(),
             "#[cfg(test)] mod tests;\n".to_owned(),
             "#[cfg(test)]\n\n// leading comment\n#[expect(unused)]\nmod helpers;\n".to_owned(),
+            "#[cfg(test)]\npub(crate) mod testing;\n".to_owned(),
+            "#[cfg(test)]\npub mod published;\n".to_owned(),
         ]);
-        assert_eq!(
-            stems,
-            ["body_reader_tests", "helpers", "tests"]
-                .into_iter()
-                .map(str::to_owned)
-                .collect()
-        );
+        let expected: BTreeSet<String> = [
+            "body_reader_tests",
+            "helpers",
+            "published",
+            "testing",
+            "tests",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+        assert_eq!(stems, expected);
 
         let not_stems = cfg_test_module_stems_from([
             "#[cfg(not(test))]\nmod production;\n".to_owned(),
@@ -686,12 +848,107 @@ mod tests {
         ] {
             let mut result = empty_result();
             scan_source(NON_OWNER, source, &mut result);
-            assert!(
-                result.index_capability_violations.is_empty(),
-                "{source}"
-            );
+            assert!(result.index_capability_violations.is_empty(), "{source}");
             assert_eq!(result.index_capability_sites, 0, "{source}");
         }
+    }
+
+    #[test]
+    fn only_the_p2p_owner_and_audited_handles_mutate_peers() {
+        for (path, call, expected_violations) in [
+            (
+                "/workspace/crates/p2p/src/peer_table.rs",
+                "table.register(addr, lease.clone());",
+                0,
+            ),
+            (
+                "/workspace/crates/p2p/src/connection.rs",
+                "self.table.cancel_all();",
+                0,
+            ),
+            (
+                "/workspace/crates/node/src/sync/headers.rs",
+                "self.peer_table.disconnect_source(source)",
+                0,
+            ),
+            (
+                "/workspace/crates/node/src/sync/headers.rs",
+                "if self.peer_table.disconnect_source(source) {",
+                0,
+            ),
+            (
+                "/workspace/crates/node/src/sync/headers.rs",
+                "xself.peer_table.disconnect_source(source)",
+                1,
+            ),
+            (
+                "/workspace/crates/node/src/sync/peers.rs",
+                "if !self\n    .peer_table\n    .disconnect_connection(peer_addr, connection_id)\n{\n}",
+                0,
+            ),
+            (
+                "/workspace/crates/rpc/src/handlers/network.rs",
+                "ctx.peer_table.disconnect(addr);",
+                0,
+            ),
+            (
+                "/workspace/crates/node/src/fake.rs",
+                "self.peer_table.disconnect_source(source)",
+                1,
+            ),
+            (
+                "/workspace/crates/node/src/sync/headers.rs",
+                "other.peer_table.disconnect_source(source)",
+                1,
+            ),
+            (
+                "/workspace/crates/rpc/src/handlers/mining.rs",
+                "ctx.peer_table.register(addr, lease.clone());",
+                1,
+            ),
+            (
+                "/workspace/crates/rpc/src/handlers/network.rs",
+                "ctx.peer_table.register(addr, lease.clone());",
+                1,
+            ),
+            (
+                "/workspace/crates/node/src/fake.rs",
+                "ctx.peer_table.disconnect(addr);",
+                1,
+            ),
+        ] {
+            let mut result = empty_result();
+            scan_source(path, call, &mut result);
+            assert_eq!(
+                result.peer_owner_violations.len(),
+                expected_violations,
+                "{path}: {call}"
+            );
+        }
+    }
+
+    #[test]
+    fn peer_scan_excludes_other_disconnects_and_masked_text() {
+        // `ChainTransition::disconnect` shares the bare name and must stay
+        // outside the peer scan entirely.
+        let mut result = empty_result();
+        scan_source(
+            "/workspace/crates/node/src/apply/entrypoints.rs",
+            "let result = transition.disconnect(block);",
+            &mut result,
+        );
+        assert!(result.peer_owner_violations.is_empty());
+        assert_eq!(result.peer_mutations_found, 0);
+
+        // Text that only looks like a mutator is masked out.
+        let mut result = empty_result();
+        scan_source(
+            NON_OWNER,
+            "const T: &str = \"peer_table.register(addr)\";",
+            &mut result,
+        );
+        assert!(result.peer_owner_violations.is_empty());
+        assert_eq!(result.peer_mutations_found, 0);
     }
 
     #[test]

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -1,8 +1,9 @@
 //! Static source scan used by `overhaul_ownership` to enforce single-owner
 //! boundaries that `cargo metadata` cannot see.
 //!
-//! The scan walks workspace Rust sources (excluding `tests/`, `benches/`, and
-//! `examples/`) and ignores code inside top-level `#[cfg(test)]` items and
+//! The scan walks the cargo-metadata workspace member directories (skipping
+//! `tests/`, `benches/`, and `examples/` subdirectories and any
+//! dot-directory) and ignores code inside top-level `#[cfg(test)]` items and
 //! `#[test]` functions. Whole files whose module is declared with a
 //! `#[cfg(test)] mod <name>;` attribute — test-support files whose helpers
 //! carry no `#[test]` marks of their own — are skipped as well. A small Rust
@@ -17,6 +18,7 @@
 //! cancellation fail the scan outside `crates/p2p/src/` apart from
 //! explicitly audited receiver expressions.
 
+use super::dependency_graph::workspace_member_dirs;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -157,11 +159,13 @@ fn empty_result() -> OwnershipScanResult {
     }
 }
 
-/// Walks the workspace and returns every single-owner boundary violation.
+/// Walks the workspace members and returns every single-owner boundary
+/// violation.
 pub(crate) fn scan_ownership_violations() -> OwnershipScanResult {
-    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let mut files = Vec::new();
-    collect_rust_files(&root, &mut files);
+    for member in workspace_member_dirs() {
+        collect_rust_files(member, &mut files);
+    }
     files.sort();
     let test_modules = cfg_test_module_stems(&files);
     let mut result = empty_result();
@@ -175,21 +179,23 @@ pub(crate) fn scan_ownership_violations() -> OwnershipScanResult {
 }
 
 fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) {
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                let name = path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or("");
-                if matches!(name, "target" | "tests" | "benches" | "examples") {
-                    continue;
-                }
-                collect_rust_files(&path, files);
-            } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
-                files.push(path);
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        panic!("scan cannot read workspace member dir {}", dir.display());
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            if name.starts_with('.') || matches!(name, "target" | "tests" | "benches" | "examples")
+            {
+                continue;
             }
+            collect_rust_files(&path, files);
+        } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
+            files.push(path);
         }
     }
 }
@@ -202,10 +208,15 @@ fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) {
 /// carry no `#[test]` marks of their own — out of the production scan without
 /// guessing from file names alone. An inline `mod <stem> { .. }` block is not
 /// recorded: [`scan_source`] already skips its items line by line.
+/// A plain `mod <stem>;` inside an already-skipped file (for example
+/// `consensus_rule_tests/behavior_*.rs`) is transitively test-gated but not
+/// collected; those files stay in the walk and pass today because their
+/// items carry `#[test]` marks.
 fn cfg_test_module_stems(files: &[PathBuf]) -> BTreeSet<String> {
-    let contents = files
-        .iter()
-        .map(|path| std::fs::read_to_string(path).unwrap_or_default());
+    let contents = files.iter().map(|path| {
+        std::fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("scan cannot read {}: {error}", path.display()))
+    });
     cfg_test_module_stems_from(contents)
 }
 
@@ -293,7 +304,8 @@ fn is_test_module_file(path: &Path, test_modules: &BTreeSet<String>) -> bool {
 
 fn scan_file(path: &Path, result: &mut OwnershipScanResult) {
     let path_str = path.to_string_lossy();
-    let content = std::fs::read_to_string(path).unwrap_or_default();
+    let content = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("scan cannot read {}: {error}", path.display()));
     scan_source(&path_str, &content, result);
     result.files_scanned += 1;
 }


### PR DESCRIPTION
Implements the unblocked slice of #652 (measured-apply-cost leg stays blocked on #650 T02 baseline, untouched).

- Optional-index-becoming-required gate (capability-site scan + negatives).
- P2P peer single-owner registration/cancellation gate (42 sites, 0 violations + 12-row fixture matrix).
- Feature-profile ownership parity across 5 CI-mirroring profiles + synthetic negatives.
- Scanner robustness: walk bound to cargo-metadata members (sibling checkouts/vendored trees unreachable), fail-closed reads, files_scanned floor.
- Ownership gate independently re-run: 40/40 green.

Merge stays gated as always.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The ownership gate now covers derived-index capability selection, P2P peer mutation, and binary feature-profile parity in addition to mempool writer ownership, and scans only the cargo-metadata workspace members so sibling checkouts and vendored trees can no longer influence a run.

- Index capability forcing (`IndexCapabilities {`, `IndexCapabilities::`, `derived_index_capabilities`, `build_derived_index_open_spec`) is flagged outside `crates/index`, the node txindex runtime, and the node state config projection.
- Peer registration and cancellation is flagged outside `crates/p2p`, including qualified `PeerTable::disconnect(` calls, apart from the audited sync teardown receivers and the RPC `disconnectnode` operator path.
- Profile parity resolves five CI-mirroring binary profiles (`default`, `minimal-native`, `minimal-zmq`, `full-node`, `optional-kernel`) and asserts each reaches a storage backend through the node forwarding chain, keeps backend features on the forwarding allowlist, and selects `kernel`/`zmq` exactly when the profile asks.
- Synthetic negative tests prove a backendless minimal profile and a kernel leak fail; a `rocksdb`-only profile passes.
- The scanner skips whole `#[cfg(test)]` module files, panics on unreadable files and directory entries instead of scanning nothing, and asserts a `files_scanned` floor so a collapsed walk cannot pass green.
- The measured-apply-cost leg stays blocked on the #650 baseline and is untouched.

<sup>Written for commit 34f1bcaf72c2ef29169b33b8445faa420b8f284b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

