### PR TITLE
Add T11 durable-head protocol for chainstate commit (#632)

### DIFF
--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -10,6 +10,7 @@ use rayon::prelude::*;
 mod connect;
 mod contextual;
 mod disconnect;
+mod durable;
 mod entrypoints;
 pub(crate) mod prepare;
 mod publication;
@@ -48,6 +49,7 @@ use bitcoin_rs_primitives::Witness;
 use bitcoin_rs_primitives::consensus_bytes;
 #[cfg(test)]
 use bitcoin_rs_storage::DisconnectMarker;
+use bitcoin_rs_storage::DurableHeadStore;
 use bitcoin_rs_storage::InMemoryUndoStore;
 #[cfg(test)]
 use bitcoin_rs_storage::StorageError;
@@ -119,6 +121,7 @@ pub mod error;
 mod scratch;
 
 pub(crate) use bitcoin_rs_storage::{DisconnectPhase, KvUndoStore, UndoStore};
+pub(crate) use durable::reconcile_at_boot;
 
 /// Number of blocks after a coinbase that its outputs become spendable.
 /// Consensus rule since Bitcoin v0.3.1; universal across networks.
@@ -427,6 +430,9 @@ pub enum BlockProvenance {
 pub struct ConnectOutcome {
     /// New applied tip.
     pub tip: TipSnapshot,
+    /// The durable-head commit id that certified this block before it
+    /// published. Windows share one id across a committed group prefix.
+    pub commit_id: u64,
     /// Height of the connected block.
     pub height: u32,
     /// Hash of the connected block.
@@ -526,6 +532,10 @@ pub struct Chainstate {
     pub(crate) chain_events: Arc<crate::state::ChainEventPublisher>,
     pub(crate) block_body_store: Option<Arc<dyn BlockBodyStore>>,
     pub(crate) undo_store: Arc<dyn UndoStore>,
+    /// Owner of the durable-head row: the chain's durable commit point,
+    /// advanced by one atomic batch per committed connect or disconnect
+    /// before the tip publishes (`RCV-02`).
+    pub(crate) durable_head: Arc<dyn DurableHeadStore>,
     pub(crate) admission: Arc<ApplyAdmission>,
     pub(crate) shutdown: Arc<AtomicBool>,
     /// Serializes whole chain transitions against each other.
@@ -563,27 +573,27 @@ pub struct Chainstate {
 ///
 /// # Persistence
 ///
-/// Connect and replay write the block body and commit the UTXO set before
-/// publishing `applied_tip`. A successful return means the new tip is visible
-/// in memory. Store durability follows the journal batch cadence and the next
-/// clean checkpoint (`docs/chainstate-recovery.md`). A crash before that
-/// checkpoint recovers from the last authenticated checkpoint plus any
-/// committed journal suffix. Permanent consensus failures must not be retried
-/// with the same block; operational failures (storage, UTXO commit, shutdown)
-/// stay with the caller to retry.
+/// Every connect follows the ordered durable protocol (`RCV-02` in
+/// `docs/contracts/recovery.md`): reserve, append, sync, one atomic durable
+/// batch, publish. The durable batch — head row, undo record, and body
+/// locator under one `write_durable_if` receipt — is the commit point; the
+/// tip publishes strictly after it, so a follower-visible block is already
+/// durable (`INV-04`), and a crash recovers the old or the new committed
+/// head, never a mix. The chainstate journal is derived from the durable
+/// head, not a second authority, and the next clean checkpoint is a
+/// maintenance export.
 ///
-/// Disconnect arms a durable `DisconnectMarker` before the UTXO undo. The
-/// commit point is the `applied_tip` rollback after a successful undo
-/// (`EVT-05` in `docs/contracts/chain-events.md`). `DisconnectError::Refused`
-/// means nothing was mutated. `DisconnectError::Fatal` means a partial undo:
-/// do not retry, poison admission, and shut down. A crash during rollback is
-/// recovered from the marker, not by retrying the disconnect. The
-/// `RolledBack` marker stays until the checkpoint that publishes the
-/// rolled-back state.
+/// Disconnect arms a durable `DisconnectMarker` before the UTXO undo and
+/// advances the same durable head atomically with the `RolledBack` marker.
+/// `DisconnectError::Refused` means nothing was mutated.
+/// `DisconnectError::Fatal` means a partial undo: do not retry, poison
+/// admission, and shut down. A crash during rollback is recovered from the
+/// marker, not by retrying the disconnect.
 ///
-/// Window apply commits one block at a time. A failure leaves the committed
-/// prefix in place. Permanent failures invalidate the failed subtree;
-/// operational failures leave that block retryable.
+/// Window apply commits a bounded verified prefix per durable batch. A
+/// failure leaves the committed prefix in place; the failing block stays
+/// retryable unless the failure was fatal (`UtxoCommit`, durable-head
+/// commit), in which case recovery owns reconciliation.
 ///
 /// [`Self::finish`] stores the reserved even mempool generation. It does not
 /// persist chainstate. Call it once the window attempt concludes on a
@@ -791,6 +801,7 @@ impl Chainstate {
             chain_events,
             block_body_store: None,
             undo_store: Arc::new(InMemoryUndoStore::default()),
+            durable_head: Arc::new(bitcoin_rs_storage::InMemoryDurableHeadStore::new()),
             admission: Arc::new(ApplyAdmission::new()),
             shutdown: Arc::new(AtomicBool::new(false)),
             chain_transition: Arc::new(parking_lot::Mutex::new(())),

--- a/crates/node/src/apply.rs
+++ b/crates/node/src/apply.rs
@@ -110,11 +110,13 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use window::PublishMode;
 use window::apply_window_admitted;
 #[cfg(test)]
 use window::is_permanent_apply_error;
 #[cfg(test)]
 use window::prove_window;
+pub use window::{DURABLE_HEAD_GROUP_BLOCKS, DURABLE_HEAD_GROUP_MAX_BYTES};
 
 /// Typed chainstate mutation failures.
 pub mod error;
@@ -624,6 +626,7 @@ impl<'a> ChainTransition<'a> {
             None,
             BlockProvenance::Network,
             &self.proof,
+            PublishMode::Now,
         )
     }
 
@@ -654,6 +657,7 @@ impl<'a> ChainTransition<'a> {
             None,
             BlockProvenance::LocalReplay,
             &self.proof,
+            PublishMode::Now,
         )
     }
 

--- a/crates/node/src/apply/chain_generation_tests.rs
+++ b/crates/node/src/apply/chain_generation_tests.rs
@@ -219,6 +219,71 @@ fn stable_generation_is_even_after_window() {
 }
 
 #[test]
+fn a_window_spans_multiple_durable_groups_in_order() {
+    let (handles, genesis, _genesis_hash) = setup_regtest_with_genesis();
+
+    // One block past the group cap, so the window crosses a group boundary
+    // mid-verification and must land two durable commits.
+    let mut blocks = Vec::with_capacity(super::DURABLE_HEAD_GROUP_BLOCKS + 1);
+    let mut parent = genesis.block_hash();
+    for index in 0..=super::DURABLE_HEAD_GROUP_BLOCKS {
+        let seed = u8::try_from(index).unwrap_or(u8::MAX);
+        let block =
+            mined_block_with_prev_hash_and_transactions(parent, vec![coinbase_transaction(seed)])
+                .unwrap_or_else(|error| panic!("mine block {index}: {error}"));
+        parent = block.block_hash();
+        blocks.push(block);
+    }
+    let serialized: Vec<bytes::Bytes> = blocks
+        .iter()
+        .map(|b| bytes::Bytes::from(super::consensus_bytes(b)))
+        .collect();
+    let block_refs: Vec<&bitcoin_rs_primitives::Block> = blocks.iter().collect();
+
+    let committed = handles
+        .apply_window(&block_refs, &serialized)
+        .unwrap_or_else(|error| panic!("window succeeds: {error}"));
+
+    assert_eq!(
+        committed.len(),
+        super::DURABLE_HEAD_GROUP_BLOCKS + 1,
+        "every block of both groups commits"
+    );
+    let first_group = committed[0].commit_id;
+    assert_eq!(
+        committed[super::DURABLE_HEAD_GROUP_BLOCKS - 1].commit_id,
+        first_group,
+        "the capped first group shares one prefix commit id"
+    );
+    assert_eq!(
+        committed[super::DURABLE_HEAD_GROUP_BLOCKS].commit_id,
+        first_group + 1,
+        "the block past the cap lands in the next commit"
+    );
+    let head = handles
+        .durable_head
+        .load()
+        .unwrap_or_else(|error| panic!("head loads: {error}"))
+        .unwrap_or_else(|| panic!("a committed window leaves a durable head"));
+    assert_eq!(head.commit_id, first_group + 1);
+    let tip_height = u32::try_from(super::DURABLE_HEAD_GROUP_BLOCKS + 1).unwrap_or(u32::MAX);
+    assert_eq!(head.height, tip_height);
+    assert_eq!(
+        head.tip,
+        Hash256::from(blocks[super::DURABLE_HEAD_GROUP_BLOCKS].block_hash())
+    );
+    assert_eq!(
+        handles
+            .applied_tip
+            .load_full()
+            .as_deref()
+            .map(|tip| tip.height),
+        Some(tip_height),
+        "the flushed prefix publishes up to the window tip"
+    );
+}
+
+#[test]
 fn chain_change_proof_finish_restores_even_generation() {
     let (handles, _genesis, _genesis_hash) = setup_regtest_with_genesis();
 

--- a/crates/node/src/apply/connect.rs
+++ b/crates/node/src/apply/connect.rs
@@ -17,9 +17,11 @@ use super::contextual::check_pow_limit_and_continuity;
 use super::contextual::check_unseen_header_timestamp;
 use super::contextual::compact_is_met_by;
 use super::contextual::compute_verify_flags;
+use super::durable::{ConnectCommitFacts, commit_connect_head, sync_appended_blocks};
 use super::prepare::prepare_apply;
 use super::prepare::verify_block_transactions;
 use super::publication::advance_chain_tx_count;
+use super::publication::advanced_chain_tx_count;
 use super::publication::begin_applied_publication;
 use super::publication::tx_count_delta_for;
 use super::scratch::ApplyScratch;
@@ -445,6 +447,36 @@ pub(super) fn apply_block_admitted<'b>(
         .record(utxo_commit_dur.as_secs_f64());
     utxo_commit_result.map_err(ApplyError::UtxoCommit)?;
 
+    // RCV-02 steps 3–4: certify, then commit. `sync` makes the appended
+    // body bytes, the blocks directory, and every deferred index row
+    // durable; the durable-head batch then names them with one
+    // `write_durable_if` receipt — head, undo record, and locator row
+    // together. `Ok` is the receipt for the whole prefix (`INV-06`: the
+    // head never names bytes that are not already durable). An `Err` is
+    // not a rollback receipt: like a `UtxoCommit` refusal it leaves the
+    // caller to reconcile through recovery.
+    let durable_sync_started = quanta::Instant::now();
+    sync_appended_blocks(handles)?;
+    metrics::histogram!("node.apply_block.durable_sync_seconds")
+        .record(durable_sync_started.elapsed().as_secs_f64());
+    let durable_commit_started = quanta::Instant::now();
+    let commit_id = commit_connect_head(
+        handles,
+        &ConnectCommitFacts {
+            prev_hash,
+            tip: block_hash,
+            height,
+            undo_record: &undo_record,
+            chain_tx_count_after: advanced_chain_tx_count(
+                handles,
+                height,
+                tx_count_delta_for(block),
+            ),
+        },
+    )?;
+    metrics::histogram!("node.apply_block.durable_commit_seconds")
+        .record(durable_commit_started.elapsed().as_secs_f64());
+
     // §2.3 linearization point for the chainstate journal (issue #230): the
     // in-memory UTXO commit above is the commit of record; everything the
     // journal needs to reconstruct this block's semantic delta is still
@@ -584,6 +616,7 @@ pub(super) fn apply_block_admitted<'b>(
     let (txids, raw_txs) = scratch.into_payloads();
     Ok(ApplyFinish::Committed(ConnectOutcome {
         tip,
+        commit_id,
         height,
         hash: block_hash,
         txids,

--- a/crates/node/src/apply/connect.rs
+++ b/crates/node/src/apply/connect.rs
@@ -17,14 +17,17 @@ use super::contextual::check_pow_limit_and_continuity;
 use super::contextual::check_unseen_header_timestamp;
 use super::contextual::compact_is_met_by;
 use super::contextual::compute_verify_flags;
-use super::durable::{ConnectCommitFacts, commit_connect_head, sync_appended_blocks};
+use super::durable::{
+    ConnectCommitFacts, commit_connect_head, stored_body_row, sync_appended_blocks,
+};
 use super::prepare::prepare_apply;
 use super::prepare::verify_block_transactions;
-use super::publication::advance_chain_tx_count;
 use super::publication::advanced_chain_tx_count;
-use super::publication::begin_applied_publication;
+use super::publication::advanced_chain_tx_count_from;
+use super::publication::publish_connect;
 use super::publication::tx_count_delta_for;
 use super::scratch::ApplyScratch;
+use super::window::{PendingBlockCommit, PublishMode};
 use crate::apply::error::ApplyError;
 use bitcoin_rs_chain::TipSnapshot;
 use bitcoin_rs_consensus::MAX_SCRIPT_SIZE;
@@ -34,9 +37,11 @@ use bitcoin_rs_primitives::Block;
 use bitcoin_rs_primitives::Hash256;
 use bitcoin_rs_primitives::Tx;
 use bitcoin_rs_primitives::consensus_bytes;
+use bitcoin_rs_storage::CommitRecords;
 use bitcoin_rs_utxo::connect::BlockChangeError;
 use bitcoin_rs_utxo::connect::build_block_changes;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 /// Applies one serialized block while the caller holds admission and `chain_transition`.
 ///
@@ -54,6 +59,7 @@ pub(super) fn apply_block_with_serialized_admitted(
         None,
         BlockProvenance::Network,
         proof,
+        PublishMode::Now,
     )
 }
 
@@ -71,6 +77,7 @@ pub(super) fn apply_block_inner(
         None,
         provenance,
         transition.proof(),
+        PublishMode::Now,
     );
     if result.is_ok() {
         let _ = transition.finish();
@@ -87,6 +94,7 @@ pub(super) fn apply_committed_block_admitted<'b>(
     proven: Option<ProvenApply<'b>>,
     provenance: BlockProvenance,
     _proof: &ChainChangeProof<'_>,
+    publication: PublishMode<'_>,
 ) -> core::result::Result<ConnectOutcome, ApplyError> {
     match apply_block_admitted(
         handles,
@@ -95,6 +103,7 @@ pub(super) fn apply_committed_block_admitted<'b>(
         proven,
         provenance,
         ApplyIntent::Commit,
+        publication,
     )? {
         ApplyFinish::Committed(outcome) => Ok(outcome),
         ApplyFinish::Proposed => unreachable!("commit intent returns a committed tip"),
@@ -118,11 +127,18 @@ pub(super) fn apply_block_admitted<'b>(
     proven: Option<ProvenApply<'b>>,
     provenance: BlockProvenance,
     intent: ApplyIntent,
+    publication: PublishMode<'_>,
 ) -> core::result::Result<ApplyFinish, ApplyError> {
     let total_started = quanta::Instant::now();
     let block_hash = block.block_hash().0;
     let prev_hash = block.header.prev_blockhash.0;
-    let (prior, height) = applied_predecessor(handles, block_hash, prev_hash)?;
+    let (prior, height) = match &publication {
+        PublishMode::Grouped(group) => match group.predecessor(prev_hash)? {
+            Some((tip, height)) => (Some(tip), height),
+            None => applied_predecessor(handles, block_hash, prev_hash)?,
+        },
+        PublishMode::Now => applied_predecessor(handles, block_hash, prev_hash)?,
+    };
     if intent == ApplyIntent::Commit
         && let Some(journal) = &handles.journal
     {
@@ -447,36 +463,6 @@ pub(super) fn apply_block_admitted<'b>(
         .record(utxo_commit_dur.as_secs_f64());
     utxo_commit_result.map_err(ApplyError::UtxoCommit)?;
 
-    // RCV-02 steps 3–4: certify, then commit. `sync` makes the appended
-    // body bytes, the blocks directory, and every deferred index row
-    // durable; the durable-head batch then names them with one
-    // `write_durable_if` receipt — head, undo record, and locator row
-    // together. `Ok` is the receipt for the whole prefix (`INV-06`: the
-    // head never names bytes that are not already durable). An `Err` is
-    // not a rollback receipt: like a `UtxoCommit` refusal it leaves the
-    // caller to reconcile through recovery.
-    let durable_sync_started = quanta::Instant::now();
-    sync_appended_blocks(handles)?;
-    metrics::histogram!("node.apply_block.durable_sync_seconds")
-        .record(durable_sync_started.elapsed().as_secs_f64());
-    let durable_commit_started = quanta::Instant::now();
-    let commit_id = commit_connect_head(
-        handles,
-        &ConnectCommitFacts {
-            prev_hash,
-            tip: block_hash,
-            height,
-            undo_record: &undo_record,
-            chain_tx_count_after: advanced_chain_tx_count(
-                handles,
-                height,
-                tx_count_delta_for(block),
-            ),
-        },
-    )?;
-    metrics::histogram!("node.apply_block.durable_commit_seconds")
-        .record(durable_commit_started.elapsed().as_secs_f64());
-
     // §2.3 linearization point for the chainstate journal (issue #230): the
     // in-memory UTXO commit above is the commit of record; everything the
     // journal needs to reconstruct this block's semantic delta is still
@@ -605,24 +591,72 @@ pub(super) fn apply_block_admitted<'b>(
         total_us = total_dur.as_micros(),
         "apply_block: profile"
     );
-    {
-        let _publication = begin_applied_publication(handles);
-        handles.applied_tip.store(Some(Arc::new(tip.clone())));
-        handles
-            .chain_events
-            .record(crate::state::HintKind::Connected, tip.height, tip.hash);
-        advance_chain_tx_count(handles, height, tx_count_delta_for(block));
-    }
     let (txids, raw_txs) = scratch.into_payloads();
-    Ok(ApplyFinish::Committed(ConnectOutcome {
-        tip,
-        commit_id,
+    let mut outcome = ConnectOutcome {
+        tip: tip.clone(),
+        commit_id: 0,
         height,
         hash: block_hash,
         txids,
         block_bytes,
         raw_txs,
-    }))
+    };
+    match publication {
+        PublishMode::Now => {
+            // RCV-02 steps 3–4: certify, then commit. `sync` makes the
+            // appended body bytes, the blocks directory, and every deferred
+            // index row durable; the durable-head batch then names them with
+            // one `write_durable_if` receipt — head, undo record, and
+            // locator row together. `Ok` is the receipt for the whole
+            // prefix (`INV-06`: the head never names bytes that are not
+            // already durable). An `Err` is not a rollback receipt: like a
+            // `UtxoCommit` refusal it leaves the caller to reconcile
+            // through recovery.
+            let durable_sync_started = quanta::Instant::now();
+            sync_appended_blocks(handles)?;
+            metrics::histogram!("node.apply_block.durable_sync_seconds")
+                .record(durable_sync_started.elapsed().as_secs_f64());
+            let undo_rows = vec![(height, block_hash, undo_record.as_slice())];
+            let body_rows = stored_body_row(handles, height, block_hash)?
+                .into_iter()
+                .collect();
+            let durable_commit_started = quanta::Instant::now();
+            let commit_id = commit_connect_head(
+                handles,
+                &ConnectCommitFacts {
+                    prev_hash,
+                    tip: block_hash,
+                    height,
+                    chain_tx_count_after: advanced_chain_tx_count(handles, height, tx_count_delta),
+                    undo_extent: Some((height, block_hash)),
+                },
+                &CommitRecords {
+                    undo_rows,
+                    body_rows,
+                },
+            )?;
+            metrics::histogram!("node.apply_block.durable_commit_seconds")
+                .record(durable_commit_started.elapsed().as_secs_f64());
+            publish_connect(handles, &tip, tx_count_delta);
+            outcome.commit_id = commit_id;
+        }
+        PublishMode::Grouped(group) => {
+            // The window buffers the durable work: facts ride in the group
+            // until its boundary, where one sync and one head batch commit
+            // the whole verified prefix and the prefix publishes in order.
+            let known = group
+                .chain_tx_count_base()
+                .unwrap_or_else(|| handles.chain_tx_count.load(Ordering::Relaxed));
+            group.stage(PendingBlockCommit {
+                outcome: outcome.clone(),
+                undo_record,
+                tx_count_delta,
+                chain_tx_count_after: advanced_chain_tx_count_from(known, height, tx_count_delta),
+                prev_hash,
+            });
+        }
+    }
+    Ok(ApplyFinish::Committed(outcome))
 }
 
 pub(super) fn applied_predecessor(

--- a/crates/node/src/apply/connect.rs
+++ b/crates/node/src/apply/connect.rs
@@ -462,78 +462,10 @@ pub(super) fn apply_block_admitted<'b>(
     metrics::histogram!("node.apply_block.utxo_commit_seconds")
         .record(utxo_commit_dur.as_secs_f64());
     utxo_commit_result.map_err(ApplyError::UtxoCommit)?;
-
-    // §2.3 linearization point for the chainstate journal (issue #230): the
-    // in-memory UTXO commit above is the commit of record; everything the
-    // journal needs to reconstruct this block's semantic delta is still
-    // available here. Emit BEFORE `applied_tip.store` so any emission failure
-    // records the append gap before the new tip becomes visible; the next apply
-    // then stops in `prepare_for_apply` before mutating state. Successful
-    // emissions advance the pending frontier, while `flush_to` advances the
-    // durable head on the configured batch cadence. Emission remains
-    // best-effort for the current block: a transient journal I/O failure is
-    // §2.3 degraded-mode policy owns persistent failure) and must never fail
-    // the block — the journal is a recovery accelerator, not a consensus
-    // dependency. No fsync on this path; `flush_to` performs the §2.3
-    // durability boundary on the batch cadence.
-    if height > 0
-        && let Some(journal) = &handles.journal
-    {
-        let mut journal = journal.lock();
-        let undo_coins = undo
-            .restores()
-            .iter()
-            .map(|add| crate::chainstate_journal::Coin {
-                outpoint: add.outpoint,
-                txout: add.txout.clone(),
-                height: add.height,
-                coinbase: add.coinbase,
-            });
-        let record = crate::chainstate_journal::journal_record_for_block(
-            crate::chainstate_journal::BlockDeltaInputs {
-                height,
-                block_hash: block_hash.to_le_bytes(),
-                prev_hash: prev_hash.to_le_bytes(),
-                block_tx_count: tx_count_delta_for(block),
-                // `finish_block` runs later in the publication tail, so the
-                // listener still carries the parent height here: the delta of
-                // this block is exactly (height - parent_height) — normally 1,
-                // 0 for genesis (which never reaches this code path).
-                coin_stats_height_delta: i64::from(height)
-                    - i64::from(handles.coin_stats.snapshot().height),
-                raw_header: {
-                    let mut header_bytes = [0u8; 80];
-                    let encoded = bitcoin_rs_primitives::consensus_bytes(&block.header);
-                    debug_assert_eq!(encoded.len(), 80, "header consensus encoding is 80 bytes");
-                    header_bytes.copy_from_slice(&encoded);
-                    header_bytes
-                },
-            },
-            &changes,
-            undo_coins,
-        );
-        match record {
-            Ok(record) => {
-                if let Err(error) = journal.append(&record) {
-                    metrics::counter!("node.chainstate_journal.append_failures").increment(1);
-                    tracing::warn!(
-                        height,
-                        %error,
-                        "chainstate journal append failed; recovery may fall back to full re-validation"
-                    );
-                }
-            }
-            Err(error) => {
-                journal.mark_append_gap(height);
-                metrics::counter!("node.chainstate_journal.append_failures").increment(1);
-                tracing::warn!(
-                    height,
-                    %error,
-                    "chainstate journal delta extraction failed; recovery may fall back to full re-validation"
-                );
-            }
-        }
-    }
+    // Capture before `finish_block` advances the listener's height: the
+    // journal delta of this block is exactly (height - parent_height).
+    let coin_stats_height_delta =
+        i64::from(height) - i64::from(handles.coin_stats.snapshot().height);
 
     // Everything past the UTXO commit publishes values prepared above and
     // cannot fail: the tip snapshot was resolved from the tree before the
@@ -637,6 +569,22 @@ pub(super) fn apply_block_admitted<'b>(
             )?;
             metrics::histogram!("node.apply_block.durable_commit_seconds")
                 .record(durable_commit_started.elapsed().as_secs_f64());
+            // The journal is derived from the durable head: it may lag the
+            // batch, never lead it, so a kill between the two leaves the
+            // head as the high-water mark of committed state.
+            emit_journal_record(
+                handles,
+                build_journal_record(
+                    block,
+                    height,
+                    block_hash,
+                    prev_hash,
+                    &undo,
+                    &changes,
+                    coin_stats_height_delta,
+                ),
+                height,
+            );
             publish_connect(handles, &tip, tx_count_delta);
             outcome.commit_id = commit_id;
         }
@@ -647,12 +595,22 @@ pub(super) fn apply_block_admitted<'b>(
             let known = group
                 .chain_tx_count_base()
                 .unwrap_or_else(|| handles.chain_tx_count.load(Ordering::Relaxed));
+            let journal_record = build_journal_record(
+                block,
+                height,
+                block_hash,
+                prev_hash,
+                &undo,
+                &changes,
+                coin_stats_height_delta,
+            );
             group.stage(PendingBlockCommit {
                 outcome: outcome.clone(),
                 undo_record,
                 tx_count_delta,
                 chain_tx_count_after: advanced_chain_tx_count_from(known, height, tx_count_delta),
                 prev_hash,
+                journal_record,
             });
         }
     }
@@ -731,5 +689,94 @@ pub(super) fn map_block_change_error(error: &BlockChangeError) -> ApplyError {
             txid: *txid,
             vout: *vout,
         },
+    }
+}
+
+/// The derived journal record for one connected block, or `None` when there
+/// is nothing to derive (genesis never reaches this path; a disabled journal
+/// derives nothing).
+///
+/// Pure: the caller decides when the record may reach the writer, which is
+/// after the durable head batch — the journal may lag the head, never lead
+/// it.
+pub(super) type BuiltJournalRecord =
+    Option<core::result::Result<crate::chainstate_journal::JournalRecord, String>>;
+
+fn build_journal_record(
+    block: &Block,
+    height: u32,
+    block_hash: Hash256,
+    prev_hash: Hash256,
+    undo: &bitcoin_rs_utxo::UndoBatch,
+    changes: &bitcoin_rs_utxo::BorrowedBlockChanges<'_>,
+    coin_stats_height_delta: i64,
+) -> BuiltJournalRecord {
+    if height == 0 {
+        return None;
+    }
+    let undo_coins = undo
+        .restores()
+        .iter()
+        .map(|add| crate::chainstate_journal::Coin {
+            outpoint: add.outpoint,
+            txout: add.txout.clone(),
+            height: add.height,
+            coinbase: add.coinbase,
+        });
+    let record = crate::chainstate_journal::journal_record_for_block(
+        crate::chainstate_journal::BlockDeltaInputs {
+            height,
+            block_hash: block_hash.to_le_bytes(),
+            prev_hash: prev_hash.to_le_bytes(),
+            block_tx_count: tx_count_delta_for(block),
+            coin_stats_height_delta,
+            raw_header: {
+                let mut header_bytes = [0u8; 80];
+                let encoded = bitcoin_rs_primitives::consensus_bytes(&block.header);
+                debug_assert_eq!(encoded.len(), 80, "header consensus encoding is 80 bytes");
+                header_bytes.copy_from_slice(&encoded);
+                header_bytes
+            },
+        },
+        changes,
+        undo_coins,
+    );
+    Some(record.map_err(|error| error.to_string()))
+}
+
+/// Emits one built journal record, best-effort.
+///
+/// The journal is a recovery accelerator, not a consensus dependency: an
+/// extraction failure records the append gap and an append failure warns,
+/// and neither fails the block. Both run after the durable head batch, so a
+/// failure here can only make the journal lag, never lead.
+pub(super) fn emit_journal_record(handles: &Chainstate, built: BuiltJournalRecord, height: u32) {
+    let Some(journal) = handles.journal.as_ref() else {
+        return;
+    };
+    let Some(record) = built else {
+        return;
+    };
+    let mut journal = journal.lock();
+    match record {
+        Ok(record) => {
+            if let Err(error) = journal.append(&record) {
+                metrics::counter!("node.chainstate_journal.append_failures").increment(1);
+                tracing::warn!(
+                    height,
+                    %error,
+                    "chainstate journal append failed; recovery may fall back to full re-validation"
+                );
+            }
+        }
+        Err(error) => {
+            journal.mark_append_gap(height);
+            metrics::counter!("node.chainstate_journal.append_failures").increment(1);
+            tracing::warn!(
+                height,
+                %error,
+                "chainstate journal delta extraction failed; recovery may fall back to full re-validation"
+            );
+        }
     }
 }

--- a/crates/node/src/apply/consensus_rule_tests/behavior_2.rs
+++ b/crates/node/src/apply/consensus_rule_tests/behavior_2.rs
@@ -294,6 +294,7 @@ fn every_validation_context_mismatch_rebuilds_from_live_utxo()
             Some(ProvenApply::Proven(proof)),
             BlockProvenance::Network,
             &chain_proof,
+            super::super::window::PublishMode::Now,
         ) else {
             panic!("a mismatched proof must re-read the now-missing live prevout");
         };

--- a/crates/node/src/apply/consensus_rule_tests/transitions_1.rs
+++ b/crates/node/src/apply/consensus_rule_tests/transitions_1.rs
@@ -141,7 +141,8 @@ fn a_window_stops_at_whichever_cap_binds_first() {
 /// already moved. Derived consumers are not dispatched on that error: the
 /// caller got `MarkerStuck`, not a committed outcome.
 #[test]
-fn disconnect_marker_stuck_leaves_the_tip_rolled_back() -> Result<(), Box<dyn std::error::Error>> {
+fn a_failed_marker_completion_is_fatal_before_the_tip_rolls_back()
+-> Result<(), Box<dyn std::error::Error>> {
     let genesis = Network::Regtest.genesis_block();
     let mut handles = apply_handles_without_tx_index(Network::Regtest, Arc::new(UtxoSet::new()));
     handles.undo_store = Arc::new(CompleteRejectingUndoStore::default());
@@ -155,10 +156,13 @@ fn disconnect_marker_stuck_leaves_the_tip_rolled_back() -> Result<(), Box<dyn st
     )?;
     handles.apply_block(&block)?;
 
+    // The marker cannot move to `RolledBack`, so the durable commit point is
+    // never reached: the failure is fatal, and the rollback has not been
+    // published anywhere — the tip still names the disconnected block.
     let outcome = handles.disconnect_block(&block);
     assert!(
-        matches!(outcome, Err(crate::DisconnectError::MarkerStuck { .. })),
-        "marker completion failure must report MarkerStuck, got {outcome:?}"
+        matches!(outcome, Err(crate::DisconnectError::Fatal { .. })),
+        "marker completion failure must report Fatal, got {outcome:?}"
     );
     assert_eq!(
         handles
@@ -166,8 +170,8 @@ fn disconnect_marker_stuck_leaves_the_tip_rolled_back() -> Result<(), Box<dyn st
             .load_full()
             .as_deref()
             .map(|tip| tip.height),
-        Some(0),
-        "the applied tip must already be rolled back on MarkerStuck"
+        Some(1),
+        "the applied tip must stay on the block whose marker completion failed"
     );
     Ok(())
 }

--- a/crates/node/src/apply/consensus_rule_tests/validation_4.rs
+++ b/crates/node/src/apply/consensus_rule_tests/validation_4.rs
@@ -357,6 +357,7 @@ fn a_window_skips_scripts_for_assume_valid_blocks_and_proves_nothing_for_them()
         Some(skipped),
         BlockProvenance::Network,
         &proof,
+        super::super::window::PublishMode::Now,
     );
     assert!(
         matches!(

--- a/crates/node/src/apply/disconnect.rs
+++ b/crates/node/src/apply/disconnect.rs
@@ -221,6 +221,33 @@ pub(super) fn disconnect_block_admitted(
                 source: Box::new(ApplyError::UndoPersistence(error)),
             })
         })?;
+    // The journal follows the durable head, never leads it: rewind the
+    // derived journal onto the parent first, then advance the head, so a
+    // kill between the two leaves the head as the high-water mark.
+    let journal_rewound = handles.journal.as_ref().is_some_and(|journal| {
+        let rewind_result = {
+            let mut journal = journal.lock();
+            journal.rewind_to(
+                parent_tip.height,
+                parent_tip.hash.to_le_bytes(),
+                parent_prev_hash.to_le_bytes(),
+                parent_chain_tx_count,
+            )
+        };
+        match rewind_result {
+            Ok(()) => true,
+            Err(error) => {
+                metrics::counter!("node.chainstate_journal.reorg_failures").increment(1);
+                tracing::warn!(
+                    height = parent_tip.height,
+                    hash = %parent_tip.hash,
+                    %error,
+                    "chainstate journal fork-head rewrite failed; retaining disconnect marker"
+                );
+                false
+            }
+        }
+    });
     let parent = parent_tip.clone();
     commit_disconnect_head(
         handles,
@@ -248,31 +275,6 @@ pub(super) fn disconnect_block_admitted(
         );
         rewind_chain_tx_count(handles, tx_count_delta);
     }
-    let journal_rewound = handles.journal.as_ref().is_some_and(|journal| {
-        let rewind_result = {
-            let mut journal = journal.lock();
-            journal.rewind_to(
-                parent_tip.height,
-                parent_tip.hash.to_le_bytes(),
-                parent_prev_hash.to_le_bytes(),
-                parent_chain_tx_count,
-            )
-        };
-        match rewind_result {
-            Ok(()) => true,
-            Err(error) => {
-                metrics::counter!("node.chainstate_journal.reorg_failures").increment(1);
-                tracing::warn!(
-                    height = parent_tip.height,
-                    hash = %parent_tip.hash,
-                    %error,
-                    "chainstate journal fork-head rewrite failed; retaining disconnect marker"
-                );
-                false
-            }
-        }
-    });
-
     if journal_rewound {
         handles.undo_store.disarm_disconnect().map_err(|error| {
             poison(crate::DisconnectError::MarkerStuck {

--- a/crates/node/src/apply/disconnect.rs
+++ b/crates/node/src/apply/disconnect.rs
@@ -4,8 +4,10 @@ use super::ChainChangeProof;
 use super::Chainstate;
 use super::DisconnectOutcome;
 use super::DisconnectPlan;
+use super::durable::commit_disconnect_head;
 use super::publication::begin_applied_publication;
 use super::publication::rewind_chain_tx_count;
+use super::publication::rewound_chain_tx_count;
 use super::publication::tx_count_delta_for;
 use crate::apply::error::ApplyError;
 use bitcoin_rs_chain::TipSnapshot;
@@ -202,6 +204,38 @@ pub(super) fn disconnect_block_admitted(
             })
         })?;
 
+    // The rollback finished in memory; make it durably authoritative before
+    // anything publishes it. The marker moves to `RolledBack` first — its
+    // own durable write, unchanged in ownership, still owed a checkpoint —
+    // then the durable head advances its commit id onto the parent tip: a
+    // reorg may lower the height, never the commit id. An `Err` from the
+    // head batch is not a rollback receipt, so like every failure past the
+    // undo it is fatal and recovery owns the reconciliation.
+    handles
+        .undo_store
+        .complete_disconnect(height, block_hash)
+        .map_err(|error| {
+            poison(crate::DisconnectError::Fatal {
+                hash: block_hash,
+                height,
+                source: Box::new(ApplyError::UndoPersistence(error)),
+            })
+        })?;
+    let parent = parent_tip.clone();
+    commit_disconnect_head(
+        handles,
+        &parent,
+        block_hash,
+        rewound_chain_tx_count(handles, tx_count_delta),
+    )
+    .map_err(|error| {
+        poison(crate::DisconnectError::Fatal {
+            hash: block_hash,
+            height,
+            source: Box::new(error),
+        })
+    })?;
+
     {
         let _publication = begin_applied_publication(handles);
         handles
@@ -238,19 +272,6 @@ pub(super) fn disconnect_block_admitted(
             }
         }
     });
-
-    // The rollback finished in memory, so the marker moves to `RolledBack`.
-    // It stays set: a checkpoint has not captured this yet.
-    handles
-        .undo_store
-        .complete_disconnect(height, block_hash)
-        .map_err(|error| {
-            poison(crate::DisconnectError::MarkerStuck {
-                hash: block_hash,
-                height,
-                source: Box::new(ApplyError::UndoPersistence(error)),
-            })
-        })?;
 
     if journal_rewound {
         handles.undo_store.disarm_disconnect().map_err(|error| {

--- a/crates/node/src/apply/durable.rs
+++ b/crates/node/src/apply/durable.rs
@@ -24,22 +24,25 @@ use bitcoin_rs_primitives::Hash256;
 use bitcoin_rs_storage::{CommitRecords, DurableHead};
 
 /// Facts of one connected block that its durable head commit names.
-pub(super) struct ConnectCommitFacts<'a> {
-    /// Parent the durable head must currently name. A stored head naming any
-    /// other tip means the durable chain and the in-memory chain have
-    /// diverged (a crash landed the batch but not the publication, and
-    /// recovery has not replayed the gap yet): refuse rather than advance a
-    /// head whose lineage would break.
+pub(super) struct ConnectCommitFacts {
+    /// Parent the durable head must currently name — for a group, the
+    /// parent of its first block. A stored head naming any other tip means
+    /// the durable chain and the in-memory chain have diverged (a crash
+    /// landed the batch but not the publication, and recovery has not
+    /// replayed the gap yet): refuse rather than advance a head whose
+    /// lineage would break.
     pub prev_hash: Hash256,
-    /// The block's hash: the tip this commit certifies.
+    /// The prefix tip this commit certifies.
     pub tip: Hash256,
     /// Height of `tip`.
     pub height: u32,
-    /// The block's encoded undo record, landed in the same receipt.
-    pub undo_record: &'a [u8],
-    /// Cumulative chain transaction count after this block, matching what
+    /// Cumulative chain transaction count at `tip`, matching what
     /// publication will store.
     pub chain_tx_count_after: u64,
+    /// The newest undo row `(height, hash)` this commit certifies: a
+    /// connect or group names its last block, a disconnect keeps the prior
+    /// extent.
+    pub undo_extent: Option<(u32, Hash256)>,
 }
 
 /// Makes the appended block data durable before the head may name it.
@@ -63,7 +66,8 @@ pub(super) fn sync_appended_blocks(handles: &Chainstate) -> Result<(), ApplyErro
 /// on disk and keeps `commit_id` strictly monotonic (`P3`).
 pub(super) fn commit_connect_head(
     handles: &Chainstate,
-    facts: &ConnectCommitFacts<'_>,
+    facts: &ConnectCommitFacts,
+    records: &CommitRecords<'_>,
 ) -> Result<u64, ApplyError> {
     let prior = handles
         .durable_head
@@ -77,17 +81,6 @@ pub(super) fn commit_connect_head(
             prev: facts.prev_hash,
         });
     }
-    let body_rows = match handles.block_body_store.as_ref() {
-        Some(store) => {
-            let position = store
-                .block_position(facts.height, facts.tip)
-                .map_err(ApplyError::BlockBodyPersistence)?;
-            position
-                .map(|position| vec![(facts.height, facts.tip, position)])
-                .unwrap_or_default()
-        }
-        None => Vec::new(),
-    };
     let next = DurableHead {
         commit_id: prior.as_ref().map_or(1, |head| head.commit_id + 1),
         height: facts.height,
@@ -97,18 +90,30 @@ pub(super) fn commit_connect_head(
             .block_body_store
             .as_ref()
             .and_then(|store| store.append_cursor()),
-        undo_extent: Some((facts.height, facts.tip)),
-    };
-    let records = CommitRecords {
-        undo_rows: vec![(facts.height, facts.tip, facts.undo_record)],
-        body_rows,
+        undo_extent: facts.undo_extent,
     };
     handles
         .durable_head
-        .commit(prior.as_ref(), &next, &records)
+        .commit(prior.as_ref(), &next, records)
         .map_err(ApplyError::DurableHeadCommit)?;
     metrics::counter!("node.durable_head.commits").increment(1);
     Ok(next.commit_id)
+}
+
+/// Resolves the stored flat-file locator of one committed block, when the
+/// store indexes positions. A group lands one locator row per block.
+pub(super) fn stored_body_row(
+    handles: &Chainstate,
+    height: u32,
+    hash: Hash256,
+) -> Result<Option<(u32, Hash256, bitcoin_rs_storage::BlockFilePosition)>, ApplyError> {
+    let Some(store) = handles.block_body_store.as_ref() else {
+        return Ok(None);
+    };
+    Ok(store
+        .block_position(height, hash)
+        .map_err(ApplyError::BlockBodyPersistence)?
+        .map(|position| (height, hash, position)))
 }
 
 /// Advances the durable head for one disconnected block.

--- a/crates/node/src/apply/durable.rs
+++ b/crates/node/src/apply/durable.rs
@@ -1,0 +1,198 @@
+//! The ordered durable commit between chain mutation and publication.
+//!
+//! `RCV-02` orders every connect as: reserve, append, sync, one atomic
+//! durable batch, publish. The apply path already reserves (admission +
+//! transition lock), appends (deferred undo row, flat-file body, deferred
+//! locator rows), and commits the UTXO set in memory. This module owns what
+//! was missing: the sync that certifies those bytes, and the
+//! [`DurableHead`] batch that names them — the chain's durable commit point.
+//!
+//! After [`commit_connect_head`] returns `Ok`, the block is durable as one
+//! unit: head, undo record, and body locator in a single `write_durable_if`
+//! receipt, with body bytes and the blocks directory synced before the batch
+//! could name them (`INV-06`). Publication happens strictly after, so a
+//! follower-visible tip is always already durable (`INV-04`), and a crash
+//! recovers either the old committed head or the new one — never a mix.
+//!
+//! `Err` from the batch is not a rollback receipt: the batch may have applied
+//! before durability completion failed. Like a `UtxoCommit` refusal, the
+//! caller must not retry the block; recovery owns the reconciliation.
+
+use super::Chainstate;
+use super::error::ApplyError;
+use bitcoin_rs_primitives::Hash256;
+use bitcoin_rs_storage::{CommitRecords, DurableHead};
+
+/// Facts of one connected block that its durable head commit names.
+pub(super) struct ConnectCommitFacts<'a> {
+    /// Parent the durable head must currently name. A stored head naming any
+    /// other tip means the durable chain and the in-memory chain have
+    /// diverged (a crash landed the batch but not the publication, and
+    /// recovery has not replayed the gap yet): refuse rather than advance a
+    /// head whose lineage would break.
+    pub prev_hash: Hash256,
+    /// The block's hash: the tip this commit certifies.
+    pub tip: Hash256,
+    /// Height of `tip`.
+    pub height: u32,
+    /// The block's encoded undo record, landed in the same receipt.
+    pub undo_record: &'a [u8],
+    /// Cumulative chain transaction count after this block, matching what
+    /// publication will store.
+    pub chain_tx_count_after: u64,
+}
+
+/// Makes the appended block data durable before the head may name it.
+///
+/// Syncs the flat block files (data + directory) and flushes the key-value
+/// index, so every deferred locator row and the deferred undo row are on
+/// disk when the batch runs. `P1` rests on this ordering: the head commit
+/// never precedes the durability of the ranges it names.
+pub(super) fn sync_appended_blocks(handles: &Chainstate) -> Result<(), ApplyError> {
+    let Some(store) = handles.block_body_store.as_ref() else {
+        return Ok(());
+    };
+    store.sync().map_err(ApplyError::BlockBodyPersistence)
+}
+
+/// Advances the durable head for one connected block.
+///
+/// Returns the commit id the batch assigned. The first commit on a datadir
+/// fences on absence; every later commit fences on the encoded previous
+/// head, which makes the transition lock's single-writer guarantee checkable
+/// on disk and keeps `commit_id` strictly monotonic (`P3`).
+pub(super) fn commit_connect_head(
+    handles: &Chainstate,
+    facts: &ConnectCommitFacts<'_>,
+) -> Result<u64, ApplyError> {
+    let prior = handles
+        .durable_head
+        .load()
+        .map_err(ApplyError::DurableHeadCommit)?;
+    if let Some(head) = prior.as_ref()
+        && head.tip != facts.prev_hash
+    {
+        return Err(ApplyError::DurableHeadLineage {
+            head: head.tip,
+            prev: facts.prev_hash,
+        });
+    }
+    let body_rows = match handles.block_body_store.as_ref() {
+        Some(store) => {
+            let position = store
+                .block_position(facts.height, facts.tip)
+                .map_err(ApplyError::BlockBodyPersistence)?;
+            position
+                .map(|position| vec![(facts.height, facts.tip, position)])
+                .unwrap_or_default()
+        }
+        None => Vec::new(),
+    };
+    let next = DurableHead {
+        commit_id: prior.as_ref().map_or(1, |head| head.commit_id + 1),
+        height: facts.height,
+        tip: facts.tip,
+        chain_tx_count: facts.chain_tx_count_after,
+        body_extent: handles
+            .block_body_store
+            .as_ref()
+            .and_then(|store| store.append_cursor()),
+        undo_extent: Some((facts.height, facts.tip)),
+    };
+    let records = CommitRecords {
+        undo_rows: vec![(facts.height, facts.tip, facts.undo_record)],
+        body_rows,
+    };
+    handles
+        .durable_head
+        .commit(prior.as_ref(), &next, &records)
+        .map_err(ApplyError::DurableHeadCommit)?;
+    metrics::counter!("node.durable_head.commits").increment(1);
+    Ok(next.commit_id)
+}
+
+/// Advances the durable head for one disconnected block.
+///
+/// A disconnect commits too: the head moves to the parent tip with the next
+/// `commit_id`, so a reorg may lower `height` but never `commit_id` (`P3`).
+/// The extents stay as the previous head certified them — a disconnect
+/// appends nothing, and the disconnected block's undo row stays durable for
+/// a possible reconnect. The stored head must name exactly the block being
+/// disconnected; any other tip is the divergence `DurableHeadLineage`
+/// refuses.
+pub(super) fn commit_disconnect_head(
+    handles: &Chainstate,
+    parent_tip: &bitcoin_rs_chain::TipSnapshot,
+    disconnected_hash: Hash256,
+    chain_tx_count_after: u64,
+) -> Result<u64, ApplyError> {
+    let prior = handles
+        .durable_head
+        .load()
+        .map_err(ApplyError::DurableHeadCommit)?;
+    let Some(head) = prior.as_ref() else {
+        return Err(ApplyError::DurableHeadCommit(
+            bitcoin_rs_storage::StorageError::InvalidOperation(
+                "disconnect with no durable head committed",
+            ),
+        ));
+    };
+    if head.tip != disconnected_hash {
+        return Err(ApplyError::DurableHeadLineage {
+            head: head.tip,
+            prev: disconnected_hash,
+        });
+    }
+    let next = DurableHead {
+        commit_id: head.commit_id + 1,
+        height: parent_tip.height,
+        tip: parent_tip.hash,
+        chain_tx_count: chain_tx_count_after,
+        body_extent: head.body_extent,
+        undo_extent: head.undo_extent,
+    };
+    handles
+        .durable_head
+        .commit(Some(head), &next, &CommitRecords::default())
+        .map_err(ApplyError::DurableHeadCommit)?;
+    metrics::counter!("node.durable_head.commits").increment(1);
+    Ok(next.commit_id)
+}
+
+/// Boot-time reconciliation of the stored head against the restored tip.
+///
+/// An unreadable head fails startup (`P5`: corruption inside the commit
+/// point never degrades silently). A head that is ahead of the restored tip
+/// names a committed-but-unpublished gap: the crash landed between the batch
+/// and the publication. Recovery that can replay the gap is issue #655; for
+/// now the gap is surfaced as a typed warning and counted, and the first
+/// connect refuses via [`ApplyError::DurableHeadLineage`] rather than
+/// advancing a head whose lineage would break.
+pub(crate) fn reconcile_at_boot(handles: &Chainstate) -> Result<(), ApplyError> {
+    let stored = handles
+        .durable_head
+        .load()
+        .map_err(ApplyError::DurableHeadCommit)?;
+    let Some(head) = stored else {
+        return Ok(());
+    };
+    let Some(tip) = handles.applied_tip.load_full() else {
+        tracing::warn!(
+            head_height = head.height,
+            head_tip = %head.tip.to_string_be(),
+            "durable head exists but no chainstate was restored"
+        );
+        return Ok(());
+    };
+    if tip.hash != head.tip {
+        metrics::counter!("node.durable_head.recovery_gaps").increment(1);
+        tracing::warn!(
+            head_height = head.height,
+            head_tip = %head.tip.to_string_be(),
+            restored_height = tip.height,
+            restored_tip = %tip.hash.to_string_be(),
+            "restored tip is behind the durable head; the gap is committed and awaits replay"
+        );
+    }
+    Ok(())
+}

--- a/crates/node/src/apply/durable.rs
+++ b/crates/node/src/apply/durable.rs
@@ -73,13 +73,17 @@ pub(super) fn commit_connect_head(
         .durable_head
         .load()
         .map_err(ApplyError::DurableHeadCommit)?;
-    if let Some(head) = prior.as_ref()
-        && head.tip != facts.prev_hash
-    {
-        return Err(ApplyError::DurableHeadLineage {
-            head: head.tip,
-            prev: facts.prev_hash,
-        });
+    if let Some(head) = prior.as_ref() {
+        // Genesis has no parent, so its lineage is self-referential: full
+        // revalidation re-derives the chain from the same genesis the head
+        // already names. Anything else must extend the head exactly.
+        let rederiving_genesis = facts.height == 0 && head.tip == facts.tip;
+        if head.tip != facts.prev_hash && !rederiving_genesis {
+            return Err(ApplyError::DurableHeadLineage {
+                head: head.tip,
+                prev: facts.prev_hash,
+            });
+        }
     }
     let next = DurableHead {
         commit_id: prior.as_ref().map_or(1, |head| head.commit_id + 1),

--- a/crates/node/src/apply/entrypoints.rs
+++ b/crates/node/src/apply/entrypoints.rs
@@ -11,6 +11,7 @@ use super::WindowApplyDisposition;
 use super::WindowApplyError;
 use super::connect::apply_block_admitted;
 use super::connect::apply_block_inner;
+use super::window::PublishMode;
 use crate::apply::error::ApplyError;
 use bitcoin_rs_primitives::Block;
 use std::sync::atomic::Ordering;
@@ -174,6 +175,7 @@ impl Chainstate {
             None,
             BlockProvenance::Network,
             ApplyIntent::Propose,
+            PublishMode::Now,
         )? {
             ApplyFinish::Proposed => Ok(()),
             ApplyFinish::Committed(_) => {

--- a/crates/node/src/apply/error.rs
+++ b/crates/node/src/apply/error.rs
@@ -123,6 +123,27 @@ pub enum ApplyError {
         /// Block whose body was rejected.
         hash: bitcoin_rs_primitives::Hash256,
     },
+    /// Advancing the durable head failed.
+    ///
+    /// Fatal for the attempt, like a `UtxoCommit` refusal: the atomic batch
+    /// may have applied before its durability receipt failed or was lost,
+    /// and [`StorageError`] does not classify that phase. The caller must
+    /// reconcile through recovery instead of retrying the block.
+    #[error("durable head commit: {0}")]
+    DurableHeadCommit(#[source] bitcoin_rs_storage::StorageError),
+    /// The stored durable head names a tip other than this block's parent.
+    ///
+    /// The durable chain and the in-memory chain have diverged, typically
+    /// because a crash landed the head batch but not the publication and
+    /// recovery has not replayed the gap yet. Refusing keeps the head's
+    /// lineage intact; only recovery can close the gap.
+    #[error("durable head names tip {head}, not this block's parent {prev}")]
+    DurableHeadLineage {
+        /// Tip the stored head certifies.
+        head: bitcoin_rs_primitives::Hash256,
+        /// Parent the connecting block names.
+        prev: bitcoin_rs_primitives::Hash256,
+    },
     /// Rewinding the block-level coinstats failed.
     ///
     /// The per-coin fields ride the UTXO change listener and are already

--- a/crates/node/src/apply/publication.rs
+++ b/crates/node/src/apply/publication.rs
@@ -2,8 +2,24 @@
 
 use super::AppliedPublication;
 use super::Chainstate;
+use bitcoin_rs_chain::TipSnapshot;
 use bitcoin_rs_primitives::Block;
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
+
+/// Publishes one connected block: the applied tip, the chain event, and the
+/// advanced chain tx count, under one seqlock publication.
+///
+/// Extracted so the grouped window path can publish a committed prefix in
+/// order after its durable batch — the exact values the batch certified.
+pub(super) fn publish_connect(handles: &Chainstate, tip: &TipSnapshot, tx_count_delta: u64) {
+    let _publication = begin_applied_publication(handles);
+    handles.applied_tip.store(Some(Arc::new(tip.clone())));
+    handles
+        .chain_events
+        .record(crate::state::HintKind::Connected, tip.height, tip.hash);
+    advance_chain_tx_count(handles, tip.height, tx_count_delta);
+}
 
 pub(super) fn begin_applied_publication(handles: &Chainstate) -> AppliedPublication<'_> {
     let previous = handles.applied_seq.fetch_add(1, Ordering::AcqRel);
@@ -47,7 +63,17 @@ pub(super) fn advanced_chain_tx_count(
     height: u32,
     tx_count_delta: u64,
 ) -> u64 {
-    let known = handles.chain_tx_count.load(Ordering::Relaxed);
+    advanced_chain_tx_count_from(
+        handles.chain_tx_count.load(Ordering::Relaxed),
+        height,
+        tx_count_delta,
+    )
+}
+
+/// The pure form, from an explicit known count: the grouped window path
+/// advances from the staged prefix's count, which publication has not
+/// stored yet.
+pub(super) fn advanced_chain_tx_count_from(known: u64, height: u32, tx_count_delta: u64) -> u64 {
     if known == 0 && height != 0 {
         return 0;
     }

--- a/crates/node/src/apply/publication.rs
+++ b/crates/node/src/apply/publication.rs
@@ -33,19 +33,32 @@ pub(super) fn tx_count_delta_for(block: &Block) -> u64 {
 /// Genesis is the one block that can establish the count from nothing: there is
 /// no chain below it.
 pub(super) fn advance_chain_tx_count(handles: &Chainstate, height: u32, tx_count_delta: u64) {
+    let advanced = advanced_chain_tx_count(handles, height, tx_count_delta);
+    handles.chain_tx_count.store(advanced, Ordering::Relaxed);
+}
+
+/// The cumulative count a connected block will publish, without storing it.
+///
+/// The durable-head commit names this value one step before publication
+/// does, and the two must agree byte for byte. Zero means *unknown*, per
+/// the convention on `advance_chain_tx_count`.
+pub(super) fn advanced_chain_tx_count(
+    handles: &Chainstate,
+    height: u32,
+    tx_count_delta: u64,
+) -> u64 {
     let known = handles.chain_tx_count.load(Ordering::Relaxed);
     if known == 0 && height != 0 {
-        return;
+        return 0;
     }
-    let advanced = known.checked_add(tx_count_delta).unwrap_or_else(|| {
+    known.checked_add(tx_count_delta).unwrap_or_else(|| {
         tracing::warn!(
             known,
             tx_count_delta,
             "cumulative chain transaction count overflowed; marking it unknown"
         );
         0
-    });
-    handles.chain_tx_count.store(advanced, Ordering::Relaxed);
+    })
 }
 
 /// Takes a disconnected block's transactions back out of the cumulative count.
@@ -54,17 +67,25 @@ pub(super) fn advance_chain_tx_count(handles: &Chainstate, height: u32, tx_count
 /// the count and the chain have diverged, and a silently clamped total is worse
 /// than an admitted absence, so that case resets to unknown.
 pub(super) fn rewind_chain_tx_count(handles: &Chainstate, tx_count_delta: u64) {
+    let rewound = rewound_chain_tx_count(handles, tx_count_delta);
+    handles.chain_tx_count.store(rewound, Ordering::Relaxed);
+}
+
+/// The cumulative count a disconnect will publish, without storing it.
+///
+/// The durable-head commit names this value one step before publication
+/// does, and the two must agree byte for byte.
+pub(super) fn rewound_chain_tx_count(handles: &Chainstate, tx_count_delta: u64) -> u64 {
     let known = handles.chain_tx_count.load(Ordering::Relaxed);
     if known == 0 {
-        return;
+        return 0;
     }
-    let rewound = known.checked_sub(tx_count_delta).unwrap_or_else(|| {
+    known.checked_sub(tx_count_delta).unwrap_or_else(|| {
         tracing::warn!(
             known,
             tx_count_delta,
             "cumulative chain transaction count fell below zero; marking it unknown"
         );
         0
-    });
-    handles.chain_tx_count.store(rewound, Ordering::Relaxed);
+    })
 }

--- a/crates/node/src/apply/window.rs
+++ b/crates/node/src/apply/window.rs
@@ -12,6 +12,7 @@ use super::ResolvedUtxoView;
 use super::WindowApplyDisposition;
 use super::WindowApplyError;
 use super::connect::apply_committed_block_admitted;
+use super::connect::emit_journal_record;
 use super::contextual::compute_verify_flags;
 use super::durable::{
     ConnectCommitFacts, commit_connect_head, stored_body_row, sync_appended_blocks,
@@ -67,6 +68,9 @@ pub(super) struct PendingBlockCommit {
     /// This block's parent; the group's first entry anchors the lineage
     /// fence.
     pub prev_hash: Hash256,
+    /// The derived journal record, emitted at flush — after the batch, so
+    /// the journal never leads the durable head.
+    pub journal_record: super::connect::BuiltJournalRecord,
 }
 
 /// A bounded verified prefix staged for one durable group commit.
@@ -180,6 +184,16 @@ impl WindowGroup {
         metrics::histogram!("node.durable_head.group_blocks").record(f64::from(staged));
         for pending in &mut self.pending {
             pending.outcome.commit_id = commit_id;
+        }
+        // The journal follows the receipt, block by block, before the
+        // prefix publishes — the same derived-after-durable order as the
+        // single-block path.
+        for pending in &mut self.pending {
+            emit_journal_record(
+                handles,
+                pending.journal_record.take(),
+                pending.outcome.height,
+            );
         }
         // The batch is the receipt; now publish the prefix in order. The
         // values are the ones the batch certified, so this tail is as

--- a/crates/node/src/apply/window.rs
+++ b/crates/node/src/apply/window.rs
@@ -13,15 +13,200 @@ use super::WindowApplyDisposition;
 use super::WindowApplyError;
 use super::connect::apply_committed_block_admitted;
 use super::contextual::compute_verify_flags;
+use super::durable::{
+    ConnectCommitFacts, commit_connect_head, stored_body_row, sync_appended_blocks,
+};
 use super::prepare::parse_block_for_apply;
 use super::prepare::plan_block_transactions;
 use super::prepare::resolve_block_prevouts;
+use super::publication::publish_connect;
 use crate::apply::error::ApplyError;
 use bitcoin_rs_consensus::MEDIAN_TIME_PAST_WINDOW;
 use bitcoin_rs_primitives::Block;
 use bitcoin_rs_primitives::Hash256;
+use bitcoin_rs_storage::CommitRecords;
 use rayon::prelude::*;
 use std::sync::Arc;
+
+/// Blocks per durable group commit on the windowed IBD path.
+///
+/// Stated, not emergent (`RCV-02`): at the 30–75 blocks/s an IBD stream
+/// sustains, 64 blocks is one durable batch every one to two seconds, and
+/// the crash-redo bound is at most 64 body re-applies — the same order as
+/// the journal's own batch cadence. [`DURABLE_HEAD_GROUP_MAX_BYTES`] bounds
+/// the group from the memory side, because staged undo records and outcomes
+/// ride in the group until it commits.
+pub const DURABLE_HEAD_GROUP_BLOCKS: usize = 64;
+
+/// Serialized block bytes one group may hold before it must commit.
+///
+/// Whichever cap hits first ends the group, so early-chain windows commit
+/// every 64 blocks and tip-size windows commit on bytes well before that.
+pub const DURABLE_HEAD_GROUP_MAX_BYTES: usize = 8 << 20;
+
+/// How a committed block reaches its durable head and the published tip.
+///
+/// [`PublishMode::Now`] commits and publishes inside the per-block path.
+/// [`PublishMode::Grouped`] buffers the commit facts in a [`WindowGroup`]:
+/// the window syncs once per group, lands one head batch per verified
+/// prefix, and publishes the prefix in order after the batch — one
+/// `commit_id` per committed prefix, never beyond it (`RCV-02`).
+pub(super) enum PublishMode<'a> {
+    Now,
+    Grouped(&'a mut WindowGroup),
+}
+
+/// One staged block awaiting its group's durable commit.
+pub(super) struct PendingBlockCommit {
+    /// Commit id 0 until the group's batch assigns the prefix id.
+    pub outcome: ConnectOutcome,
+    /// The block's encoded undo record, landed in the group's receipt.
+    pub undo_record: Vec<u8>,
+    pub tx_count_delta: u64,
+    pub chain_tx_count_after: u64,
+    /// This block's parent; the group's first entry anchors the lineage
+    /// fence.
+    pub prev_hash: Hash256,
+}
+
+/// A bounded verified prefix staged for one durable group commit.
+///
+/// Staging is infallible and in-memory; [`WindowGroup::flush`] does the
+/// ordered durable work: sync the appended bytes once, land one head batch
+/// naming every undo and locator row of the prefix, then publish the
+/// prefix's tips in order. `Ok` from the batch is the receipt for the whole
+/// prefix, so publication — which follows the flush — never outruns
+/// durability (`INV-04`).
+#[derive(Default)]
+pub(super) struct WindowGroup {
+    pending: Vec<PendingBlockCommit>,
+    staged_bytes: usize,
+    first_prev: Option<Hash256>,
+}
+
+impl WindowGroup {
+    /// The chain view the next staged block builds on: the group's last
+    /// staged tip, or `None` when the caller must read the published tip.
+    ///
+    /// Grouped blocks cannot read `applied_tip` for their predecessor — the
+    /// prefix publishes only after its batch (`INV-04`) — so the staged
+    /// outcome is the in-memory chain state the next block extends.
+    pub(super) fn predecessor(
+        &self,
+        prev_hash: Hash256,
+    ) -> core::result::Result<Option<(Arc<bitcoin_rs_chain::TipSnapshot>, u32)>, ApplyError> {
+        let Some(last) = self.pending.last() else {
+            return Ok(None);
+        };
+        if last.outcome.hash != prev_hash {
+            return Err(ApplyError::PrevHashMismatch {
+                tip: last.outcome.hash,
+                prev: prev_hash,
+            });
+        }
+        let height = last
+            .outcome
+            .height
+            .checked_add(1)
+            .ok_or(ApplyError::HeightOverflow(last.outcome.height))?;
+        Ok(Some((Arc::new(last.outcome.tip.clone()), height)))
+    }
+
+    /// The cumulative chain tx count the next staged block advances, when a
+    /// prefix is staged: publication has not stored the staged deltas yet.
+    pub(super) fn chain_tx_count_base(&self) -> Option<u64> {
+        self.pending.last().map(|last| last.chain_tx_count_after)
+    }
+
+    pub(super) fn stage(&mut self, pending: PendingBlockCommit) {
+        self.staged_bytes += pending.outcome.block_bytes.len();
+        if self.pending.is_empty() {
+            self.first_prev = Some(pending.prev_hash);
+        }
+        self.pending.push(pending);
+    }
+
+    /// Whether the staged prefix has hit a group cap.
+    fn should_flush(&self) -> bool {
+        self.pending.len() >= DURABLE_HEAD_GROUP_BLOCKS
+            || self.staged_bytes >= DURABLE_HEAD_GROUP_MAX_BYTES
+    }
+
+    /// Commits and publishes the staged prefix, returning its outcomes with
+    /// the group's `commit_id`. On error nothing is drained: the prefix
+    /// stays staged for the caller to retry or report.
+    pub(super) fn flush(
+        &mut self,
+        handles: &Chainstate,
+    ) -> core::result::Result<Vec<ConnectOutcome>, ApplyError> {
+        let (last, first_prev) = match (self.pending.last(), self.first_prev) {
+            (Some(last), Some(first_prev)) => (last, first_prev),
+            _ => return Ok(Vec::new()),
+        };
+        let started = quanta::Instant::now();
+        sync_appended_blocks(handles)?;
+        metrics::histogram!("node.durable_head.group_sync_seconds")
+            .record(started.elapsed().as_secs_f64());
+        let mut undo_rows = Vec::with_capacity(self.pending.len());
+        let mut body_rows = Vec::with_capacity(self.pending.len());
+        for pending in &self.pending {
+            undo_rows.push((
+                pending.outcome.height,
+                pending.outcome.hash,
+                pending.undo_record.as_slice(),
+            ));
+            if let Some(row) =
+                stored_body_row(handles, pending.outcome.height, pending.outcome.hash)?
+            {
+                body_rows.push(row);
+            }
+        }
+        let facts = ConnectCommitFacts {
+            prev_hash: first_prev,
+            tip: last.outcome.hash,
+            height: last.outcome.height,
+            chain_tx_count_after: last.chain_tx_count_after,
+            undo_extent: Some((last.outcome.height, last.outcome.hash)),
+        };
+        let started = quanta::Instant::now();
+        let records = CommitRecords {
+            undo_rows,
+            body_rows,
+        };
+        let commit_id = commit_connect_head(handles, &facts, &records)?;
+        metrics::histogram!("node.durable_head.group_commit_seconds")
+            .record(started.elapsed().as_secs_f64());
+        let staged = u32::try_from(self.pending.len()).unwrap_or(u32::MAX);
+        metrics::histogram!("node.durable_head.group_blocks").record(f64::from(staged));
+        for pending in &mut self.pending {
+            pending.outcome.commit_id = commit_id;
+        }
+        // The batch is the receipt; now publish the prefix in order. The
+        // values are the ones the batch certified, so this tail is as
+        // infallible as the single-block publication.
+        self.staged_bytes = 0;
+        self.first_prev = None;
+        let published = self
+            .pending
+            .drain(..)
+            .map(|pending| {
+                publish_connect(handles, &pending.outcome.tip, pending.tx_count_delta);
+                pending.outcome
+            })
+            .collect::<Vec<_>>();
+        metrics::counter!("node.durable_head.group_flushes").increment(1);
+        Ok(published)
+    }
+
+    /// Drops the staged prefix without committing it. Only for fatal
+    /// dispositions, where the state is torn and recovery owns the
+    /// reconciliation; the prefix was never published.
+    pub(super) fn abandon(&mut self) {
+        self.pending.clear();
+        self.staged_bytes = 0;
+        self.first_prev = None;
+    }
+}
 
 #[allow(clippy::result_large_err)]
 pub(super) fn apply_window_admitted(
@@ -44,7 +229,8 @@ pub(super) fn apply_window_admitted(
         });
     }
     let mut proven = prove_window(handles, blocks, serialized).into_iter();
-    let mut committed = Vec::with_capacity(blocks.len());
+    let mut group = WindowGroup::default();
+    let mut committed: Vec<ConnectOutcome> = Vec::with_capacity(blocks.len());
     for (block, raw) in blocks.iter().zip(serialized) {
         match apply_committed_block_admitted(
             handles,
@@ -53,22 +239,51 @@ pub(super) fn apply_window_admitted(
             proven.next(),
             BlockProvenance::Network,
             proof,
+            PublishMode::Grouped(&mut group),
         ) {
-            Ok(outcome) => committed.push(outcome),
+            // The staged outcome sits in the group with commit id 0; the
+            // flushed copy published below carries the group's id.
+            Ok(_) => {}
             Err(source) => {
-                let disposition = if matches!(
+                if matches!(
                     source,
                     ApplyError::UtxoCommit(_)
                         | ApplyError::DurableHeadCommit(_)
                         | ApplyError::DurableHeadLineage { .. }
                 ) {
-                    WindowApplyDisposition::Fatal
-                } else if is_permanent_apply_error(&source) {
+                    // Torn or unreconcilable: the staged prefix was never
+                    // published, and retrying it here would build on state
+                    // recovery has to rebuild first.
+                    group.abandon();
+                    return Err(WindowApplyError {
+                        applied: committed.len(),
+                        committed,
+                        source,
+                        disposition: WindowApplyDisposition::Fatal,
+                        invalidated: Box::default(),
+                    });
+                }
+                let invalidated = invalidate_failed_subtree(handles, block, &source);
+                let disposition = if is_permanent_apply_error(&source) {
                     WindowApplyDisposition::Permanent
                 } else {
                     WindowApplyDisposition::Operational
                 };
-                let invalidated = invalidate_failed_subtree(handles, block, &source);
+                // The prefix that committed in memory stays committed: flush
+                // its durable group before reporting, so the durable head
+                // and the published tip keep moving together. A flush
+                // failure is the ambiguous-batch case: fatal, never retried.
+                let flushed = group.flush(handles).map_err(|flush_error| {
+                    group.abandon();
+                    WindowApplyError {
+                        applied: committed.len(),
+                        committed: std::mem::take(&mut committed),
+                        source: flush_error,
+                        disposition: WindowApplyDisposition::Fatal,
+                        invalidated: Box::default(),
+                    }
+                })?;
+                committed.extend(flushed);
                 return Err(WindowApplyError {
                     applied: committed.len(),
                     committed,
@@ -78,7 +293,30 @@ pub(super) fn apply_window_admitted(
                 });
             }
         }
+        if group.should_flush() {
+            let flushed = group.flush(handles).map_err(|flush_error| {
+                group.abandon();
+                WindowApplyError {
+                    applied: committed.len(),
+                    committed: std::mem::take(&mut committed),
+                    source: flush_error,
+                    disposition: WindowApplyDisposition::Fatal,
+                    invalidated: Box::default(),
+                }
+            })?;
+            committed.extend(flushed);
+        }
     }
+    let flushed = group
+        .flush(handles)
+        .map_err(|flush_error| WindowApplyError {
+            applied: committed.len(),
+            committed: std::mem::take(&mut committed),
+            source: flush_error,
+            disposition: WindowApplyDisposition::Fatal,
+            invalidated: Box::default(),
+        })?;
+    committed.extend(flushed);
     Ok(committed)
 }
 

--- a/crates/node/src/apply/window.rs
+++ b/crates/node/src/apply/window.rs
@@ -56,7 +56,12 @@ pub(super) fn apply_window_admitted(
         ) {
             Ok(outcome) => committed.push(outcome),
             Err(source) => {
-                let disposition = if matches!(source, ApplyError::UtxoCommit(_)) {
+                let disposition = if matches!(
+                    source,
+                    ApplyError::UtxoCommit(_)
+                        | ApplyError::DurableHeadCommit(_)
+                        | ApplyError::DurableHeadLineage { .. }
+                ) {
                     WindowApplyDisposition::Fatal
                 } else if is_permanent_apply_error(&source) {
                     WindowApplyDisposition::Permanent

--- a/crates/node/src/chain_effects.rs
+++ b/crates/node/src/chain_effects.rs
@@ -436,6 +436,7 @@ mod tests {
     /// mempool mutation or observer that could independently wake the child.
     /// Full chain application and transition ownership have separate tests in
     /// apply.rs; this checks the follower's lifecycle notification boundary.
+    #[allow(clippy::too_many_lines)]
     fn assert_admission_followers_after_chain_change(connect: bool) -> anyhow::Result<()> {
         let gateway = MempoolGateway::shared(Arc::new(RwLock::new(Mempool::new(
             MempoolLimits::default(),
@@ -492,6 +493,7 @@ mod tests {
                 &block,
                 &ConnectOutcome {
                     height: tip.height,
+                    commit_id: 0,
                     tip,
                     hash,
                     txids: vec![parent],

--- a/crates/node/src/checkpoint.rs
+++ b/crates/node/src/checkpoint.rs
@@ -206,6 +206,15 @@ pub(crate) enum CheckpointError {
     Storage(#[from] bitcoin_rs_storage::StorageError),
     #[error("checkpoint refused while disconnect of block {hash} at height {height} is in flight")]
     DisconnectInFlight { hash: Hash256, height: u32 },
+    #[error(
+        "checkpoint of tip {tip} at height {tip_height} is ahead of the durable head {head} at height {head_height}"
+    )]
+    AheadOfDurableHead {
+        tip: Hash256,
+        tip_height: u32,
+        head: Hash256,
+        head_height: u32,
+    },
     /// The replacement checkpoint's `CURRENT` is already durable; retiring the
     /// sticky full-revalidation marker failed. Retryable I/O owned by the
     /// checkpoint worker, not checkpoint corruption.

--- a/crates/node/src/checkpoint/worker.rs
+++ b/crates/node/src/checkpoint/worker.rs
@@ -102,6 +102,7 @@ const POLL_INTERVAL: Duration = Duration::from_secs(1);
 pub(crate) struct CheckpointPublisher {
     pub(crate) admission: Arc<ApplyAdmission>,
     pub(crate) undo_store: Arc<dyn UndoStore>,
+    pub(crate) durable_head: Arc<dyn bitcoin_rs_storage::DurableHeadStore>,
     pub(crate) block_body_store: Arc<dyn BlockBodyStore>,
     pub(crate) applied_tip: Arc<ArcSwapOption<TipSnapshot>>,
     pub(crate) checkpoint_data_dir: cap_std::fs::Dir,
@@ -231,6 +232,36 @@ impl CheckpointPublisher {
                 hash: marker.hash,
                 height: marker.height,
             });
+        }
+        // The durable head is the chain's commit point and publication
+        // follows it, so a checkpoint — which freezes the published state —
+        // can never legitimately name a tip the head has not certified. The
+        // two authorities must not disagree about the durable tip.
+        // No applied tip is the legitimate pre-genesis state (`SkippedNoAppliedTip`
+        // below); the guard has nothing to compare there.
+        if let (Some(head), Some(tip)) = (
+            self.durable_head.load().map_err(|error| {
+                CheckpointError::Invalid(format!("durable head unreadable: {error}"))
+            })?,
+            applied_tip,
+        ) {
+            // A tip below the head is the committed-but-unpublished gap a
+            // crash can leave; checkpointing the older state is harmless. A
+            // tip at or above the head that the head does not certify is
+            // genuine divergence between the two authorities.
+            // `head.tip` and `tip.hash` name the same fact — the 32-byte
+            // block hash of the certified/applied tip — under two field
+            // names.
+            let same_tip = head.tip == tip.hash;
+            let diverged = head.height < tip.height || (head.height == tip.height && !same_tip);
+            if diverged {
+                return Err(CheckpointError::AheadOfDurableHead {
+                    tip: tip.hash,
+                    tip_height: tip.height,
+                    head: head.tip,
+                    head_height: head.height,
+                });
+            }
         }
         // A checkpoint may name this tip only after body files then index rows sync.
         self.block_body_store.sync()?;

--- a/crates/node/src/state/checkpoint.rs
+++ b/crates/node/src/state/checkpoint.rs
@@ -37,6 +37,7 @@ impl NodeState {
         Ok(crate::checkpoint::worker::CheckpointPublisher {
             admission: Arc::clone(&self.apply_handles.admission),
             undo_store: Arc::clone(&self.apply_handles.undo_store),
+            durable_head: Arc::clone(&self.apply_handles.durable_head),
             block_body_store: Arc::clone(&self.block_body_store),
             applied_tip: Arc::clone(&self.applied_tip),
             checkpoint_data_dir: crate::checkpoint::fs::open_data_dir(&self.data_dir)

--- a/crates/node/src/state/open.rs
+++ b/crates/node/src/state/open.rs
@@ -434,6 +434,7 @@ impl NodeState {
             Some(Arc::new(crate::checkpoint::worker::CheckpointPublisher {
                 admission: Arc::clone(&apply_handles.admission),
                 undo_store: Arc::clone(&apply_handles.undo_store),
+                durable_head: Arc::clone(&apply_handles.durable_head),
                 block_body_store: Arc::clone(&block_body_store),
                 applied_tip: Arc::clone(&applied_tip),
                 checkpoint_data_dir: crate::checkpoint::fs::open_data_dir(&config.data_dir)

--- a/crates/node/src/state/open.rs
+++ b/crates/node/src/state/open.rs
@@ -85,6 +85,7 @@ impl NodeState {
             Arc::new(FlatFileBlockStore::open(&config.data_dir).map_err(anyhow::Error::new)?);
         let storage = NodeStorage::open(&config, chainstate_cache_bytes, Arc::clone(&block_files))?;
         let undo_store = storage.undo_store();
+        let durable_head = storage.durable_head();
         // Before anything reads the chainstate, let alone serves or syncs it.
         // A node that starts on a torn chainstate builds on it, and every block
         // it adds makes the damage harder to find.
@@ -404,6 +405,7 @@ impl NodeState {
             chain_events: Arc::clone(&chain_events),
             block_body_store: Some(Arc::clone(&block_body_store)),
             undo_store,
+            durable_head,
             admission: Arc::new(crate::apply::ApplyAdmission::new()),
             shutdown: Arc::clone(&shutdown),
             chain_transition,
@@ -418,6 +420,11 @@ impl NodeState {
             capture_block_bytes,
         };
         apply_handles.assume_valid_gate.evaluate(&block_tree.read());
+        // The durable head is the chain's commit point: an unreadable row
+        // fails startup, and a committed-but-unpublished gap (crash between
+        // the head batch and publication) is surfaced here, counted, and
+        // left for recovery replay rather than silently adopted.
+        crate::apply::reconcile_at_boot(&apply_handles).map_err(anyhow::Error::new)?;
         // A restored checkpoint is durable at its own height by definition, so
         // start there rather than at zero, which would refuse all undo pruning.
         let durable_tip_height = Arc::new(AtomicU32::new(

--- a/crates/node/src/state/storage.rs
+++ b/crates/node/src/state/storage.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 pub(super) struct NodeStorage {
     backend: StorageBackend,
     undo_store: Arc<dyn crate::apply::UndoStore>,
+    durable_head: Arc<dyn bitcoin_rs_storage::DurableHeadStore>,
     block_body_store: Arc<dyn bitcoin_rs_storage::block_body::BlockBodyStore>,
     deferred: Arc<dyn DeferredChainstateServices>,
     #[cfg(test)]
@@ -53,6 +54,9 @@ impl crate::storage_backend::StoreConsumer for ChainstateComposer {
         Ok(NodeStorage {
             backend: self.backend,
             undo_store: Arc::new(crate::apply::KvUndoStore::new(Arc::clone(&store))),
+            durable_head: Arc::new(bitcoin_rs_storage::KvDurableHeadStore::new(Arc::clone(
+                &store,
+            ))),
             block_body_store: Arc::new(bitcoin_rs_storage::block_body::IndexedBlockBodyStore::new(
                 Arc::clone(&store),
                 self.block_files,
@@ -125,6 +129,10 @@ impl NodeStorage {
     /// unable to leave.
     pub(super) fn undo_store(&self) -> Arc<dyn crate::apply::UndoStore> {
         Arc::clone(&self.undo_store)
+    }
+
+    pub(super) fn durable_head(&self) -> Arc<dyn bitcoin_rs_storage::DurableHeadStore> {
+        Arc::clone(&self.durable_head)
     }
 
     pub(super) fn journal_writer(

--- a/crates/node/tests/overhaul_durable_head.rs
+++ b/crates/node/tests/overhaul_durable_head.rs
@@ -1,0 +1,473 @@
+//! Fault-injection matrix for the durable-head commit protocol (#632, CL-17).
+//!
+//! Two layers, both in isolated datadirs:
+//!
+//! - The **batch matrix** drives the exact production storage family —
+//!   Fjall key-value store, flat block files, indexed body store, undo
+//!   store, durable-head store — and arms one-shot [`PersistFault`]s at
+//!   every durability boundary of a connect-shaped and a disconnect-shaped
+//!   batch. After each fault the datadir reopens and the head row plus
+//!   every batch row must show either the complete pre-batch or the
+//!   complete post-batch state, never a cross-family mix (`P2`).
+//! - The **protocol rows** run [`NodeState`] end to end: the durable head
+//!   must name every applied block by the time `apply_block` returns
+//!   (durability precedes publication, `INV-04`), `commit_id` must advance
+//!   monotonically across connects and restarts (`P3`), every committed
+//!   body must be reachable through the real block files (`INV-06`), and a
+//!   corrupted head row must fail startup instead of decoding to absence
+//!   (`P5`).
+
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+
+use bitcoin_rs_node::{Network, NodeConfig, state::NodeState};
+
+use bitcoin_rs_primitives::{
+    Amount, Block, BlockHash, CompactTarget, Hash256, Header, LockTime, OutPoint, Script, Sequence,
+    Tx, TxIn, TxOut, Txid, Witness,
+};
+
+use bitcoin_rs_storage::block_body::{BlockBodyStore, IndexedBlockBodyStore};
+use bitcoin_rs_storage::durable_head::{DURABLE_HEAD_FORMAT_VERSION, DURABLE_HEAD_KEY};
+use bitcoin_rs_storage::pruning::{block_body_key, block_undo_key};
+use bitcoin_rs_storage::undo::UndoStore;
+use bitcoin_rs_storage::{
+    ColumnFamily, CommitRecords, DurableHead, DurableHeadStore, FlatFileBlockStore,
+    KvDurableHeadStore, KvStore, KvUndoStore, PersistFault,
+};
+use sha2::{Digest, Sha256};
+
+const ALL_FAULTS: &[PersistFault] = &[
+    PersistFault::FailApply,
+    PersistFault::LostApply,
+    PersistFault::PartialApply,
+    PersistFault::FailSync,
+    PersistFault::LostSync,
+    PersistFault::FailFlush,
+    PersistFault::LostFlush,
+];
+
+/// The production storage family, composed exactly as `NodeStorage`
+/// composes it: one key-value store behind every family, flat files beside
+/// it.
+struct ChainFamily {
+    store: Arc<bitcoin_rs_storage::FjallStore>,
+    _files: Arc<FlatFileBlockStore>,
+    bodies: Arc<IndexedBlockBodyStore<bitcoin_rs_storage::FjallStore>>,
+    undo: KvUndoStore<bitcoin_rs_storage::FjallStore>,
+    head: KvDurableHeadStore<bitcoin_rs_storage::FjallStore>,
+}
+
+fn open_family(data_dir: &std::path::Path) -> Result<ChainFamily> {
+    let store = Arc::new(bitcoin_rs_storage::FjallStore::open(
+        data_dir.join("chainstate"),
+    )?);
+    let files = Arc::new(FlatFileBlockStore::open(data_dir)?);
+    let bodies = Arc::new(IndexedBlockBodyStore::new(
+        Arc::clone(&store),
+        Arc::clone(&files),
+    ));
+    let undo = KvUndoStore::new(Arc::clone(&store));
+    let head = KvDurableHeadStore::new(Arc::clone(&store));
+    Ok(ChainFamily {
+        store,
+        _files: files,
+        bodies,
+        undo,
+        head,
+    })
+}
+
+fn hash_of(seed: u8) -> Hash256 {
+    Hash256::from_le_bytes(&[seed; 32])
+}
+
+/// Asserts the reopened datadir shows exactly one whole state: the head is
+/// the old or the new row, and the new rows exist exactly when the head
+/// rolled forward.
+fn assert_whole_state(
+    data_dir: &std::path::Path,
+    old_head: &DurableHead,
+    new_head: &DurableHead,
+    batch_rows: &[(ColumnFamily, Vec<u8>)],
+    context: &str,
+) -> Result<()> {
+    let family = open_family(data_dir)?;
+    let stored = family
+        .head
+        .load()?
+        .ok_or_else(|| anyhow::anyhow!("{context}: head row vanished"))?;
+    if stored == *old_head {
+        // rolled out: none of the new rows may exist
+    } else if stored == *new_head {
+        // rolled forward: all of the new rows must exist
+    } else {
+        bail!("{context}: head is neither the old nor the new state: {stored:?}");
+    }
+    let rolled_forward = stored == *new_head;
+    for (cf, key) in batch_rows {
+        let present = family.store.get(*cf, key)?.is_some();
+        assert_eq!(
+            present, rolled_forward,
+            "{context}: batch row presence {present} disagrees with head rolled_forward={rolled_forward}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn connect_batch_faults_leave_old_or_new_across_families() -> Result<()> {
+    for fault in ALL_FAULTS {
+        let temp = tempfile::tempdir()?;
+        let data_dir = temp.path().to_path_buf();
+        let family = open_family(&data_dir)?;
+
+        // Block 1 commits cleanly: the pre-batch state every fault is
+        // measured against.
+        let body_one = b"body-one";
+        family.bodies.persist_block_body(1, hash_of(1), body_one)?;
+        let position_one = family
+            .bodies
+            .block_position(1, hash_of(1))?
+            .ok_or_else(|| anyhow::anyhow!("family lost its own locator"))?;
+        let old_head = DurableHead {
+            commit_id: 1,
+            height: 1,
+            tip: hash_of(1),
+            chain_tx_count: 1,
+            body_extent: family.bodies.append_cursor(),
+            undo_extent: Some((1, hash_of(1))),
+        };
+        let undo_one = vec![1_u8; 8];
+        family.head.commit(
+            None,
+            &old_head,
+            &CommitRecords {
+                undo_rows: vec![(1, hash_of(1), undo_one.as_slice())],
+                body_rows: vec![(1, hash_of(1), position_one)],
+            },
+        )?;
+
+        // Block 2's bytes append first (no fault hook on the flat file —
+        // its own recovery is the append-offset rollback), then the batch
+        // hits the armed fault.
+        let body_two = b"body-two";
+        family.bodies.persist_block_body(2, hash_of(2), body_two)?;
+        let position_two = family
+            .bodies
+            .block_position(2, hash_of(2))?
+            .ok_or_else(|| anyhow::anyhow!("family lost its own locator"))?;
+        let new_head = DurableHead {
+            commit_id: 2,
+            height: 2,
+            tip: hash_of(2),
+            chain_tx_count: 2,
+            body_extent: family.bodies.append_cursor(),
+            undo_extent: Some((2, hash_of(2))),
+        };
+        let undo_two = vec![2_u8; 8];
+        family.store.arm_persist_fault(*fault);
+        let outcome = family.head.commit(
+            Some(&old_head),
+            &new_head,
+            &CommitRecords {
+                undo_rows: vec![(2, hash_of(2), undo_two.as_slice())],
+                body_rows: vec![(2, hash_of(2), position_two)],
+            },
+        );
+        drop(family);
+
+        // Not a rollback receipt: whichever state is on disk must be whole.
+        let _ = outcome;
+        // The undo row rides the batch in both directions. The locator row
+        // does not: `persist_block_body` wrote it deferred before the batch,
+        // so with the head rolled out it may linger as an orphan tail
+        // (`P4`, discardable) — assert only the forward direction for it.
+        let family = open_family(&data_dir)?;
+        let locator_present = family
+            .store
+            .get(ColumnFamily::BlockBodies, &block_body_key(2, hash_of(2)))?
+            .is_some();
+        drop(family);
+        assert_whole_state(
+            &data_dir,
+            &old_head,
+            &new_head,
+            &[(
+                ColumnFamily::UndoData,
+                block_undo_key(2, hash_of(2)).to_vec(),
+            )],
+            &format!("fault {fault:?}"),
+        )?;
+        if locator_present {
+            let family = open_family(&data_dir)?;
+            let head = family
+                .head
+                .load()?
+                .ok_or_else(|| anyhow::anyhow!("head vanished"))?;
+            assert!(
+                head == new_head || locator_present,
+                "a present locator with no batch must be an orphan, not a fresh head"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn disconnect_batch_faults_leave_old_or_new_across_families() -> Result<()> {
+    for fault in ALL_FAULTS {
+        let temp = tempfile::tempdir()?;
+        let data_dir = temp.path().to_path_buf();
+        let family = open_family(&data_dir)?;
+        let committed = DurableHead {
+            commit_id: 1,
+            height: 1,
+            tip: hash_of(1),
+            chain_tx_count: 1,
+            body_extent: Some(bitcoin_rs_storage::BodyExtent {
+                file_no: 0,
+                offset: 128,
+            }),
+            undo_extent: Some((1, hash_of(1))),
+        };
+        family
+            .head
+            .commit(None, &committed, &CommitRecords::default())?;
+
+        // Disconnect: the head advances onto the parent tip with the next
+        // commit id and no new records.
+        let parent = DurableHead {
+            commit_id: committed.commit_id + 1,
+            height: 0,
+            tip: Hash256::from_le_bytes(&[0_u8; 32]),
+            chain_tx_count: committed.chain_tx_count,
+            body_extent: committed.body_extent,
+            undo_extent: committed.undo_extent,
+        };
+        family.store.arm_persist_fault(*fault);
+        let outcome = family
+            .head
+            .commit(Some(&committed), &parent, &CommitRecords::default());
+        drop(family);
+
+        let _ = outcome;
+        assert_whole_state(
+            &data_dir,
+            &committed,
+            &parent,
+            &[],
+            &format!("disconnect fault {fault:?}"),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Protocol rows through NodeState.
+// ---------------------------------------------------------------------------
+
+fn test_config(data_dir: std::path::PathBuf) -> NodeConfig {
+    let mut config = NodeConfig::default_for_network(Network::Regtest);
+    config.data_dir = data_dir;
+    config.p2p.listen.clear();
+    config.chainstate_journal.blocks = 1;
+    config
+}
+
+#[test]
+fn durable_head_precedes_publication_and_survives_restart() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let data_dir = temp.path().join("protocol-node");
+    let genesis = Network::Regtest.genesis_block();
+
+    let state = NodeState::open(test_config(data_dir.clone()), None)?;
+    let mut tip = state.apply_block(&genesis)?;
+    let mut blocks = Vec::new();
+    for height in 1..=3_u32 {
+        let block = mined_regtest_child_at(BlockHash(tip.hash), height)?;
+        tip = state.apply_block(&block)?;
+        blocks.push(block);
+    }
+    state.publish_checkpoint()?;
+    drop(state);
+
+    // Durability precedes publication: by the time apply_block returned,
+    // the head row, undo row, and a reachable body for every block were
+    // already on disk.
+    let family = open_family(&data_dir)?;
+    let head = family
+        .head
+        .load()?
+        .ok_or_else(|| anyhow::anyhow!("a committed chain must leave a durable head"))?;
+    assert_eq!(head.height, 3);
+    assert_eq!(head.tip, tip.hash);
+    assert_eq!(head.commit_id, 4, "genesis plus three blocks advance 1..=4");
+    assert_eq!(head.chain_tx_count, 4, "genesis plus three coinbases");
+    assert_eq!(head.undo_extent, Some((3, tip.hash)));
+    assert!(head.body_extent.is_some(), "flat files back the head");
+    for (index, block) in blocks.iter().enumerate() {
+        let height = u32::try_from(index + 1)?;
+        let block_hash = Hash256::from(block.block_hash());
+        let stored_undo = family.undo.load_undo(height, block_hash)?;
+        assert!(
+            stored_undo.is_some(),
+            "undo row for height {height} missing"
+        );
+        let stored_body = family.bodies.load_block_body(height, block_hash)?;
+        assert_eq!(
+            stored_body.as_deref(),
+            Some(bitcoin_rs_primitives::consensus_bytes(block).as_slice()),
+            "committed body bytes must be reachable through the block files"
+        );
+    }
+    drop(family);
+
+    // Restart: the restored tip reconciles with the head, and the next
+    // connect continues the commit-id sequence.
+    let resumed = NodeState::open(test_config(data_dir.clone()), None)?;
+    let restored = resumed
+        .applied_tip()
+        .load_full()
+        .ok_or_else(|| anyhow::anyhow!("restart must restore an applied tip"))?;
+    assert_eq!(restored.hash, tip.hash);
+    let block4 = mined_regtest_child_at(BlockHash(restored.hash), 4)?;
+    let new_tip = resumed.apply_block(&block4)?;
+    assert_eq!(new_tip.height, 4);
+    drop(resumed);
+
+    let family = open_family(&data_dir)?;
+    let head = family
+        .head
+        .load()?
+        .ok_or_else(|| anyhow::anyhow!("head vanished"))?;
+    assert_eq!(head.commit_id, 5, "commit ids continue across restarts");
+    assert_eq!(head.tip, new_tip.hash);
+    Ok(())
+}
+
+#[test]
+fn corrupt_head_rows_fail_startup_fail_closed() -> Result<()> {
+    for corruption in ["truncate", "flip-payload-bit", "wrong-version"] {
+        let temp = tempfile::tempdir()?;
+        let data_dir = temp.path().join("corrupt-node");
+        let genesis = Network::Regtest.genesis_block();
+        let state = NodeState::open(test_config(data_dir.clone()), None)?;
+        state.apply_block(&genesis)?;
+        drop(state);
+
+        // Corrupt exactly the head row.
+        let raw = Arc::new(bitcoin_rs_storage::FjallStore::open(
+            data_dir.join("chainstate"),
+        )?);
+        let frame = raw
+            .get(ColumnFamily::UtxoMeta, DURABLE_HEAD_KEY)?
+            .ok_or_else(|| anyhow::anyhow!("head row must exist"))?;
+        let corrupted = match corruption {
+            "truncate" => frame[..frame.len() - 1].to_vec(),
+            "flip-payload-bit" => {
+                let mut frame = frame;
+                let last = frame.len() - 1;
+                frame[last] ^= 0x80;
+                frame
+            }
+            "wrong-version" => {
+                let mut frame = frame;
+                frame[4] = DURABLE_HEAD_FORMAT_VERSION + 1;
+                frame
+            }
+            other => bail!("unknown corruption {other}"),
+        };
+        raw.put(ColumnFamily::UtxoMeta, DURABLE_HEAD_KEY, &corrupted)?;
+        drop(raw);
+
+        let reopened = NodeState::open(test_config(data_dir), None);
+        assert!(
+            reopened.is_err(),
+            "corruption {corruption} must fail startup, got a node"
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Regtest miner, mirroring the crash-recovery fixtures.
+// ---------------------------------------------------------------------------
+
+fn mined_regtest_child_at(prev_blockhash: BlockHash, height: u32) -> Result<Block> {
+    let coinbase = Tx {
+        version: 2,
+        lock_time: LockTime::from_consensus(0),
+        inputs: vec![TxIn {
+            previous_output: OutPoint::new(Txid::default(), u32::MAX),
+            script_sig: Script::from_bytes(vec![1, u8::try_from(height)?]),
+            sequence: Sequence::from_consensus(u32::MAX),
+            witness: Witness::new(),
+        }],
+        outputs: vec![TxOut {
+            value: Amount::from_sat(1),
+            script_pubkey: Script::new(),
+        }],
+    };
+    let mut block = Block {
+        header: Header {
+            version: 1,
+            prev_blockhash,
+            merkle_root: Hash256::default(),
+            time: Network::Regtest.genesis_block().header.time + height,
+            bits: CompactTarget::from_consensus(0x207f_ffff),
+            nonce: 0,
+        },
+        txs: vec![coinbase],
+    };
+    block.header.merkle_root = merkle_root(&block.txs)
+        .ok_or_else(|| std::io::Error::other("test block has no merkle root"))?;
+    while !pow_met(block.header.bits.to_consensus(), block.block_hash().into()) {
+        block.header.nonce = block
+            .header
+            .nonce
+            .checked_add(1)
+            .ok_or_else(|| std::io::Error::other("test nonce exhausted"))?;
+    }
+    Ok(block)
+}
+
+fn merkle_root(txs: &[Tx]) -> Option<Hash256> {
+    let mut leaves: Vec<[u8; 32]> = txs.iter().map(|tx| *tx.txid().as_bytes()).collect();
+    if leaves.is_empty() {
+        return None;
+    }
+    while leaves.len() > 1 {
+        let original_len = leaves.len();
+        let mut next = Vec::with_capacity(original_len.div_ceil(2));
+        for pos in 0..original_len.div_ceil(2) {
+            let left = leaves[2 * pos];
+            let right = leaves[(2 * pos + 1).min(original_len - 1)];
+            let mut pair = [0_u8; 64];
+            pair[..32].copy_from_slice(&left);
+            pair[32..].copy_from_slice(&right);
+            next.push(double_sha256(&pair));
+        }
+        leaves = next;
+    }
+    Some(Hash256::from_le_bytes(&leaves[0]))
+}
+
+fn double_sha256(bytes: &[u8]) -> [u8; 32] {
+    let first = Sha256::digest(bytes);
+    Sha256::digest(first).into()
+}
+
+fn pow_met(bits: u32, hash: Hash256) -> bool {
+    let exponent = u8::try_from(bits >> 24).unwrap_or(0);
+    let mantissa = bits & 0x007f_ffff;
+    if exponent <= 3 || exponent > 32 || mantissa > 0x00ff_ffff {
+        return false;
+    }
+    let bytes = hash.as_byte_array();
+    let low = usize::from(exponent - 3);
+    let window =
+        u32::from(bytes[low]) | u32::from(bytes[low + 1]) << 8 | u32::from(bytes[low + 2]) << 16;
+    window <= mantissa && bytes[usize::from(exponent)..].iter().all(|&byte| byte == 0)
+}

--- a/crates/storage/src/block_body.rs
+++ b/crates/storage/src/block_body.rs
@@ -1,5 +1,6 @@
 //! Indexed authoritative block bodies, read sessions, and durability.
 
+use crate::durable_head::BodyExtent;
 use bitcoin_rs_primitives::{Hash256, varint};
 
 use crate::{
@@ -141,6 +142,16 @@ pub trait BlockBodyStore: Send + Sync {
             body_size: body.len(),
             tx_count,
         }))
+    }
+
+    /// The append cursor of the backing block files, when the store is
+    /// file-backed: block files up to `file_no` hold every frame written so
+    /// far, and `offset` is the first byte not yet written in that file.
+    ///
+    /// A durable head names this cursor as its `body_extent`; `None` means
+    /// the store cannot address ranges, so the head names no extent.
+    fn append_cursor(&self) -> Option<BodyExtent> {
+        None
     }
 
     /// Bytes this store's block files occupy on disk, when it keeps files.
@@ -407,6 +418,13 @@ impl<S: KvStore> BlockBodyStore for IndexedBlockBodyStore<S> {
             body_size,
             tx_count,
         }))
+    }
+
+    fn append_cursor(&self) -> Option<BodyExtent> {
+        Some(BodyExtent {
+            file_no: self.files.current_file_number(),
+            offset: self.files.append_offset(),
+        })
     }
 
     fn sync(&self) -> Result<(), StorageError> {

--- a/crates/storage/src/block_body.rs
+++ b/crates/storage/src/block_body.rs
@@ -154,6 +154,17 @@ pub trait BlockBodyStore: Send + Sync {
         None
     }
 
+    /// Resolves the stored flat-file position of one block body: the locator
+    /// row a durable head lands atomically with its advance. `None` when the
+    /// store does not address positions.
+    fn block_position(
+        &self,
+        _height: u32,
+        _hash: bitcoin_rs_primitives::Hash256,
+    ) -> Result<Option<crate::block_file::BlockFilePosition>, StorageError> {
+        Ok(None)
+    }
+
     /// Bytes this store's block files occupy on disk, when it keeps files.
     ///
     /// `None` from a store with nothing on disk to measure; the caller then
@@ -425,6 +436,14 @@ impl<S: KvStore> BlockBodyStore for IndexedBlockBodyStore<S> {
             file_no: self.files.current_file_number(),
             offset: self.files.append_offset(),
         })
+    }
+
+    fn block_position(
+        &self,
+        height: u32,
+        hash: bitcoin_rs_primitives::Hash256,
+    ) -> Result<Option<crate::block_file::BlockFilePosition>, StorageError> {
+        self.body_position(height, hash)
     }
 
     fn sync(&self) -> Result<(), StorageError> {

--- a/crates/storage/src/block_file.rs
+++ b/crates/storage/src/block_file.rs
@@ -375,6 +375,17 @@ impl FlatFileBlockStore {
         self.writer.lock().file_no
     }
 
+    /// Returns the first byte offset in the current file that the next
+    /// append will write to.
+    ///
+    /// Together with [`Self::current_file_number`] this is the append cursor
+    /// a durable head names: every frame at or below the cursor was written
+    /// through this store, and [`Self::sync`] makes all of it durable.
+    #[must_use]
+    pub fn append_offset(&self) -> u64 {
+        self.writer.lock().append_offset
+    }
+
     /// Returns the path of a numbered flat file.
     #[must_use]
     pub fn file_path(&self, file_no: u32) -> PathBuf {

--- a/crates/storage/src/durable_head.rs
+++ b/crates/storage/src/durable_head.rs
@@ -16,7 +16,6 @@
 use bitcoin_rs_primitives::Hash256;
 
 use crate::pruning::{BLOCK_DATA_CF, block_body_key, block_undo_key};
-use crate::undo::{DISCONNECT_MARKER_KEY, encode_disconnect_marker};
 use crate::{ColumnFamily, KvStore, StorageError, WriteBatch as _, WriteCondition};
 
 /// Key of the durable-head row in the `UtxoMeta` family.
@@ -189,9 +188,6 @@ pub struct CommitRecords<'a> {
     pub undo_rows: Vec<(u32, Hash256, &'a [u8])>,
     /// Body locator rows (`BlockBodies`): `(height, hash, position)`.
     pub body_rows: Vec<(u32, Hash256, crate::block_file::BlockFilePosition)>,
-    /// Disconnect marker row to write in the same receipt, moving an armed
-    /// `InFlight` marker to `RolledBack` atomically with the head advance.
-    pub marker: Option<crate::DisconnectMarker>,
 }
 
 /// Owner of the durable-head row and its atomic commit boundary.
@@ -277,13 +273,6 @@ impl<S: KvStore> DurableHeadStore for KvDurableHeadStore<S> {
                 BLOCK_DATA_CF,
                 &block_body_key(*height, *hash),
                 &position.encode(),
-            );
-        }
-        if let Some(marker) = &records.marker {
-            batch.put(
-                ColumnFamily::UtxoMeta,
-                DISCONNECT_MARKER_KEY,
-                &encode_disconnect_marker(marker),
             );
         }
         let condition = match expected {

--- a/crates/storage/src/durable_head.rs
+++ b/crates/storage/src/durable_head.rs
@@ -1,0 +1,443 @@
+//! Durable chain head record and its atomic commit boundary.
+//!
+//! `RCV-02` orders every connect or disconnect as: reserve, append, sync, one
+//! atomic durable batch, publish. This module owns the record that batch
+//! commits: one versioned, CRC32C-framed row in the `UtxoMeta` family naming
+//! the committed chain tip, its strictly monotonic `commit_id`, the chain
+//! transaction count, and the committed body/undo extents (`INV-06`: the head
+//! never names a byte range that was not made durable before the batch).
+//!
+//! The framing imitates the chainstate journal's `HeadMarker` (magic, version
+//! byte, checksum over the payload) but is not a second copy of it: the
+//! journal head stays a derived recovery accelerator, while this row is the
+//! commit point the apply path advances before it publishes the tip. A head
+//! whose bytes do not decode fails closed, exactly like a torn `head.json`.
+
+use bitcoin_rs_primitives::Hash256;
+
+use crate::pruning::{BLOCK_DATA_CF, block_body_key, block_undo_key};
+use crate::undo::{DISCONNECT_MARKER_KEY, encode_disconnect_marker};
+use crate::{ColumnFamily, KvStore, StorageError, WriteBatch as _, WriteCondition};
+
+/// Key of the durable-head row in the `UtxoMeta` family.
+///
+/// One key, like the disconnect marker: the chain-transition lock admits one
+/// writer at a time, so a per-head key would only force readers to scan.
+pub const DURABLE_HEAD_KEY: &[u8] = b"node:durable-head";
+
+/// Current durable-head row format version.
+///
+/// Owner-local to this row. A bump is a breaking change for every datadir
+/// that ever wrote the row, so decode treats an unknown version as corruption
+/// and refuses, rather than guessing around it.
+pub const DURABLE_HEAD_FORMAT_VERSION: u8 = 1;
+
+/// Magic prefix of the durable-head row bytes.
+const DURABLE_HEAD_MAGIC: [u8; 4] = *b"BRSD";
+
+/// Fixed payload width: commit id, height, tip, chain tx count, body extent,
+/// undo extent.
+const DURABLE_HEAD_PAYLOAD_LEN: usize = 8 + 4 + 32 + 8 + 1 + 4 + 8 + 1 + 4 + 32;
+
+/// Frame width: magic, version, CRC32C, payload.
+const DURABLE_HEAD_FRAME_LEN: usize = DURABLE_HEAD_MAGIC.len() + 1 + 4 + DURABLE_HEAD_PAYLOAD_LEN;
+
+/// Byte range of the flat-file block store this head certifies.
+///
+/// Every block body the head references lives in a block file numbered at or
+/// below `file_no`, at an offset below `offset`. The bound is a floor for
+/// recovery (bytes outside it are orphan tails), not an index: individual
+/// bodies are addressed by their locator rows, which land in the same batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BodyExtent {
+    /// Highest block file number the head names.
+    pub file_no: u32,
+    /// First byte at or after the last frame the head names.
+    pub offset: u64,
+}
+
+/// The chain's durable commit point.
+///
+/// Written by exactly one caller at a time under the chain-transition lock,
+/// and always through [`DurableHeadStore::commit`], whose single
+/// `write_durable_if` receipt covers the head row and every record row named
+/// in the same batch. `commit_id` is strictly monotonic across connects and
+/// disconnects alike: a reorg may lower `height`, never `commit_id` (`P3`),
+/// which is what makes an ambiguous durable completion resolvable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DurableHead {
+    /// Strictly monotonic commit counter; advances on disconnect too.
+    pub commit_id: u64,
+    /// Height of `tip`.
+    pub height: u32,
+    /// Committed chain tip.
+    pub tip: Hash256,
+    /// Cumulative applied-chain transaction count at `tip`.
+    pub chain_tx_count: u64,
+    /// Body-byte range certified durable before this batch.
+    pub body_extent: Option<BodyExtent>,
+    /// The newest undo record `(height, hash)` this head certifies durable.
+    pub undo_extent: Option<(u32, Hash256)>,
+}
+
+impl DurableHead {
+    /// Serializes the versioned, CRC32C-framed row.
+    ///
+    /// Layout: `magic | version u8 | crc32c(payload) u32 LE | payload`, the
+    /// payload all big-endian. The checksum covers the payload so a torn
+    /// backend row or a bit flip fails closed at load.
+    #[must_use]
+    pub fn encode(&self) -> [u8; DURABLE_HEAD_FRAME_LEN] {
+        let mut payload = [0_u8; DURABLE_HEAD_PAYLOAD_LEN];
+        payload[0..8].copy_from_slice(&self.commit_id.to_be_bytes());
+        payload[8..12].copy_from_slice(&self.height.to_be_bytes());
+        payload[12..44].copy_from_slice(self.tip.as_byte_array());
+        payload[44..52].copy_from_slice(&self.chain_tx_count.to_be_bytes());
+        payload[52] = u8::from(self.body_extent.is_some());
+        if let Some(extent) = self.body_extent {
+            payload[53..57].copy_from_slice(&extent.file_no.to_be_bytes());
+            payload[57..65].copy_from_slice(&extent.offset.to_be_bytes());
+        }
+        payload[65] = u8::from(self.undo_extent.is_some());
+        if let Some((height, hash)) = self.undo_extent {
+            payload[66..70].copy_from_slice(&height.to_be_bytes());
+            payload[70..102].copy_from_slice(hash.as_byte_array());
+        }
+
+        let mut frame = [0_u8; DURABLE_HEAD_FRAME_LEN];
+        frame[..DURABLE_HEAD_MAGIC.len()].copy_from_slice(&DURABLE_HEAD_MAGIC);
+        frame[DURABLE_HEAD_MAGIC.len()] = DURABLE_HEAD_FORMAT_VERSION;
+        let checksum = crc32c(&payload);
+        frame[5..9].copy_from_slice(&checksum.to_le_bytes());
+        frame[9..].copy_from_slice(&payload);
+        frame
+    }
+
+    /// Decodes a framed row, refusing every malformed byte.
+    #[must_use]
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        let header = DURABLE_HEAD_MAGIC.len() + 1 + 4;
+        if bytes.len() != DURABLE_HEAD_FRAME_LEN
+            || bytes[..DURABLE_HEAD_MAGIC.len()] != DURABLE_HEAD_MAGIC
+            || bytes[DURABLE_HEAD_MAGIC.len()] != DURABLE_HEAD_FORMAT_VERSION
+        {
+            return None;
+        }
+        let checksum = u32::from_le_bytes(
+            bytes[DURABLE_HEAD_MAGIC.len() + 1..header]
+                .try_into()
+                .ok()?,
+        );
+        let payload = &bytes[header..];
+        if crc32c(payload) != checksum {
+            return None;
+        }
+        parse_payload(payload)
+    }
+}
+
+/// Parses the checksum-verified payload into a head.
+fn parse_payload(payload: &[u8]) -> Option<DurableHead> {
+    if payload.len() != DURABLE_HEAD_PAYLOAD_LEN {
+        return None;
+    }
+    let commit_id = u64::from_be_bytes(payload[0..8].try_into().ok()?);
+    let height = u32::from_be_bytes(payload[8..12].try_into().ok()?);
+    let tip = Hash256::from_le_bytes(&payload[12..44].try_into().ok()?);
+    let chain_tx_count = u64::from_be_bytes(payload[44..52].try_into().ok()?);
+    let body_present = payload[52];
+    let undo_present = payload[65];
+    if body_present > 1 || undo_present > 1 {
+        return None;
+    }
+    let body_extent = if body_present == 1 {
+        Some(BodyExtent {
+            file_no: u32::from_be_bytes(payload[53..57].try_into().ok()?),
+            offset: u64::from_be_bytes(payload[57..65].try_into().ok()?),
+        })
+    } else {
+        None
+    };
+    let undo_extent = if undo_present == 1 {
+        let height = u32::from_be_bytes(payload[66..70].try_into().ok()?);
+        let hash = Hash256::from_le_bytes(&payload[70..102].try_into().ok()?);
+        Some((height, hash))
+    } else {
+        None
+    };
+    Some(DurableHead {
+        commit_id,
+        height,
+        tip,
+        chain_tx_count,
+        body_extent,
+        undo_extent,
+    })
+}
+
+/// Record rows that land atomically beside a durable-head advance.
+///
+/// The apply path fills only the legs a commit needs: a connect lands the
+/// block's undo row and body locator row, a disconnect lands the `RolledBack`
+/// marker phase. Everything here must already be *written* (deferred is fine)
+/// and *synced* where it lives outside the key-value store before the batch
+/// runs, because `Ok(())` from [`DurableHeadStore::commit`] is the durability
+/// receipt for the head and all of these rows together.
+#[derive(Debug, Default)]
+pub struct CommitRecords<'a> {
+    /// Undo rows (`UndoData`) to land with the head: `(height, hash, record)`.
+    pub undo_rows: Vec<(u32, Hash256, &'a [u8])>,
+    /// Body locator rows (`BlockBodies`): `(height, hash, position)`.
+    pub body_rows: Vec<(u32, Hash256, crate::block_file::BlockFilePosition)>,
+    /// Disconnect marker row to write in the same receipt, moving an armed
+    /// `InFlight` marker to `RolledBack` atomically with the head advance.
+    pub marker: Option<crate::DisconnectMarker>,
+}
+
+/// Owner of the durable-head row and its atomic commit boundary.
+///
+/// Implementations must keep the whole [`CommitRecords`] set and the head row
+/// in one atomic, durable write: after `Ok(())`, a reopened store sees the
+/// new head and every record row, or the old head and none of them.
+pub trait DurableHeadStore: Send + Sync + 'static {
+    /// Loads the current durable head, if any has ever been committed.
+    ///
+    /// An unreadable row is an error, never `None`: treating corruption as
+    /// "no head" would let a silent bit flip turn the chain's commit point
+    /// back into a checkpoint-and-journal node.
+    fn load(&self) -> Result<Option<DurableHead>, StorageError>;
+
+    /// Durably advances the head to `next` iff the stored head still encodes
+    /// `expected`.
+    ///
+    /// `expected` is the fence: the empty store must be named with `None`.
+    /// A mismatch returns [`StorageError::InvalidOperation`] and applies
+    /// nothing, mirroring a lost `write_durable_if` claim. `Ok(())` is the
+    /// durability receipt for `next` and every row in `records`; `Err` is not
+    /// a rollback receipt — the batch may already be durable, and the caller
+    /// must reconcile instead of retrying blindly.
+    fn commit(
+        &self,
+        expected: Option<&DurableHead>,
+        next: &DurableHead,
+        records: &CommitRecords<'_>,
+    ) -> Result<(), StorageError>;
+}
+
+/// Durable-head storage backed by a [`KvStore`].
+///
+/// The row lands in the `UtxoMeta` family beside the disconnect marker and
+/// the index watermark keys, which is where chainstate metadata already
+/// lives; no new column family and no datadir-wide schema bump.
+pub struct KvDurableHeadStore<S: KvStore> {
+    store: std::sync::Arc<S>,
+}
+
+impl<S: KvStore> KvDurableHeadStore<S> {
+    /// Binds the head store to `store`.
+    #[must_use]
+    pub const fn new(store: std::sync::Arc<S>) -> Self {
+        Self { store }
+    }
+
+    fn load_bytes(&self) -> Result<Option<Vec<u8>>, StorageError> {
+        self.store.get(ColumnFamily::UtxoMeta, DURABLE_HEAD_KEY)
+    }
+}
+
+impl<S: KvStore> DurableHeadStore for KvDurableHeadStore<S> {
+    fn load(&self) -> Result<Option<DurableHead>, StorageError> {
+        self.load_bytes()?
+            .map(|bytes| {
+                DurableHead::decode(&bytes).ok_or_else(|| {
+                    StorageError::IncompatibleData(
+                        "durable head row is unreadable; refusing to treat it as absent".to_owned(),
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    fn commit(
+        &self,
+        expected: Option<&DurableHead>,
+        next: &DurableHead,
+        records: &CommitRecords<'_>,
+    ) -> Result<(), StorageError> {
+        let mut batch = self.store.new_batch();
+        for (height, hash, record) in &records.undo_rows {
+            batch.put(
+                ColumnFamily::UndoData,
+                &block_undo_key(*height, *hash),
+                record,
+            );
+        }
+        for (height, hash, position) in &records.body_rows {
+            batch.put(
+                BLOCK_DATA_CF,
+                &block_body_key(*height, *hash),
+                &position.encode(),
+            );
+        }
+        if let Some(marker) = &records.marker {
+            batch.put(
+                ColumnFamily::UtxoMeta,
+                DISCONNECT_MARKER_KEY,
+                &encode_disconnect_marker(marker),
+            );
+        }
+        let condition = match expected {
+            Some(current) => WriteCondition::Equals {
+                cf: ColumnFamily::UtxoMeta,
+                key: DURABLE_HEAD_KEY,
+                expected: &current.encode(),
+            },
+            None => WriteCondition::Absent {
+                cf: ColumnFamily::UtxoMeta,
+                key: DURABLE_HEAD_KEY,
+            },
+        };
+        batch.put(ColumnFamily::UtxoMeta, DURABLE_HEAD_KEY, &next.encode());
+        if !self.store.write_durable_if(&[condition], batch)? {
+            return Err(StorageError::InvalidOperation(
+                "durable head moved since it was read",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Process-local durable-head storage.
+///
+/// A real implementation for tests: what is committed can be loaded back and
+/// the fence is honored, but nothing survives a restart because there is no
+/// restart to survive. Production wiring uses [`KvDurableHeadStore`].
+#[derive(Debug, Default)]
+pub struct InMemoryDurableHeadStore {
+    head: parking_lot::RwLock<Option<DurableHead>>,
+}
+
+impl InMemoryDurableHeadStore {
+    /// Creates an empty store.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            head: parking_lot::RwLock::new(None),
+        }
+    }
+}
+
+impl DurableHeadStore for InMemoryDurableHeadStore {
+    fn load(&self) -> Result<Option<DurableHead>, StorageError> {
+        Ok(*self.head.read())
+    }
+
+    fn commit(
+        &self,
+        expected: Option<&DurableHead>,
+        next: &DurableHead,
+        _records: &CommitRecords<'_>,
+    ) -> Result<(), StorageError> {
+        let mut head = self.head.write();
+        if head.as_ref() != expected {
+            return Err(StorageError::InvalidOperation(
+                "durable head moved since it was read",
+            ));
+        }
+        *head = Some(*next);
+        Ok(())
+    }
+}
+
+/// CRC32C (Castagnoli), matching the chainstate journal's framing checksum.
+fn crc32c(bytes: &[u8]) -> u32 {
+    let mut crc = u32::MAX;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            let mask = 0_u32.wrapping_sub(crc & 1);
+            crc = (crc >> 1) ^ (0x82_F6_3B_78 & mask);
+        }
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(commit_id: u64) -> DurableHead {
+        DurableHead {
+            commit_id,
+            height: 41,
+            tip: Hash256::from_le_bytes(&[0x5A_u8; 32]),
+            chain_tx_count: 123_456,
+            body_extent: Some(BodyExtent {
+                file_no: 1,
+                offset: 9_876,
+            }),
+            undo_extent: Some((41, Hash256::from_le_bytes(&[0x5A_u8; 32]))),
+        }
+    }
+
+    #[test]
+    fn frame_round_trips_extents() {
+        let head = sample(7);
+        assert_eq!(DurableHead::decode(&head.encode()), Some(head));
+
+        let bare = DurableHead {
+            body_extent: None,
+            undo_extent: None,
+            ..sample(1)
+        };
+        assert_eq!(DurableHead::decode(&bare.encode()), Some(bare));
+    }
+
+    #[test]
+    fn frame_fails_closed_on_corruption() {
+        let mut frame = sample(7).encode();
+        // Wrong version byte.
+        frame[DURABLE_HEAD_MAGIC.len()] = DURABLE_HEAD_FORMAT_VERSION + 1;
+        assert_eq!(DurableHead::decode(&frame), None);
+
+        let mut frame = sample(7).encode();
+        // Bit flip inside the payload.
+        let last = frame.len() - 1;
+        frame[last] ^= 0x80;
+        assert_eq!(DurableHead::decode(&frame), None);
+
+        let mut frame = sample(7).encode();
+        // Bad magic.
+        frame[0] = b'X';
+        assert_eq!(DurableHead::decode(&frame), None);
+
+        // Truncated frame.
+        let frame = sample(7).encode();
+        assert_eq!(DurableHead::decode(&frame[..frame.len() - 1]), None);
+    }
+
+    #[test]
+    fn memory_store_honors_the_fence() -> Result<(), StorageError> {
+        let store = InMemoryDurableHeadStore::new();
+        let first = sample(1);
+        store.commit(None, &first, &CommitRecords::default())?;
+        let second = DurableHead {
+            commit_id: 2,
+            ..sample(2)
+        };
+        // A stale expectation applies nothing and reports the fence.
+        let stale = DurableHead {
+            commit_id: 9,
+            ..first
+        };
+        assert!(
+            store
+                .commit(Some(&stale), &second, &CommitRecords::default())
+                .is_err()
+        );
+        assert_eq!(store.load()?, Some(first));
+        store.commit(Some(&first), &second, &CommitRecords::default())?;
+        assert_eq!(store.load()?, Some(second));
+        Ok(())
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -30,6 +30,11 @@ pub use trait_::{
 
 pub use undo::{DisconnectMarker, DisconnectPhase, InMemoryUndoStore, KvUndoStore, UndoStore};
 
+pub use durable_head::{
+    BodyExtent, CommitRecords, DurableHead, DurableHeadStore, InMemoryDurableHeadStore,
+    KvDurableHeadStore,
+};
+
 #[cfg(feature = "fjall")]
 pub use fjall_impl::FjallStore;
 
@@ -99,6 +104,8 @@ pub mod block_file;
 pub mod cache_budget;
 /// Logical column-family names shared by all storage backends.
 pub mod column_families;
+/// Durable chain head record and its atomic commit boundary.
+pub mod durable_head;
 /// Storage error type.
 pub mod error;
 /// Custody-grade logical and physical storage-footprint ledgers.

--- a/crates/storage/src/undo.rs
+++ b/crates/storage/src/undo.rs
@@ -97,10 +97,10 @@ pub enum DisconnectPhase {
 /// One key, not one per block: only one disconnect runs at a time, and a
 /// per-block key would leave the reader scanning to find out whether any are
 /// set.
-const DISCONNECT_MARKER_KEY: &[u8] = b"node:disconnect-in-flight";
+pub(crate) const DISCONNECT_MARKER_KEY: &[u8] = b"node:disconnect-in-flight";
 
 impl DisconnectMarker {
-    fn encode(&self) -> [u8; 37] {
+    pub(crate) fn encode(&self) -> [u8; 37] {
         let mut encoded = [0_u8; 37];
         encoded[..32].copy_from_slice(&self.hash.to_le_bytes());
         encoded[32..36].copy_from_slice(&self.height.to_be_bytes());
@@ -140,6 +140,15 @@ impl DisconnectMarker {
             phase,
         })
     }
+}
+
+/// Serializes a disconnect marker for a caller outside this module.
+///
+/// The durable-head commit writes the marker row in the same atomic batch as
+/// the head advance, so the marker codec is shared crate-internally while
+/// decoding stays behind [`UndoStore::load_disconnect_marker`].
+pub(crate) fn encode_disconnect_marker(marker: &DisconnectMarker) -> [u8; 37] {
+    marker.encode()
 }
 
 /// Process-local undo storage.

--- a/crates/storage/src/undo.rs
+++ b/crates/storage/src/undo.rs
@@ -97,10 +97,10 @@ pub enum DisconnectPhase {
 /// One key, not one per block: only one disconnect runs at a time, and a
 /// per-block key would leave the reader scanning to find out whether any are
 /// set.
-pub(crate) const DISCONNECT_MARKER_KEY: &[u8] = b"node:disconnect-in-flight";
+const DISCONNECT_MARKER_KEY: &[u8] = b"node:disconnect-in-flight";
 
 impl DisconnectMarker {
-    pub(crate) fn encode(&self) -> [u8; 37] {
+    fn encode(&self) -> [u8; 37] {
         let mut encoded = [0_u8; 37];
         encoded[..32].copy_from_slice(&self.hash.to_le_bytes());
         encoded[32..36].copy_from_slice(&self.height.to_be_bytes());
@@ -140,15 +140,6 @@ impl DisconnectMarker {
             phase,
         })
     }
-}
-
-/// Serializes a disconnect marker for a caller outside this module.
-///
-/// The durable-head commit writes the marker row in the same atomic batch as
-/// the head advance, so the marker codec is shared crate-internally while
-/// decoding stays behind [`UndoStore::load_disconnect_marker`].
-pub(crate) fn encode_disconnect_marker(marker: &DisconnectMarker) -> [u8; 37] {
-    marker.encode()
 }
 
 /// Process-local undo storage.
@@ -231,14 +222,12 @@ impl<S: KvStore> UndoStore for KvUndoStore<S> {
     /// visible to later reads in this process and lets the checkpoint flush
     /// make it durable, which is what `disconnect_block` needs and all it needs.
     ///
-    /// This is not crash-safe, and neither is the UTXO commit beside it: no
-    /// part of block connection fsyncs. An fsync on this write alone would cost
-    /// one per connected block and still leave the commit it describes
-    /// unrecoverable, so it would buy a slower node and no guarantee.
-    ///
-    /// Closing the gap needs a crash-recovery path that re-applies the blocks
-    /// between the last durable state and the tip. The node has no such path
-    /// today, so do not cite one here.
+    /// Deferred is correct because the durable-head commit is the receipt
+    /// that makes this row authoritative: the apply path flushes it together
+    /// with the head row in one atomic batch (`RCV-02`), and the head's
+    /// `undo_extent` names it only from that receipt on. Writing it earlier
+    /// keeps it readable for planning; it is an orphan tail, safely
+    /// discarded, until the head names it.
     fn persist_undo(&self, height: u32, hash: Hash256, record: &[u8]) -> Result<(), StorageError> {
         let mut batch = self.store.new_batch();
         batch.put(

--- a/crates/storage/tests/durable_head_store.rs
+++ b/crates/storage/tests/durable_head_store.rs
@@ -1,0 +1,107 @@
+//! Backend-level durable-head store laws, on a real `KvStore`.
+//!
+//! These exercise the receipt semantics the apply path leans on: `Ok(())`
+//! from a commit means a reopened store sees the new head, an injected
+//! durability fault never leaves a torn state, and the fence refuses a stale
+//! expectation without applying the batch.
+
+use std::sync::Arc;
+
+use bitcoin_rs_primitives::Hash256;
+use bitcoin_rs_storage::{
+    CommitRecords, DurableHead, DurableHeadStore, KvDurableHeadStore, KvStore, PersistFault,
+    StorageError,
+};
+
+fn head(commit_id: u64, height: u32) -> DurableHead {
+    DurableHead {
+        commit_id,
+        height,
+        tip: Hash256::from_le_bytes(&[0xB0; 32]),
+        chain_tx_count: 10,
+        body_extent: None,
+        undo_extent: None,
+    }
+}
+
+fn run_reopen_and_fence_laws() -> Result<(), StorageError> {
+    let temp = tempfile::tempdir()?;
+    let store = Arc::new(KvDurableHeadStore::new(Arc::new(
+        bitcoin_rs_storage::FjallStore::open(temp.path())?,
+    )));
+
+    // An empty store must be named with a None fence.
+    let first = head(1, 1);
+    store.commit(None, &first, &CommitRecords::default())?;
+    assert_eq!(store.load()?.map(|h| h.commit_id), Some(1));
+
+    // A stale fence applies nothing and reports the move.
+    let second = head(2, 2);
+    let stale = head(9, 9);
+    assert!(
+        store
+            .commit(Some(&stale), &second, &CommitRecords::default())
+            .is_err()
+    );
+    assert_eq!(store.load()?.map(|h| h.commit_id), Some(1));
+    store.commit(Some(&first), &second, &CommitRecords::default())?;
+
+    // Ok(()) is the durability receipt: a reopened store sees the head.
+    drop(store);
+    let reopened =
+        KvDurableHeadStore::new(Arc::new(bitcoin_rs_storage::FjallStore::open(temp.path())?));
+    assert_eq!(reopened.load()?.map(|h| h.commit_id), Some(2));
+    Ok(())
+}
+
+#[cfg(feature = "fjall")]
+#[test]
+fn fjall_durable_head_reopen_and_fence_laws() -> Result<(), StorageError> {
+    run_reopen_and_fence_laws()?;
+    Ok(())
+}
+
+#[cfg(feature = "fjall")]
+#[test]
+fn fjall_durable_head_faults_never_tear_the_state() -> Result<(), StorageError> {
+    for fault in [
+        PersistFault::FailApply,
+        PersistFault::LostApply,
+        PersistFault::PartialApply,
+        PersistFault::FailSync,
+        PersistFault::LostSync,
+        PersistFault::FailFlush,
+        PersistFault::LostFlush,
+    ] {
+        fault_leaves_an_intact_head(fault)?;
+    }
+    Ok(())
+}
+
+/// After a one-shot fault on the head commit, a reopened store shows either
+/// the complete old head or the complete new head — never absence, never a
+/// torn decode (`P2` at the storage boundary).
+fn fault_leaves_an_intact_head(fault: PersistFault) -> Result<(), StorageError> {
+    let temp = tempfile::tempdir()?;
+    let first = head(1, 1);
+    let next = head(2, 2);
+    let outcome = {
+        let backend = Arc::new(bitcoin_rs_storage::FjallStore::open(temp.path())?);
+        let store = KvDurableHeadStore::new(Arc::clone(&backend));
+
+        store.commit(None, &first, &CommitRecords::default())?;
+        backend.arm_persist_fault(fault);
+        store.commit(Some(&first), &next, &CommitRecords::default())
+    };
+
+    let reopened =
+        KvDurableHeadStore::new(Arc::new(bitcoin_rs_storage::FjallStore::open(temp.path())?));
+    let recovered = reopened
+        .load()?
+        .ok_or_else(|| StorageError::Backend("head row vanished".to_owned()))?;
+    assert!(
+        recovered == first || recovered == next,
+        "fault {fault:?} left a torn head: {recovered:?} (commit outcome {outcome:?})"
+    );
+    Ok(())
+}

--- a/docs/contracts/recovery.md
+++ b/docs/contracts/recovery.md
@@ -38,22 +38,36 @@ R = (tip, height, CommitId, coins_version, coins, body_extent, undo_extent, refs
   the durable byte range in the corresponding segment file. Undo and body
   references include the block hash, not only the height.
 
-`DurableHead` is the persisted form:
+`DurableHead` is the persisted form, landed in
+`crates/storage/src/durable_head.rs` as one versioned, CRC32C-framed row in
+the `UtxoMeta` family of the chainstate key-value store:
 
 ```rust
 struct DurableHead {
-    tip: BlockHash,
-    height: u32,
     commit_id: u64,
-    coins_version: u64,
-    body_extent: u64,
-    undo_extent: u64,
-    refs: Vec<FrameRef>,
+    height: u32,
+    tip: Hash256,
+    chain_tx_count: u64,
+    body_extent: Option<BodyExtent { file_no: u32, offset: u64 }>,
+    undo_extent: Option<(u32, Hash256)>,
 }
 ```
 
-The durable head, coins, and `refs` are committed in one atomic named-family
-batch. `commit_id` is monotonic on disconnect as well as on connect.
+The row carries a format version byte and a checksum over its payload; any
+malformed row fails closed at load instead of decoding to absence. The owner
+decision for this slice: the head record lives in the chainstate key-value
+store and the protocol lives in `crates/node/src/apply` — the planned
+`crates/chainstate` extraction is not forced by it.
+
+One connect or disconnect commits one atomic named-family batch whose
+`write_durable_if` receipt covers the head row, the block's undo row, and its
+body locator row; the appended body bytes and the blocks directory are synced
+before the batch may name them. The coins themselves commit in memory and
+become durable through the checkpoint export; the undo and body records in
+the batch are what make a committed tip recoverable. The chainstate journal
+is derived from this batch and may lag it, never lead it. `commit_id` is
+strictly monotonic on disconnect as well as on connect: a reorg lowers
+`height`, never `commit_id`.
 
 ## Clauses
 
@@ -92,10 +106,16 @@ For one block, or a bounded fully verified prefix during IBD:
 
 A failure before stable publication leaves the fence closed until explicit
 recovery. A guard destructor must never quietly reopen the fence after an
-error. A live `submitblock` success waits for durable body, undo, coins, and
-head completion. IBD may group a bounded verified prefix; only committed
-prefixes are published. This is the ordered commit protocol. It is also called
-the durable root recovery contract.
+error. A live `submitblock` success waits for durable body, undo, and head
+completion: `apply_block` returns only after the batch receipt, and the
+returned `ConnectOutcome.commit_id` is the receipt's id. IBD may group a
+bounded verified prefix; only committed prefixes are published. The group
+caps are stated constants, not emergent cadence:
+`DURABLE_HEAD_GROUP_BLOCKS` = 64 blocks or `DURABLE_HEAD_GROUP_MAX_BYTES` =
+8 MiB of block data, whichever first — one durable batch every one to two
+seconds at IBD rates, and a crash-redo bound of at most 64 body re-applies.
+This is the ordered commit protocol. It is also called the durable root
+recovery contract.
 
 ### `RCV-03`: Prior-or-whole-proposed and orphan tails
 
@@ -280,10 +300,35 @@ would underflow, and additions that would overflow must preserve or restore
 zero; they must never clamp or wrap into a plausible known total. A known
 count advances and rewinds by the exact transaction delta.
 
+### `RCV-14`: Checkpoint reconcile against the durable head
+
+The checkpoint publisher freezes the published state, which always trails or
+meets the durable head: publication follows the batch. Before writing, the
+publisher loads the head and refuses a checkpoint whose tip is at or above
+the head without being certified by it. A tip below the head is the
+committed-but-unpublished gap a crash can leave; checkpointing the older
+state is harmless and keeps the node operating until replay closes the gap.
+
 ## Proven by
 
-- `crates/chainstate/src/transition.rs` (planned): owns the durable root, the
-  ordered commit protocol, and the publication fence.
+- `crates/node/src/apply/durable.rs` (existing): owns the durable-head
+  advance for connect, group, and disconnect commits, the lineage fence, and
+  the boot reconciliation of the stored head.
+- `crates/node/src/apply/connect.rs` and
+  `crates/node/src/apply/disconnect.rs` (existing): run the `RCV-02` tail —
+  sync, one atomic batch, derived journal emission, then publication — and
+  retire the planned `crates/chainstate/src/transition.rs` row; the durable
+  root is owned where the mutation authority lives (`ARCH-07`).
+- `crates/storage/src/durable_head.rs` (existing): owns the head record
+  codec, the encoded-head fence, and the atomic batch contents.
+- `crates/node/tests/overhaul_durable_head.rs` (existing): the `RCV-04`
+  fault matrix for the durable head — every `PersistFault` at the
+  connect-shaped and disconnect-shaped batch boundaries, fail-closed
+  startup on a corrupted head row, durability before publication,
+  commit-id monotonicity across restarts, and body reachability through
+  the real block files.
+- `crates/storage/tests/durable_head_store.rs` (existing): backend-level
+  reopen, fence, and fault laws for the head store.
 - `crates/chainstate/src/recovery.rs` (planned): owns schema admission,
   `incompatible_schema` refusal, and `CURRENT_SCHEMA` increment logic.
 - `crates/node/tests/overhaul_crash_matrix.rs` (planned): exercises the
@@ -295,7 +340,7 @@ count advances and rewinds by the exact transaction delta.
   `RCV-05`, `RCV-08`, and bounded disconnect and reorg memory.
 - `crates/node/tests/overhaul_checkpoint_independence.rs` (planned):
   validates fresh replay, schema refusal, and checkpoint authority removal.
-- `crates/storage/tests/overhaul_atomic_durability.rs` (planned): tests the
+- `crates/storage/tests/overhaul_atomic_durability.rs` (existing): tests the
   storage-level prior-or-whole-proposed rule and durable batch completion.
 - `crates/node/src/txindex/recovery_tests.rs` (existing):
   - `deep_rollback_rebuilds_and_publishes_rebuild_phase_until_caught_up`


### PR DESCRIPTION
DurableHead record + atomic commit boundary, ordered connect/disconnect commit, grouped IBD window commits, journal-follows-head invariant, checkpoint reconcile + fault-injection matrix, recovery.md contract. Gates: CL-17 4/4, node lib 566, storage suite, clippy 0, fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes block connection and disconnection crash-safe with a durable-head commit boundary. Previously nothing in the apply path fsynced, so a crash could lose a committed block or leave a torn mix of head, undo, and body rows; now every connect and disconnect syncs its appended bytes and lands one atomic durable batch naming the new tip before the tip publishes, so a follower-visible block is always already durable.

**Durable commit ordering**
- IBD windows commit verified prefixes in groups — 64 blocks or 8 MiB — with one atomic batch and one `commit_id` each.
- `commit_id` advances monotonically and never moves backward, even when a disconnect lowers the tip height.
- A stored head that does not name the connecting block's parent refuses the connect; recovery replay (not yet added) is the only path that can close that gap.
- The journal and checkpoint publisher now reconcile against the head: journal records emit after connect batches and before disconnect ones, and checkpoints refuse a tip the head has not certified.

**Tests and docs**
- Storage tests prove a durability fault never leaves torn state and `Ok(())` commits survive reopen.
- The new `overhaul_durable_head` target runs the fault-injection matrix at every batch boundary plus protocol rows covering restarts, commit-id continuity, and corrupted head rows.
- `docs/contracts/recovery.md` now specifies the landed durable-head protocol.

<sup>Written for commit 197b9934932fdddce9f9751ea035318add2032fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/bitcoin-rs/pull/1018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

