### PR TITLE
Extend dependency-direction gate to transition ownership (#652)

### DIFF
--- a/bin/bitcoin-rs/tests/gates/g17_dependency_direction.rs
+++ b/bin/bitcoin-rs/tests/gates/g17_dependency_direction.rs
@@ -1,11 +1,13 @@
-//! G17 — One-way crate dependency direction.
+//! G17 — One-way crate dependency direction and single-writer boundaries.
 //!
-//! **G17 — Dependency direction.** The workspace crates form a one-way layer
-//! model; `cargo metadata` proves every edge points the approved way, no crate
-//! outside `bitcoin-rs-storage` names a storage-engine dependency
-//! (`rust-rocksdb`, `fjall`, `redb`), and the RPC crate
-//! names no storage backend at all — neither as a dependency nor as a
-//! forwarded cargo feature.
+//! **G17 — Dependency direction and ownership.** The workspace crates form a
+//! one-way, acyclic layer model; `cargo metadata` proves every edge points the
+//! approved way, `bitcoin-rs-mempool` never depends on its transaction consumers,
+//! no crate outside `bitcoin-rs-storage` names a storage-engine dependency
+//! (`rust-rocksdb`, `fjall`, `redb`), the RPC crate names no storage backend at
+//! all, and the static source scan confirms single-writer mutation boundaries:
+//! mempool pool mutations through the gateway, derived-index capability selection,
+//! peer registration/cancellation, and chainstate transition promotion.
 //!
 //! Approved layer direction (a crate may depend only on crates in the same or
 //! a strictly lower layer):
@@ -26,30 +28,38 @@
 //! - `rpc` may consume node capabilities (`index`, `mining`, `mempool`,
 //!   `chain`, `utxo`, `p2p`) but never `node` or the binary, and never names a
 //!   storage backend.
+//! - `mempool` must not depend on `p2p`, `rpc`, `node`, or the binary:
+//!   consumers and composition depend on the mempool, not the reverse.
 //! - The engine rule is the storage-boundary rule: only the storage crate may
 //!   name a backend engine. Everything above talks to the `KvStore` facade.
 //! - Backend *feature* forwarding is confined to the operator-facing tiers
 //!   (node, binary) and the services-tier adapters that actually select an
 //!   engine; rpc, consensus, script, mempool, and mining define none.
+//! - Chainstate transition promotion (`lock_transition`,
+//!   `begin_transition_locked`) is owned by the node crate; it may not be called
+//!   from production code outside `crates/node/src/`.
 //!
-//! The gate fails loudly, naming the offending edge, when any assertion does
-//! not hold.
+//! The gate fails loudly, naming the offending edge or source site, when any
+//! assertion does not hold.
 //!
 //! Contract: `docs/contracts/architecture.md` —
-//! `workspace_dependency_direction_is_one_way` pins `ARCH-01` (one-way
-//! layer edges), `ARCH-02` (engine-crate exclusivity), `ARCH-03` (backend
-//! feature-forwarding confinement), and `ARCH-04` (RPC storage
-//! independence).
+//! `workspace_dependency_direction_is_one_way` pins `ARCH-01` (one-way,
+//! acyclic layer edges and mempool consumer direction), `ARCH-02` (engine-crate
+//! exclusivity), `ARCH-03` (backend feature-forwarding confinement), and
+//! `ARCH-04` (RPC storage independence); `workspace_single_writer_boundaries_are_respected`
+//! pins `ARCH-07` (chainstate transition owner).
 //!
-//! The layer table, metadata parser, and validation rules live in exactly one
-//! place — `tests/support/dependency_graph.rs`, shared with
-//! `overhaul_ownership`. This gate only drives the shared validator over the
-//! live workspace metadata so the two can never disagree.
+//! The layer table, metadata parser, validation rules, and source-scan rules
+//! live in exactly one place — `tests/support/dependency_graph.rs` and
+//! `tests/support/ownership_scan.rs`, shared with `overhaul_ownership`. This
+//! gate only drives the shared validators over the live workspace metadata and
+//! source tree so the two can never disagree.
 
 #[path = "../support/mod.rs"]
 mod support;
 
 use support::dependency_graph::WorkspaceGraph;
+use support::ownership_scan::{OwnershipScanResult, scan_ownership_violations};
 
 #[test]
 fn workspace_dependency_direction_is_one_way() {
@@ -66,6 +76,11 @@ fn workspace_dependency_direction_is_one_way() {
                 "validator checked nothing: {}",
                 report.summary
             );
+            assert!(
+                report.cycle_checked_crates >= 12,
+                "cycle check did not run: {}",
+                report.summary
+            );
         }
         Err(violations) => {
             panic!(
@@ -74,4 +89,37 @@ fn workspace_dependency_direction_is_one_way() {
             );
         }
     }
+}
+
+#[test]
+fn workspace_single_writer_boundaries_are_respected() {
+    let OwnershipScanResult {
+        mempool_writer_violations,
+        index_capability_violations,
+        peer_owner_violations,
+        transition_owner_violations,
+        files_scanned,
+        ..
+    } = scan_ownership_violations();
+    assert!(
+        files_scanned >= 100,
+        "the ownership scan saw only {files_scanned} files; the workspace walk \
+         collapsed"
+    );
+    assert!(
+        mempool_writer_violations.is_empty(),
+        "mempool single-writer boundary violations: {mempool_writer_violations:?}"
+    );
+    assert!(
+        index_capability_violations.is_empty(),
+        "index capability boundary violations: {index_capability_violations:?}"
+    );
+    assert!(
+        peer_owner_violations.is_empty(),
+        "peer owner boundary violations: {peer_owner_violations:?}"
+    );
+    assert!(
+        transition_owner_violations.is_empty(),
+        "chainstate transition owner boundary violations: {transition_owner_violations:?}"
+    );
 }

--- a/bin/bitcoin-rs/tests/overhaul_ownership.rs
+++ b/bin/bitcoin-rs/tests/overhaul_ownership.rs
@@ -38,6 +38,7 @@ fn real_metadata_validates() {
         checked_engine_edges,
         checked_features,
         classified,
+        cycle_checked_crates,
         summary,
     } = graph
         .validate()
@@ -57,6 +58,10 @@ fn real_metadata_validates() {
         checked_features > 0,
         "no feature forwarding assertions were checked"
     );
+    assert!(
+        cycle_checked_crates >= 12,
+        "cycle check did not run over the workspace: {summary}"
+    );
 }
 
 #[test]
@@ -72,6 +77,54 @@ fn synthetic_upward_dependency_fails() {
                 && line.contains("bitcoin-rs-mempool")
         }),
         "expected upward-dependency violation, got: {err:?}"
+    );
+}
+#[test]
+fn transaction_consumers_can_depend_on_mempool() {
+    let graph = WorkspaceGraph::from_cargo_metadata();
+    // Real consumer → mempool edges (p2p, rpc, node, binary) all point
+    // the approved direction and must pass the layer model.
+    assert!(
+        graph.validate().is_ok(),
+        "transaction consumers depending on mempool must be allowed"
+    );
+}
+
+#[test]
+fn mempool_cannot_depend_on_transaction_consumers() {
+    let mut graph = WorkspaceGraph::from_cargo_metadata();
+    graph.add_normal_dep("bitcoin-rs-mempool", "bitcoin-rs-p2p");
+    graph.add_normal_dep("bitcoin-rs-mempool", "bitcoin-rs-rpc");
+    graph.add_normal_dep("bitcoin-rs-mempool", "bitcoin-rs-node");
+    graph.add_normal_dep("bitcoin-rs-mempool", "bitcoin-rs");
+
+    let err = graph
+        .validate()
+        .expect_err("mempool depending on its consumers must fail");
+    assert!(
+        err.iter().any(|line| {
+            line.contains("bitcoin-rs-mempool")
+                && line.contains("transaction consumer")
+                && line.contains("bitcoin-rs-p2p")
+        }),
+        "expected mempool consumer-direction violation, got: {err:?}"
+    );
+}
+
+#[test]
+fn synthetic_same_layer_cycle_fails() {
+    let mut graph = WorkspaceGraph::from_cargo_metadata();
+    // Construct a pure same-layer cycle: mempool → p2p → mining → mempool.
+    // All three are Layer 2, so the layer check alone accepts it.
+    graph.add_normal_dep("bitcoin-rs-mempool", "bitcoin-rs-p2p");
+    graph.add_normal_dep("bitcoin-rs-p2p", "bitcoin-rs-mining");
+    graph.add_normal_dep("bitcoin-rs-mining", "bitcoin-rs-mempool");
+
+    let err = graph.validate().expect_err("same-layer cycle must fail");
+    assert!(
+        err.iter()
+            .any(|line| line.contains("workspace dependency cycle")),
+        "expected an acyclicity violation, got: {err:?}"
     );
 }
 
@@ -272,6 +325,38 @@ fn p2p_peer_owner_scan_passes() {
     assert!(
         peer_mutations_found > 0,
         "the p2p peer owner scan matched no production peer mutation"
+    );
+}
+#[test]
+fn chainstate_transition_scan_passes() {
+    let OwnershipScanResult {
+        transition_owner_violations,
+        transition_sites,
+        files_scanned,
+        ..
+    } = scan_ownership_violations();
+    assert!(
+        files_scanned >= MIN_SCANNED_FILES,
+        "the ownership scan saw only {files_scanned} files; the workspace walk \
+         collapsed"
+    );
+
+    let _ = writeln!(
+        std::io::stderr(),
+        "chainstate transition scan: files={files_scanned}, \
+         transition sites={transition_sites}, \
+         violations={}",
+        transition_owner_violations.len()
+    );
+    assert!(
+        transition_owner_violations.is_empty(),
+        "chainstate transition promotion (`lock_transition`, \
+         `begin_transition_locked`) must stay inside the node crate \
+         (ARCH-07): {transition_owner_violations:?}"
+    );
+    assert!(
+        transition_sites > 0,
+        "the chainstate transition scan matched no production transition promotion"
     );
 }
 

--- a/bin/bitcoin-rs/tests/support/dependency_graph.rs
+++ b/bin/bitcoin-rs/tests/support/dependency_graph.rs
@@ -30,7 +30,14 @@ pub(crate) const NODE_CRATE: &str = "bitcoin-rs-node";
 
 /// The node binary.
 pub(crate) const BIN_CRATE: &str = "bitcoin-rs";
+/// The mempool admission owner.
+pub(crate) const MEMPOOL_CRATE: &str = "bitcoin-rs-mempool";
 
+/// Crates the mempool owner must never depend on. The real edges point
+/// the other way: `p2p` consumes the mempool inventory view, `rpc` and
+/// `node` submit transactions to it, and `bitcoin-rs` composes the node.
+pub(crate) const MEMPOOL_CONSUMER_CRATES: [&str; 4] =
+    ["bitcoin-rs-p2p", RPC_CRATE, NODE_CRATE, BIN_CRATE];
 /// Crates permitted to define and forward storage backend feature selection.
 pub(crate) const BACKEND_FORWARDING_CRATES: [&str; 7] = [
     STORAGE_CRATE,
@@ -89,6 +96,8 @@ pub(crate) struct Validation {
     pub checked_features: usize,
     /// Number of crate packages classified.
     pub classified: usize,
+    /// Number of crate packages checked for dependency cycles.
+    pub cycle_checked_crates: usize,
     /// Human-readable summary.
     pub summary: String,
 }
@@ -303,6 +312,24 @@ impl WorkspaceGraph {
             }
         }
 
+        // 1b. Mempool must not depend on its transaction consumers. The real
+        //     edges point the other way; this keeps admission owning the pool
+        //     while consumers read or submit through the gateway.
+        if let Some(mempool_edges) = self.normal_deps.get(MEMPOOL_CRATE) {
+            for dep in mempool_edges {
+                if MEMPOOL_CONSUMER_CRATES.contains(&dep.as_str()) {
+                    violations.push(format!(
+                        "dependency direction violation: `{MEMPOOL_CRATE}` must not depend on \
+                         its transaction consumer `{dep}`; consumers depend on the mempool"
+                    ));
+                }
+            }
+        }
+
+        // 1c. Workspace dependency diagrams must stay acyclic; a cycle would
+        //     make the one-way layer model vacuously satisfiable.
+        let cycle_checked_crates = self.detect_cycles(&mut violations);
+
         // 2. No crate outside storage names a storage-engine dependency.
         let mut checked_engine_edges = 0_usize;
         for (name, engines) in &self.engine_deps {
@@ -362,10 +389,11 @@ impl WorkspaceGraph {
                 checked_engine_edges,
                 checked_features,
                 classified: self.classified,
+                cycle_checked_crates,
                 summary: format!(
                     "dependency direction: {checked_edges} edges; \
                      engine edges: {checked_engine_edges}; features: {checked_features}; \
-                     classified crates: {}",
+                     cycle-checked crates: {cycle_checked_crates}; classified crates: {}",
                     self.classified
                 ),
             })
@@ -471,6 +499,53 @@ impl WorkspaceGraph {
             ),
         }
         checked
+    }
+    /// Detects cycles in the internal bitcoin-rs-* dependency graph using
+    /// a depth-first coloring. Returns the number of crates visited.
+    fn detect_cycles(&self, violations: &mut Vec<String>) -> usize {
+        let mut color: BTreeMap<&str, u8> = BTreeMap::new();
+        let mut stack: Vec<String> = Vec::new();
+
+        #[allow(clippy::items_after_statements)]
+        fn visit<'a>(
+            graph: &'a WorkspaceGraph,
+            color: &mut BTreeMap<&'a str, u8>,
+            stack: &mut Vec<String>,
+            violations: &mut Vec<String>,
+            node: &'a str,
+        ) {
+            color.insert(node, 1);
+            stack.push(node.to_owned());
+            for next in graph.normal_deps.get(node).into_iter().flatten() {
+                match color.get(next.as_str()).copied().unwrap_or(0) {
+                    0 => visit(graph, color, stack, violations, next),
+                    1 => {
+                        let cycle = stack
+                            .iter()
+                            .skip_while(|n| n.as_str() != next.as_str())
+                            .cloned()
+                            .chain(std::iter::once(next.to_owned()))
+                            .collect::<Vec<_>>()
+                            .join("` -> `");
+                        violations.push(format!(
+                            "dependency direction violation: workspace dependency cycle: \
+                             `{cycle}`; edges must form an acyclic DAG"
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+            stack.pop();
+            color.insert(node, 2);
+        }
+
+        for node in self.normal_deps.keys() {
+            if color.get(node.as_str()).copied().unwrap_or(0) == 0 {
+                visit(self, &mut color, &mut stack, violations, node);
+            }
+        }
+
+        color.len()
     }
 
     /// Resolves one binary feature profile to the activated workspace

--- a/bin/bitcoin-rs/tests/support/ownership_scan.rs
+++ b/bin/bitcoin-rs/tests/support/ownership_scan.rs
@@ -119,6 +119,17 @@ pub(crate) const AUTHORIZED_PEER_TABLE_CALLS: &[(&str, &str)] = &[
     ("crates/node/src/sync/peers.rs", "self.peer_table"),
 ];
 
+/// Chainstate transition promotion/lock constructors (ARCH-07).
+///
+/// `Chainstate::begin_transition` is the public constructor, but the
+/// promotion path (`lock_transition`, `begin_transition_locked`) is
+/// `pub(crate)` and must stay inside the node crate that owns applied-tip
+/// mutation. The pattern list deliberately omits plain `begin_transition(`:
+/// `PersistentUtxoSet` in `crates/utxo` legitimately defines its own private
+/// method with that name, so the scan cannot disambiguate lexically.
+pub(crate) const TRANSITION_PROMOTION_PATTERNS: &[&str] =
+    &["lock_transition(", "begin_transition_locked("];
+
 /// Paths allowed to call the receiver-qualified peer mutators from non-owner
 /// code: the RPC operator surface (`disconnectnode`) is the one permitted
 /// caller.
@@ -133,6 +144,8 @@ pub(crate) struct OwnershipScanResult {
     pub index_capability_violations: Vec<String>,
     /// Peer registration/cancellation outside the P2P owner and its audits.
     pub peer_owner_violations: Vec<String>,
+    /// Chainstate transition promotion/lock construction outside node.
+    pub transition_owner_violations: Vec<String>,
     /// Number of production source files examined.
     pub files_scanned: usize,
     /// Number of raw pool write sites found.
@@ -145,6 +158,9 @@ pub(crate) struct OwnershipScanResult {
     pub index_capability_sites: usize,
     /// Number of peer mutation call sites found (including owner files).
     pub peer_mutations_found: usize,
+    /// Number of chainstate transition promotion sites found (including owner
+    /// files).
+    pub transition_sites: usize,
 }
 
 fn empty_result() -> OwnershipScanResult {
@@ -152,11 +168,13 @@ fn empty_result() -> OwnershipScanResult {
         mempool_writer_violations: Vec::new(),
         index_capability_violations: Vec::new(),
         peer_owner_violations: Vec::new(),
+        transition_owner_violations: Vec::new(),
         files_scanned: 0,
         pool_writes_found: 0,
         mempool_mutations_found: 0,
         index_capability_sites: 0,
         peer_mutations_found: 0,
+        transition_sites: 0,
     }
 }
 
@@ -595,7 +613,27 @@ fn scan_source(path_str: &str, content: &str, result: &mut OwnershipScanResult) 
                 }
             }
         }
+
+        for constructor in TRANSITION_PROMOTION_PATTERNS {
+            if line.contains(constructor) {
+                result.transition_sites += 1;
+                if !is_node_owner(path_str) {
+                    result.transition_owner_violations.push(format!(
+                        "chainstate transition promotion `{constructor}` at {}:{}: {}",
+                        path_str,
+                        index + 1,
+                        raw_lines[index].trim()
+                    ));
+                }
+            }
+        }
     }
+}
+/// Returns true when `path` is inside the node crate: `Chainstate` and its
+/// transition promotion path are the single owner of applied-tip mutation
+/// (ARCH-07).
+fn is_node_owner(path: &str) -> bool {
+    path.replace('\\', "/").contains("/crates/node/src/")
 }
 
 /// Returns true only when the call is on a receiver expression explicitly
@@ -968,6 +1006,47 @@ mod tests {
         );
         assert!(result.peer_owner_violations.is_empty());
         assert_eq!(result.peer_mutations_found, 0);
+    }
+    #[test]
+    fn chainstate_transition_promotion_stays_in_node() {
+        const NODE_APPLY: &str = "/workspace/crates/node/src/apply.rs";
+        const RPC_HANDLER: &str = "/workspace/crates/rpc/src/handlers/network.rs";
+
+        let mut result = empty_result();
+        scan_source(
+            NODE_APPLY,
+            "let lock = self.lock_transition()?;",
+            &mut result,
+        );
+        assert!(result.transition_owner_violations.is_empty());
+        assert_eq!(result.transition_sites, 1);
+
+        let mut result = empty_result();
+        scan_source(
+            NODE_APPLY,
+            "let transition = self.begin_transition_locked(lock)?;",
+            &mut result,
+        );
+        assert!(result.transition_owner_violations.is_empty());
+        assert_eq!(result.transition_sites, 1);
+
+        let mut result = empty_result();
+        scan_source(
+            RPC_HANDLER,
+            "let lock = handles.lock_transition()?;",
+            &mut result,
+        );
+        assert_eq!(result.transition_owner_violations.len(), 1);
+        assert_eq!(result.transition_sites, 1);
+
+        let mut result = empty_result();
+        scan_source(
+            RPC_HANDLER,
+            "let transition = handles.begin_transition_locked(lock)?;",
+            &mut result,
+        );
+        assert_eq!(result.transition_owner_violations.len(), 1);
+        assert_eq!(result.transition_sites, 1);
     }
 
     #[test]

--- a/docs/contracts/architecture.md
+++ b/docs/contracts/architecture.md
@@ -50,6 +50,8 @@ Owners:
 - A crate may depend only on crates in the same layer or a strictly lower layer.
   Edges pointing upward or across forbidden boundaries fail the
   `g17_dependency_direction` gate.
+- The resolved workspace dependency graph is a directed acyclic graph. Any
+  cycle among workspace crates, even within the same layer, fails the gate.
 - Crate layer assignments:
   - **Layer 0 (Core)**: `bitcoin-rs-primitives`, `bitcoin-rs-script`,
     `bitcoin-rs-consensus`. Pure protocol types, consensus verification, and
@@ -262,15 +264,29 @@ Owners:
 - `bin/bitcoin-rs/tests/gates/g17_dependency_direction.rs`:
   - `workspace_dependency_direction_is_one_way`: parses `cargo metadata --no-deps`,
     validates every internal workspace dependency edge against the approved
-    layer table, verifies `bitcoin-rs-storage` exclusively owns storage engine
-    dependencies, confirms `bitcoin-rs-rpc` has no dependency on storage and
-    forwards no backend features, and verifies backend feature forwarding is
-    confined to operator tiers and service adapters, and rejects empty
-    backend markers on crates that do not own an engine.
-    It also rejects mempool dependencies on transaction consumers, including
-    the same-layer P2P edge; `transaction_consumers_can_depend_on_mempool`
-    and `mempool_cannot_depend_on_transaction_consumers` exercise the allowed
-    and forbidden directions.
+    layer table, rejects any workspace dependency cycle, and verifies
+    `bitcoin-rs-mempool` does not depend on its transaction consumers (`p2p`,
+    `rpc`, `node`, or the binary). It also verifies `bitcoin-rs-storage`
+    exclusively owns storage engine dependencies, confirms `bitcoin-rs-rpc` has
+    no dependency on storage and forwards no backend features, and verifies
+    backend feature forwarding is confined to operator tiers and service
+    adapters, and rejects empty backend markers on crates that do not own an
+    engine.
+  - `workspace_single_writer_boundaries_are_respected`: walks all production
+    `.rs` files under workspace member `src/` directories and confirms the
+    single-writer boundaries: mempool mutations go through the `MempoolGateway`,
+    derived-index capability selection stays with its owners (`crates/index`,
+    the node txindex runtime, and the node state config projection), peer
+    registration/cancellation stays with `crates/p2p`, and chainstate
+    transition promotion (`lock_transition`, `begin_transition_locked`) stays
+    inside `crates/node/src/`.
+- `bin/bitcoin-rs/tests/overhaul_ownership.rs`:
+  - `transaction_consumers_can_depend_on_mempool` and
+    `mempool_cannot_depend_on_transaction_consumers` exercise the allowed and
+    forbidden consumer directions.
+  - `synthetic_same_layer_cycle_fails` demonstrates the acyclicity check.
+  - `chainstate_transition_scan_passes` demonstrates the chainstate transition
+    promotion boundary stays inside `crates/node/src/`.
 - Manifest enforcement:
   - Root `Cargo.toml`: workspace member list and package versions.
   - `crates/storage/Cargo.toml`: engine dependency definitions.


### PR DESCRIPTION
g17 extension: transition promotion patterns, peer-mutator allowlist, dependency graph; 27 g17 + 45 ownership tests green with lock_transition mutation proof. No admission-code rows (held for #637's shape; follow-up if needed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the G17 dependency-direction gate so the workspace layer model also enforces acyclicity, mempool's one-way consumer direction, and chainstate transition ownership by the node crate.

- Rejects any dependency cycle among workspace crates, even within the same layer.
- Blocks `bitcoin-rs-mempool` from depending on `bitcoin-rs-p2p`, `bitcoin-rs-rpc`, `bitcoin-rs-node`, or the binary.
- Scans production source so `lock_transition` and `begin_transition_locked` can only be called from `crates/node/src/`.
- Adds ownership-scan coverage for consumer direction, same-layer cycles, and chainstate transition promotion in `overhaul_ownership.rs`.
- Pins the new acyclicity and transition-owner rules in `docs/contracts/architecture.md`.
- Admission-code rows are left out intentionally, held for #637's shape as a follow-up.

<sup>Written for commit a06ed94c7b99713f989bf8317e9b03fa911123de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

