### PR TITLE
Correct txindex readiness scrape atomicity claim

### DIFF
--- a/crates/node/src/metrics/readiness.rs
+++ b/crates/node/src/metrics/readiness.rs
@@ -3,8 +3,9 @@
 //! The gauge reads the same live snapshot the RPC `getcapabilities`
 //! projection reads — [`DerivedIndexCapabilitySource`] — and never
 //! re-derives what ready, catching up, rebuilding, failed, or disabled
-//! means. Each pass writes every outcome label, so a scrape always shows
-//! exactly one active outcome even right after a transition.
+//! means. Each pass writes every outcome label independently, so a scrape
+//! that lands between two writes may briefly show zero or two active
+//! outcomes; see [`publish_txindex_readiness`] for the scrape caveats.
 
 use alloc::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -50,8 +51,9 @@ pub(crate) fn readiness_state_name(state: &CapabilityState) -> &'static str {
 
 /// Publishes one readiness sample from the RPC capability source.
 ///
-/// The active outcome carries 1 and every other outcome 0, all within one
-/// pass, so a scrape never reports two active outcomes across a transition.
+/// Outcome labels are set independently, so a scrape during a transition may
+/// observe zero or two active outcomes; the 1s sample interval bounds the window.
+/// Treat a single scrape as approximate and the RPC source as authoritative.
 pub(crate) fn publish_txindex_readiness(source: &dyn DerivedIndexCapabilitySource) {
     let status = source.capability();
     let active = readiness_state_name(&status.state);


### PR DESCRIPTION
Comment-only: the eight gauge labels set independently, so a scrape during a flip may see zero or two active outcomes; RPC source stays authoritative. No behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the module-level and publish-function comments to accurately state that readiness gauge labels are written independently, so a scrape during a transition may briefly see zero or two active outcomes. The RPC source remains authoritative.

<sup>Written for commit 265ee93dd3fb73e05868488a3db431e3ac4e4c96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

