### PR TITLE
docs: restore Why bitcoin-rs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,72 @@ identifying wallet queries.
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-2024%20edition-orange.svg)](https://doc.rust-lang.org/edition-guide/rust-2024/index.html)
 
-## Why evaluate bitcoin-rs?
+## Why bitcoin-rs
 
-- **Typed Rust integration.** Explore the async `Node` embedding API for
-  in-process integrations alongside the HTTP JSON-RPC path.
-- **Node-owned indexing.** Evaluate integrated ScriptIndex and Esplora APIs
-  without a separate indexer process. Indexes are optional; check configuration
-  and capability readiness before relying on a query. Wallet keys, policies,
-  and metadata remain outside the node.
-- **Explicit build lanes.** The default binary enables `fjall`, `redb`, and
-  `zmq`, but excludes `libbitcoinkernel`. Consensus/node library defaults and
-  the Compose image differ. The
-  [validation-default contract](docs/contracts/validation-default.md) owns that
-  split; a kernel-free binary is not a blanket claim about native dependencies
-  across all build configurations.
+[Bitcoin Core](https://github.com/bitcoin/bitcoin) is the most successful
+implementation of Bitcoin. Its conservatism, stability, and compatibility
+discipline are major reasons for
+that success. Over time, however, those safeguards also shape which changes are
+practical: existing boundaries accumulate dependencies, and implementation
+choices harden into assumptions that Bitcoin consensus does not require.
 
-The project explores alternative full-node architecture and AI-assisted
-engineering. Bitcoin Core, consensus vectors, and differential tests provide
-independent references; a different implementation or development process does
-not remove the obligation to demonstrate correctness. Inspect the
-[constraint register](CONSTRAINTS.md) and distinguish implemented behavior,
-required evidence, and measured results.
+bitcoin-rs asks a simple question:
+
+> **If a Bitcoin full node were designed again today, what would we keep, and
+> what would we change?**
+
+### Why now?
+
+AI is changing how software is built. Work that once required large teams and
+long development cycles can now be attempted by much smaller teams with far
+faster iteration. Bitcoin is unusually well suited to this model because
+implementations can be checked against Bitcoin Core, `libbitcoinkernel`,
+historical chain data, consensus test vectors, fuzzing, and differential tests.
+
+**Bitcoin is well suited to AI-native development; Bitcoin Core's development
+culture is not.** Its review process prioritizes minimizing change risk,
+rewarding incrementalism, entrenching existing boundaries, and making radical
+architectural experimentation prohibitively expensive.
+
+**That is why we built `bitcoin-rs`: to preserve Bitcoin's consensus while
+making bold architectural experimentation practical—build alternatives,
+verify them against reproducible evidence, and keep iterating until better
+designs emerge.**
+
+### What can be improved
+
+- **Performance is a first-class requirement.** `bitcoin-rs` is not aiming for
+  parity with Bitcoin Core simply by changing languages. Synchronization,
+  storage, memory ownership, concurrency, caching, I/O, and indexing can all be
+  reconsidered. Improvements must be demonstrated with matched whole-node
+  benchmarks against Core.
+- **The UTXO set is the node's authoritative coin state.** Much of the Bitcoin
+  application ecosystem grew by rebuilding or duplicating wallet-, Electrum-,
+  and explorer-specific views around the same chain data. `bitcoin-rs`
+  simplifies that boundary: the node owns the canonical UTXO set used for
+  validation and an integrated script index exposed through Esplora-compatible
+  APIs. This eliminates the need for a separate Electrum server with its own
+  duplicate chain state and ingestion pipeline.
+  Wallet-specific keys, policies, and metadata remain outside the node.
+  Consumers build on node state; they do not redefine where Bitcoin's coin
+  state lives.
+- **Modularity keeps the core isolated and components composable.** Clear
+  dependency and failure boundaries keep extensions from destabilizing
+  validation or chainstate while allowing components to be reused independently.
+  Extensions own their state and lifecycle and may build on core capabilities,
+  but they do not become dependencies of the core.
+- **Rust-native integration is a primary path.** Applications and extensions in
+  the Rust Bitcoin ecosystem can attach to the node as typed, in-process
+  components instead of routing through serialized RPC or separate processes.
+  This improves runtime efficiency and simplifies integration and deployment,
+  making the full node a native, composable part of the ecosystem.
+
+Bitcoin is not defined by the continued preservation of one codebase. **The code
+can change; consensus is what must remain.** `bitcoin-rs` aims to challenge
+Bitcoin Core and build a better Bitcoin implementation. That challenge
+strengthens the Bitcoin ecosystem: a separately designed codebase cross-checks
+consensus interpretation, increases implementation diversity, and reduces the
+risk of correlated implementation failures.
 
 ## Features
 


### PR DESCRIPTION
## Summary

- restore the full `Why bitcoin-rs` section removed by `8095019c`
- preserve the current README introduction, safety guidance, feature details, and benchmark status
- use `8095019c^` as the source of truth for the restored section

## Acceptance criteria

- the README contains the original `Why bitcoin-rs`, `Why now?`, and `What can be improved` content from immediately before `8095019c`
- no sections outside the shortened `Why evaluate bitcoin-rs?` block are rolled back

## Verification

- compared the restored block with `8095019c^:README.md`
- `git diff --check`
- documentation-only change; no code tests run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the full "Why bitcoin-rs" section in the README, which was previously shortened to a brief evaluation summary. This brings back the original project rationale, including the "Why now?" and "What can be improved" subsections, while preserving the current introduction, safety guidance, and feature details.

<sup>Written for commit 0982e39cc760ba7516abb2ba177c6f7a8b7087f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

